### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/app/components/ai-content-modal.tsx
+++ b/app/components/ai-content-modal.tsx
@@ -46,6 +46,7 @@ export function AIContentModal({
 
   // Escape HTML special characters in user-supplied notes
   function escapeHTML(str: string): string {
+    if (!str) return '';
     return str.replace(/&/g, "&amp;")
               .replace(/</g, "&lt;")
               .replace(/>/g, "&gt;")


### PR DESCRIPTION
Potential fix for [https://github.com/bstewart2255/speddy/security/code-scanning/2](https://github.com/bstewart2255/speddy/security/code-scanning/2)

To fix the vulnerability, we must ensure that any user-supplied text (in this case, `notes`) is properly escaped before being inserted into the HTML string. The best way to do this is to encode special HTML characters in `notes` so that any potentially malicious input is rendered as plain text, not interpreted as HTML or JavaScript.

**How to fix:**  
- Create a helper function to escape HTML special characters (`<`, `>`, `&`, `"`, `'`) in the `notes` string.
- Use this function to encode `notes` before interpolating it into the HTML string on line 153.

**Where to change:**  
- Add the escape function in the same file (app/components/ai-content-modal.tsx).
- Update line 153 to use the escaped version of `notes`.

**What is needed:**  
- A simple `escapeHTML` function (can be defined locally).
- No external dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
