### PR TITLE
feat: add comprehensive student assessment data inputs (#167)

### DIFF
--- a/app/components/students/assessment-inputs.tsx
+++ b/app/components/students/assessment-inputs.tsx
@@ -1,0 +1,583 @@
+'use client';
+
+import { Input, Label, FormGroup } from '../ui/form';
+import { StudentAssessment } from '../../../lib/supabase/queries/student-assessments';
+import { AssessmentSection } from './assessment-section';
+
+interface AssessmentInputsProps {
+  assessment: StudentAssessment;
+  onChange: (assessment: StudentAssessment) => void;
+}
+
+export function AssessmentInputs({ assessment, onChange }: AssessmentInputsProps) {
+  const updateField = (field: keyof StudentAssessment, value: any) => {
+    onChange({
+      ...assessment,
+      [field]: value === '' ? null : value
+    });
+  };
+
+  const parseNumberInput = (value: string) => {
+    if (value === '') return null;
+    const num = parseFloat(value);
+    return isNaN(num) ? null : num;
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Reading Assessments */}
+      <AssessmentSection title="Reading Assessments" icon="📖">
+        <div className="space-y-3">
+          <div>
+            <h5 className="text-sm font-medium text-gray-700 mb-2">Decoding & Fluency</h5>
+            <div className="grid grid-cols-2 gap-3">
+              <FormGroup>
+                <Label htmlFor="dibels_wpm">DIBELS WPM Accuracy (%)</Label>
+                <Input
+                  id="dibels_wpm"
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="0.1"
+                  value={assessment.dibels_wpm_accuracy ?? ''}
+                  onChange={(e) => updateField('dibels_wpm_accuracy', parseNumberInput(e.target.value))}
+                  placeholder="0-100"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="nonsense_word">Nonsense Word Fluency</Label>
+                <Input
+                  id="nonsense_word"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={assessment.dibels_nonsense_word_fluency ?? ''}
+                  onChange={(e) => updateField('dibels_nonsense_word_fluency', parseNumberInput(e.target.value))}
+                  placeholder="Score"
+                />
+              </FormGroup>
+            </div>
+          </div>
+
+          <div>
+            <h5 className="text-sm font-medium text-gray-700 mb-2">Comprehension</h5>
+            <div className="grid grid-cols-3 gap-3">
+              <FormGroup>
+                <Label htmlFor="reading_comp">Accuracy (%)</Label>
+                <Input
+                  id="reading_comp"
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="0.1"
+                  value={assessment.reading_comprehension_accuracy ?? ''}
+                  onChange={(e) => updateField('reading_comprehension_accuracy', parseNumberInput(e.target.value))}
+                  placeholder="0-100"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="lexile">Lexile Level</Label>
+                <Input
+                  id="lexile"
+                  type="text"
+                  value={assessment.lexile_level ?? ''}
+                  onChange={(e) => updateField('lexile_level', e.target.value)}
+                  placeholder="e.g., 450L"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="fp_dra">F&P/DRA Level</Label>
+                <Input
+                  id="fp_dra"
+                  type="text"
+                  value={assessment.fp_dra_level ?? ''}
+                  onChange={(e) => updateField('fp_dra_level', e.target.value)}
+                  placeholder="Level"
+                />
+              </FormGroup>
+            </div>
+          </div>
+
+          <div>
+            <h5 className="text-sm font-medium text-gray-700 mb-2">Phonemic Awareness</h5>
+            <FormGroup>
+              <Label htmlFor="psf">PSF Score</Label>
+              <Input
+                id="psf"
+                type="number"
+                min="0"
+                step="1"
+                value={assessment.phoneme_segmentation_fluency ?? ''}
+                onChange={(e) => updateField('phoneme_segmentation_fluency', parseNumberInput(e.target.value))}
+                placeholder="Score"
+              />
+            </FormGroup>
+          </div>
+
+          <div>
+            <h5 className="text-sm font-medium text-gray-700 mb-2">Sight Words</h5>
+            <div className="grid grid-cols-2 gap-3">
+              <FormGroup>
+                <Label htmlFor="sight_words">Words Known</Label>
+                <Input
+                  id="sight_words"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={assessment.sight_words_known ?? ''}
+                  onChange={(e) => updateField('sight_words_known', parseNumberInput(e.target.value))}
+                  placeholder="Number"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="sight_words_level">List Level</Label>
+                <select
+                  id="sight_words_level"
+                  value={assessment.sight_words_list_level ?? ''}
+                  onChange={(e) => updateField('sight_words_list_level', e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                >
+                  <option value="">Select level</option>
+                  <option value="Dolch Pre-K">Dolch Pre-K</option>
+                  <option value="Dolch K">Dolch K</option>
+                  <option value="Dolch 1st">Dolch 1st</option>
+                  <option value="Dolch 2nd">Dolch 2nd</option>
+                  <option value="Dolch 3rd">Dolch 3rd</option>
+                  <option value="Fry 1-100">Fry 1-100</option>
+                  <option value="Fry 101-200">Fry 101-200</option>
+                  <option value="Fry 201-300">Fry 201-300</option>
+                  <option value="Fry 301-400">Fry 301-400</option>
+                  <option value="Fry 401-500">Fry 401-500</option>
+                </select>
+              </FormGroup>
+            </div>
+          </div>
+        </div>
+      </AssessmentSection>
+
+      {/* Math Assessments */}
+      <AssessmentSection title="Math Assessments" icon="🔢">
+        <div className="space-y-3">
+          <div>
+            <h5 className="text-sm font-medium text-gray-700 mb-2">Computation Accuracy (%)</h5>
+            <div className="grid grid-cols-4 gap-3">
+              <FormGroup>
+                <Label htmlFor="math_add">Addition</Label>
+                <Input
+                  id="math_add"
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="0.1"
+                  value={assessment.math_computation_addition_accuracy ?? ''}
+                  onChange={(e) => updateField('math_computation_addition_accuracy', parseNumberInput(e.target.value))}
+                  placeholder="%"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="math_sub">Subtraction</Label>
+                <Input
+                  id="math_sub"
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="0.1"
+                  value={assessment.math_computation_subtraction_accuracy ?? ''}
+                  onChange={(e) => updateField('math_computation_subtraction_accuracy', parseNumberInput(e.target.value))}
+                  placeholder="%"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="math_mult">Multiplication</Label>
+                <Input
+                  id="math_mult"
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="0.1"
+                  value={assessment.math_computation_multiplication_accuracy ?? ''}
+                  onChange={(e) => updateField('math_computation_multiplication_accuracy', parseNumberInput(e.target.value))}
+                  placeholder="%"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="math_div">Division</Label>
+                <Input
+                  id="math_div"
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="0.1"
+                  value={assessment.math_computation_division_accuracy ?? ''}
+                  onChange={(e) => updateField('math_computation_division_accuracy', parseNumberInput(e.target.value))}
+                  placeholder="%"
+                />
+              </FormGroup>
+            </div>
+          </div>
+
+          <div>
+            <h5 className="text-sm font-medium text-gray-700 mb-2">Fact Fluency (facts/min)</h5>
+            <div className="grid grid-cols-4 gap-3">
+              <FormGroup>
+                <Label htmlFor="fluency_add">Addition</Label>
+                <Input
+                  id="fluency_add"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={assessment.math_fact_fluency_addition ?? ''}
+                  onChange={(e) => updateField('math_fact_fluency_addition', parseNumberInput(e.target.value))}
+                  placeholder="Facts/min"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="fluency_sub">Subtraction</Label>
+                <Input
+                  id="fluency_sub"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={assessment.math_fact_fluency_subtraction ?? ''}
+                  onChange={(e) => updateField('math_fact_fluency_subtraction', parseNumberInput(e.target.value))}
+                  placeholder="Facts/min"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="fluency_mult">Multiplication</Label>
+                <Input
+                  id="fluency_mult"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={assessment.math_fact_fluency_multiplication ?? ''}
+                  onChange={(e) => updateField('math_fact_fluency_multiplication', parseNumberInput(e.target.value))}
+                  placeholder="Facts/min"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="fluency_div">Division</Label>
+                <Input
+                  id="fluency_div"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={assessment.math_fact_fluency_division ?? ''}
+                  onChange={(e) => updateField('math_fact_fluency_division', parseNumberInput(e.target.value))}
+                  placeholder="Facts/min"
+                />
+              </FormGroup>
+            </div>
+          </div>
+
+          <div>
+            <h5 className="text-sm font-medium text-gray-700 mb-2">Problem Solving</h5>
+            <div className="grid grid-cols-2 gap-3">
+              <FormGroup>
+                <Label htmlFor="word_problems">Word Problems Accuracy (%)</Label>
+                <Input
+                  id="word_problems"
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="0.1"
+                  value={assessment.math_problem_solving_accuracy ?? ''}
+                  onChange={(e) => updateField('math_problem_solving_accuracy', parseNumberInput(e.target.value))}
+                  placeholder="0-100"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="number_sense">Number Sense Score</Label>
+                <Input
+                  id="number_sense"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={assessment.math_number_sense_score ?? ''}
+                  onChange={(e) => updateField('math_number_sense_score', parseNumberInput(e.target.value))}
+                  placeholder="Score"
+                />
+              </FormGroup>
+            </div>
+          </div>
+        </div>
+      </AssessmentSection>
+
+      {/* Writing Assessments */}
+      <AssessmentSection title="Writing Assessments" icon="✍️">
+        <div className="space-y-3">
+          <div>
+            <h5 className="text-sm font-medium text-gray-700 mb-2">Spelling</h5>
+            <div className="grid grid-cols-2 gap-3">
+              <FormGroup>
+                <Label htmlFor="spelling_stage">Developmental Stage</Label>
+                <select
+                  id="spelling_stage"
+                  value={assessment.spelling_developmental_stage ?? ''}
+                  onChange={(e) => updateField('spelling_developmental_stage', e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                >
+                  <option value="">Select stage</option>
+                  <option value="Emergent">Emergent</option>
+                  <option value="Letter Name">Letter Name</option>
+                  <option value="Within Word Pattern">Within Word Pattern</option>
+                  <option value="Syllables and Affixes">Syllables and Affixes</option>
+                  <option value="Derivational Relations">Derivational Relations</option>
+                </select>
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="spelling_acc">Accuracy (%)</Label>
+                <Input
+                  id="spelling_acc"
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="0.1"
+                  value={assessment.spelling_accuracy ?? ''}
+                  onChange={(e) => updateField('spelling_accuracy', parseNumberInput(e.target.value))}
+                  placeholder="0-100"
+                />
+              </FormGroup>
+            </div>
+          </div>
+
+          <div>
+            <h5 className="text-sm font-medium text-gray-700 mb-2">Expression</h5>
+            <div className="grid grid-cols-2 gap-3">
+              <FormGroup>
+                <Label htmlFor="wj_score">WJ-IV Score</Label>
+                <Input
+                  id="wj_score"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={assessment.written_expression_score ?? ''}
+                  onChange={(e) => updateField('written_expression_score', parseNumberInput(e.target.value))}
+                  placeholder="Score"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="words_sentence">Avg Words per Sentence</Label>
+                <Input
+                  id="words_sentence"
+                  type="number"
+                  min="0"
+                  step="0.1"
+                  value={assessment.words_per_sentence_average ?? ''}
+                  onChange={(e) => updateField('words_per_sentence_average', parseNumberInput(e.target.value))}
+                  placeholder="Average"
+                />
+              </FormGroup>
+            </div>
+          </div>
+
+          <div>
+            <h5 className="text-sm font-medium text-gray-700 mb-2">Handwriting</h5>
+            <FormGroup>
+              <Label htmlFor="handwriting">Letters per Minute</Label>
+              <Input
+                id="handwriting"
+                type="number"
+                min="0"
+                step="1"
+                value={assessment.handwriting_letters_per_minute ?? ''}
+                onChange={(e) => updateField('handwriting_letters_per_minute', parseNumberInput(e.target.value))}
+                placeholder="Letters/min"
+              />
+            </FormGroup>
+          </div>
+        </div>
+      </AssessmentSection>
+
+      {/* Cognitive Profile */}
+      <AssessmentSection title="Cognitive Profile" icon="🧠">
+        <div className="space-y-3">
+          <div>
+            <h5 className="text-sm font-medium text-gray-700 mb-2">WISC-V Standard Scores (mean=100)</h5>
+            <div className="grid grid-cols-3 gap-3">
+              <FormGroup>
+                <Label htmlFor="wisc_psi">Processing Speed</Label>
+                <Input
+                  id="wisc_psi"
+                  type="number"
+                  min="0"
+                  max="200"
+                  step="1"
+                  value={assessment.wisc_processing_speed_index ?? ''}
+                  onChange={(e) => updateField('wisc_processing_speed_index', parseNumberInput(e.target.value))}
+                  placeholder="Score"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="wisc_wmi">Working Memory</Label>
+                <Input
+                  id="wisc_wmi"
+                  type="number"
+                  min="0"
+                  max="200"
+                  step="1"
+                  value={assessment.wisc_working_memory_index ?? ''}
+                  onChange={(e) => updateField('wisc_working_memory_index', parseNumberInput(e.target.value))}
+                  placeholder="Score"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="wisc_fri">Fluid Reasoning</Label>
+                <Input
+                  id="wisc_fri"
+                  type="number"
+                  min="0"
+                  max="200"
+                  step="1"
+                  value={assessment.wisc_fluid_reasoning_index ?? ''}
+                  onChange={(e) => updateField('wisc_fluid_reasoning_index', parseNumberInput(e.target.value))}
+                  placeholder="Score"
+                />
+              </FormGroup>
+            </div>
+          </div>
+
+          <div>
+            <h5 className="text-sm font-medium text-gray-700 mb-2">Academic Achievement</h5>
+            <div className="grid grid-cols-3 gap-3">
+              <FormGroup>
+                <Label htmlFor="academic_fluency">Fluency Score</Label>
+                <Input
+                  id="academic_fluency"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={assessment.academic_fluency_score ?? ''}
+                  onChange={(e) => updateField('academic_fluency_score', parseNumberInput(e.target.value))}
+                  placeholder="Score"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="processing_speed">Processing Speed</Label>
+                <Input
+                  id="processing_speed"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={assessment.processing_speed_score ?? ''}
+                  onChange={(e) => updateField('processing_speed_score', parseNumberInput(e.target.value))}
+                  placeholder="Score"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="cognitive_eff">Cognitive Efficiency</Label>
+                <Input
+                  id="cognitive_eff"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={assessment.cognitive_efficiency_score ?? ''}
+                  onChange={(e) => updateField('cognitive_efficiency_score', parseNumberInput(e.target.value))}
+                  placeholder="Score"
+                />
+              </FormGroup>
+            </div>
+          </div>
+
+          <div>
+            <h5 className="text-sm font-medium text-gray-700 mb-2">Executive Function (T-scores, mean=50)</h5>
+            <div className="grid grid-cols-3 gap-3">
+              <FormGroup>
+                <Label htmlFor="brief_wm">Working Memory</Label>
+                <Input
+                  id="brief_wm"
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="1"
+                  value={assessment.brief_working_memory_tscore ?? ''}
+                  onChange={(e) => updateField('brief_working_memory_tscore', parseNumberInput(e.target.value))}
+                  placeholder="T-score"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="brief_inhib">Inhibition</Label>
+                <Input
+                  id="brief_inhib"
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="1"
+                  value={assessment.brief_inhibition_tscore ?? ''}
+                  onChange={(e) => updateField('brief_inhibition_tscore', parseNumberInput(e.target.value))}
+                  placeholder="T-score"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="brief_flex">Flexibility</Label>
+                <Input
+                  id="brief_flex"
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="1"
+                  value={assessment.brief_shift_flexibility_tscore ?? ''}
+                  onChange={(e) => updateField('brief_shift_flexibility_tscore', parseNumberInput(e.target.value))}
+                  placeholder="T-score"
+                />
+              </FormGroup>
+            </div>
+          </div>
+
+          <div>
+            <h5 className="text-sm font-medium text-gray-700 mb-2">Memory (Scaled scores)</h5>
+            <div className="grid grid-cols-3 gap-3">
+              <FormGroup>
+                <Label htmlFor="immediate_recall">Immediate Recall</Label>
+                <Input
+                  id="immediate_recall"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={assessment.immediate_recall_score ?? ''}
+                  onChange={(e) => updateField('immediate_recall_score', parseNumberInput(e.target.value))}
+                  placeholder="Score"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="delayed_recall">Delayed Recall</Label>
+                <Input
+                  id="delayed_recall"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={assessment.delayed_recall_score ?? ''}
+                  onChange={(e) => updateField('delayed_recall_score', parseNumberInput(e.target.value))}
+                  placeholder="Score"
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="recognition">Recognition</Label>
+                <Input
+                  id="recognition"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={assessment.recognition_score ?? ''}
+                  onChange={(e) => updateField('recognition_score', parseNumberInput(e.target.value))}
+                  placeholder="Score"
+                />
+              </FormGroup>
+            </div>
+          </div>
+        </div>
+      </AssessmentSection>
+
+      {/* Assessment Date */}
+      <FormGroup>
+        <Label htmlFor="assessment_date">Assessment Date</Label>
+        <Input
+          id="assessment_date"
+          type="date"
+          value={assessment.assessment_date ?? ''}
+          onChange={(e) => updateField('assessment_date', e.target.value)}
+        />
+      </FormGroup>
+    </div>
+  );
+}

--- a/app/components/students/assessment-section.tsx
+++ b/app/components/students/assessment-section.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+
+interface AssessmentSectionProps {
+  title: string;
+  icon: string;
+  children: React.ReactNode;
+  defaultExpanded?: boolean;
+}
+
+export function AssessmentSection({ 
+  title, 
+  icon, 
+  children, 
+  defaultExpanded = false 
+}: AssessmentSectionProps) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  return (
+    <div className="border border-gray-200 rounded-lg overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full px-4 py-3 bg-gray-50 hover:bg-gray-100 transition-colors flex items-center justify-between text-left"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-lg">{icon}</span>
+          <h4 className="font-medium text-gray-900">{title}</h4>
+        </div>
+        <div className="text-gray-500">
+          {isExpanded ? (
+            <ChevronDownIcon className="h-5 w-5" />
+          ) : (
+            <ChevronRightIcon className="h-5 w-5" />
+          )}
+        </div>
+      </button>
+      
+      {isExpanded && (
+        <div className="p-4 space-y-4 bg-white">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/supabase/queries/student-assessments.ts
+++ b/lib/supabase/queries/student-assessments.ts
@@ -1,0 +1,164 @@
+import { createClient } from '@/lib/supabase/client';
+import { safeQuery } from '@/lib/supabase/safe-query';
+import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
+import type { Database } from '../../../src/types/database';
+
+export interface StudentAssessment {
+  // Reading Assessments
+  dibels_wpm_accuracy?: number | null;
+  dibels_nonsense_word_fluency?: number | null;
+  reading_comprehension_accuracy?: number | null;
+  lexile_level?: string | null;
+  fp_dra_level?: string | null;
+  phoneme_segmentation_fluency?: number | null;
+  sight_words_known?: number | null;
+  sight_words_list_level?: string | null;
+  
+  // Math Assessments
+  math_computation_addition_accuracy?: number | null;
+  math_computation_subtraction_accuracy?: number | null;
+  math_computation_multiplication_accuracy?: number | null;
+  math_computation_division_accuracy?: number | null;
+  math_fact_fluency_addition?: number | null;
+  math_fact_fluency_subtraction?: number | null;
+  math_fact_fluency_multiplication?: number | null;
+  math_fact_fluency_division?: number | null;
+  math_problem_solving_accuracy?: number | null;
+  math_number_sense_score?: number | null;
+  
+  // Writing Assessments
+  spelling_developmental_stage?: string | null;
+  spelling_accuracy?: number | null;
+  written_expression_score?: number | null;
+  words_per_sentence_average?: number | null;
+  handwriting_letters_per_minute?: number | null;
+  
+  // Cognitive Assessments
+  wisc_processing_speed_index?: number | null;
+  wisc_working_memory_index?: number | null;
+  wisc_fluid_reasoning_index?: number | null;
+  
+  // Academic Achievement
+  academic_fluency_score?: number | null;
+  processing_speed_score?: number | null;
+  cognitive_efficiency_score?: number | null;
+  
+  // Executive Function
+  brief_working_memory_tscore?: number | null;
+  brief_inhibition_tscore?: number | null;
+  brief_shift_flexibility_tscore?: number | null;
+  
+  // Memory Assessments
+  immediate_recall_score?: number | null;
+  delayed_recall_score?: number | null;
+  recognition_score?: number | null;
+  
+  // Metadata
+  assessment_date?: string | null;
+}
+
+export async function getStudentAssessment(studentId: string): Promise<StudentAssessment | null> {
+  const supabase = createClient<Database>();
+
+  const fetchPerf = measurePerformanceWithAlerts('fetch_student_assessment', 'database');
+  const fetchResult = await safeQuery(
+    async () => {
+      const { data, error } = await supabase
+        .from('student_assessments')
+        .select('*')
+        .eq('student_id', studentId)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+    { 
+      operation: 'fetch_student_assessment', 
+      studentId 
+    }
+  );
+  fetchPerf.end({ success: !fetchResult.error });
+
+  if (fetchResult.error) {
+    console.error('Error fetching student assessment:', fetchResult.error);
+    throw fetchResult.error;
+  }
+
+  const data = fetchResult.data;
+  if (!data) return null;
+
+  // Return all assessment fields
+  return {
+    dibels_wpm_accuracy: data.dibels_wpm_accuracy,
+    dibels_nonsense_word_fluency: data.dibels_nonsense_word_fluency,
+    reading_comprehension_accuracy: data.reading_comprehension_accuracy,
+    lexile_level: data.lexile_level,
+    fp_dra_level: data.fp_dra_level,
+    phoneme_segmentation_fluency: data.phoneme_segmentation_fluency,
+    sight_words_known: data.sight_words_known,
+    sight_words_list_level: data.sight_words_list_level,
+    math_computation_addition_accuracy: data.math_computation_addition_accuracy,
+    math_computation_subtraction_accuracy: data.math_computation_subtraction_accuracy,
+    math_computation_multiplication_accuracy: data.math_computation_multiplication_accuracy,
+    math_computation_division_accuracy: data.math_computation_division_accuracy,
+    math_fact_fluency_addition: data.math_fact_fluency_addition,
+    math_fact_fluency_subtraction: data.math_fact_fluency_subtraction,
+    math_fact_fluency_multiplication: data.math_fact_fluency_multiplication,
+    math_fact_fluency_division: data.math_fact_fluency_division,
+    math_problem_solving_accuracy: data.math_problem_solving_accuracy,
+    math_number_sense_score: data.math_number_sense_score,
+    spelling_developmental_stage: data.spelling_developmental_stage,
+    spelling_accuracy: data.spelling_accuracy,
+    written_expression_score: data.written_expression_score,
+    words_per_sentence_average: data.words_per_sentence_average,
+    handwriting_letters_per_minute: data.handwriting_letters_per_minute,
+    wisc_processing_speed_index: data.wisc_processing_speed_index,
+    wisc_working_memory_index: data.wisc_working_memory_index,
+    wisc_fluid_reasoning_index: data.wisc_fluid_reasoning_index,
+    academic_fluency_score: data.academic_fluency_score,
+    processing_speed_score: data.processing_speed_score,
+    cognitive_efficiency_score: data.cognitive_efficiency_score,
+    brief_working_memory_tscore: data.brief_working_memory_tscore,
+    brief_inhibition_tscore: data.brief_inhibition_tscore,
+    brief_shift_flexibility_tscore: data.brief_shift_flexibility_tscore,
+    immediate_recall_score: data.immediate_recall_score,
+    delayed_recall_score: data.delayed_recall_score,
+    recognition_score: data.recognition_score,
+    assessment_date: data.assessment_date,
+  };
+}
+
+export async function upsertStudentAssessment(
+  studentId: string, 
+  assessment: StudentAssessment
+): Promise<void> {
+  const supabase = createClient<Database>();
+
+  const upsertPerf = measurePerformanceWithAlerts('upsert_student_assessment', 'database');
+  const upsertResult = await safeQuery(
+    async () => {
+      const { error } = await supabase
+        .from('student_assessments')
+        .upsert({
+          student_id: studentId,
+          ...assessment,
+          updated_at: new Date().toISOString(),
+        }, {
+          onConflict: 'student_id'
+        });
+      if (error) throw error;
+      return null;
+    },
+    { 
+      operation: 'upsert_student_assessment', 
+      studentId
+    }
+  );
+  upsertPerf.end({ success: !upsertResult.error });
+
+  if (upsertResult.error) {
+    console.error('Error saving student assessment:', upsertResult.error);
+    throw upsertResult.error;
+  }
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -277,6 +277,134 @@ export interface Database {
           updated_at?: string
         }
       },
+      student_assessments: {
+        Row: {
+          id: string
+          student_id: string
+          dibels_wpm_accuracy: number | null
+          dibels_nonsense_word_fluency: number | null
+          reading_comprehension_accuracy: number | null
+          lexile_level: string | null
+          fp_dra_level: string | null
+          phoneme_segmentation_fluency: number | null
+          sight_words_known: number | null
+          sight_words_list_level: string | null
+          math_computation_addition_accuracy: number | null
+          math_computation_subtraction_accuracy: number | null
+          math_computation_multiplication_accuracy: number | null
+          math_computation_division_accuracy: number | null
+          math_fact_fluency_addition: number | null
+          math_fact_fluency_subtraction: number | null
+          math_fact_fluency_multiplication: number | null
+          math_fact_fluency_division: number | null
+          math_problem_solving_accuracy: number | null
+          math_number_sense_score: number | null
+          spelling_developmental_stage: string | null
+          spelling_accuracy: number | null
+          written_expression_score: number | null
+          words_per_sentence_average: number | null
+          handwriting_letters_per_minute: number | null
+          wisc_processing_speed_index: number | null
+          wisc_working_memory_index: number | null
+          wisc_fluid_reasoning_index: number | null
+          academic_fluency_score: number | null
+          processing_speed_score: number | null
+          cognitive_efficiency_score: number | null
+          brief_working_memory_tscore: number | null
+          brief_inhibition_tscore: number | null
+          brief_shift_flexibility_tscore: number | null
+          immediate_recall_score: number | null
+          delayed_recall_score: number | null
+          recognition_score: number | null
+          assessment_date: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          student_id: string
+          dibels_wpm_accuracy?: number | null
+          dibels_nonsense_word_fluency?: number | null
+          reading_comprehension_accuracy?: number | null
+          lexile_level?: string | null
+          fp_dra_level?: string | null
+          phoneme_segmentation_fluency?: number | null
+          sight_words_known?: number | null
+          sight_words_list_level?: string | null
+          math_computation_addition_accuracy?: number | null
+          math_computation_subtraction_accuracy?: number | null
+          math_computation_multiplication_accuracy?: number | null
+          math_computation_division_accuracy?: number | null
+          math_fact_fluency_addition?: number | null
+          math_fact_fluency_subtraction?: number | null
+          math_fact_fluency_multiplication?: number | null
+          math_fact_fluency_division?: number | null
+          math_problem_solving_accuracy?: number | null
+          math_number_sense_score?: number | null
+          spelling_developmental_stage?: string | null
+          spelling_accuracy?: number | null
+          written_expression_score?: number | null
+          words_per_sentence_average?: number | null
+          handwriting_letters_per_minute?: number | null
+          wisc_processing_speed_index?: number | null
+          wisc_working_memory_index?: number | null
+          wisc_fluid_reasoning_index?: number | null
+          academic_fluency_score?: number | null
+          processing_speed_score?: number | null
+          cognitive_efficiency_score?: number | null
+          brief_working_memory_tscore?: number | null
+          brief_inhibition_tscore?: number | null
+          brief_shift_flexibility_tscore?: number | null
+          immediate_recall_score?: number | null
+          delayed_recall_score?: number | null
+          recognition_score?: number | null
+          assessment_date?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          student_id?: string
+          dibels_wpm_accuracy?: number | null
+          dibels_nonsense_word_fluency?: number | null
+          reading_comprehension_accuracy?: number | null
+          lexile_level?: string | null
+          fp_dra_level?: string | null
+          phoneme_segmentation_fluency?: number | null
+          sight_words_known?: number | null
+          sight_words_list_level?: string | null
+          math_computation_addition_accuracy?: number | null
+          math_computation_subtraction_accuracy?: number | null
+          math_computation_multiplication_accuracy?: number | null
+          math_computation_division_accuracy?: number | null
+          math_fact_fluency_addition?: number | null
+          math_fact_fluency_subtraction?: number | null
+          math_fact_fluency_multiplication?: number | null
+          math_fact_fluency_division?: number | null
+          math_problem_solving_accuracy?: number | null
+          math_number_sense_score?: number | null
+          spelling_developmental_stage?: string | null
+          spelling_accuracy?: number | null
+          written_expression_score?: number | null
+          words_per_sentence_average?: number | null
+          handwriting_letters_per_minute?: number | null
+          wisc_processing_speed_index?: number | null
+          wisc_working_memory_index?: number | null
+          wisc_fluid_reasoning_index?: number | null
+          academic_fluency_score?: number | null
+          processing_speed_score?: number | null
+          cognitive_efficiency_score?: number | null
+          brief_working_memory_tscore?: number | null
+          brief_inhibition_tscore?: number | null
+          brief_shift_flexibility_tscore?: number | null
+          immediate_recall_score?: number | null
+          delayed_recall_score?: number | null
+          recognition_score?: number | null
+          assessment_date?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+      },
       bell_schedules: {
         Row: {
           id: string

--- a/supabase/migrations/20250820_add_student_assessments_table.sql
+++ b/supabase/migrations/20250820_add_student_assessments_table.sql
@@ -1,0 +1,163 @@
+-- Add student_assessments table for comprehensive assessment data
+-- Migration: 20250820_add_student_assessments_table.sql
+
+-- Create the student_assessments table
+CREATE TABLE student_assessments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  student_id UUID REFERENCES students(id) ON DELETE CASCADE NOT NULL,
+  
+  -- Reading Assessments
+  dibels_wpm_accuracy NUMERIC,
+  dibels_nonsense_word_fluency NUMERIC,
+  reading_comprehension_accuracy NUMERIC,
+  lexile_level VARCHAR(20),
+  fp_dra_level VARCHAR(20),
+  phoneme_segmentation_fluency NUMERIC,
+  sight_words_known INTEGER,
+  sight_words_list_level VARCHAR(50),
+  
+  -- Math Assessments
+  math_computation_addition_accuracy NUMERIC,
+  math_computation_subtraction_accuracy NUMERIC,
+  math_computation_multiplication_accuracy NUMERIC,
+  math_computation_division_accuracy NUMERIC,
+  math_fact_fluency_addition NUMERIC,
+  math_fact_fluency_subtraction NUMERIC,
+  math_fact_fluency_multiplication NUMERIC,
+  math_fact_fluency_division NUMERIC,
+  math_problem_solving_accuracy NUMERIC,
+  math_number_sense_score NUMERIC,
+  
+  -- Writing Assessments
+  spelling_developmental_stage VARCHAR(50),
+  spelling_accuracy NUMERIC,
+  written_expression_score NUMERIC,
+  words_per_sentence_average NUMERIC,
+  handwriting_letters_per_minute NUMERIC,
+  
+  -- Cognitive Assessments (WISC-V)
+  wisc_processing_speed_index INTEGER,
+  wisc_working_memory_index INTEGER,
+  wisc_fluid_reasoning_index INTEGER,
+  
+  -- Academic Achievement (WJ-IV, KTEA-3)
+  academic_fluency_score INTEGER,
+  processing_speed_score INTEGER,
+  cognitive_efficiency_score INTEGER,
+  
+  -- Executive Function (BRIEF-2)
+  brief_working_memory_tscore INTEGER,
+  brief_inhibition_tscore INTEGER,
+  brief_shift_flexibility_tscore INTEGER,
+  
+  -- Memory Assessments
+  immediate_recall_score INTEGER,
+  delayed_recall_score INTEGER,
+  recognition_score INTEGER,
+  
+  -- Metadata
+  assessment_date DATE,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Create indexes for common queries
+CREATE INDEX idx_student_assessments_student_id ON student_assessments(student_id);
+CREATE INDEX idx_student_assessments_date ON student_assessments(assessment_date DESC);
+
+-- Add comments for documentation
+COMMENT ON TABLE student_assessments IS 'Comprehensive assessment data for students to enable personalized AI lesson generation';
+
+-- Reading assessment comments
+COMMENT ON COLUMN student_assessments.dibels_wpm_accuracy IS 'DIBELS Words Per Minute accuracy percentage';
+COMMENT ON COLUMN student_assessments.dibels_nonsense_word_fluency IS 'DIBELS Nonsense Word Fluency score';
+COMMENT ON COLUMN student_assessments.reading_comprehension_accuracy IS 'Reading comprehension accuracy percentage';
+COMMENT ON COLUMN student_assessments.lexile_level IS 'Lexile reading level (e.g., 450L)';
+COMMENT ON COLUMN student_assessments.fp_dra_level IS 'Fountas & Pinnell or DRA reading level';
+COMMENT ON COLUMN student_assessments.phoneme_segmentation_fluency IS 'PSF score for phonemic awareness';
+COMMENT ON COLUMN student_assessments.sight_words_known IS 'Number of sight words known';
+COMMENT ON COLUMN student_assessments.sight_words_list_level IS 'Sight word list level (Dolch/Fry)';
+
+-- Math assessment comments
+COMMENT ON COLUMN student_assessments.math_computation_addition_accuracy IS 'Addition computation accuracy percentage';
+COMMENT ON COLUMN student_assessments.math_computation_subtraction_accuracy IS 'Subtraction computation accuracy percentage';
+COMMENT ON COLUMN student_assessments.math_computation_multiplication_accuracy IS 'Multiplication computation accuracy percentage';
+COMMENT ON COLUMN student_assessments.math_computation_division_accuracy IS 'Division computation accuracy percentage';
+COMMENT ON COLUMN student_assessments.math_fact_fluency_addition IS 'Addition facts per minute';
+COMMENT ON COLUMN student_assessments.math_fact_fluency_subtraction IS 'Subtraction facts per minute';
+COMMENT ON COLUMN student_assessments.math_fact_fluency_multiplication IS 'Multiplication facts per minute';
+COMMENT ON COLUMN student_assessments.math_fact_fluency_division IS 'Division facts per minute';
+COMMENT ON COLUMN student_assessments.math_problem_solving_accuracy IS 'Word problem solving accuracy percentage';
+COMMENT ON COLUMN student_assessments.math_number_sense_score IS 'TEMA-3 or similar number sense composite score';
+
+-- Writing assessment comments
+COMMENT ON COLUMN student_assessments.spelling_developmental_stage IS 'Words Their Way developmental spelling stage';
+COMMENT ON COLUMN student_assessments.spelling_accuracy IS 'Spelling accuracy percentage';
+COMMENT ON COLUMN student_assessments.written_expression_score IS 'WJ-IV written expression score';
+COMMENT ON COLUMN student_assessments.words_per_sentence_average IS 'Average words per sentence in writing samples';
+COMMENT ON COLUMN student_assessments.handwriting_letters_per_minute IS 'Legible letters written per minute';
+
+-- Cognitive assessment comments
+COMMENT ON COLUMN student_assessments.wisc_processing_speed_index IS 'WISC-V PSI standard score (mean=100)';
+COMMENT ON COLUMN student_assessments.wisc_working_memory_index IS 'WISC-V WMI standard score (mean=100)';
+COMMENT ON COLUMN student_assessments.wisc_fluid_reasoning_index IS 'WISC-V FRI standard score (mean=100)';
+
+-- Enable RLS
+ALTER TABLE student_assessments ENABLE ROW LEVEL SECURITY;
+
+-- Create RLS policies
+CREATE POLICY "Users can view their students' assessments" ON student_assessments
+  FOR SELECT
+  USING (
+    student_id IN (
+      SELECT id FROM students 
+      WHERE provider_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can insert assessments for their students" ON student_assessments
+  FOR INSERT
+  WITH CHECK (
+    student_id IN (
+      SELECT id FROM students 
+      WHERE provider_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can update their students' assessments" ON student_assessments
+  FOR UPDATE
+  USING (
+    student_id IN (
+      SELECT id FROM students 
+      WHERE provider_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    student_id IN (
+      SELECT id FROM students 
+      WHERE provider_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can delete their students' assessments" ON student_assessments
+  FOR DELETE
+  USING (
+    student_id IN (
+      SELECT id FROM students 
+      WHERE provider_id = auth.uid()
+    )
+  );
+
+-- Create trigger to update updated_at
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_student_assessments_updated_at
+  BEFORE UPDATE ON student_assessments
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();

--- a/supabase/migrations/20250820_add_student_assessments_table.sql
+++ b/supabase/migrations/20250820_add_student_assessments_table.sql
@@ -1,6 +1,12 @@
 -- Add student_assessments table for comprehensive assessment data
 -- Migration: 20250820_add_student_assessments_table.sql
 
+-- This table stores the most recent assessment data for each student.
+-- The UNIQUE constraint on student_id ensures only one assessment record per student,
+-- which gets updated (upserted) with new data when assessments are updated.
+-- If historical assessment tracking is needed in the future, remove the UNIQUE constraint
+-- and modify the application logic to handle multiple assessment records per student.
+
 -- Create the student_assessments table
 CREATE TABLE student_assessments (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -58,11 +64,13 @@ CREATE TABLE student_assessments (
   -- Metadata
   assessment_date DATE,
   created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
-  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  
+  -- Add unique constraint to allow upsert on student_id
+  CONSTRAINT unique_student_assessment UNIQUE(student_id)
 );
 
 -- Create indexes for common queries
-CREATE INDEX idx_student_assessments_student_id ON student_assessments(student_id);
 CREATE INDEX idx_student_assessments_date ON student_assessments(assessment_date DESC);
 
 -- Add comments for documentation


### PR DESCRIPTION
- Create student_assessments table with fields for reading, math, writing, and cognitive assessments
- Add collapsible assessment input sections to Student Details modal
- Implement database queries and TypeScript types for assessment data
- Create reusable AssessmentSection component for organized UI
- Add comprehensive input fields for all assessment types requested
- Include RLS policies for secure data access

This enables teachers to input optional assessment data that will be used by AI to generate more personalized lesson content.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Academic Assessments to the Student Details modal with expandable sections for Reading, Math, Writing, Cognitive Profile, and Assessment Date.
  - New editable form supports numeric, text, and dropdown inputs for many common assessment metrics and updates in real time.

- **Improvements**
  - Assessment data loads automatically when opening the modal and can be saved per student.
  - Persisted assessments are retrieved on revisit, ensuring continuity across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->