### PR TITLE
feat: add manual scheduling path when auto-scheduler can't place sess…

### DIFF
--- a/app/(dashboard)/dashboard/schedule/page.tsx
+++ b/app/(dashboard)/dashboard/schedule/page.tsx
@@ -82,7 +82,7 @@ export default function SchedulePage() {
   
   // Debounced save function to avoid excessive localStorage writes
   const debouncedSaveFilters = useMemo(() => {
-    let timeoutId: number;
+    let timeoutId: ReturnType<typeof setTimeout>;
     return (filters: typeof visualFilters, schoolId?: string) => {
       clearTimeout(timeoutId);
       timeoutId = setTimeout(() => {
@@ -96,7 +96,7 @@ export default function SchedulePage() {
 
   // Save visual filters to localStorage with school-specific key (debounced)
   useEffect(() => {
-    debouncedSaveFilters(visualFilters, currentSchool?.school_id);
+    debouncedSaveFilters(visualFilters, currentSchool?.school_id || undefined);
   }, [visualFilters, currentSchool?.school_id, debouncedSaveFilters]);
 
   // Clear visual filters when switching schools if teacher is not valid

--- a/app/components/schedule/manual-placement-modal.tsx
+++ b/app/components/schedule/manual-placement-modal.tsx
@@ -23,12 +23,12 @@ export function ManualPlacementModal({
 }: ManualPlacementModalProps) {
   const handlePlaceAnyway = async () => {
     await onPlaceAnyway();
-    onClose();
+    // onClose is handled by the parent component after successful placement
   };
 
   const handleKeepUnscheduled = () => {
     onKeepUnscheduled();
-    onClose();
+    // onClose is handled by the parent component
   };
 
   return (

--- a/app/components/schedule/manual-placement-modal.tsx
+++ b/app/components/schedule/manual-placement-modal.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { Modal } from '../ui/modal';
+import { Button } from '../ui/button';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+
+interface ManualPlacementModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  unplacedCount: number;
+  onPlaceAnyway: () => Promise<void>;
+  onKeepUnscheduled: () => void;
+  isPlacing?: boolean;
+}
+
+export function ManualPlacementModal({
+  isOpen,
+  onClose,
+  unplacedCount,
+  onPlaceAnyway,
+  onKeepUnscheduled,
+  isPlacing = false
+}: ManualPlacementModalProps) {
+  const handlePlaceAnyway = async () => {
+    await onPlaceAnyway();
+    onClose();
+  };
+
+  const handleKeepUnscheduled = () => {
+    onKeepUnscheduled();
+    onClose();
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Scheduling Conflict Detected"
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex items-start gap-3">
+          <ExclamationTriangleIcon className="h-6 w-6 text-amber-500 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-gray-700">
+              There isn't enough space to fit <span className="font-semibold">{unplacedCount} session{unplacedCount > 1 ? 's' : ''}</span>. 
+            </p>
+            <p className="text-gray-600 mt-2">
+              Should they be put on the calendar anyway so you can adjust manually?
+            </p>
+          </div>
+        </div>
+
+        <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+          <p className="text-sm text-amber-800">
+            <span className="font-semibold">Note:</span> Placing sessions anyway may create scheduling conflicts that you'll need to resolve manually.
+          </p>
+        </div>
+
+        <div className="flex gap-3 justify-end mt-2">
+          <Button
+            variant="secondary"
+            onClick={handleKeepUnscheduled}
+            disabled={isPlacing}
+          >
+            Keep Unscheduled
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handlePlaceAnyway}
+            disabled={isPlacing}
+          >
+            {isPlacing ? 'Placing...' : 'Place Anyway'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/app/utils/date-helpers.ts
+++ b/app/utils/date-helpers.ts
@@ -51,5 +51,6 @@ export function getMinutesUntilFirstSession(sessions: Array<{ start_time: string
   if (!upcomingSessions.length) return null;
 
   const nextSession = upcomingSessions[0];
+  if (!nextSession) return null;
   return nextSession.sessionMinutes - currentMinutes;
 }

--- a/lib/hooks/use-activity-tracker.ts
+++ b/lib/hooks/use-activity-tracker.ts
@@ -14,6 +14,8 @@ export interface ActivityConfig {
 export interface KeepAliveOptions {
   activityType?: string;
   skipThrottle?: boolean;
+  suppressStorageUpdate?: boolean;
+  fromCrossTab?: boolean;
 }
 
 export function useActivityTracker({
@@ -24,8 +26,8 @@ export function useActivityTracker({
   onTimeout,
   throttleInterval = 30000, // 30 seconds default throttle
 }: ActivityConfig) {
-  const timeoutRef = useRef<NodeJS.Timeout>();
-  const warningRef = useRef<NodeJS.Timeout>();
+  const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
+  const warningRef = useRef<NodeJS.Timeout | undefined>(undefined);
   const lastActivityRef = useRef<number>(Date.now());
   const lastThrottledUpdate = useRef<number>(0);
   const isWarningShownRef = useRef<boolean>(false);

--- a/lib/services/manual-placement-service.ts
+++ b/lib/services/manual-placement-service.ts
@@ -1,0 +1,247 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { SchedulingDataManager } from '../scheduling/scheduling-data-manager';
+import { sessionUpdateService } from './session-update-service';
+
+interface TimeSlot {
+  day: number;
+  startTime: string;
+  endTime: string;
+}
+
+interface Student {
+  id: string;
+  session_duration?: number;
+}
+
+interface PlacementResult {
+  sessionId?: string;
+  studentId: string;
+  status: 'success' | 'failed';
+  conflicts?: any[];
+  error?: string;
+  timeSlot?: TimeSlot;
+}
+
+interface ManualPlacementOptions {
+  ignoreConflicts?: boolean;
+  preferEarliestSlot?: boolean;
+  maxConflictsPerSession?: number;
+}
+
+export class ManualPlacementService {
+  constructor(
+    private supabase: SupabaseClient,
+    private dataManager: SchedulingDataManager
+  ) {}
+
+  async findAvailableSlots(
+    studentIds: string[],
+    providerId: string,
+    options: ManualPlacementOptions = {}
+  ): Promise<TimeSlot[]> {
+    const availableSlots: TimeSlot[] = [];
+    
+    if (studentIds.length === 0) {
+      return [];
+    }
+
+    // Get data from supabase directly since DataManager doesn't expose these methods
+    const { data: students } = await this.supabase
+      .from('students')
+      .select('*')
+      .in('id', studentIds);
+    
+    if (!students || students.length === 0) {
+      return [];
+    }
+
+    const existingSessions = this.dataManager.getExistingSessions();
+    
+    // Generate time slots for each day (Monday to Friday, 8am to 3pm)
+    const days = [1, 2, 3, 4, 5];
+    const sessionDuration = students[0].minutes_per_session || 30;
+    
+    for (const day of days) {
+      // Generate slots every 30 minutes from 8am to 2:30pm
+      for (let hour = 8; hour <= 14; hour++) {
+        for (let minute = 0; minute < 60; minute += 30) {
+          if (hour === 14 && minute > 30) break; // Don't go past 2:30pm
+          
+          const startTime = `${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}:00`;
+          const endHour = Math.floor((hour * 60 + minute + sessionDuration) / 60);
+          const endMinute = (hour * 60 + minute + sessionDuration) % 60;
+          const endTime = `${endHour.toString().padStart(2, '0')}:${endMinute.toString().padStart(2, '0')}:00`;
+          
+          const slot: TimeSlot = {
+            day,
+            startTime,
+            endTime
+          };
+          
+          if (options.ignoreConflicts) {
+            availableSlots.push(slot);
+          } else {
+            const conflicts = this.detectConflicts(slot, existingSessions, providerId);
+            if (conflicts.length === 0) {
+              availableSlots.push(slot);
+            }
+          }
+          
+          if (options.preferEarliestSlot && availableSlots.length >= studentIds.length) {
+            return availableSlots;
+          }
+        }
+      }
+    }
+
+    return availableSlots;
+  }
+
+  async placeSessionsWithConflicts(
+    studentIds: string[],
+    providerId: string,
+    options: ManualPlacementOptions = { ignoreConflicts: true }
+  ): Promise<PlacementResult[]> {
+    const results: PlacementResult[] = [];
+    const availableSlots = await this.findAvailableSlots(studentIds, providerId, options);
+    
+    if (availableSlots.length === 0) {
+      return studentIds.map(id => ({
+        studentId: id,
+        status: 'failed' as const,
+        error: 'No available time slots found'
+      }));
+    }
+
+    let slotIndex = 0;
+    for (const studentId of studentIds) {
+      if (slotIndex >= availableSlots.length) {
+        results.push({
+          studentId,
+          status: 'failed',
+          error: 'Insufficient time slots available'
+        });
+        continue;
+      }
+
+      const slot = availableSlots[slotIndex];
+      const placementResult = await this.placeSession(studentId, providerId, slot, options);
+      results.push(placementResult);
+      
+      if (placementResult.status === 'success') {
+        slotIndex++;
+      }
+    }
+
+    return results;
+  }
+
+  async validateManualPlacement(
+    studentId: string,
+    providerId: string,
+    timeSlot: TimeSlot
+  ): Promise<{ valid: boolean; errors: string[] }> {
+    const errors: string[] = [];
+    
+    // For now, do basic validation
+    // Check if time is within reasonable school hours (8am - 3pm)
+    const [startHour] = timeSlot.startTime.split(':').map(Number);
+    const [endHour, endMinute] = timeSlot.endTime.split(':').map(Number);
+    const endTotalMinutes = endHour * 60 + endMinute;
+    
+    if (startHour < 8 || endTotalMinutes > 15 * 60) {
+      errors.push('Session falls outside school hours (8am - 3pm)');
+    }
+    
+    // Check if day is a weekday
+    if (timeSlot.day < 1 || timeSlot.day > 5) {
+      errors.push('Session must be on a weekday');
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors
+    };
+  }
+
+  private detectConflicts(
+    slot: TimeSlot,
+    existingSessions: any[],
+    providerId: string
+  ): any[] {
+    return existingSessions.filter(session => {
+      if (session.provider_id !== providerId) return false;
+      if (session.day_of_week !== slot.day) return false;
+      
+      const sessionStart = new Date(`2000-01-01T${session.start_time}`);
+      const sessionEnd = new Date(`2000-01-01T${session.end_time}`);
+      const slotStart = new Date(`2000-01-01T${slot.startTime}`);
+      const slotEnd = new Date(`2000-01-01T${slot.endTime}`);
+      
+      return (
+        (slotStart >= sessionStart && slotStart < sessionEnd) ||
+        (slotEnd > sessionStart && slotEnd <= sessionEnd) ||
+        (slotStart <= sessionStart && slotEnd >= sessionEnd)
+      );
+    });
+  }
+
+  private async placeSession(
+    studentId: string,
+    providerId: string,
+    timeSlot: TimeSlot,
+    options: ManualPlacementOptions
+  ): Promise<PlacementResult> {
+    try {
+      const validation = await this.validateManualPlacement(studentId, providerId, timeSlot);
+      
+      if (!validation.valid && !options.ignoreConflicts) {
+        return {
+          studentId,
+          status: 'failed',
+          error: validation.errors.join(', ')
+        };
+      }
+
+      const { data, error } = await this.supabase
+        .from('schedule_sessions')
+        .insert({
+          student_id: studentId,
+          provider_id: providerId,
+          day_of_week: timeSlot.day,
+          start_time: timeSlot.startTime,
+          end_time: timeSlot.endTime,
+          service_type: 'provider',
+          delivered_by: 'provider',
+          manually_placed: true
+        })
+        .select()
+        .single();
+
+      if (error) {
+        return {
+          studentId,
+          status: 'failed',
+          error: error.message
+        };
+      }
+
+      const existingSessions = await this.dataManager.getExistingSessions();
+      const conflicts = this.detectConflicts(timeSlot, existingSessions, providerId);
+
+      return {
+        sessionId: data.id,
+        studentId,
+        status: 'success',
+        conflicts: conflicts.length > 0 ? conflicts : undefined,
+        timeSlot
+      };
+    } catch (error) {
+      return {
+        studentId,
+        status: 'failed',
+        error: error instanceof Error ? error.message : 'Unknown error occurred'
+      };
+    }
+  }
+}

--- a/lib/services/manual-placement-service.ts
+++ b/lib/services/manual-placement-service.ts
@@ -226,7 +226,7 @@ export class ManualPlacementService {
         };
       }
 
-      const existingSessions = await this.dataManager.getExistingSessions();
+      const existingSessions = this.dataManager.getExistingSessions();
       const conflicts = this.detectConflicts(timeSlot, existingSessions, providerId);
 
       return {

--- a/lib/supabase/hooks/use-auto-schedule.ts
+++ b/lib/supabase/hooks/use-auto-schedule.ts
@@ -55,12 +55,13 @@ export function useAutoSchedule(debug: boolean = false) {
       return result;
     } catch (error) {
       if (debug) console.error('Auto-scheduling error:', error);
-      setSchedulingErrors([error.message]);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      setSchedulingErrors([errorMessage]);
       return {
         success: false,
         scheduledSessions: [],
         unscheduledStudents: [student],
-        errors: [error.message]
+        errors: [errorMessage]
       };
     } finally {
       setIsScheduling(false);
@@ -149,11 +150,12 @@ export function useAutoSchedule(debug: boolean = false) {
       return results;
     } catch (error) {
       if (debug) console.error('Batch scheduling error:', error);
-      setSchedulingErrors([error.message]);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      setSchedulingErrors([errorMessage]);
       return {
         totalScheduled: 0,
         totalFailed: students.length,
-        errors: [error.message],
+        errors: [errorMessage],
         unplacedStudents: students,
         canManuallyPlace: false
       };
@@ -219,12 +221,13 @@ export function useAutoSchedule(debug: boolean = false) {
       };
     } catch (error) {
       if (debug) console.error('Manual placement error:', error);
-      setSchedulingErrors([error.message]);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      setSchedulingErrors([errorMessage]);
       return {
         success: false,
         placedSessions: [],
         failedStudents: students,
-        errors: [error.message]
+        errors: [errorMessage]
       };
     } finally {
       setIsScheduling(false);

--- a/lib/supabase/hooks/use-auto-schedule.ts
+++ b/lib/supabase/hooks/use-auto-schedule.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
-import { OptimizedScheduler } from '../../scheduling/optimized-scheduler';
+import { OptimizedScheduler, EnhancedSchedulingResult } from '../../scheduling/optimized-scheduler';
 import { SchedulingDataManager } from '../../scheduling/scheduling-data-manager';
 import type { Database } from '../../../src/types/database';
 
@@ -66,16 +66,20 @@ export function useAutoSchedule(debug: boolean = false) {
       setIsScheduling(false);
     }
   };
-  const scheduleBatchStudents = async (students: Student[]) => {
+  const scheduleBatchStudents = async (students: Student[]): Promise<EnhancedSchedulingResult> => {
     setIsScheduling(true);
     setSchedulingErrors([]);
 
-    const results = {
+    const results: EnhancedSchedulingResult = {
       totalScheduled: 0,
       totalFailed: 0,
       errors: [] as string[],
-      lastSchool: null as string | null
+      unplacedStudents: [] as Student[],
+      canManuallyPlace: false,
+      availableSlots: undefined
     };
+    
+    let lastSchool: string | null = null;
 
     try {
       // Get current user and profile
@@ -115,9 +119,9 @@ export function useAutoSchedule(debug: boolean = false) {
         // Ensure data manager is initialized for this school
         // Get school_district from the first student in this school group
         const schoolDistrict = schoolStudents[0]?.school_district || '';
-        if (!dataManager.isInitialized() || schoolSite !== results.lastSchool) {
+        if (!dataManager.isInitialized() || schoolSite !== lastSchool) {
           await dataManager.initialize(user.id, schoolSite, schoolDistrict);
-          results.lastSchool = schoolSite;
+          lastSchool = schoolSite;
         } else if (dataManager.isCacheStale()) {
           await dataManager.refresh();
         }
@@ -134,6 +138,11 @@ export function useAutoSchedule(debug: boolean = false) {
         results.totalScheduled += schoolResults.totalScheduled;
         results.totalFailed += schoolResults.totalFailed;
         results.errors.push(...schoolResults.errors);
+        results.unplacedStudents.push(...(schoolResults.unplacedStudents || []));
+        results.canManuallyPlace = results.canManuallyPlace || schoolResults.canManuallyPlace;
+        if (schoolResults.availableSlots) {
+          results.availableSlots = schoolResults.availableSlots;
+        }
       }
 
       setSchedulingErrors(results.errors);
@@ -144,6 +153,77 @@ export function useAutoSchedule(debug: boolean = false) {
       return {
         totalScheduled: 0,
         totalFailed: students.length,
+        errors: [error.message],
+        unplacedStudents: students,
+        canManuallyPlace: false
+      };
+    } finally {
+      setIsScheduling(false);
+    }
+  };
+
+  const placeSessionsManually = async (students: Student[]) => {
+    setIsScheduling(true);
+    setSchedulingErrors([]);
+
+    try {
+      // Get current user and profile
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error('Not authenticated');
+
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('role')
+        .eq('id', user.id)
+        .single();
+
+      if (!profile) throw new Error('Profile not found');
+
+      // Group students by school for manual placement
+      const studentsBySchool = new Map<string, Student[]>();
+      students.forEach(student => {
+        const school = student.school_site;
+        if (school) {
+          if (!studentsBySchool.has(school)) {
+            studentsBySchool.set(school, []);
+          }
+          studentsBySchool.get(school)!.push(student);
+        }
+      });
+
+      const allPlacedSessions: any[] = [];
+      const allFailedStudents: Student[] = [];
+      const allErrors: string[] = [];
+
+      // Place sessions for each school
+      for (const [schoolSite, schoolStudents] of studentsBySchool) {
+        const schoolDistrict = schoolStudents[0]?.school_district || '';
+        
+        // Create scheduler and initialize context
+        const scheduler = new OptimizedScheduler(user.id, profile.role, debug);
+        await scheduler.initializeContext(schoolSite, schoolDistrict);
+
+        // Try manual placement with conflict tolerance
+        const result = await scheduler.tryManualPlacement(schoolStudents, true);
+        
+        allPlacedSessions.push(...result.placedSessions);
+        allFailedStudents.push(...result.failedStudents);
+        allErrors.push(...result.errors);
+      }
+
+      return {
+        success: allPlacedSessions.length > 0,
+        placedSessions: allPlacedSessions,
+        failedStudents: allFailedStudents,
+        errors: allErrors
+      };
+    } catch (error) {
+      if (debug) console.error('Manual placement error:', error);
+      setSchedulingErrors([error.message]);
+      return {
+        success: false,
+        placedSessions: [],
+        failedStudents: students,
         errors: [error.message]
       };
     } finally {
@@ -154,6 +234,7 @@ export function useAutoSchedule(debug: boolean = false) {
   return {
     scheduleStudent,
     scheduleBatchStudents,
+    placeSessionsManually,
     isScheduling,
     schedulingErrors
   };

--- a/supabase/migrations/20250820_add_manually_placed_to_sessions.sql
+++ b/supabase/migrations/20250820_add_manually_placed_to_sessions.sql
@@ -1,6 +1,6 @@
 -- Add manually_placed column to schedule_sessions table
 ALTER TABLE schedule_sessions 
-ADD COLUMN IF NOT EXISTS manually_placed BOOLEAN DEFAULT FALSE;
+ADD COLUMN IF NOT EXISTS manually_placed BOOLEAN NOT NULL DEFAULT FALSE;
 
 -- Add comment for documentation
 COMMENT ON COLUMN schedule_sessions.manually_placed IS 'Indicates if this session was manually placed despite conflicts';

--- a/supabase/migrations/20250820_add_manually_placed_to_sessions.sql
+++ b/supabase/migrations/20250820_add_manually_placed_to_sessions.sql
@@ -1,0 +1,11 @@
+-- Add manually_placed column to schedule_sessions table
+ALTER TABLE schedule_sessions 
+ADD COLUMN IF NOT EXISTS manually_placed BOOLEAN DEFAULT FALSE;
+
+-- Add comment for documentation
+COMMENT ON COLUMN schedule_sessions.manually_placed IS 'Indicates if this session was manually placed despite conflicts';
+
+-- Create index for faster filtering of manually placed sessions
+CREATE INDEX IF NOT EXISTS idx_schedule_sessions_manually_placed 
+ON schedule_sessions(manually_placed) 
+WHERE manually_placed = TRUE;


### PR DESCRIPTION
…ions

Implements issue #77 - Manual scheduling feature

- Created ManualPlacementService to handle conflict-tolerant session placement
- Enhanced OptimizedScheduler with manual placement support and enhanced results
- Added ManualPlacementModal component for user confirmation
- Updated ScheduleSessions component to show modal when auto-scheduling fails
- Added placeSessionsManually function to useAutoSchedule hook
- Added database migration for manually_placed column
- When auto-scheduler fails, users now get option to place sessions anyway
- Sessions placed manually can have conflicts that need manual adjustment

This allows users to choose between keeping sessions unscheduled or placing them on the calendar with potential conflicts for manual adjustment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Modal prompts when auto-scheduling yields unplaced sessions, letting users Keep Unscheduled or Place Anyway.
  - Manual placement workflow to place previously unplaced sessions and report placed/failed counts.
  - Scheduling results now expose unplaced counts and whether manual placement is available.

- UX Improvements
  - Clearer messaging, disabled states and progress labels during placement actions to prevent duplicate actions.

- Chores
  - Manually placed sessions are tracked for filtering/reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->