### PR TITLE
Fix team widget to properly use fuzzy school name matching

### DIFF
--- a/supabase/migrations/20250110_fix_team_matching.sql
+++ b/supabase/migrations/20250110_fix_team_matching.sql
@@ -1,0 +1,68 @@
+-- Create a comprehensive function to find all team members at a school
+-- This function finds all users at the same normalized school, regardless of spelling variations
+CREATE OR REPLACE FUNCTION find_all_team_members(
+  p_school_site TEXT,
+  p_school_district TEXT,
+  p_exclude_user_id UUID DEFAULT NULL
+)
+RETURNS TABLE(
+  id UUID,
+  full_name TEXT,
+  role TEXT,
+  school_site TEXT,
+  school_district TEXT
+) AS $$
+BEGIN
+  RETURN QUERY
+  WITH normalized_input AS (
+    SELECT 
+      normalize_school_name(p_school_site) as norm_site,
+      normalize_district_name(p_school_district) as norm_district
+  ),
+  -- Find all users from profiles table at this normalized school
+  profile_users AS (
+    SELECT 
+      p.id,
+      p.full_name,
+      p.role,
+      p.school_site,
+      p.school_district
+    FROM profiles p, normalized_input n
+    WHERE 
+      normalize_school_name(p.school_site) = n.norm_site
+      AND normalize_district_name(p.school_district) = n.norm_district
+      AND (p_exclude_user_id IS NULL OR p.id != p_exclude_user_id)
+  ),
+  -- Find all users from provider_schools table at this normalized school
+  provider_school_users AS (
+    SELECT DISTINCT
+      p.id,
+      p.full_name,
+      p.role,
+      ps.school_site,
+      ps.school_district
+    FROM provider_schools ps
+    JOIN profiles p ON p.id = ps.provider_id, normalized_input n
+    WHERE 
+      normalize_school_name(ps.school_site) = n.norm_site
+      AND normalize_district_name(ps.school_district) = n.norm_district
+      AND (p_exclude_user_id IS NULL OR p.id != p_exclude_user_id)
+  )
+  -- Combine both sets, keeping the user's actual school spelling from their profile
+  SELECT DISTINCT ON (u.id)
+    u.id,
+    u.full_name,
+    u.role,
+    COALESCE(pu.school_site, u.school_site) as school_site,
+    COALESCE(pu.school_district, u.school_district) as school_district
+  FROM (
+    SELECT * FROM profile_users
+    UNION ALL
+    SELECT * FROM provider_school_users
+  ) u
+  LEFT JOIN profile_users pu ON pu.id = u.id
+  ORDER BY u.id, u.role, u.full_name;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION find_all_team_members IS 'Finds all team members at a school using fuzzy matching, returning each user only once with their profile school spelling preferred';


### PR DESCRIPTION
## Problem
The team widget was not showing all team members when there were minor spelling variations in school or district names (e.g., "Mt." vs "Mt" or "Elementary School" vs "Elementary").

## Root Cause
The team widget was using the current user's exact school spelling from their `provider_schools` entries to search for teammates. This meant:
- If Blair has "Mt Diablo" (no period) in provider_schools
- And Jenna has "Mt. Diablo" (with period) in her profile
- The fuzzy matching functions were working correctly, but the widget logic was flawed

## Solution
1. Created a new comprehensive function `find_all_team_members` that:
   - Searches both `profiles` and `provider_schools` tables
   - Uses normalized school names for matching
   - Returns all team members regardless of spelling variations
   - Eliminates duplicates and returns each user only once

2. Simplified the team widget to use this single function instead of calling two separate functions and trying to merge results

## Testing
After merging and running the migration:
1. The team widget should show Blair Stewart, Jenna Boyd, and SEA Test 1 all on the same team
2. This will work regardless of whether users entered "Mt." or "Mt" or included "School" at the end

## Migration Required
Run this SQL in Supabase after merging:
```sql
-- Or copy from: supabase/migrations/20250110_fix_team_matching.sql
```