### PR TITLE
feat: move reading level to assessment section with grade/month break…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -43,10 +43,12 @@
       "Bash(npm search @modelcontextprotocol/server-playwright)",
       "mcp__context7__resolve-library-id",
       "mcp__context7__get-library-docs",
-      "Bash(psql:*)"
+      "Bash(psql:*)",
+      "Bash(npm run dev)",
+      "Bash(gh pr list --head fix/react-hook-dependencies-build-errors)"
     ],
     "deny": []
   },
-  "enabledMcpjsonServers": ["github", "context7", "playwright"],
-  "enableAllProjectMcpServers": true
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": ["github", "context7", "playwright"]
 }

--- a/app/components/students/assessment-inputs.tsx
+++ b/app/components/students/assessment-inputs.tsx
@@ -3,6 +3,7 @@
 import { Input, Label, FormGroup } from '../ui/form';
 import { StudentAssessment } from '../../../lib/supabase/queries/student-assessments';
 import { AssessmentSection } from './assessment-section';
+import { GradeMonthReadingLevelInput } from './grade-month-reading-level-input';
 
 interface AssessmentInputsProps {
   assessment: StudentAssessment;
@@ -30,32 +31,38 @@ export function AssessmentInputs({ assessment, onChange }: AssessmentInputsProps
         <div className="space-y-3">
           <div>
             <h5 className="text-sm font-medium text-gray-700 mb-2">Decoding & Fluency</h5>
-            <div className="grid grid-cols-2 gap-3">
-              <FormGroup>
-                <Label htmlFor="dibels_wpm">DIBELS WPM Accuracy (%)</Label>
-                <Input
-                  id="dibels_wpm"
-                  type="number"
-                  min="0"
-                  max="100"
-                  step="0.1"
-                  value={assessment.dibels_wpm_accuracy ?? ''}
-                  onChange={(e) => updateField('dibels_wpm_accuracy', parseNumberInput(e.target.value))}
-                  placeholder="0-100"
-                />
-              </FormGroup>
-              <FormGroup>
-                <Label htmlFor="nonsense_word">Nonsense Word Fluency</Label>
-                <Input
-                  id="nonsense_word"
-                  type="number"
-                  min="0"
-                  step="1"
-                  value={assessment.dibels_nonsense_word_fluency ?? ''}
-                  onChange={(e) => updateField('dibels_nonsense_word_fluency', parseNumberInput(e.target.value))}
-                  placeholder="Score"
-                />
-              </FormGroup>
+            <div className="space-y-3">
+              <GradeMonthReadingLevelInput
+                value={assessment.grade_month_reading_level}
+                onChange={(value) => updateField('grade_month_reading_level', value)}
+              />
+              <div className="grid grid-cols-2 gap-3">
+                <FormGroup>
+                  <Label htmlFor="dibels_wpm">DIBELS WPM Accuracy (%)</Label>
+                  <Input
+                    id="dibels_wpm"
+                    type="number"
+                    min="0"
+                    max="100"
+                    step="0.1"
+                    value={assessment.dibels_wpm_accuracy ?? ''}
+                    onChange={(e) => updateField('dibels_wpm_accuracy', parseNumberInput(e.target.value))}
+                    placeholder="0-100"
+                  />
+                </FormGroup>
+                <FormGroup>
+                  <Label htmlFor="nonsense_word">Nonsense Word Fluency</Label>
+                  <Input
+                    id="nonsense_word"
+                    type="number"
+                    min="0"
+                    step="1"
+                    value={assessment.dibels_nonsense_word_fluency ?? ''}
+                    onChange={(e) => updateField('dibels_nonsense_word_fluency', parseNumberInput(e.target.value))}
+                    placeholder="Score"
+                  />
+                </FormGroup>
+              </div>
             </div>
           </div>
 

--- a/app/components/students/grade-month-reading-level-input.tsx
+++ b/app/components/students/grade-month-reading-level-input.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import React from 'react';
+import { Label } from "../ui/form";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
+import { cn } from '@/src/utils/cn';
+
+interface GradeMonthReadingLevelInputProps {
+  value?: number | null;
+  onChange: (value: number | null) => void;
+  className?: string;
+}
+
+export function GradeMonthReadingLevelInput({ 
+  value, 
+  onChange, 
+  className 
+}: GradeMonthReadingLevelInputProps) {
+  const gradeValue = value ? Math.floor(value) : null;
+  const monthValue = value ? Math.round((value - Math.floor(value)) * 10) : null;
+
+  const handleGradeChange = (grade: string) => {
+    const gradeNum = grade === 'K' ? 0 : parseInt(grade);
+    const currentMonth = monthValue || 1;
+    onChange(gradeNum + (currentMonth / 10));
+  };
+
+  const handleMonthChange = (month: string) => {
+    const monthNum = parseInt(month);
+    const currentGrade = gradeValue ?? 0;
+    onChange(currentGrade + (monthNum / 10));
+  };
+
+  const formatDisplay = () => {
+    if (value === null || value === undefined) return "Not assessed";
+    const grade = Math.floor(value);
+    const month = Math.round((value - grade) * 10);
+    const gradeLabel = grade === 0 ? 'Kindergarten' : `Grade ${grade}`;
+    return `${gradeLabel}, Month ${month} (${value.toFixed(1)})`;
+  };
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <Label>Reading Level (Grade.Month)</Label>
+      <div className="flex gap-2">
+        <Select 
+          value={gradeValue === 0 ? 'K' : gradeValue?.toString() || ''} 
+          onValueChange={handleGradeChange}
+        >
+          <SelectTrigger className="w-[140px]">
+            <SelectValue placeholder="Select grade" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="K">Kindergarten</SelectItem>
+            <SelectItem value="1">1st Grade</SelectItem>
+            <SelectItem value="2">2nd Grade</SelectItem>
+            <SelectItem value="3">3rd Grade</SelectItem>
+            <SelectItem value="4">4th Grade</SelectItem>
+            <SelectItem value="5">5th Grade</SelectItem>
+            <SelectItem value="6">6th Grade</SelectItem>
+            <SelectItem value="7">7th Grade</SelectItem>
+            <SelectItem value="8">8th Grade</SelectItem>
+            <SelectItem value="9">9th Grade</SelectItem>
+            <SelectItem value="10">10th Grade</SelectItem>
+            <SelectItem value="11">11th Grade</SelectItem>
+            <SelectItem value="12">12th Grade</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select 
+          value={monthValue?.toString() || ''} 
+          onValueChange={handleMonthChange}
+          disabled={gradeValue === null && gradeValue !== 0}
+        >
+          <SelectTrigger className="w-[120px]">
+            <SelectValue placeholder="Month" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="1">Month 1</SelectItem>
+            <SelectItem value="2">Month 2</SelectItem>
+            <SelectItem value="3">Month 3</SelectItem>
+            <SelectItem value="4">Month 4</SelectItem>
+            <SelectItem value="5">Month 5</SelectItem>
+            <SelectItem value="6">Month 6</SelectItem>
+            <SelectItem value="7">Month 7</SelectItem>
+            <SelectItem value="8">Month 8</SelectItem>
+            <SelectItem value="9">Month 9</SelectItem>
+            <SelectItem value="10">Month 10</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        {formatDisplay()}
+      </p>
+      <p className="text-xs text-muted-foreground">
+        Example: 2nd grade, 5th month = 2.5 | Kindergarten, 3rd month = 0.3
+      </p>
+    </div>
+  );
+}

--- a/app/components/students/student-details-modal.tsx
+++ b/app/components/students/student-details-modal.tsx
@@ -7,7 +7,6 @@ import { getStudentDetails, upsertStudentDetails, StudentDetails } from '../../.
 import { getStudentAssessment, upsertStudentAssessment, StudentAssessment } from '../../../lib/supabase/queries/student-assessments';
 import { SkillsChecklist } from './skills-checklist';
 import { AreasOfNeedDropdown } from './areas-of-need-dropdown';
-import { ReadingLevelDropdown } from './reading-level-dropdown';
 import { AssessmentInputs } from './assessment-inputs';
 
 interface StudentDetailsModalProps {
@@ -46,8 +45,7 @@ export function StudentDetailsModal({
     upcoming_iep_date: '',
     upcoming_triennial_date: '',
     iep_goals: [],
-    working_skills: [],
-    reading_level: '',
+    working_skills: []
   });
   const [assessment, setAssessment] = useState<StudentAssessment>({});
   const [loading, setLoading] = useState(false);
@@ -89,9 +87,8 @@ export function StudentDetailsModal({
               upcoming_iep_date: '',
               upcoming_triennial_date: '',
               iep_goals: [],
-              working_skills: [],
-              reading_level: '',
-            });
+              working_skills: []
+                      });
           }
 
           // Load assessment data
