### PR TITLE
Fix: Visual availability filter persisting across school switches

### DIFF
--- a/app/(dashboard)/dashboard/schedule/components/ConflictFilterPanel.tsx
+++ b/app/(dashboard)/dashboard/schedule/components/ConflictFilterPanel.tsx
@@ -81,6 +81,13 @@ export function ConflictFilterPanel({
   };
 
   const handleTeacherChange = (teacher: string | null) => {
+    // Validate teacher exists in current school's teacher list
+    if (teacher && !teachers.includes(teacher)) {
+      // Teacher not found in current school, clear selection
+      console.log('[ConflictFilterPanel] Teacher not found in current school, clearing selection:', teacher);
+      teacher = null;
+    }
+    
     onFilterChange({
       ...selectedFilters,
       specialActivityTeacher: teacher,

--- a/app/(dashboard)/dashboard/schedule/page.tsx
+++ b/app/(dashboard)/dashboard/schedule/page.tsx
@@ -45,7 +45,13 @@ export default function SchedulePage() {
   // Track if this is the first render to avoid saving on mount
   const isFirstRender = useRef(true);
   
-  // Visual filter state (persisted to localStorage)
+  // Helper function to generate school-specific localStorage keys
+  const getSchoolSpecificKey = (key: string, schoolId?: string) => {
+    if (!schoolId) return key; // fallback for no school
+    return `${key}-${schoolId}`;
+  };
+
+  // Visual filter state (persisted to localStorage with school-specific keys)
   const [visualFilters, setVisualFilters] = useState(() => {
     if (typeof window === 'undefined') {
       return {
@@ -54,7 +60,9 @@ export default function SchedulePage() {
       };
     }
     
-    const savedFilters = localStorage.getItem('speddy-visual-filters');
+    const savedFilters = localStorage.getItem(
+      getSchoolSpecificKey('speddy-visual-filters', currentSchool?.school_id)
+    );
     if (savedFilters) {
       try {
         return JSON.parse(savedFilters);
@@ -72,12 +80,36 @@ export default function SchedulePage() {
     };
   });
   
-  // Save visual filters to localStorage
+  // Save visual filters to localStorage with school-specific key
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('speddy-visual-filters', JSON.stringify(visualFilters));
+    if (typeof window !== 'undefined' && currentSchool?.school_id) {
+      localStorage.setItem(
+        getSchoolSpecificKey('speddy-visual-filters', currentSchool.school_id), 
+        JSON.stringify(visualFilters)
+      );
     }
-  }, [visualFilters]);
+  }, [visualFilters, currentSchool?.school_id]);
+
+  // Clear visual filters when switching schools if teacher is not valid
+  useEffect(() => {
+    if (currentSchool?.school_id && visualFilters.specialActivityTeacher) {
+      // Check if the selected teacher exists in the current school's teacher list
+      const teacherExists = teachers.some(teacher => {
+        // Handle both string format and object format
+        const teacherName = typeof teacher === 'string' ? teacher : 
+          `${teacher.first_name} ${teacher.last_name}`.trim();
+        return teacherName === visualFilters.specialActivityTeacher;
+      });
+      
+      if (!teacherExists) {
+        console.log('[SchedulePage] Clearing teacher filter - teacher not found in current school:', visualFilters.specialActivityTeacher);
+        setVisualFilters(prev => ({
+          ...prev,
+          specialActivityTeacher: null,
+        }));
+      }
+    }
+  }, [currentSchool?.school_id, teachers, visualFilters.specialActivityTeacher]);
   
   // Fetch teachers from the teachers table filtered by current school
   useEffect(() => {


### PR DESCRIPTION
Fixes issue where SpecAct teacher filter persisted when switching schools, showing incorrect teacher from previous school.

## Changes
- Implement school-specific localStorage keys for visual filters
- Add automatic teacher validation when switching schools
- Clear invalid teacher selections automatically
- Preserve user preferences per school

Closes #135

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual filters now persist per school (with global fallback) and saves are debounced to reduce frequent writes.

* **Bug Fixes**
  * Automatically clears the teacher filter when switching schools if the selected teacher isn’t available.
  * Prevents applying invalid teacher selections, avoiding inconsistent filter states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->