### PR TITLE
fix: sort sessions chronologically in calendar week view (fixes #98)

### DIFF
--- a/app/components/calendar/calendar-week-view-dragversion.tsx
+++ b/app/components/calendar/calendar-week-view-dragversion.tsx
@@ -1201,9 +1201,11 @@ export function CalendarWeekView({
                     No sessions
                   </p>
                 ) : (
-                  daySessions.map((session) => {
-                    const student = students.get(session.student_id);
-                    const currentSession = sessionsState.find(s => s.id === session.id) || session;
+                  daySessions
+                    .sort((a, b) => a.start_time.localeCompare(b.start_time))
+                    .map((session) => {
+                      const student = students.get(session.student_id);
+                      const currentSession = sessionsState.find(s => s.id === session.id) || session;
                     return (
                       <div
                         key={session.id}

--- a/app/components/calendar/calendar-week-view-dragversion.tsx
+++ b/app/components/calendar/calendar-week-view-dragversion.tsx
@@ -986,6 +986,9 @@ export function CalendarWeekView({
           const dayOfWeek = index + 1; // 1 = Monday, 2 = Tuesday, etc.
           const daySessions = sessionsByDay[dayOfWeek] || [];
           const isToday = date.toDateString() === new Date().toDateString();
+          
+          // Sort sessions by start time for chronological order
+          const sortedDaySessions = [...daySessions].sort((a, b) => a.start_time.localeCompare(b.start_time));
 
           return (
             <div
@@ -1045,12 +1048,12 @@ export function CalendarWeekView({
               </div>
 
               {/* AI Lesson Buttons - only show if there are sessions */}
-              {daySessions.length > 0 && (
+              {sortedDaySessions.length > 0 && (
                 <div className="px-2 pt-1 pb-2 space-y-1">
                   {/* AI Daily Lesson Button */}
                   <button
                     onClick={() =>
-                      handleGenerateDailyAILesson(date, daySessions)
+                      handleGenerateDailyAILesson(date, sortedDaySessions)
                     }
                     disabled={savedLessons.has(
                       date.toISOString().split("T")[0],
@@ -1196,14 +1199,12 @@ export function CalendarWeekView({
                     </p>
                   </div>
                 )}
-                {daySessions.length === 0 ? (
+                {sortedDaySessions.length === 0 ? (
                   <p className="text-xs text-gray-400 text-center mt-4">
                     No sessions
                   </p>
                 ) : (
-                  daySessions
-                    .sort((a, b) => a.start_time.localeCompare(b.start_time))
-                    .map((session) => {
+                  sortedDaySessions.map((session) => {
                       const student = students.get(session.student_id);
                       const currentSession = sessionsState.find(s => s.id === session.id) || session;
                     return (

--- a/app/components/calendar/calendar-week-view.tsx
+++ b/app/components/calendar/calendar-week-view.tsx
@@ -792,24 +792,26 @@ export function CalendarWeekView({
                       No sessions
                     </p>
                   ) : (
-                    daySessions.map((session) => {
-                      const student = students.get(session.student_id);
-                      return (
-                        <div key={session.id} className="mb-2">
-                          <div className="bg-white border border-gray-200 rounded p-2 text-xs">
-                            <div className="font-medium text-gray-900">
-                              {formatTime(session.start_time)}
-                            </div>
-                            <div className={session.delivered_by === 'sea' ? 'text-green-600' : 'text-gray-700'}>
-                              {student?.initials || 'S'}
-                              {session.delivered_by === 'sea' && (
-                                <div className="text-green-600 text-xs">SEA</div>
-                              )}
+                    daySessions
+                      .sort((a, b) => a.start_time.localeCompare(b.start_time))
+                      .map((session) => {
+                        const student = students.get(session.student_id);
+                        return (
+                          <div key={session.id} className="mb-2">
+                            <div className="bg-white border border-gray-200 rounded p-2 text-xs">
+                              <div className="font-medium text-gray-900">
+                                {formatTime(session.start_time)}
+                              </div>
+                              <div className={session.delivered_by === 'sea' ? 'text-green-600' : 'text-gray-700'}>
+                                {student?.initials || 'S'}
+                                {session.delivered_by === 'sea' && (
+                                  <div className="text-green-600 text-xs">SEA</div>
+                                )}
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      );
-                    })
+                        );
+                      })
                   )
                 )}
               </div>

--- a/app/components/calendar/calendar-week-view.tsx
+++ b/app/components/calendar/calendar-week-view.tsx
@@ -686,6 +686,9 @@ export function CalendarWeekView({
           const hasAIContent = savedLessons.has(dateStr);
           const dayManualLessons = manualLessons.get(dateStr) || [];
           const isPast = isDateInPast(date);
+          
+          // Sort sessions by start time for chronological order
+          const sortedDaySessions = [...daySessions].sort((a, b) => a.start_time.localeCompare(b.start_time));
 
           return (
             <div
@@ -734,8 +737,8 @@ export function CalendarWeekView({
                       <button
                         onClick={() => handleCreateLesson(date)}
                         className="w-full text-xs bg-blue-100 hover:bg-blue-200 text-blue-700 py-1 px-2 rounded"
-                        disabled={daySessions.length === 0}
-                        title={daySessions.length === 0 ? "No sessions scheduled" : "Create lesson plan"}
+                        disabled={sortedDaySessions.length === 0}
+                        title={sortedDaySessions.length === 0 ? "No sessions scheduled" : "Create lesson plan"}
                       >
                         + Create Lesson
                       </button>
@@ -787,14 +790,12 @@ export function CalendarWeekView({
                     Holiday - No sessions
                   </p>
                 ) : (
-                  daySessions.length === 0 ? (
+                  sortedDaySessions.length === 0 ? (
                     <p className="text-xs text-gray-400 text-center mt-4">
                       No sessions
                     </p>
                   ) : (
-                    daySessions
-                      .sort((a, b) => a.start_time.localeCompare(b.start_time))
-                      .map((session) => {
+                    sortedDaySessions.map((session) => {
                         const student = students.get(session.student_id);
                         return (
                           <div key={session.id} className="mb-2">


### PR DESCRIPTION
## Summary
- Fixed sessions displaying out of chronological order in calendar week view
- Added `.sort()` to ensure sessions appear in time order within each day column
- Applied fix to both regular and drag-enabled calendar week view components

## Test plan
- [x] Sessions now display in chronological order (8:30 AM before 10:30 AM before 1:00 PM)
- [x] Sorting works correctly in both calendar-week-view.tsx and calendar-week-view-dragversion.tsx
- [x] No TypeScript errors
- [x] Linting passes

Fixes #98

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Week view now lists sessions within each day in chronological order by start time, improving readability and reducing confusion.
  - Drag-and-drop week view applies the same chronological ordering for consistency across views.
  - Time display, student initials, and badges are unchanged—only the order of sessions is updated.
  - Improves day-by-day scanning and planning without affecting data or other behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->