### PR TITLE
feat: Allow roles beyond Resource to mark holidays

### DIFF
--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -14,7 +14,7 @@ export interface Database {
           id: string
           email: string
           full_name: string
-          role: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' | 'sea'
+          role: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' | 'sea' | 'admin'
           school_id: string
           district_id: string
           state_id: string
@@ -36,7 +36,7 @@ export interface Database {
           id: string
           email: string
           full_name: string
-          role: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' | 'sea'
+          role: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' | 'sea' | 'admin'
           school_id: string
           district_id: string
           state_id: string
@@ -53,7 +53,7 @@ export interface Database {
           id?: string
           email?: string
           full_name?: string
-          role?: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist'| 'sea'
+          role?: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' | 'sea' | 'admin'
           school_id?: string
           district_id?: string
           state_id?: string
@@ -1111,6 +1111,50 @@ export interface Database {
           created_at?: string
           updated_at?: string
         }
+      },
+      holidays: {
+        Row: {
+          id: string
+          date: string
+          name: string | null
+          school_site: string
+          school_district: string
+          school_id: string | null
+          district_id: string | null
+          created_by: string | null
+          updated_by: string | null
+          reason: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          date: string
+          name?: string | null
+          school_site: string
+          school_district: string
+          school_id?: string | null
+          district_id?: string | null
+          created_by?: string | null
+          updated_by?: string | null
+          reason?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          date?: string
+          name?: string | null
+          school_site?: string
+          school_district?: string
+          school_id?: string | null
+          district_id?: string | null
+          created_by?: string | null
+          updated_by?: string | null
+          reason?: string | null
+          created_at?: string
+          updated_at?: string
+        }
       }
     }
   }
@@ -1129,6 +1173,7 @@ export type District = Tables<'districts'>;
 export type School = Tables<'schools'>;
 export type IEPGoalProgress = Tables<'iep_goal_progress'>;
 export type CalendarEvent = Tables<'calendar_events'>;
+export type Holiday = Tables<'holidays'>;
 export type Subscription = Tables<'subscriptions'>;
 export type ReferralCode = Tables<'referral_codes'>;
 export type ReferralRelationship = Tables<'referral_relationships'>;