@@ -320,13 +317,6 @@ export function StudentDetailsModal({
                 </FormGroup>
               </div>
 
-              {/* Reading Level Section */}
-              <div className="grid grid-cols-2 gap-4">
-                <ReadingLevelDropdown
-                  value={details.reading_level}
-                  onChange={(value) => setDetails({...details, reading_level: value})}
-                />
-              </div>
 
               <div className="grid grid-cols-2 gap-4">
                 <FormGroup>

--- a/lib/supabase/queries/student-assessments.ts
+++ b/lib/supabase/queries/student-assessments.ts
@@ -13,6 +13,7 @@ export interface StudentAssessment {
   phoneme_segmentation_fluency?: number | null;
   sight_words_known?: number | null;
   sight_words_list_level?: string | null;
+  grade_month_reading_level?: number | null;
   
   // Math Assessments
   math_computation_addition_accuracy?: number | null;
@@ -98,6 +99,7 @@ export async function getStudentAssessment(studentId: string): Promise<StudentAs
     phoneme_segmentation_fluency: data.phoneme_segmentation_fluency,
     sight_words_known: data.sight_words_known,
     sight_words_list_level: data.sight_words_list_level,
+    grade_month_reading_level: data.grade_month_reading_level,
     math_computation_addition_accuracy: data.math_computation_addition_accuracy,
     math_computation_subtraction_accuracy: data.math_computation_subtraction_accuracy,
     math_computation_multiplication_accuracy: data.math_computation_multiplication_accuracy,

--- a/lib/supabase/queries/student-details.ts
+++ b/lib/supabase/queries/student-details.ts
@@ -12,7 +12,6 @@ export interface StudentDetails {
   upcoming_triennial_date: string;
   iep_goals: string[];
   working_skills: string[];
-  reading_level: string;
 }
 
 export async function getStudentDetails(studentId: string): Promise<StudentDetails | null> {
@@ -53,8 +52,7 @@ export async function getStudentDetails(studentId: string): Promise<StudentDetai
     upcoming_iep_date: data.upcoming_iep_date || '',
     upcoming_triennial_date: data.upcoming_triennial_date || '',
     iep_goals: data.iep_goals || [],
-    working_skills: data.working_skills || [],
-    reading_level: data.reading_level || '',
+    working_skills: data.working_skills || []
   };
 }
 
@@ -79,7 +77,6 @@ export async function upsertStudentDetails(
           upcoming_triennial_date: details.upcoming_triennial_date || null,
           iep_goals: details.iep_goals,
           working_skills: details.working_skills,
-          reading_level: details.reading_level || null,
           updated_at: new Date().toISOString(),
         }, {
           onConflict: 'student_id'  // Add this to specify the conflict column

--- a/supabase/migrations/20250820_add_grade_month_reading_level.sql
+++ b/supabase/migrations/20250820_add_grade_month_reading_level.sql
@@ -1,0 +1,8 @@
+-- Add grade_month_reading_level column to student_assessments table
+-- This column stores reading level in grade.month format (e.g., 2.1 = 2nd grade, 1st month)
+
+ALTER TABLE student_assessments 
+ADD COLUMN grade_month_reading_level DECIMAL(3,1);
+
+-- Add comment for documentation
+COMMENT ON COLUMN student_assessments.grade_month_reading_level IS 'Reading level in grade.month format (e.g., 2.1 = 2nd grade 1st month, K = 0.x)';


### PR DESCRIPTION
…down (#170)

- Created GradeMonthReadingLevelInput component for grade.month format (e.g., 2.5 = 2nd grade, 5th month)
- Added grade_month_reading_level column to student_assessments table
- Removed old reading_level field from student details interface and queries
- Integrated new component into assessment inputs section
- Supports Kindergarten as grade 0

This completes the migration of reading level from student details to the assessment section with improved granularity.

🤖 Generated with [Claude Code](https://claude.ai/code)