### PR TITLE
Fix: Remove honorific from teacher name placeholder

### DIFF
--- a/app/components/special-activities/add-special-activity-form.tsx
+++ b/app/components/special-activities/add-special-activity-form.tsx
@@ -111,7 +111,7 @@ export default function AddSpecialActivityForm({ teacherName: initialTeacherName
           type="text"
           value={teacherName}
           onChange={(e) => setTeacherName(e.target.value)}
-          placeholder="e.g., Mrs. Smith"
+          placeholder="Smith"
           className="w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
           required
         />


### PR DESCRIPTION
## Summary
- Removes gender/title assumption from the Add Special Activity form
- Replaces "e.g., Mrs. Smith" with neutral "Smith" placeholder text
- Ensures inclusive language throughout the application

## Changes
- Updated placeholder text in `app/components/special-activities/add-special-activity-form.tsx` (line 114)
- Changed from `"e.g., Mrs. Smith"` to `"Smith"` for a cleaner, bias-free example

## Test plan
- [x] Verified placeholder text change in the component
- [ ] Manual test: Navigate to Special Activities page, open Add Activity form, confirm placeholder displays "Smith"
- [ ] Verify form functionality remains unchanged

Fixes #33

🤖 Generated with [Claude Code](https://claude.ai/code)