--- a/supabase/migrations/20250819_create_holidays_table.sql
+++ b/supabase/migrations/20250819_create_holidays_table.sql
@@ -1,0 +1,156 @@
+-- Create holidays table with audit trail support
+CREATE TABLE IF NOT EXISTS holidays (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  date DATE NOT NULL,
+  name TEXT,
+  school_site TEXT NOT NULL,
+  school_district TEXT NOT NULL,
+  school_id TEXT REFERENCES schools(id) ON DELETE CASCADE,
+  district_id TEXT REFERENCES districts(id) ON DELETE CASCADE,
+  created_by UUID REFERENCES profiles(id) ON DELETE SET NULL,
+  updated_by UUID REFERENCES profiles(id) ON DELETE SET NULL,
+  reason TEXT, -- Optional reason for adding/removing holiday
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Create indexes for performance
+CREATE INDEX idx_holidays_date ON holidays(date);
+CREATE INDEX idx_holidays_school_site ON holidays(school_site);
+CREATE INDEX idx_holidays_school_district ON holidays(school_district);
+CREATE INDEX idx_holidays_school_id ON holidays(school_id);
+CREATE INDEX idx_holidays_district_id ON holidays(district_id);
+CREATE INDEX idx_holidays_created_by ON holidays(created_by);
+
+-- Unique constraint to prevent duplicate holidays for same date at same location
+CREATE UNIQUE INDEX idx_holidays_unique_date_location 
+ON holidays(date, school_site, school_district);
+
+-- Add RLS policies
+ALTER TABLE holidays ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Users can view holidays for their school/district
+CREATE POLICY "Users can view holidays for their school" ON holidays
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = auth.uid()
+      AND (
+        (profiles.school_site = holidays.school_site AND profiles.school_district = holidays.school_district)
+        OR
+        (profiles.school_id = holidays.school_id AND holidays.school_id IS NOT NULL)
+        OR  
+        (profiles.district_id = holidays.district_id AND holidays.district_id IS NOT NULL)
+      )
+    )
+  );
+
+-- Policy: Resource, SEA, and Admin roles can create holidays for their school/district
+CREATE POLICY "Eligible roles can create holidays" ON holidays
+  FOR INSERT
+  WITH CHECK (
+    auth.uid() = created_by
+    AND EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = auth.uid()
+      AND profiles.role IN ('resource', 'sea', 'admin')
+      AND (
+        (profiles.school_site = holidays.school_site AND profiles.school_district = holidays.school_district)
+        OR
+        (profiles.school_id = holidays.school_id AND holidays.school_id IS NOT NULL)
+        OR
+        (profiles.district_id = holidays.district_id AND holidays.district_id IS NOT NULL)
+      )
+    )
+  );
+
+-- Policy: Resource, SEA, and Admin roles can update holidays for their school/district
+CREATE POLICY "Eligible roles can update holidays" ON holidays
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = auth.uid()
+      AND profiles.role IN ('resource', 'sea', 'admin')
+      AND (
+        (profiles.school_site = holidays.school_site AND profiles.school_district = holidays.school_district)
+        OR
+        (profiles.school_id = holidays.school_id AND holidays.school_id IS NOT NULL)
+        OR
+        (profiles.district_id = holidays.district_id AND holidays.district_id IS NOT NULL)
+      )
+    )
+  )
+  WITH CHECK (
+    updated_by = auth.uid()
+    AND EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = auth.uid()
+      AND profiles.role IN ('resource', 'sea', 'admin')
+      AND (
+        (profiles.school_site = holidays.school_site AND profiles.school_district = holidays.school_district)
+        OR
+        (profiles.school_id = holidays.school_id AND holidays.school_id IS NOT NULL)
+        OR
+        (profiles.district_id = holidays.district_id AND holidays.district_id IS NOT NULL)
+      )
+    )
+  );
+
+-- Policy: Resource, SEA, and Admin roles can delete holidays for their school/district
+-- Only admins can delete past holidays (optional restriction)
+CREATE POLICY "Eligible roles can delete holidays" ON holidays
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = auth.uid()
+      AND profiles.role IN ('resource', 'sea', 'admin')
+      AND (
+        (profiles.school_site = holidays.school_site AND profiles.school_district = holidays.school_district)
+        OR
+        (profiles.school_id = holidays.school_id AND holidays.school_id IS NOT NULL)
+        OR
+        (profiles.district_id = holidays.district_id AND holidays.district_id IS NOT NULL)
+      )
+      AND (
+        -- Allow all eligible roles to delete future holidays
+        date >= CURRENT_DATE
+        OR
+        -- Only allow admins to delete past holidays
+        profiles.role = 'admin'
+      )
+    )
+  );
+
+-- Create function to update updated_at timestamp and set updated_by
+CREATE OR REPLACE FUNCTION update_holidays_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  NEW.updated_by = auth.uid();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger to automatically update updated_at and updated_by
+CREATE TRIGGER update_holidays_updated_at
+  BEFORE UPDATE ON holidays
+  FOR EACH ROW
+  EXECUTE FUNCTION update_holidays_updated_at();
+
+-- Create function to automatically set created_by on insert
+CREATE OR REPLACE FUNCTION set_holidays_created_by()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.created_by = auth.uid();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger to automatically set created_by
+CREATE TRIGGER set_holidays_created_by
+  BEFORE INSERT ON holidays
+  FOR EACH ROW
+  EXECUTE FUNCTION set_holidays_created_by();


### PR DESCRIPTION
Implements feature to allow Resource, SEA, and Admin roles to mark holidays with proper security controls and audit trail.

## Changes
- Create holidays table with audit fields (created_by, updated_by, reason)
- Add RLS policies for resource, sea, and admin roles scoped by school_id
- Add admin role to profiles type definitions
- Remove hardcoded SEA restriction in calendar component
- Add confirmation dialogs for holiday removal with past date protection
- Update holiday creation to include school_id and district_id references
- Add role-based UI instructions and permissions

Closes #64

Generated with [Claude Code](https://claude.ai/code)