### PR TITLE
Fix: Include legacy students with NULL school_id in student list

### DIFF
--- a/lib/supabase/queries/students.ts
+++ b/lib/supabase/queries/students.ts
@@ -160,8 +160,9 @@ export async function getStudents(school?: SchoolIdentifier) {
       // Apply intelligent school filter for optimal performance
       if (school) {
         if (school.school_id) {
-          // Use indexed school_id for optimal performance
-          query = query.eq('school_id', school.school_id);
+          // Include both records matching school_id AND legacy records with NULL school_id
+          // This ensures legacy students show up alongside new structured records
+          query = query.or(`school_id.eq.${school.school_id},school_id.is.null`);
         } else {
           // Fall back to text-based filtering for legacy data
           if (school.school_site) {


### PR DESCRIPTION
Fixes #131

This PR resolves the issue where legacy students (created before the structured school system) were not appearing in the student list despite their sessions being visible.

## Problem
Students created by legacy users have NULL values for `school_id` and `district_id` in the database. The existing filtering logic in `getStudents()` was excluding these records when a modern school context was available.

## Solution
Modified the filtering logic in `lib/supabase/queries/students.ts` to use an OR condition that includes:
- Students with matching `school_id` (new structured records)
- Students with NULL `school_id` (legacy records)

## Changes
- Updated `getStudents()` function to use `query.or()` instead of `query.eq()`
- Maintains backward compatibility with text-based filtering
- Preserves performance benefits of indexed queries for new records

## Testing
- Legacy students should now appear in the student list
- New students continue to work as expected
- No impact on session functionality

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filtering students by school now also returns legacy records without a school assigned, in addition to exact school matches, so the list reflects all relevant students.
  * No changes to how you apply filters; behavior is adjusted to include these records automatically.
  * No visible UI changes; results are more comprehensive when a school filter is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->