### PR TITLE
Fix TypeScript configuration to support @ import alias

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,11 @@
         "name": "next"
       }
     ],
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Fix TypeScript Path Mapping

This PR adds the missing TypeScript path mapping configuration to support the `@/` import alias pattern.

### Changes:
- Added `baseUrl: "."` to tsconfig.json
- Added `paths` mapping for `@/*` to `./*`

### Why this fixes the issue:
The TypeScript compiler was failing because it couldn't resolve imports using the `@/` alias. This is a common Next.js pattern, but it requires explicit configuration in tsconfig.json.

### Alternative approach in PR #15:
PR #15 took the approach of converting all `@/` imports to relative imports. This also works, but the `@/` pattern is cleaner for deeply nested files and is the standard in many Next.js projects.

With this fix, either approach will work - you can choose to:
1. Merge this PR to enable `@/` imports throughout the project
2. Continue with PR #15's approach of using relative imports

Both are valid solutions!