### PR TITLE
Fix: Update signup email copy to include .org and other domains

### DIFF
--- a/app/(auth)/signup/signup-form.tsx
+++ b/app/(auth)/signup/signup-form.tsx
@@ -429,10 +429,10 @@ const handleSubmit = async (e: React.FormEvent) => {
           value={formData.email}
           onChange={handleChange}
           className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-          placeholder="you@district.edu"
+          placeholder="you@school.edu"
         />
         <p className="mt-1 text-xs text-gray-500">
-          Must be a valid district email address (.edu)
+          Use your school or organization email (.edu, .org, etc.)
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- Updated the email helper text in the signup form to clarify that .edu, .org, and other domain types are accepted
- Changed placeholder from "you@district.edu" to "you@school.edu" for better clarity
- Helper text now reads: "Use your school or organization email (.edu, .org, etc.)"

## Related Issue
Fixes #73

## Changes Made
- Modified `app/(auth)/signup/signup-form.tsx`:
  - Line 432: Updated placeholder text
  - Line 435: Updated helper text to be more inclusive

## Test Plan
- [ ] View the signup page
- [ ] Verify the email field placeholder shows "you@school.edu"
- [ ] Verify the helper text below email field shows "Use your school or organization email (.edu, .org, etc.)"
- [ ] Test that email validation still works correctly for various domain types

🤖 Generated with [Claude Code](https://claude.ai/code)