### PR TITLE
fix: remove 'Tip: save this lesson...' from AI lesson content modal

### DIFF
--- a/app/components/ai-content-modal.tsx
+++ b/app/components/ai-content-modal.tsx
@@ -351,7 +351,6 @@ export function AIContentModal({
                 Lesson saved successfully!
               </span>
             )}
-            {!saved && content && !isViewingSaved && "Tip: Save this lesson to access it later."}
           </div>
           <div className="flex gap-3">
             <button


### PR DESCRIPTION
## Summary
- Removed the "Tip: Save this lesson to access it later." text from the AI lesson content modal
- This tip was misleading since there is no save feature in that modal currently
- Fixes #41

## Test plan
- [x] Open the AI lesson content modal
- [x] Verify the tip text no longer appears at the bottom
- [x] Confirm all other functionality remains unchanged
- [x] Lint and type checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)