### PR TITLE
feat: add last saved timestamps to forms (fixes #60)

### DIFF
--- a/app/(dashboard)/dashboard/bell-schedules/page.tsx
+++ b/app/(dashboard)/dashboard/bell-schedules/page.tsx
@@ -148,42 +148,46 @@ export default function BellSchedulesPage() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
 
         {/* Page Header with School Info */}
-        <div className="flex justify-between items-center mb-8">
-          <div>
-            <h1 className="text-3xl font-bold text-gray-900 mb-2">Bell Schedules</h1>
-            <p className="text-gray-600">Set grade-wide time restrictions (Start/End, Recess, Lunch, etc)</p>
-            {currentSchool && (
-              <p className="text-sm text-gray-500 mt-1">
-                {currentSchool.display_name}
-                {currentSchool.is_migrated && (
-                  <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
-                    Optimized
-                  </span>
-                )}
-              </p>
-            )}
-          </div>
-          <div className="flex items-center gap-3">
-            <LastSaved timestamp={lastSaved} />
-            <Button 
-              variant="secondary" 
-              onClick={() => setShowImportSection(!showImportSection)}
-            >
-              Import CSV
-            </Button>
-            <AIUploadButton 
-              uploadType="bell_schedule" 
-              onSuccess={() => {
-                // Refresh bell schedules
-                window.location.reload();
-              }} 
-            />
-            <Button 
-              variant="primary" 
-              onClick={() => setShowAddForm(!showAddForm)}
-            >
-              + Add Schedule
-            </Button>
+        <div className="mb-8">
+          <div className="flex justify-between items-center">
+            <div>
+              <h1 className="text-3xl font-bold text-gray-900 mb-2">Bell Schedules</h1>
+              <p className="text-gray-600">Set grade-wide time restrictions (Start/End, Recess, Lunch, etc)</p>
+              {currentSchool && (
+                <p className="text-sm text-gray-500 mt-1">
+                  {currentSchool.display_name}
+                  {currentSchool.is_migrated && (
+                    <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
+                      Optimized
+                    </span>
+                  )}
+                </p>
+              )}
+            </div>
+            <div className="flex flex-col items-end gap-2">
+              <div className="flex items-center gap-3">
+                <Button 
+                  variant="secondary" 
+                  onClick={() => setShowImportSection(!showImportSection)}
+                >
+                  Import CSV
+                </Button>
+                <AIUploadButton 
+                  uploadType="bell_schedule" 
+                  onSuccess={() => {
+                    // Refresh bell schedules
+                    window.location.reload();
+                  }} 
+                />
+                <Button 
+                  variant="primary" 
+                  onClick={() => setShowAddForm(!showAddForm)}
+                >
+                  + Add Schedule
+                </Button>
+              </div>
+              <LastSaved timestamp={lastSaved} />
+            </div>
           </div>
         </div>
 

--- a/app/(dashboard)/dashboard/bell-schedules/page.tsx
+++ b/app/(dashboard)/dashboard/bell-schedules/page.tsx
@@ -14,6 +14,8 @@ import AIUploadButton from '../../../components/ai-upload/ai-upload-button';
 import { CollapsibleCard } from '../../../components/ui/collapsible-card';
 import SchoolHoursForm from '../../../components/bell-schedules/school-hours-form';
 import { FilterSelect } from '../../../components/schedule/filter-select';
+import { LastSaved } from '../../../components/ui/last-saved';
+import { getLastSavedBellSchedule } from '../../../../lib/supabase/queries/last-saved';
 
 export default function BellSchedulesPage() {
   const [showAddForm, setShowAddForm] = useState(false);
@@ -23,6 +25,7 @@ export default function BellSchedulesPage() {
   const [loading, setLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [sortByGrade, setSortByGrade] = useState(false);
+  const [lastSaved, setLastSaved] = useState<string | null>(null);
   const supabase = createClient();
   const { currentSchool, loading: schoolLoading } = useSchool();
   
@@ -39,6 +42,10 @@ export default function BellSchedulesPage() {
       console.log('School migration status:', currentSchool?.is_migrated ? 'Migrated (fast)' : 'Legacy (normal)');
 
       const data = await getBellSchedules(currentSchool || undefined);
+      
+      // Fetch last saved timestamp
+      const lastUpdated = await getLastSavedBellSchedule(currentSchool || undefined);
+      setLastSaved(lastUpdated);
 
       const endTime = performance.now();
       console.log(`Bell schedules loaded in ${Math.round(endTime - startTime)}ms`);
@@ -157,6 +164,7 @@ export default function BellSchedulesPage() {
             )}
           </div>
           <div className="flex items-center gap-3">
+            <LastSaved timestamp={lastSaved} />
             <Button 
               variant="secondary" 
               onClick={() => setShowImportSection(!showImportSection)}

--- a/app/(dashboard)/dashboard/special-activities/page.tsx
+++ b/app/(dashboard)/dashboard/special-activities/page.tsx
@@ -154,32 +154,36 @@ export default function SpecialActivitiesPage() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
 
         {/* Page Header */}
-        <div className="flex justify-between items-center mb-8">
-          <div>
-            <h1 className="text-3xl font-bold text-gray-900 mb-2">Special Activities</h1>
-            <p className="text-gray-600">Manage teacher-specific activities (Music, Library, STEM, etc)</p>
-          </div>
-          <div className="flex items-center gap-3">
-            <LastSaved timestamp={lastSaved} />
-            <Button 
-              variant="secondary" 
-              onClick={() => setShowImportSection(!showImportSection)}
-            >
-              Import CSV
-            </Button>
-            <AIUploadButton 
-              uploadType="special_activities" 
-              onSuccess={() => {
-                // Refresh special activities
-                window.location.reload();
-              }} 
-            />
-            <Button 
-              variant="primary" 
-              onClick={() => setShowAddForm(!showAddForm)}
-            >
-              + Add Activity
-            </Button>
+        <div className="mb-8">
+          <div className="flex justify-between items-center">
+            <div>
+              <h1 className="text-3xl font-bold text-gray-900 mb-2">Special Activities</h1>
+              <p className="text-gray-600">Manage teacher-specific activities (Music, Library, STEM, etc)</p>
+            </div>
+            <div className="flex flex-col items-end gap-2">
+              <div className="flex items-center gap-3">
+                <Button 
+                  variant="secondary" 
+                  onClick={() => setShowImportSection(!showImportSection)}
+                >
+                  Import CSV
+                </Button>
+                <AIUploadButton 
+                  uploadType="special_activities" 
+                  onSuccess={() => {
+                    // Refresh special activities
+                    window.location.reload();
+                  }} 
+                />
+                <Button 
+                  variant="primary" 
+                  onClick={() => setShowAddForm(!showAddForm)}
+                >
+                  + Add Activity
+                </Button>
+              </div>
+              <LastSaved timestamp={lastSaved} />
+            </div>
           </div>
         </div>
 

--- a/app/(dashboard)/dashboard/special-activities/page.tsx
+++ b/app/(dashboard)/dashboard/special-activities/page.tsx
@@ -12,6 +12,8 @@ import { createClient } from '@/lib/supabase/client';
 import { useSchool } from '../../../components/providers/school-context';
 import AIUploadButton from '../../../components/ai-upload/ai-upload-button';
 import { FilterSelect } from '../../../components/schedule/filter-select';
+import { LastSaved } from '../../../components/ui/last-saved';
+import { getLastSavedSpecialActivity } from '../../../../lib/supabase/queries/last-saved';
 
 interface SpecialActivity {
   id: string;
@@ -29,6 +31,7 @@ export default function SpecialActivitiesPage() {
   const [specialActivities, setSpecialActivities] = useState<SpecialActivity[]>([]);
   const [loading, setLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [lastSaved, setLastSaved] = useState<string | null>(null);
   const { currentSchool } = useSchool();
   const supabase = createClient();
   
@@ -59,6 +62,10 @@ export default function SpecialActivitiesPage() {
 
       if (error) throw error;
       setSpecialActivities(data || []);
+      
+      // Fetch last saved timestamp
+      const lastUpdated = await getLastSavedSpecialActivity(currentSchool || undefined);
+      setLastSaved(lastUpdated);
     } catch (error) {
       console.error('Error fetching special activities:', error);
     } finally {
@@ -153,6 +160,7 @@ export default function SpecialActivitiesPage() {
             <p className="text-gray-600">Manage teacher-specific activities (Music, Library, STEM, etc)</p>
           </div>
           <div className="flex items-center gap-3">
+            <LastSaved timestamp={lastSaved} />
             <Button 
               variant="secondary" 
               onClick={() => setShowImportSection(!showImportSection)}

--- a/app/components/bell-schedules/school-hours-form.tsx
+++ b/app/components/bell-schedules/school-hours-form.tsx
@@ -527,11 +527,11 @@ export default function SchoolHoursForm({ onSuccess }: { onSuccess: () => void }
         )}
       </div>
 
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-3">
         <Button type="submit" disabled={loading} variant="primary">
           {loading ? 'Saving...' : 'Save School Hours'}
         </Button>
-        <LastSaved timestamp={lastSaved} />
+        <LastSaved timestamp={lastSaved} className="ml-2" />
       </div>
     </form>
   );

--- a/app/components/ui/last-saved.tsx
+++ b/app/components/ui/last-saved.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface LastSavedProps {
+  timestamp: string | null | undefined;
+  className?: string;
+}
+
+export function LastSaved({ timestamp, className = '' }: LastSavedProps) {
+  const [relativeTime, setRelativeTime] = useState<string>('');
+
+  useEffect(() => {
+    if (!timestamp) {
+      setRelativeTime('Never saved');
+      return;
+    }
+
+    const updateRelativeTime = () => {
+      const date = new Date(timestamp);
+      const now = new Date();
+      const diffMs = now.getTime() - date.getTime();
+      const diffSecs = Math.floor(diffMs / 1000);
+      const diffMins = Math.floor(diffSecs / 60);
+      const diffHours = Math.floor(diffMins / 60);
+      const diffDays = Math.floor(diffHours / 24);
+
+      if (diffSecs < 5) {
+        setRelativeTime('Just now');
+      } else if (diffSecs < 60) {
+        setRelativeTime(`${diffSecs} seconds ago`);
+      } else if (diffMins === 1) {
+        setRelativeTime('1 minute ago');
+      } else if (diffMins < 60) {
+        setRelativeTime(`${diffMins} minutes ago`);
+      } else if (diffHours === 1) {
+        setRelativeTime('1 hour ago');
+      } else if (diffHours < 24) {
+        setRelativeTime(`${diffHours} hours ago`);
+      } else if (diffDays === 1) {
+        setRelativeTime('1 day ago');
+      } else if (diffDays < 7) {
+        setRelativeTime(`${diffDays} days ago`);
+      } else {
+        // For older dates, show the actual date
+        setRelativeTime(date.toLocaleDateString());
+      }
+    };
+
+    updateRelativeTime();
+    // Update every minute for recent saves, less frequently for older ones
+    const interval = setInterval(updateRelativeTime, 60000);
+
+    return () => clearInterval(interval);
+  }, [timestamp]);
+
+  return (
+    <span className={`text-sm text-gray-500 ${className}`}>
+      Last saved: {relativeTime}
+    </span>
+  );
+}

--- a/app/components/ui/last-saved.tsx
+++ b/app/components/ui/last-saved.tsx
@@ -54,9 +54,13 @@ export function LastSaved({ timestamp, className = '' }: LastSavedProps) {
     return () => clearInterval(interval);
   }, [timestamp]);
 
+  if (!timestamp) {
+    return null; // Don't show anything if never saved
+  }
+
   return (
-    <span className={`text-sm text-gray-500 ${className}`}>
-      Last saved: {relativeTime}
+    <span className={`text-xs text-gray-400 italic ${className}`}>
+      Saved {relativeTime}
     </span>
   );
 }

--- a/lib/supabase/queries/last-saved.ts
+++ b/lib/supabase/queries/last-saved.ts
@@ -1,0 +1,81 @@
+import { createClient } from '@/lib/supabase/client';
+import { type SchoolIdentifier } from '@/lib/school-helpers';
+
+export async function getLastSavedBellSchedule(school: SchoolIdentifier | undefined) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  
+  if (!user || !school) return null;
+
+  let query = supabase
+    .from('bell_schedules')
+    .select('updated_at')
+    .eq('provider_id', user.id);
+
+  // Add school filtering
+  if (school.school_id) {
+    query = query.eq('school_id', school.school_id);
+  } else if (school.school_site) {
+    query = query.eq('school_site', school.school_site);
+  }
+
+  const { data, error } = await query
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (error || !data) return null;
+  return data.updated_at;
+}
+
+export async function getLastSavedSpecialActivity(school: SchoolIdentifier | undefined) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  
+  if (!user || !school) return null;
+
+  let query = supabase
+    .from('special_activities')
+    .select('updated_at')
+    .eq('provider_id', user.id);
+
+  // Add school filtering
+  if (school.school_id) {
+    query = query.eq('school_id', school.school_id);
+  } else if (school.school_site) {
+    query = query.eq('school_site', school.school_site);
+  }
+
+  const { data, error } = await query
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (error || !data) return null;
+  return data.updated_at;
+}
+
+export async function getLastSavedSchoolHours(school: SchoolIdentifier | undefined) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  
+  if (!user || !school) return null;
+
+  let query = supabase
+    .from('school_hours')
+    .select('updated_at')
+    .eq('provider_id', user.id);
+
+  // Add school filtering - school_hours only has school_site
+  if (school.school_site) {
+    query = query.eq('school_site', school.school_site);
+  }
+
+  const { data, error } = await query
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (error || !data) return null;
+  return data.updated_at;
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -287,6 +287,7 @@ export interface Database {
           school_district: string | null
           school_id: string | null
           created_at: string
+          updated_at: string
         }
         Insert: {
           id?: string
@@ -300,6 +301,7 @@ export interface Database {
           school_district?: string | null
           school_id?: string | null
           created_at?: string
+          updated_at?: string
         }
         Update: {
           id?: string
@@ -328,6 +330,7 @@ export interface Database {
           school_district: string | null
           school_id: string | null
           created_at: string
+          updated_at: string
         }
         Insert: {
           id?: string
@@ -341,6 +344,7 @@ export interface Database {
           school_district?: string | null
           school_id?: string | null
           created_at?: string
+          updated_at?: string
         }
         Update: {
           id?: string

--- a/supabase/migrations/20250815_add_updated_at_columns.sql
+++ b/supabase/migrations/20250815_add_updated_at_columns.sql
@@ -1,0 +1,50 @@
+-- Add updated_at column to bell_schedules table
+ALTER TABLE bell_schedules 
+ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW();
+
+-- Add updated_at column to special_activities table
+ALTER TABLE special_activities 
+ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW();
+
+-- Create trigger function to automatically update updated_at
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger for bell_schedules
+DROP TRIGGER IF EXISTS update_bell_schedules_updated_at ON bell_schedules;
+CREATE TRIGGER update_bell_schedules_updated_at
+    BEFORE UPDATE ON bell_schedules
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Create trigger for special_activities
+DROP TRIGGER IF EXISTS update_special_activities_updated_at ON special_activities;
+CREATE TRIGGER update_special_activities_updated_at
+    BEFORE UPDATE ON special_activities
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Create trigger for school_hours (in case it doesn't exist)
+DROP TRIGGER IF EXISTS update_school_hours_updated_at ON school_hours;
+CREATE TRIGGER update_school_hours_updated_at
+    BEFORE UPDATE ON school_hours
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Update existing records to set updated_at to created_at where updated_at is NULL
+UPDATE bell_schedules 
+SET updated_at = COALESCE(updated_at, created_at, NOW())
+WHERE updated_at IS NULL;
+
+UPDATE special_activities 
+SET updated_at = COALESCE(updated_at, created_at, NOW())
+WHERE updated_at IS NULL;
+
+UPDATE school_hours 
+SET updated_at = COALESCE(updated_at, created_at, NOW())
+WHERE updated_at IS NULL;


### PR DESCRIPTION
## Summary
- Implements "Last saved" timestamp display for Bell Schedules, Special Activities, and School Hours forms
- Shows relative time (e.g., "2 minutes ago", "1 hour ago") that updates automatically
- Addresses GitHub issue #60 requirements

## Changes
- Added `updated_at` columns to `bell_schedules` and `special_activities` tables via migration
- Created reusable `LastSaved` component that displays relative timestamps
- Integrated timestamp display near save buttons on all three forms
- Added database triggers to automatically update timestamps on record changes

## Test Plan
- [x] Migration runs successfully and adds `updated_at` columns
- [x] TypeScript compilation passes without errors
- [ ] Last saved timestamp appears on Bell Schedules page
- [ ] Last saved timestamp appears on Special Activities page  
- [ ] Last saved timestamp appears on School Hours form
- [ ] Timestamps update immediately after saving
- [ ] Relative time updates dynamically (e.g., "Just now" → "1 minute ago")

🤖 Generated with [Claude Code](https://claude.ai/code)