### PR TITLE
Fix module resolution errors by configuring @/ path alias

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,11 @@
         "name": "next"
       }
     ],
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Problem
The build is failing with module resolution errors for imports using the `@/` path alias. Multiple files cannot resolve imports like `@/app/components/payment/checkout-form`.

## Root Cause
The TypeScript configuration was missing the path alias configuration that maps `@/` to the project root. Without this configuration, the TypeScript compiler and Next.js bundler cannot resolve these module paths.

## Solution
Added the following to `tsconfig.json`:
- `baseUrl: "."` - Sets the base directory for resolving non-relative module names
- `paths: { "@/*": ["./*"] }` - Maps the `@/` alias to the project root

This is a standard Next.js configuration that enables clean imports throughout the project.

## Impact
- Fixes all module resolution errors in the build
- Ensures consistent import patterns across the codebase
- Prevents this issue from recurring

## Testing
After merging this PR:
1. Run `git pull origin main` in Replit
2. The build should now complete successfully
3. All imports using `@/` will resolve correctly