### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,6 +1,8 @@
 permissions:
   contents: read
 name: TypeScript Check
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: TypeScript Check
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/bstewart2255/speddy/security/code-scanning/1](https://github.com/bstewart2255/speddy/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to read repository contents (for checkout and installing dependencies), the minimal permission required is `contents: read`. This block can be added at the workflow level (top-level, after `name:` and before `on:`) or at the job level (under `typecheck:`). The best practice is to add it at the workflow level so all jobs inherit the restriction unless they need more. Edit `.github/workflows/typecheck.yml` to add:

```yaml
permissions:
  contents: read
```

immediately after the `name:` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
