### PR TITLE
feat: add reading level input to student details

### DIFF
--- a/app/components/students/reading-level-dropdown.tsx
+++ b/app/components/students/reading-level-dropdown.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import React from 'react';
+import { Label, FormGroup } from '../ui/form';
+
+export const READING_LEVELS = [
+  { value: '', label: 'Select reading level' },
+  { value: 'Beginner', label: 'Beginner' },
+  { value: 'Intermediate', label: 'Intermediate' },
+  { value: 'Advanced', label: 'Advanced' },
+] as const;
+
+interface ReadingLevelDropdownProps {
+  value: string;
+  onChange: (value: string) => void;
+  label?: string;
+  helperText?: string;
+  required?: boolean;
+}
+
+export function ReadingLevelDropdown({ 
+  value, 
+  onChange, 
+  label = "Reading Level",
+  helperText = "Select the student's reading level for AI lesson content tailoring",
+  required = false
+}: ReadingLevelDropdownProps) {
+  return (
+    <FormGroup>
+      <Label htmlFor="reading_level" required={required}>
+        {label}
+      </Label>
+      <select
+        id="reading_level"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+        required={required}
+      >
+        {READING_LEVELS.map((level) => (
+          <option key={level.value} value={level.value}>
+            {level.label}
+          </option>
+        ))}
+      </select>
+      {helperText && (
+        <p className="text-sm text-gray-600 mt-1">
+          {helperText}
+        </p>
+      )}
+    </FormGroup>
+  );
+}

--- a/app/components/students/student-details-modal.tsx
+++ b/app/components/students/student-details-modal.tsx
@@ -6,6 +6,7 @@ import { Input, Label, FormGroup } from '../ui/form';
 import { getStudentDetails, upsertStudentDetails, StudentDetails } from '../../../lib/supabase/queries/student-details';
 import { SkillsChecklist } from './skills-checklist';
 import { AreasOfNeedDropdown } from './areas-of-need-dropdown';
+import { ReadingLevelDropdown } from './reading-level-dropdown';
 
 interface StudentDetailsModalProps {
   isOpen: boolean;
@@ -43,6 +44,7 @@ export function StudentDetailsModal({
     upcoming_triennial_date: '',
     iep_goals: [],
     working_skills: [],
+    reading_level: '',
   });
   const [loading, setLoading] = useState(false);
 
@@ -81,6 +83,7 @@ export function StudentDetailsModal({
               upcoming_triennial_date: '',
               iep_goals: [],
               working_skills: [],
+              reading_level: '',
             });
           }
         } catch (error) {
@@ -280,6 +283,14 @@ export function StudentDetailsModal({
                     placeholder="Enter district ID"
                   />
                 </FormGroup>
+              </div>
+
+              {/* Reading Level Section */}
+              <div className="grid grid-cols-2 gap-4">
+                <ReadingLevelDropdown
+                  value={details.reading_level}
+                  onChange={(value) => setDetails({...details, reading_level: value})}
+                />
               </div>
 
               <div className="grid grid-cols-2 gap-4">

--- a/lib/supabase/queries/student-details.ts
+++ b/lib/supabase/queries/student-details.ts
@@ -12,6 +12,7 @@ export interface StudentDetails {
   upcoming_triennial_date: string;
   iep_goals: string[];
   working_skills: string[];
+  reading_level: string;
 }
 
 export async function getStudentDetails(studentId: string): Promise<StudentDetails | null> {
@@ -57,6 +58,7 @@ export async function getStudentDetails(studentId: string): Promise<StudentDetai
     upcoming_triennial_date: data.upcoming_triennial_date || '',
     iep_goals: data.iep_goals || [],
     working_skills: data.working_skills || [],
+    reading_level: data.reading_level || '',
   };
 }
 
@@ -81,6 +83,7 @@ export async function upsertStudentDetails(
           upcoming_triennial_date: details.upcoming_triennial_date || null,
           iep_goals: details.iep_goals,
           working_skills: details.working_skills,
+          reading_level: details.reading_level || null,
           updated_at: new Date().toISOString(),
         }, {
           onConflict: 'student_id'  // Add this to specify the conflict column

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -242,6 +242,7 @@ export interface Database {
           upcoming_triennial_date: string | null
           iep_goals: string[] | null
           working_skills: string[] | null
+          reading_level: string | null
           created_at: string
           updated_at: string
         }
@@ -256,6 +257,7 @@ export interface Database {
           upcoming_triennial_date?: string | null
           iep_goals?: string[] | null
           working_skills?: string[] | null
+          reading_level?: string | null
           created_at?: string
           updated_at?: string
         }
@@ -270,6 +272,7 @@ export interface Database {
           upcoming_triennial_date?: string | null
           iep_goals?: string[] | null
           working_skills?: string[] | null
+          reading_level?: string | null
           created_at?: string
           updated_at?: string
         }

--- a/supabase/migrations/20250819_add_reading_level_to_student_details.sql
+++ b/supabase/migrations/20250819_add_reading_level_to_student_details.sql
@@ -1,0 +1,12 @@
+-- Add reading_level column to student_details table
+-- Migration: 20250819_add_reading_level_to_student_details.sql
+
+-- Add the reading_level column to student_details table
+ALTER TABLE student_details 
+ADD COLUMN reading_level VARCHAR(20);
+
+-- Add a comment to document the purpose
+COMMENT ON COLUMN student_details.reading_level IS 'Reading level for AI lesson content tailoring (Beginner, Intermediate, Advanced)';
+
+-- Create an index for potential queries filtering by reading level
+CREATE INDEX IF NOT EXISTS idx_student_details_reading_level ON student_details(reading_level);


### PR DESCRIPTION
Adds reading level selection to student details for AI lesson content tailoring.

**Changes:**
- Add reading_level column to student_details table
- Create ReadingLevelDropdown component with predefined options
- Integrate dropdown in StudentDetailsModal
- Update database types and query functions

Fixes #137

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a Reading Level selector in Student Details with options: Beginner, Intermediate, and Advanced (plus a placeholder). Includes label, helper text, and required support. Selection is saved with the student’s details.

* Chores
  * Updated data storage to include a reading level for students and profiles, with indexing to support efficient filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->