### PR TITLE
feat: add specialist-to-specialist session assignment

### DIFF
--- a/app/(dashboard)/dashboard/schedule/components/schedule-controls.tsx
+++ b/app/(dashboard)/dashboard/schedule/components/schedule-controls.tsx
@@ -3,12 +3,13 @@
 import React from 'react';
 
 interface ScheduleControlsProps {
-  sessionFilter: 'all' | 'mine' | 'sea';
+  sessionFilter: 'all' | 'mine' | 'sea' | 'specialist';
   selectedGrades: Set<string>;
   selectedTimeSlot: string | null;
   selectedDay: number | null;
   highlightedStudentId: string | null;
-  onSessionFilterChange: (filter: 'all' | 'mine' | 'sea') => void;
+  onSessionFilterChange: (filter: 'all' | 'mine' | 'sea' | 'specialist') => void;
+  showSpecialistFilter?: boolean;
   onGradeToggle: (grade: string) => void;
   onTimeSlotClear: () => void;
   onDayClear: () => void;
@@ -33,6 +34,7 @@ export function ScheduleControls({
   selectedDay,
   highlightedStudentId,
   onSessionFilterChange,
+  showSpecialistFilter = false,
   onGradeToggle,
   onTimeSlotClear,
   onDayClear,
@@ -70,6 +72,14 @@ export function ScheduleControls({
           >
             SEA Sessions
           </FilterButton>
+          {showSpecialistFilter && (
+            <FilterButton
+              active={sessionFilter === 'specialist'}
+              onClick={() => onSessionFilterChange('specialist')}
+            >
+              Specialist Sessions
+            </FilterButton>
+          )}
         </div>
       </div>
 

--- a/app/(dashboard)/dashboard/schedule/components/schedule-grid.tsx
+++ b/app/(dashboard)/dashboard/schedule/components/schedule-grid.tsx
@@ -25,7 +25,7 @@ interface ScheduleGridProps {
   selectedSession: any | null;
   popupPosition: any | null;
   seaProfiles: Array<{ id: string; full_name: string; is_shared?: boolean }>;
-  otherSpecialists: Array<{ id: string; full_name: string; role: 'speech' | 'ot' | 'counseling' | 'specialist' }>;
+  otherSpecialists: Array<{ id: string; full_name: string; role: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' }>;
   providerRole: string;
   currentUserId: string | null;
   sessionTags: Record<string, string>;

--- a/app/(dashboard)/dashboard/schedule/components/schedule-grid.tsx
+++ b/app/(dashboard)/dashboard/schedule/components/schedule-grid.tsx
@@ -19,7 +19,7 @@ interface ScheduleGridProps {
   selectedTimeSlot: string | null;
   selectedDay: number | null;
   highlightedStudentId: string | null;
-  sessionFilter: 'all' | 'mine' | 'sea';
+  sessionFilter: 'all' | 'mine' | 'sea' | 'specialist';
   draggedSession: any | null;
   dragPosition: any | null;
   selectedSession: any | null;

--- a/app/(dashboard)/dashboard/schedule/components/schedule-grid.tsx
+++ b/app/(dashboard)/dashboard/schedule/components/schedule-grid.tsx
@@ -24,8 +24,8 @@ interface ScheduleGridProps {
   dragPosition: any | null;
   selectedSession: any | null;
   popupPosition: any | null;
-  seaProfiles: any[];
-  otherSpecialists: any[];
+  seaProfiles: Array<{ id: string; full_name: string; is_shared?: boolean }>;
+  otherSpecialists: Array<{ id: string; full_name: string; role: 'speech' | 'ot' | 'counseling' | 'specialist' }>;
   providerRole: string;
   currentUserId: string | null;
   sessionTags: Record<string, string>;
@@ -143,7 +143,9 @@ export const ScheduleGrid = memo(function ScheduleGrid({
       case 'mine':
         return allSessions.filter(s => s.delivered_by === 'provider');
       case 'sea':
-        return allSessions.filter(s => s.delivered_by === 'sea' || s.delivered_by === 'specialist');
+        return allSessions.filter(s => s.delivered_by === 'sea');
+      case 'specialist':
+        return allSessions.filter(s => s.delivered_by === 'specialist');
       default:
         return allSessions;
     }
@@ -373,8 +375,8 @@ export const ScheduleGrid = memo(function ScheduleGrid({
                           : 'bg-gray-400';
 
                       const assignmentClass = 
-                        session.delivered_by === 'sea' ? 'ring-2 ring-orange-400 ring-inset' : 
-                        session.delivered_by === 'specialist' ? 'ring-2 ring-purple-400 ring-inset' : '';
+                        session.delivered_by === 'sea' ? 'border-2 border-orange-400' : 
+                        session.delivered_by === 'specialist' ? 'border-2 border-purple-400' : '';
                       const columnIndex = sessionColumns.get(session.id) ?? 0;
                       const fixedWidth = 25;
                       const gap = 1;

--- a/app/(dashboard)/dashboard/schedule/components/schedule-grid.tsx
+++ b/app/(dashboard)/dashboard/schedule/components/schedule-grid.tsx
@@ -25,6 +25,7 @@ interface ScheduleGridProps {
   selectedSession: any | null;
   popupPosition: any | null;
   seaProfiles: any[];
+  otherSpecialists: any[];
   providerRole: string;
   currentUserId: string | null;
   sessionTags: Record<string, string>;
@@ -76,6 +77,7 @@ export const ScheduleGrid = memo(function ScheduleGrid({
   selectedSession,
   popupPosition,
   seaProfiles,
+  otherSpecialists,
   providerRole,
   currentUserId,
   sessionTags,
@@ -139,9 +141,9 @@ export const ScheduleGrid = memo(function ScheduleGrid({
   const getFilteredSessions = (allSessions: any[]) => {
     switch (sessionFilter) {
       case 'mine':
-        return allSessions.filter(s => s.delivered_by !== 'sea');
+        return allSessions.filter(s => s.delivered_by === 'provider');
       case 'sea':
-        return allSessions.filter(s => s.delivered_by === 'sea');
+        return allSessions.filter(s => s.delivered_by === 'sea' || s.delivered_by === 'specialist');
       default:
         return allSessions;
     }
@@ -370,7 +372,9 @@ export const ScheduleGrid = memo(function ScheduleGrid({
                           ? GRADE_COLOR_MAP[student.grade_level] || 'bg-gray-400'
                           : 'bg-gray-400';
 
-                      const seaAssignmentClass = session.delivered_by === 'sea' ? 'ring-2 ring-orange-400 ring-inset' : '';
+                      const assignmentClass = 
+                        session.delivered_by === 'sea' ? 'ring-2 ring-orange-400 ring-inset' : 
+                        session.delivered_by === 'specialist' ? 'ring-2 ring-purple-400 ring-inset' : '';
                       const columnIndex = sessionColumns.get(session.id) ?? 0;
                       const fixedWidth = 25;
                       const gap = 1;
@@ -384,7 +388,7 @@ export const ScheduleGrid = memo(function ScheduleGrid({
                           draggable
                           onDragStart={(e) => onDragStart(e, session)}
                           onDragEnd={onDragEnd}
-                          className={`absolute ${gradeColor} text-white rounded shadow-sm transition-all hover:shadow-md hover:z-10 group ${highlightClass} ${seaAssignmentClass} ${
+                          className={`absolute ${gradeColor} text-white rounded shadow-sm transition-all hover:shadow-md hover:z-10 group ${highlightClass} ${assignmentClass} ${
                             draggedSession?.id === session.id ? 'opacity-50 cursor-grabbing' : 'cursor-grab'
                           }`}
                           style={{
@@ -438,6 +442,7 @@ export const ScheduleGrid = memo(function ScheduleGrid({
           student={students.find((s: any) => s.id === selectedSession.student_id)}
           triggerRect={popupPosition}
           seaProfiles={seaProfiles}
+          otherSpecialists={otherSpecialists}
           sessionTags={sessionTags}
           setSessionTags={setSessionTags}
           onClose={onPopupClose}

--- a/app/(dashboard)/dashboard/schedule/hooks/use-schedule-state.tsx
+++ b/app/(dashboard)/dashboard/schedule/hooks/use-schedule-state.tsx
@@ -8,7 +8,7 @@ export interface ScheduleUIState {
   selectedTimeSlot: string | null;
   selectedDay: number | null;
   highlightedStudentId: string | null;
-  sessionFilter: 'all' | 'mine' | 'sea';
+  sessionFilter: 'all' | 'mine' | 'sea' | 'specialist';
   draggedSession: any | null;
   dragOffset: number;
   dragPosition: {
@@ -28,7 +28,7 @@ export function useScheduleState() {
   const [selectedTimeSlot, setSelectedTimeSlot] = useState<string | null>(null);
   const [selectedDay, setSelectedDay] = useState<number | null>(null);
   const [highlightedStudentId, setHighlightedStudentId] = useState<string | null>(null);
-  const [sessionFilter, setSessionFilter] = useState<'all' | 'mine' | 'sea'>('all');
+  const [sessionFilter, setSessionFilter] = useState<'all' | 'mine' | 'sea' | 'specialist'>('all');
 
   // Drag and drop states
   const [draggedSession, setDraggedSession] = useState<any | null>(null);

--- a/app/(dashboard)/dashboard/schedule/page.tsx
+++ b/app/(dashboard)/dashboard/schedule/page.tsx
@@ -215,6 +215,7 @@ export default function SchedulePage() {
     specialActivities,
     schoolHours,
     seaProfiles,
+    otherSpecialists,
     unscheduledCount,
     currentUserId,
     providerRole,
@@ -469,6 +470,7 @@ export default function SchedulePage() {
             selectedSession={selectedSession}
             popupPosition={popupPosition}
             seaProfiles={seaProfiles}
+            otherSpecialists={otherSpecialists}
             providerRole={providerRole}
             currentUserId={currentUserId}
             gridConfig={gridConfig}
@@ -490,6 +492,17 @@ export default function SchedulePage() {
           <div className="mt-4 flex justify-between items-center">
             <div className="text-sm text-gray-600">
               Total Sessions: {filteredSessionsCount}
+            </div>
+            {/* Legend for assignment indicators */}
+            <div className="flex items-center gap-4 text-xs">
+              <div className="flex items-center gap-1">
+                <div className="w-4 h-4 bg-gray-400 rounded ring-2 ring-orange-400 ring-inset"></div>
+                <span>SEA Assigned</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <div className="w-4 h-4 bg-gray-400 rounded ring-2 ring-purple-400 ring-inset"></div>
+                <span>Specialist Assigned</span>
+              </div>
             </div>
           </div>
         </div>

--- a/app/(dashboard)/dashboard/schedule/page.tsx
+++ b/app/(dashboard)/dashboard/schedule/page.tsx
@@ -415,11 +415,15 @@ export default function SchedulePage() {
   // Count filtered sessions
   const filteredSessionsCount = providerRole === 'sea' && currentUserId
     ? sessions.filter(s => s.assigned_to_sea_id === currentUserId).length
-    : sessionFilter === 'mine'
-      ? sessions.filter(s => s.delivered_by !== 'sea').length
-      : sessionFilter === 'sea'
-        ? sessions.filter(s => s.delivered_by === 'sea').length
-        : sessions.length;
+    : ['speech', 'ot', 'counseling', 'specialist'].includes(providerRole) && currentUserId
+      ? sessions.filter(s => s.assigned_to_specialist_id === currentUserId).length
+      : sessionFilter === 'mine'
+        ? sessions.filter(s => s.delivered_by === 'provider').length
+        : sessionFilter === 'sea'
+          ? sessions.filter(s => s.delivered_by === 'sea').length
+          : sessionFilter === 'specialist'
+            ? sessions.filter(s => s.delivered_by === 'specialist').length
+            : sessions.length;
 
   return (
     <ScheduleErrorBoundary>
@@ -447,6 +451,7 @@ export default function SchedulePage() {
             selectedDay={selectedDay}
             highlightedStudentId={highlightedStudentId}
             onSessionFilterChange={setSessionFilter}
+            showSpecialistFilter={providerRole === 'resource' && otherSpecialists.length > 0}
             onGradeToggle={toggleGrade}
             onTimeSlotClear={clearTimeSlot}
             onDayClear={clearDay}
@@ -496,11 +501,11 @@ export default function SchedulePage() {
             {/* Legend for assignment indicators */}
             <div className="flex items-center gap-4 text-xs">
               <div className="flex items-center gap-1">
-                <div className="w-4 h-4 bg-gray-400 rounded ring-2 ring-orange-400 ring-inset"></div>
+                <div className="w-4 h-4 bg-gray-400 rounded border-2 border-orange-400"></div>
                 <span>SEA Assigned</span>
               </div>
               <div className="flex items-center gap-1">
-                <div className="w-4 h-4 bg-gray-400 rounded ring-2 ring-purple-400 ring-inset"></div>
+                <div className="w-4 h-4 bg-gray-400 rounded border-2 border-purple-400"></div>
                 <span>Specialist Assigned</span>
               </div>
             </div>

--- a/app/(dashboard)/dashboard/schedule/session-assignment-popup.tsx
+++ b/app/(dashboard)/dashboard/schedule/session-assignment-popup.tsx
@@ -9,7 +9,7 @@ interface SessionAssignmentPopupProps {
   student: any;
   triggerRect: DOMRect;
   seaProfiles: Array<{ id: string; full_name: string; is_shared?: boolean }>;
-  otherSpecialists: Array<{ id: string; full_name: string; role: 'speech' | 'ot' | 'counseling' | 'specialist' }>;
+  otherSpecialists: Array<{ id: string; full_name: string; role: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' }>;
   sessionTags: Record<string, string>;
   setSessionTags: React.Dispatch<React.SetStateAction<Record<string, string>>>;
   onClose: () => void;

--- a/app/(dashboard)/dashboard/schedule/session-assignment-popup.tsx
+++ b/app/(dashboard)/dashboard/schedule/session-assignment-popup.tsx
@@ -9,6 +9,7 @@ interface SessionAssignmentPopupProps {
   student: any;
   triggerRect: DOMRect;
   seaProfiles: Array<{ id: string; full_name: string; is_shared?: boolean }>;
+  otherSpecialists: Array<{ id: string; full_name: string; role: string }>;
   sessionTags: Record<string, string>;
   setSessionTags: React.Dispatch<React.SetStateAction<Record<string, string>>>;
   onClose: () => void;
@@ -20,6 +21,7 @@ export function SessionAssignmentPopup({
   student,
   triggerRect,
   seaProfiles,
+  otherSpecialists,
   sessionTags,
   setSessionTags,
   onClose,
@@ -56,22 +58,41 @@ export function SessionAssignmentPopup({
   };
 
   // Auto-save when assignment changes
-  const handleAssignmentChange = async (newSeaId: string) => {
+  const handleAssignmentChange = async (value: string) => {
+    // Parse the value to determine assignment type
+    const isSeaAssignment = value.startsWith('sea:');
+    const isSpecialistAssignment = value.startsWith('specialist:');
+    const assignmentId = isSeaAssignment || isSpecialistAssignment ? value.split(':')[1] : '';
+
     // Skip if value hasn't changed
-    if (newSeaId === (session.assigned_to_sea_id || "")) {
+    const currentAssignment = session.assigned_to_sea_id 
+      ? `sea:${session.assigned_to_sea_id}`
+      : session.assigned_to_specialist_id 
+      ? `specialist:${session.assigned_to_specialist_id}`
+      : '';
+    
+    if (value === currentAssignment) {
       return;
     }
 
     try {
-      const updateData: any = {
-        delivered_by: newSeaId ? "sea" : "provider",
-      };
+      const updateData: any = {};
 
-      // Set or clear the assigned_to_sea_id
-      if (newSeaId) {
-        updateData.assigned_to_sea_id = newSeaId;
+      if (isSeaAssignment) {
+        // Assigning to SEA
+        updateData.delivered_by = 'sea';
+        updateData.assigned_to_sea_id = assignmentId;
+        updateData.assigned_to_specialist_id = null; // Clear specialist assignment
+      } else if (isSpecialistAssignment) {
+        // Assigning to another specialist
+        updateData.delivered_by = 'specialist';
+        updateData.assigned_to_specialist_id = assignmentId;
+        updateData.assigned_to_sea_id = null; // Clear SEA assignment
       } else {
+        // Assigning back to provider (self)
+        updateData.delivered_by = 'provider';
         updateData.assigned_to_sea_id = null;
+        updateData.assigned_to_specialist_id = null;
       }
 
       const { error } = await supabase
@@ -82,8 +103,9 @@ export function SessionAssignmentPopup({
       if (error) {
         // Check if it's a permission error
         if (error.message?.includes('can_assign_sea_to_session') || 
+            error.message?.includes('can_assign_specialist_to_session') ||
             error.message?.includes('policy')) {
-          throw new Error('You do not have permission to assign sessions to this SEA. They may need to be shared at your school first.');
+          throw new Error('You do not have permission to make this assignment. The person may need to be shared at your school first.');
         }
         throw error;
       }
@@ -139,16 +161,50 @@ export function SessionAssignmentPopup({
       <div className="mb-3">
         <p className="text-xs font-medium text-gray-500 mb-2">ASSIGN TO</p>
         <select
-          value={session.assigned_to_sea_id || ""}
+          value={
+            session.assigned_to_sea_id 
+              ? `sea:${session.assigned_to_sea_id}`
+              : session.assigned_to_specialist_id 
+              ? `specialist:${session.assigned_to_specialist_id}`
+              : ''
+          }
           onChange={(e) => handleAssignmentChange(e.target.value)}
           className="w-full p-2 border rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
           <option value="">Me (Resource Specialist)</option>
-          {seaProfiles.map((sea) => (
-            <option key={sea.id} value={sea.id}>
-              {sea.full_name} ({sea.is_shared ? 'Shared SEA' : 'My SEA'})
-            </option>
-          ))}
+          
+          {/* SEAs Group */}
+          {seaProfiles.length > 0 && (
+            <optgroup label="Special Education Assistants">
+              {seaProfiles.map((sea) => (
+                <option key={`sea:${sea.id}`} value={`sea:${sea.id}`}>
+                  {sea.full_name} ({sea.is_shared ? 'Shared SEA' : 'My SEA'})
+                </option>
+              ))}
+            </optgroup>
+          )}
+          
+          {/* Other Specialists Group */}
+          {otherSpecialists.length > 0 && (
+            <optgroup label="Other Specialists">
+              {otherSpecialists.map((specialist) => {
+                // Format role display
+                const roleDisplay = {
+                  'resource': 'Resource',
+                  'speech': 'Speech',
+                  'ot': 'OT',
+                  'counseling': 'Counseling',
+                  'specialist': 'Specialist'
+                }[specialist.role] || specialist.role;
+                
+                return (
+                  <option key={`specialist:${specialist.id}`} value={`specialist:${specialist.id}`}>
+                    {specialist.full_name} ({roleDisplay})
+                  </option>
+                );
+              })}
+            </optgroup>
+          )}
         </select>
       </div>
 

--- a/app/components/navigation/navbar.tsx
+++ b/app/components/navigation/navbar.tsx
@@ -28,14 +28,27 @@ export default function Navbar() {
 
       // Get user's role if logged in
       if (user) {
-        const { data: profile } = await supabase
+        console.log('[Navbar] Fetching role for user:', user.id);
+        const { data: profile, error } = await supabase
           .from('profiles')
           .select('role')
           .eq('id', user.id)
           .single();
 
+        if (error) {
+          console.error('[Navbar] Error fetching role:', {
+            error,
+            message: error.message,
+            code: error.code,
+            details: error.details,
+            hint: error.hint,
+            status: (error as any).status
+          });
+        }
+
         if (profile) {
           setUserRole(profile.role);
+          console.log('[Navbar] User role:', profile.role);
         }
       }
     };

--- a/app/components/providers/school-context.tsx
+++ b/app/components/providers/school-context.tsx
@@ -143,11 +143,23 @@ export function SchoolProvider({ children }: { children: ReactNode }) {
       console.log('[SchoolContext] User ID:', user.id);
 
       // Fetch profile with migration status
-      const { data: profile } = await supabase
+      console.log('[SchoolContext] Fetching profile for user:', user.id);
+      const { data: profile, error: profileError } = await supabase
         .from('profiles')
         .select('works_at_multiple_schools, school_site, school_district, school_id, district_id, state_id')
         .eq('id', user.id)
         .single();
+
+      if (profileError) {
+        console.error('[SchoolContext] Error fetching profile:', {
+          error: profileError,
+          message: profileError.message,
+          code: profileError.code,
+          details: profileError.details,
+          hint: profileError.hint,
+          status: (profileError as any).status
+        });
+      }
 
       if (!profile) {
         console.log('[SchoolContext] No profile found');

--- a/lib/scheduling/optimized-scheduler.ts
+++ b/lib/scheduling/optimized-scheduler.ts
@@ -569,8 +569,13 @@ export class OptimizedScheduler {
         end_time: slot.endTime,
         service_type: this.providerRole,
         assigned_to_sea_id: this.providerRole === "sea" ? this.providerId : null,
-        assigned_to_specialist_id: null,
-        delivered_by: this.providerRole === "sea" ? "sea" : "provider",
+        assigned_to_specialist_id: ['speech', 'ot', 'counseling', 'specialist'].includes(this.providerRole) 
+          ? this.providerId : null,
+        delivered_by: this.providerRole === "sea" 
+          ? "sea" 
+          : ['speech', 'ot', 'counseling', 'specialist'].includes(this.providerRole)
+            ? "specialist"
+            : "provider",
         completed_at: null,
         completed_by: null,
         session_notes: null,

--- a/lib/scheduling/optimized-scheduler.ts
+++ b/lib/scheduling/optimized-scheduler.ts
@@ -569,11 +569,13 @@ export class OptimizedScheduler {
         end_time: slot.endTime,
         service_type: this.providerRole,
         assigned_to_sea_id: this.providerRole === "sea" ? this.providerId : null,
+        assigned_to_specialist_id: null,
         delivered_by: this.providerRole === "sea" ? "sea" : "provider",
         completed_at: null,
         completed_by: null,
         session_notes: null,
-        session_date: null
+        session_date: null,
+        manually_placed: false
       });
     }
 
@@ -1039,11 +1041,13 @@ export class OptimizedScheduler {
         end_time: session.end_time,
         service_type: session.service_type,
         assigned_to_sea_id: session.assigned_to_sea_id,
+        assigned_to_specialist_id: session.assigned_to_specialist_id || null,
         delivered_by: session.delivered_by,
         completed_at: session.completed_at,
         completed_by: session.completed_by,
         session_notes: session.session_notes,
         session_date: session.session_date,
+        manually_placed: session.manually_placed || false,
         created_at: new Date().toISOString(),
       });
     }

--- a/lib/scheduling/scheduling-coordinator.ts
+++ b/lib/scheduling/scheduling-coordinator.ts
@@ -145,7 +145,14 @@ export class SchedulingCoordinator {
       provider_id: this.providerId,
       service_type: this.providerRole,
       assigned_to_sea_id: this.providerRole === 'sea' ? this.providerId : null,
-      delivered_by: this.providerRole === 'sea' ? 'sea' as const : 'provider' as const
+      assigned_to_specialist_id: ['speech', 'ot', 'counseling', 'specialist'].includes(this.providerRole)
+        ? this.providerId
+        : (session.assigned_to_specialist_id ?? null),
+      delivered_by: this.providerRole === 'sea'
+        ? 'sea' as const
+        : ['speech', 'ot', 'counseling', 'specialist'].includes(this.providerRole)
+          ? 'specialist' as const
+          : 'provider' as const
     }));
     
     // Update context if successful

--- a/lib/scheduling/scheduling-coordinator.ts
+++ b/lib/scheduling/scheduling-coordinator.ts
@@ -475,11 +475,13 @@ export class SchedulingCoordinator {
         end_time: session.end_time,
         service_type: session.service_type,
         assigned_to_sea_id: session.assigned_to_sea_id,
+        assigned_to_specialist_id: session.assigned_to_specialist_id || null,
         delivered_by: session.delivered_by,
         completed_at: session.completed_at,
         completed_by: session.completed_by,
         session_notes: session.session_notes,
         session_date: session.session_date,
+        manually_placed: session.manually_placed || false,
         created_at: new Date().toISOString()
       });
     }

--- a/lib/scheduling/scheduling-engine.ts
+++ b/lib/scheduling/scheduling-engine.ts
@@ -478,11 +478,13 @@ export class SchedulingEngine {
       end_time: slot.endTime,
       service_type: '', // Will be set by coordinator
       assigned_to_sea_id: null,
+      assigned_to_specialist_id: null,
       delivered_by: 'provider' as const,
       completed_at: null,
       completed_by: null,
       session_notes: null,
-      session_date: null
+      session_date: null,
+      manually_placed: false
     }));
   }
 

--- a/lib/supabase/hooks/use-schedule-data.ts
+++ b/lib/supabase/hooks/use-schedule-data.ts
@@ -157,6 +157,7 @@ export function useScheduleData() {
           // The new get_user_school_ids() function handles both single and multiple schools
           
           // Get ALL SEAs - RLS will filter to user's schools automatically
+          console.log('[useScheduleData] Fetching SEAs for user:', user.id);
           const { data: schoolSeas, error } = await supabase
             .from('profiles')
             .select('id, full_name, supervising_provider_id')
@@ -164,7 +165,15 @@ export function useScheduleData() {
             .order('full_name', { ascending: true });
 
           if (error) {
-            console.error('[useScheduleData] Error fetching SEA profiles:', error);
+            console.error('[useScheduleData] Error fetching SEA profiles:', {
+              error,
+              message: error.message,
+              code: error.code,
+              details: error.details,
+              hint: error.hint,
+              status: (error as any).status,
+              statusText: (error as any).statusText
+            });
           } else if (schoolSeas) {
             seaProfiles = schoolSeas.map(sea => ({
               id: sea.id,
@@ -176,6 +185,7 @@ export function useScheduleData() {
           }
 
           // Get other Resource Specialists - RLS will filter to user's schools automatically
+          console.log('[useScheduleData] Fetching other Resource Specialists for user:', user.id);
           const { data: specialists, error: specialistsError } = await supabase
             .from('profiles')
             .select('id, full_name, role')
@@ -184,7 +194,15 @@ export function useScheduleData() {
             .order('full_name', { ascending: true });
 
           if (specialistsError) {
-            console.error('[useScheduleData] Error fetching other Resource Specialists:', specialistsError);
+            console.error('[useScheduleData] Error fetching other Resource Specialists:', {
+              error: specialistsError,
+              message: specialistsError.message,
+              code: specialistsError.code,
+              details: specialistsError.details,
+              hint: specialistsError.hint,
+              status: (specialistsError as any).status,
+              statusText: (specialistsError as any).statusText
+            });
           } else if (specialists) {
             otherSpecialists = specialists.map(specialist => ({
               id: specialist.id,

--- a/lib/supabase/hooks/use-schedule-data.ts
+++ b/lib/supabase/hooks/use-schedule-data.ts
@@ -21,7 +21,7 @@ interface ScheduleData {
   specialActivities: SpecialActivity[];
   schoolHours: any[];
   seaProfiles: Array<{ id: string; full_name: string; is_shared?: boolean }>;
-  otherSpecialists: Array<{ id: string; full_name: string; role: 'speech' | 'ot' | 'counseling' | 'specialist' }>;
+  otherSpecialists: Array<{ id: string; full_name: string; role: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' }>;
   unscheduledCount: number;
   currentUserId: string | null;
   providerRole: string;
@@ -149,7 +149,7 @@ export function useScheduleData() {
 
       // Fetch SEA profiles if user is Resource Specialist
       let seaProfiles: Array<{ id: string; full_name: string; is_shared?: boolean }> = [];
-      let otherSpecialists: Array<{ id: string; full_name: string; role: 'speech' | 'ot' | 'counseling' | 'specialist' }> = [];
+      let otherSpecialists: Array<{ id: string; full_name: string; role: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' }> = [];
       
       if (profile.role === 'resource') {
         try {
@@ -173,12 +173,12 @@ export function useScheduleData() {
             console.log(`[useScheduleData] Successfully loaded ${seaProfiles.length} SEAs: ${seaProfiles.map(s => s.full_name).join(', ')}`);
           }
 
-          // Fetch other specialists at the same school (excluding resource role to avoid confusion)
+          // Fetch other specialists at the same school (including other resource specialists)
           const { data: specialists, error: specialistsError } = await supabase
             .from('profiles')
             .select('id, full_name, role')
             .eq('school_id', currentSchool.school_id)
-            .in('role', ['speech', 'ot', 'counseling', 'specialist'])
+            .in('role', ['resource', 'speech', 'ot', 'counseling', 'specialist'])
             .neq('id', user.id)
             .order('full_name', { ascending: true });
 

--- a/lib/supabase/hooks/use-schedule-data.ts
+++ b/lib/supabase/hooks/use-schedule-data.ts
@@ -205,28 +205,15 @@ export function useScheduleData() {
             console.log(`[useScheduleData] Successfully loaded ${seaProfiles.length} SEAs from current school (${currentSchool.school_id || currentSchool.school_site}): ${seaProfiles.map(s => s.full_name).join(', ')}`);
           }
 
-          // Get other Resource Specialists from the CURRENT school only
-          console.log('[useScheduleData] Fetching other Resource Specialists for current school:', currentSchool.school_id || currentSchool.school_site);
-          let specialistsQuery = supabase
-            .from('profiles')
-            .select('id, full_name, role')
-            .eq('role', 'resource')  // Only Resource Specialists
-            .neq('id', user.id);  // Exclude self
+          // Get other specialists (resource, speech, ot, counseling, specialist) via RPC
+          console.log('[useScheduleData] Fetching other specialists for current school:', currentSchool.school_id || currentSchool.school_site);
           
-          // Filter by current school
-          if (currentSchool.school_id) {
-            specialistsQuery = specialistsQuery.eq('school_id', currentSchool.school_id);
-          } else {
-            // Legacy schools without school_id
-            specialistsQuery = specialistsQuery
-              .eq('school_site', currentSchool.school_site)
-              .eq('school_district', currentSchool.school_district);
-          }
-          
-          const { data: specialists, error: specialistsError } = await specialistsQuery.order('full_name', { ascending: true });
+          // Try RPC function first (preferred - centralizes same-school logic and RLS)
+          const { data: specialists, error: specialistsError } = await supabase
+            .rpc('get_available_specialists', { current_user_id: user.id });
 
           if (specialistsError) {
-            console.error('[useScheduleData] Error fetching other Resource Specialists:', {
+            console.error('[useScheduleData] Error fetching other specialists via RPC:', {
               error: specialistsError,
               message: specialistsError.message,
               code: specialistsError.code,
@@ -235,14 +222,52 @@ export function useScheduleData() {
               status: (specialistsError as any).status,
               statusText: (specialistsError as any).statusText
             });
-          } else if (specialists) {
-            otherSpecialists = specialists.map(specialist => ({
-              id: specialist.id,
-              full_name: specialist.full_name,
-              role: specialist.role
-            }));
             
-            console.log(`[useScheduleData] Successfully loaded ${otherSpecialists.length} other specialists from current school (${currentSchool.school_id || currentSchool.school_site}): ${otherSpecialists.map(s => `${s.full_name} (${s.role})`).join(', ')}`);
+            // Fallback to direct query if RPC fails (e.g., function not deployed yet)
+            console.log('[useScheduleData] Falling back to direct query for specialists');
+            let specialistsQuery = supabase
+              .from('profiles')
+              .select('id, full_name, role')
+              .in('role', ['resource', 'speech', 'ot', 'counseling', 'specialist'])  // All specialist roles
+              .neq('id', user.id);  // Exclude self
+            
+            // Filter by current school
+            if (currentSchool.school_id) {
+              specialistsQuery = specialistsQuery.eq('school_id', currentSchool.school_id);
+            } else {
+              // Legacy schools without school_id
+              specialistsQuery = specialistsQuery
+                .eq('school_site', currentSchool.school_site)
+                .eq('school_district', currentSchool.school_district);
+            }
+            
+            const { data: fallbackSpecialists, error: fallbackError } = await specialistsQuery.order('full_name', { ascending: true });
+            
+            if (fallbackError) {
+              console.error('[useScheduleData] Fallback query also failed:', fallbackError);
+            } else if (fallbackSpecialists) {
+              // Type narrowing for role field
+              otherSpecialists = fallbackSpecialists
+                .filter(s => ['resource', 'speech', 'ot', 'counseling', 'specialist'].includes(s.role))
+                .map(specialist => ({
+                  id: specialist.id,
+                  full_name: specialist.full_name,
+                  role: specialist.role as 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist'
+                }));
+              
+              console.log(`[useScheduleData] Successfully loaded ${otherSpecialists.length} other specialists via fallback from current school: ${otherSpecialists.map(s => `${s.full_name} (${s.role})`).join(', ')}`);
+            }
+          } else if (specialists) {
+            // Type narrowing for RPC result
+            otherSpecialists = specialists
+              .filter(s => ['resource', 'speech', 'ot', 'counseling', 'specialist'].includes(s.role))
+              .map(specialist => ({
+                id: specialist.id,
+                full_name: specialist.full_name,
+                role: specialist.role as 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist'
+              }));
+            
+            console.log(`[useScheduleData] Successfully loaded ${otherSpecialists.length} other specialists via RPC from current school: ${otherSpecialists.map(s => `${s.full_name} (${s.role})`).join(', ')}`);
           }
         } catch (error) {
           console.error('[useScheduleData] Exception fetching SEA profiles or specialists:', error);
@@ -351,12 +376,29 @@ export function useScheduleData() {
       );
     }
     
+    // For SEA users, also subscribe to sessions assigned to them
+    if (data.providerRole === 'sea') {
+      channel.on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'schedule_sessions',
+          filter: `assigned_to_sea_id=eq.${data.currentUserId}`,
+        },
+        (payload) => {
+          console.log('[useScheduleData] Real-time update (SEA assignee):', payload);
+          fetchData();
+        }
+      );
+    }
+    
     channel.subscribe();
 
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [currentSchool, data.currentUserId, fetchData, supabase]);
+  }, [currentSchool, data.currentUserId, data.providerRole, fetchData, supabase]);
 
   // Optimistic update function
   const optimisticUpdateSession = useCallback((sessionId: string, updates: Partial<ScheduleSession>) => {

--- a/lib/supabase/hooks/use-schedule-data.ts
+++ b/lib/supabase/hooks/use-schedule-data.ts
@@ -21,7 +21,7 @@ interface ScheduleData {
   specialActivities: SpecialActivity[];
   schoolHours: any[];
   seaProfiles: Array<{ id: string; full_name: string; is_shared?: boolean }>;
-  otherSpecialists: Array<{ id: string; full_name: string; role: string }>;
+  otherSpecialists: Array<{ id: string; full_name: string; role: 'speech' | 'ot' | 'counseling' | 'specialist' }>;
   unscheduledCount: number;
   currentUserId: string | null;
   providerRole: string;
@@ -149,7 +149,7 @@ export function useScheduleData() {
 
       // Fetch SEA profiles if user is Resource Specialist
       let seaProfiles: Array<{ id: string; full_name: string; is_shared?: boolean }> = [];
-      let otherSpecialists: Array<{ id: string; full_name: string; role: string }> = [];
+      let otherSpecialists: Array<{ id: string; full_name: string; role: 'speech' | 'ot' | 'counseling' | 'specialist' }> = [];
       
       if (profile.role === 'resource') {
         try {
@@ -173,12 +173,12 @@ export function useScheduleData() {
             console.log(`[useScheduleData] Successfully loaded ${seaProfiles.length} SEAs: ${seaProfiles.map(s => s.full_name).join(', ')}`);
           }
 
-          // Fetch other specialists at the same school
+          // Fetch other specialists at the same school (excluding resource role to avoid confusion)
           const { data: specialists, error: specialistsError } = await supabase
             .from('profiles')
             .select('id, full_name, role')
             .eq('school_id', currentSchool.school_id)
-            .in('role', ['resource', 'speech', 'ot', 'counseling', 'specialist'])
+            .in('role', ['speech', 'ot', 'counseling', 'specialist'])
             .neq('id', user.id)
             .order('full_name', { ascending: true });
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -521,12 +521,14 @@ export interface Database {
           end_time: string
           service_type: string
           assigned_to_sea_id: string | null
-          delivered_by: 'provider' | 'sea'
+          assigned_to_specialist_id: string | null
+          delivered_by: 'provider' | 'sea' | 'specialist'
           created_at: string
           completed_at: string | null
           completed_by: string | null
           session_date: string | null
           session_notes: string | null
+          manually_placed: boolean
         }
         Insert: {
           id?: string
@@ -537,12 +539,14 @@ export interface Database {
           end_time: string
           service_type: string
           assigned_to_sea_id?: string | null
-          delivered_by?: 'provider' | 'sea'
+          assigned_to_specialist_id?: string | null
+          delivered_by?: 'provider' | 'sea' | 'specialist'
           created_at?: string
           completed_at?: string | null
           completed_by?: string | null
           session_date?: string | null
           session_notes?: string | null
+          manually_placed?: boolean
         }
         Update: {
           id?: string
@@ -553,12 +557,14 @@ export interface Database {
           end_time?: string
           service_type?: string
           assigned_to_sea_id?: string | null
-          delivered_by?: 'provider' | 'sea'
+          assigned_to_specialist_id?: string | null
+          delivered_by?: 'provider' | 'sea' | 'specialist'
           created_at?: string
           completed_at?: string | null
           completed_by?: string | null
           session_date?: string | null
           session_notes?: string | null
+          manually_placed?: boolean
         }
       },
       lessons: {

--- a/supabase/migrations/20250823_add_specialist_assignment.sql
+++ b/supabase/migrations/20250823_add_specialist_assignment.sql
@@ -14,19 +14,33 @@ COMMENT ON COLUMN schedule_sessions.manually_placed IS 'Whether this session was
 CREATE INDEX IF NOT EXISTS idx_schedule_sessions_assigned_specialist 
 ON schedule_sessions(assigned_to_specialist_id);
 
--- Update delivered_by column to include 'specialist' option
--- First, check if we need to modify the constraint
-DO $$ 
-BEGIN
-  -- Drop the old check constraint if it exists
-  ALTER TABLE schedule_sessions 
-  DROP CONSTRAINT IF EXISTS schedule_sessions_delivered_by_check;
-  
-  -- Add the new check constraint with 'specialist' option
-  ALTER TABLE schedule_sessions 
-  ADD CONSTRAINT schedule_sessions_delivered_by_check 
-  CHECK (delivered_by IN ('provider', 'sea', 'specialist'));
-END $$;
+-- Step 1: Clean up any existing inconsistent data
+-- Convert any rows with delivered_by='specialist' but NULL assigned_to_specialist_id back to 'provider'
+UPDATE schedule_sessions 
+SET delivered_by = 'provider' 
+WHERE delivered_by = 'specialist' AND assigned_to_specialist_id IS NULL;
+
+-- Also ensure SEA assignments are consistent
+UPDATE schedule_sessions 
+SET delivered_by = 'provider' 
+WHERE delivered_by = 'sea' AND assigned_to_sea_id IS NULL;
+
+-- Step 2: Drop the old constraint if it exists
+ALTER TABLE schedule_sessions 
+DROP CONSTRAINT IF EXISTS schedule_sessions_delivered_by_check;
+
+-- Step 3: Add enhanced check constraint that enforces assignment consistency
+-- This ensures:
+-- 1. delivered_by can only be 'provider', 'sea', or 'specialist'
+-- 2. If delivered_by='specialist', then assigned_to_specialist_id must NOT be NULL
+-- 3. If delivered_by='sea', then assigned_to_sea_id must NOT be NULL
+ALTER TABLE schedule_sessions 
+ADD CONSTRAINT schedule_sessions_delivered_by_check 
+CHECK (
+  delivered_by IN ('provider', 'sea', 'specialist') 
+  AND (delivered_by != 'specialist' OR assigned_to_specialist_id IS NOT NULL)
+  AND (delivered_by != 'sea' OR assigned_to_sea_id IS NOT NULL)
+);
 
 -- Create function to check if a specialist can be assigned to a session
 CREATE OR REPLACE FUNCTION can_assign_specialist_to_session(

--- a/supabase/migrations/20250823_add_specialist_assignment.sql
+++ b/supabase/migrations/20250823_add_specialist_assignment.sql
@@ -1,0 +1,105 @@
+-- Add specialist assignment fields to schedule_sessions table
+ALTER TABLE schedule_sessions 
+ADD COLUMN IF NOT EXISTS assigned_to_specialist_id UUID REFERENCES profiles(id);
+
+-- Add comment for documentation
+COMMENT ON COLUMN schedule_sessions.assigned_to_specialist_id IS 'ID of the specialist (resource, speech, OT, counseling) assigned to deliver this session';
+
+-- Create index for performance
+CREATE INDEX IF NOT EXISTS idx_schedule_sessions_assigned_specialist 
+ON schedule_sessions(assigned_to_specialist_id);
+
+-- Update delivered_by column to include 'specialist' option
+-- First, check if we need to modify the constraint
+DO $$ 
+BEGIN
+  -- Drop the old check constraint if it exists
+  ALTER TABLE schedule_sessions 
+  DROP CONSTRAINT IF EXISTS schedule_sessions_delivered_by_check;
+  
+  -- Add the new check constraint with 'specialist' option
+  ALTER TABLE schedule_sessions 
+  ADD CONSTRAINT schedule_sessions_delivered_by_check 
+  CHECK (delivered_by IN ('provider', 'sea', 'specialist'));
+END $$;
+
+-- Create function to check if a specialist can be assigned to a session
+CREATE OR REPLACE FUNCTION can_assign_specialist_to_session(
+  provider_id UUID,
+  specialist_id UUID
+) RETURNS BOOLEAN AS $$
+DECLARE
+  provider_record RECORD;
+  specialist_record RECORD;
+BEGIN
+  -- Get provider details
+  SELECT school_id, role
+  INTO provider_record
+  FROM profiles
+  WHERE id = provider_id;
+  
+  -- Only Resource Specialists can assign to other specialists
+  IF provider_record.role != 'resource' THEN
+    RETURN FALSE;
+  END IF;
+  
+  -- Get target specialist details  
+  SELECT school_id, role
+  INTO specialist_record
+  FROM profiles
+  WHERE id = specialist_id;
+  
+  -- Target must be a specialist role (not SEA or admin)
+  IF specialist_record.role NOT IN ('resource', 'speech', 'ot', 'counseling', 'specialist') THEN
+    RETURN FALSE;
+  END IF;
+  
+  -- Must be at the same school
+  IF specialist_record.school_id = provider_record.school_id THEN
+    RETURN TRUE;
+  END IF;
+  
+  RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Add RLS policy for specialist assignment
+CREATE POLICY "Resource Specialists can assign sessions to same-school specialists"
+  ON schedule_sessions
+  FOR UPDATE
+  USING (provider_id = auth.uid())
+  WITH CHECK (
+    CASE 
+      WHEN assigned_to_specialist_id IS NULL THEN TRUE
+      ELSE can_assign_specialist_to_session(auth.uid(), assigned_to_specialist_id)
+    END
+  );
+
+-- Add function to get available specialists at the same school
+CREATE OR REPLACE FUNCTION get_available_specialists(current_user_id UUID)
+RETURNS TABLE (
+  id UUID,
+  full_name TEXT,
+  role TEXT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    p.id,
+    p.full_name,
+    p.role::TEXT
+  FROM profiles p
+  WHERE p.school_id = (
+    SELECT school_id 
+    FROM profiles 
+    WHERE id = current_user_id
+  )
+  AND p.role IN ('resource', 'speech', 'ot', 'counseling', 'specialist')
+  AND p.id != current_user_id
+  ORDER BY p.full_name;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Grant execute permission on the new functions
+GRANT EXECUTE ON FUNCTION can_assign_specialist_to_session TO authenticated;
+GRANT EXECUTE ON FUNCTION get_available_specialists TO authenticated;

--- a/supabase/migrations/20250823_add_specialist_assignment.sql
+++ b/supabase/migrations/20250823_add_specialist_assignment.sql
@@ -68,8 +68,8 @@ BEGIN
   FROM profiles
   WHERE id = specialist_id;
   
-  -- Target must be a specialist role (not SEA, admin, or resource to avoid confusion)
-  IF specialist_record.role NOT IN ('speech', 'ot', 'counseling', 'specialist') THEN
+  -- Target must be a specialist role (not SEA or admin)
+  IF specialist_record.role NOT IN ('resource', 'speech', 'ot', 'counseling', 'specialist') THEN
     RETURN FALSE;
   END IF;
   
@@ -118,7 +118,7 @@ BEGIN
     FROM profiles 
     WHERE id = current_user_id
   )
-  AND p.role IN ('speech', 'ot', 'counseling', 'specialist')
+  AND p.role IN ('resource', 'speech', 'ot', 'counseling', 'specialist')
   AND p.id != current_user_id
   ORDER BY p.full_name;
 END;

--- a/supabase/migrations/20250823_add_specialist_assignment.sql
+++ b/supabase/migrations/20250823_add_specialist_assignment.sql
@@ -125,5 +125,5 @@ END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
 -- Grant execute permission on the new functions
-GRANT EXECUTE ON FUNCTION can_assign_specialist_to_session TO authenticated;
-GRANT EXECUTE ON FUNCTION get_available_specialists TO authenticated;
+GRANT EXECUTE ON FUNCTION can_assign_specialist_to_session(uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_available_specialists(uuid) TO authenticated;

--- a/supabase/migrations/20250824_allow_resource_to_resource_assignments.sql
+++ b/supabase/migrations/20250824_allow_resource_to_resource_assignments.sql
@@ -1,0 +1,74 @@
+-- Update functions to allow resource-to-resource assignments (but still prevent self-assignment)
+
+-- Update the can_assign_specialist_to_session function
+CREATE OR REPLACE FUNCTION can_assign_specialist_to_session(
+  provider_id UUID,
+  specialist_id UUID
+) RETURNS BOOLEAN AS $$
+DECLARE
+  provider_record RECORD;
+  specialist_record RECORD;
+BEGIN
+  -- Get provider details
+  SELECT school_id, role
+  INTO provider_record
+  FROM profiles
+  WHERE id = provider_id;
+  
+  -- Only Resource Specialists can assign to other specialists
+  IF provider_record.role != 'resource' THEN
+    RETURN FALSE;
+  END IF;
+  
+  -- Get target specialist details  
+  SELECT school_id, role
+  INTO specialist_record
+  FROM profiles
+  WHERE id = specialist_id;
+  
+  -- Target must be a specialist role (including resource, but not SEA or admin)
+  IF specialist_record.role NOT IN ('resource', 'speech', 'ot', 'counseling', 'specialist') THEN
+    RETURN FALSE;
+  END IF;
+  
+  -- Prevent self-assignment
+  IF provider_id = specialist_id THEN
+    RETURN FALSE;
+  END IF;
+  
+  -- Must be at the same school
+  IF specialist_record.school_id = provider_record.school_id THEN
+    RETURN TRUE;
+  END IF;
+  
+  RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Update the get_available_specialists function
+CREATE OR REPLACE FUNCTION get_available_specialists(current_user_id UUID)
+RETURNS TABLE (
+  id UUID,
+  full_name TEXT,
+  role TEXT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    p.id,
+    p.full_name,
+    p.role::TEXT
+  FROM profiles p
+  WHERE p.school_id = (
+    SELECT school_id 
+    FROM profiles 
+    WHERE id = current_user_id
+  )
+  AND p.role IN ('resource', 'speech', 'ot', 'counseling', 'specialist')
+  AND p.id != current_user_id
+  ORDER BY p.full_name;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Update comment to reflect that resource specialists can be assigned
+COMMENT ON COLUMN schedule_sessions.assigned_to_specialist_id IS 'ID of the specialist (resource, speech, OT, counseling) assigned to deliver this session';

--- a/supabase/migrations/20250824_allow_resource_to_resource_assignments.sql
+++ b/supabase/migrations/20250824_allow_resource_to_resource_assignments.sql
@@ -15,6 +15,10 @@ BEGIN
   FROM profiles
   WHERE id = provider_id;
   
+  IF NOT FOUND THEN
+    RETURN FALSE;
+  END IF;
+  
   -- Only Resource Specialists can assign to other specialists
   IF provider_record.role != 'resource' THEN
     RETURN FALSE;
@@ -25,6 +29,10 @@ BEGIN
   INTO specialist_record
   FROM profiles
   WHERE id = specialist_id;
+  
+  IF NOT FOUND THEN
+    RETURN FALSE;
+  END IF;
   
   -- Target must be a specialist role (including resource, but not SEA or admin)
   IF specialist_record.role NOT IN ('resource', 'speech', 'ot', 'counseling', 'specialist') THEN
@@ -43,7 +51,7 @@ BEGIN
   
   RETURN FALSE;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 
 -- Update the get_available_specialists function
 CREATE OR REPLACE FUNCTION get_available_specialists(current_user_id UUID)
@@ -68,7 +76,7 @@ BEGIN
   AND p.id != current_user_id
   ORDER BY p.full_name;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 
 -- Update comment to reflect that resource specialists can be assigned
 COMMENT ON COLUMN schedule_sessions.assigned_to_specialist_id IS 'ID of the specialist (resource, speech, OT, counseling) assigned to deliver this session';

--- a/supabase/migrations/20250824_fix_specialist_assignment_constraints.sql
+++ b/supabase/migrations/20250824_fix_specialist_assignment_constraints.sql
@@ -1,30 +1,96 @@
 -- Fix data consistency for specialist assignments
 -- This migration cleans up any inconsistent data and adds enhanced constraints
 
--- Step 1: Clean up any existing inconsistent data
--- Convert any rows with delivered_by='specialist' but NULL assigned_to_specialist_id back to 'provider'
+BEGIN; -- Wrap in transaction for atomic application
+
+-- Step 1: Comprehensive data cleanup
+-- Handle all inconsistent states before adding constraints
+
+-- Fix specialist assignments with missing assignee
 UPDATE schedule_sessions 
-SET delivered_by = 'provider' 
+SET delivered_by = 'provider', 
+    assigned_to_specialist_id = NULL
 WHERE delivered_by = 'specialist' AND assigned_to_specialist_id IS NULL;
 
--- Also ensure SEA assignments are consistent
+-- Fix SEA assignments with missing assignee
 UPDATE schedule_sessions 
-SET delivered_by = 'provider' 
+SET delivered_by = 'provider',
+    assigned_to_sea_id = NULL
 WHERE delivered_by = 'sea' AND assigned_to_sea_id IS NULL;
 
--- Step 2: Drop the old constraint if it exists
+-- Normalize based on non-null assignee IDs when delivered_by is inconsistent
+UPDATE schedule_sessions
+SET delivered_by = 'specialist'
+WHERE assigned_to_specialist_id IS NOT NULL AND delivered_by != 'specialist';
+
+UPDATE schedule_sessions
+SET delivered_by = 'sea'
+WHERE assigned_to_sea_id IS NOT NULL AND delivered_by != 'sea';
+
+-- Clear stale assignee IDs when delivered_by='provider'
+UPDATE schedule_sessions
+SET assigned_to_sea_id = NULL,
+    assigned_to_specialist_id = NULL
+WHERE delivered_by = 'provider' AND (assigned_to_sea_id IS NOT NULL OR assigned_to_specialist_id IS NOT NULL);
+
+-- Handle edge case: both assignees set (should never happen, but clean it up)
+-- Prefer specialist over SEA if both are set
+UPDATE schedule_sessions
+SET assigned_to_sea_id = NULL,
+    delivered_by = 'specialist'
+WHERE assigned_to_specialist_id IS NOT NULL AND assigned_to_sea_id IS NOT NULL;
+
+-- Step 2: Drop existing constraints
 ALTER TABLE schedule_sessions 
 DROP CONSTRAINT IF EXISTS schedule_sessions_delivered_by_check;
 
--- Step 3: Add enhanced check constraint that enforces assignment consistency
--- This ensures:
--- 1. delivered_by can only be 'provider', 'sea', or 'specialist'
--- 2. If delivered_by='specialist', then assigned_to_specialist_id must NOT be NULL
--- 3. If delivered_by='sea', then assigned_to_sea_id must NOT be NULL
 ALTER TABLE schedule_sessions 
-ADD CONSTRAINT schedule_sessions_delivered_by_check 
-CHECK (
-  delivered_by IN ('provider', 'sea', 'specialist') 
-  AND (delivered_by != 'specialist' OR assigned_to_specialist_id IS NOT NULL)
-  AND (delivered_by != 'sea' OR assigned_to_sea_id IS NOT NULL)
-);
+DROP CONSTRAINT IF EXISTS schedule_sessions_assignment_exclusivity;
+
+ALTER TABLE schedule_sessions 
+DROP CONSTRAINT IF EXISTS schedule_sessions_provider_no_assignees;
+
+-- Step 3: Add comprehensive check constraints with clear names
+-- These enforce strict invariants between delivered_by and assignee columns
+
+-- Constraint 1: Ensure delivered_by values are valid
+ALTER TABLE schedule_sessions 
+ADD CONSTRAINT schedule_sessions_delivered_by_valid
+CHECK (delivered_by IN ('provider', 'sea', 'specialist'));
+
+-- Constraint 2: If specialist delivery, must have specialist assignee
+ALTER TABLE schedule_sessions 
+ADD CONSTRAINT schedule_sessions_specialist_requires_assignee
+CHECK (delivered_by != 'specialist' OR assigned_to_specialist_id IS NOT NULL);
+
+-- Constraint 3: If SEA delivery, must have SEA assignee
+ALTER TABLE schedule_sessions 
+ADD CONSTRAINT schedule_sessions_sea_requires_assignee
+CHECK (delivered_by != 'sea' OR assigned_to_sea_id IS NOT NULL);
+
+-- Constraint 4: Provider delivery means no assignees
+ALTER TABLE schedule_sessions 
+ADD CONSTRAINT schedule_sessions_provider_no_assignees
+CHECK (delivered_by != 'provider' OR (assigned_to_sea_id IS NULL AND assigned_to_specialist_id IS NULL));
+
+-- Constraint 5: At most one assignee (exclusivity)
+ALTER TABLE schedule_sessions 
+ADD CONSTRAINT schedule_sessions_assignment_exclusivity
+CHECK (NOT (assigned_to_sea_id IS NOT NULL AND assigned_to_specialist_id IS NOT NULL));
+
+-- Add foreign key constraints if they don't exist
+ALTER TABLE schedule_sessions
+DROP CONSTRAINT IF EXISTS schedule_sessions_assigned_to_specialist_id_fkey;
+
+ALTER TABLE schedule_sessions
+ADD CONSTRAINT schedule_sessions_assigned_to_specialist_id_fkey
+FOREIGN KEY (assigned_to_specialist_id) 
+REFERENCES profiles(id) 
+ON DELETE SET NULL;
+
+-- Add index for performance on specialist lookups
+CREATE INDEX IF NOT EXISTS idx_schedule_sessions_specialist_assignment 
+ON schedule_sessions(assigned_to_specialist_id) 
+WHERE assigned_to_specialist_id IS NOT NULL;
+
+COMMIT;

--- a/supabase/migrations/20250824_fix_specialist_assignment_constraints.sql
+++ b/supabase/migrations/20250824_fix_specialist_assignment_constraints.sql
@@ -1,0 +1,30 @@
+-- Fix data consistency for specialist assignments
+-- This migration cleans up any inconsistent data and adds enhanced constraints
+
+-- Step 1: Clean up any existing inconsistent data
+-- Convert any rows with delivered_by='specialist' but NULL assigned_to_specialist_id back to 'provider'
+UPDATE schedule_sessions 
+SET delivered_by = 'provider' 
+WHERE delivered_by = 'specialist' AND assigned_to_specialist_id IS NULL;
+
+-- Also ensure SEA assignments are consistent
+UPDATE schedule_sessions 
+SET delivered_by = 'provider' 
+WHERE delivered_by = 'sea' AND assigned_to_sea_id IS NULL;
+
+-- Step 2: Drop the old constraint if it exists
+ALTER TABLE schedule_sessions 
+DROP CONSTRAINT IF EXISTS schedule_sessions_delivered_by_check;
+
+-- Step 3: Add enhanced check constraint that enforces assignment consistency
+-- This ensures:
+-- 1. delivered_by can only be 'provider', 'sea', or 'specialist'
+-- 2. If delivered_by='specialist', then assigned_to_specialist_id must NOT be NULL
+-- 3. If delivered_by='sea', then assigned_to_sea_id must NOT be NULL
+ALTER TABLE schedule_sessions 
+ADD CONSTRAINT schedule_sessions_delivered_by_check 
+CHECK (
+  delivered_by IN ('provider', 'sea', 'specialist') 
+  AND (delivered_by != 'specialist' OR assigned_to_specialist_id IS NOT NULL)
+  AND (delivered_by != 'sea' OR assigned_to_sea_id IS NOT NULL)
+);

--- a/supabase/migrations/20250826_fix_profiles_rls_recursion.sql
+++ b/supabase/migrations/20250826_fix_profiles_rls_recursion.sql
@@ -7,14 +7,14 @@ DROP POLICY IF EXISTS "Users can view team members in same school" ON profiles;
 -- Create a security definer function to get the current user's school_id
 -- This avoids recursion by executing with elevated privileges
 CREATE OR REPLACE FUNCTION public.get_user_school_id()
-RETURNS varchar
+RETURNS uuid
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = public
 STABLE
 AS $$
 DECLARE
-    user_school_id varchar;
+    user_school_id uuid;
 BEGIN
     SELECT school_id INTO user_school_id
     FROM profiles
@@ -26,6 +26,7 @@ END;
 $$;
 
 -- Grant execute permission to authenticated users
+REVOKE ALL ON FUNCTION public.get_user_school_id() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.get_user_school_id() TO authenticated;
 
 -- Create a non-recursive policy using the security definer function

--- a/supabase/migrations/20250826_fix_profiles_rls_recursion.sql
+++ b/supabase/migrations/20250826_fix_profiles_rls_recursion.sql
@@ -7,14 +7,14 @@ DROP POLICY IF EXISTS "Users can view team members in same school" ON profiles;
 -- Create a security definer function to get the current user's school_id
 -- This avoids recursion by executing with elevated privileges
 CREATE OR REPLACE FUNCTION public.get_user_school_id()
-RETURNS uuid
+RETURNS varchar
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = public
 STABLE
 AS $$
 DECLARE
-    user_school_id uuid;
+    user_school_id varchar;
 BEGIN
     SELECT school_id INTO user_school_id
     FROM profiles

--- a/supabase/migrations/20250826_fix_profiles_rls_recursion.sql
+++ b/supabase/migrations/20250826_fix_profiles_rls_recursion.sql
@@ -1,0 +1,44 @@
+-- Fix the recursive RLS policy issue on profiles table that's causing 500 errors
+-- The current policy causes infinite recursion by referencing profiles table within itself
+
+-- First, drop the problematic policy
+DROP POLICY IF EXISTS "Users can view team members in same school" ON profiles;
+
+-- Create a security definer function to get the current user's school_id
+-- This avoids recursion by executing with elevated privileges
+CREATE OR REPLACE FUNCTION public.get_user_school_id()
+RETURNS varchar
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+STABLE
+AS $$
+DECLARE
+    user_school_id varchar;
+BEGIN
+    SELECT school_id INTO user_school_id
+    FROM profiles
+    WHERE id = auth.uid()
+    LIMIT 1;
+    
+    RETURN user_school_id;
+END;
+$$;
+
+-- Grant execute permission to authenticated users
+GRANT EXECUTE ON FUNCTION public.get_user_school_id() TO authenticated;
+
+-- Create a non-recursive policy using the security definer function
+CREATE POLICY "Users can view team members in same school" 
+ON profiles
+FOR SELECT 
+USING (
+    -- Allow users to view their own profile
+    auth.uid() = id
+    OR
+    -- Allow viewing profiles in the same school using the security definer function
+    (school_id IS NOT NULL AND school_id = public.get_user_school_id())
+);
+
+COMMENT ON POLICY "Users can view team members in same school" ON profiles IS 
+'Non-recursive policy that uses a security definer function to avoid infinite recursion when checking school membership.';

--- a/supabase/migrations/20250826_fix_specialist_filtering_by_school.sql
+++ b/supabase/migrations/20250826_fix_specialist_filtering_by_school.sql
@@ -1,0 +1,117 @@
+-- Fix the get_available_specialists function to properly filter by the currently selected school
+-- The previous version was getting specialists from all schools the user has access to,
+-- not just the currently selected school in the UI
+
+-- Drop the old function
+DROP FUNCTION IF EXISTS get_available_specialists(UUID);
+
+-- Create updated function that accepts school_id parameter
+CREATE OR REPLACE FUNCTION get_available_specialists(
+  current_user_id UUID,
+  current_school_id UUID
+)
+RETURNS TABLE (
+  id UUID,
+  full_name TEXT,
+  role TEXT
+) AS $$
+BEGIN
+  -- Validate that the current user has access to the specified school
+  IF NOT EXISTS (
+    SELECT 1 FROM profiles 
+    WHERE id = current_user_id 
+    AND school_id = current_school_id
+  ) THEN
+    -- For users with access to multiple schools, check if they have access to this school
+    IF NOT EXISTS (
+      SELECT 1 FROM profiles 
+      WHERE id = current_user_id
+    ) THEN
+      RAISE EXCEPTION 'User not found';
+    END IF;
+    -- User exists but doesn't have direct access to this school
+    -- They might have access through school_site/school_district (legacy) or multiple schools
+    -- For now, we'll proceed with the query and let RLS handle the filtering
+  END IF;
+
+  RETURN QUERY
+  SELECT 
+    p.id,
+    p.full_name,
+    p.role::TEXT
+  FROM profiles p
+  WHERE p.school_id = current_school_id
+  AND p.role IN ('resource', 'speech', 'ot', 'counseling', 'specialist')
+  AND p.id != current_user_id
+  ORDER BY p.full_name;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- Add a comment explaining the function
+COMMENT ON FUNCTION get_available_specialists(UUID, UUID) IS 
+'Returns specialists available for assignment at the specified school. Used by Resource Specialists to assign sessions to other specialists at the same school.';
+
+-- Also update the can_assign_specialist_to_session function to work with the current school context
+CREATE OR REPLACE FUNCTION can_assign_specialist_to_session(
+  provider_id UUID,
+  specialist_id UUID,
+  current_school_id UUID DEFAULT NULL
+) RETURNS BOOLEAN AS $$
+DECLARE
+  provider_record RECORD;
+  specialist_record RECORD;
+BEGIN
+  -- Get provider details
+  SELECT school_id, role
+  INTO provider_record
+  FROM profiles
+  WHERE id = provider_id;
+  
+  IF NOT FOUND THEN
+    RETURN FALSE;
+  END IF;
+  
+  -- Only Resource Specialists can assign to other specialists
+  IF provider_record.role != 'resource' THEN
+    RETURN FALSE;
+  END IF;
+  
+  -- Get target specialist details  
+  SELECT school_id, role
+  INTO specialist_record
+  FROM profiles
+  WHERE id = specialist_id;
+  
+  IF NOT FOUND THEN
+    RETURN FALSE;
+  END IF;
+  
+  -- Target must be a specialist role (including resource, but not SEA or admin)
+  IF specialist_record.role NOT IN ('resource', 'speech', 'ot', 'counseling', 'specialist') THEN
+    RETURN FALSE;
+  END IF;
+  
+  -- Prevent self-assignment
+  IF provider_id = specialist_id THEN
+    RETURN FALSE;
+  END IF;
+  
+  -- If current_school_id is provided, both must be at that school
+  IF current_school_id IS NOT NULL THEN
+    IF specialist_record.school_id != current_school_id OR provider_record.school_id != current_school_id THEN
+      RETURN FALSE;
+    END IF;
+  ELSE
+    -- Legacy check: must be at the same school
+    IF specialist_record.school_id != provider_record.school_id THEN
+      RETURN FALSE;
+    END IF;
+  END IF;
+  
+  RETURN TRUE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- Add comment
+COMMENT ON FUNCTION can_assign_specialist_to_session(UUID, UUID, UUID) IS 
+'Checks if a provider can assign a specialist to a session. The optional current_school_id parameter ensures both users are at the specified school.';

--- a/supabase/migrations/20250827_emergency_fix_profiles_recursion.sql
+++ b/supabase/migrations/20250827_emergency_fix_profiles_recursion.sql
@@ -1,0 +1,90 @@
+-- EMERGENCY FIX: Resolve infinite recursion in profiles table RLS policy
+-- This is causing 500 errors throughout the application
+
+-- First, drop ALL existing policies on profiles to stop the recursion
+DROP POLICY IF EXISTS "Users can view team members in same school" ON profiles;
+DROP POLICY IF EXISTS "Users can view team members in their schools" ON profiles;
+DROP POLICY IF EXISTS "Users can view own profile" ON profiles;
+DROP POLICY IF EXISTS "Users can update own profile" ON profiles;
+DROP POLICY IF EXISTS "Users can view profiles in their schools" ON profiles;
+
+-- Drop any existing functions that might be causing issues
+DROP FUNCTION IF EXISTS public.get_user_school_id() CASCADE;
+DROP FUNCTION IF EXISTS public.get_user_school_ids() CASCADE;
+
+-- Create a SIMPLE, NON-RECURSIVE security definer function
+-- This function runs with elevated privileges to avoid recursion
+CREATE OR REPLACE FUNCTION public.auth_user_school_ids()
+RETURNS TABLE(school_id varchar)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+AS $$
+    -- Direct query without recursion - uses auth.uid() directly
+    SELECT DISTINCT school_id::varchar
+    FROM (
+        -- Get primary school from profiles
+        SELECT p.school_id
+        FROM public.profiles p
+        WHERE p.id = auth.uid() 
+        AND p.school_id IS NOT NULL
+        
+        UNION
+        
+        -- Get additional schools from provider_schools
+        SELECT ps.school_id
+        FROM public.provider_schools ps
+        WHERE ps.provider_id = auth.uid() 
+        AND ps.school_id IS NOT NULL
+    ) schools
+    WHERE school_id IS NOT NULL;
+$$;
+
+-- Grant execute permission
+GRANT EXECUTE ON FUNCTION public.auth_user_school_ids() TO authenticated;
+
+-- Create SIMPLE, NON-RECURSIVE policies
+
+-- Policy 1: Users can view their own profile (no recursion possible)
+CREATE POLICY "Users can view own profile" 
+ON profiles
+FOR SELECT 
+USING (auth.uid() = id);
+
+-- Policy 2: Users can update their own profile (no recursion possible)
+CREATE POLICY "Users can update own profile" 
+ON profiles
+FOR UPDATE 
+USING (auth.uid() = id);
+
+-- Policy 3: Users can view profiles of people in their schools
+-- This uses the security definer function to avoid recursion
+CREATE POLICY "Users can view profiles in their schools" 
+ON profiles
+FOR SELECT 
+USING (
+    -- User's own profile is already handled by the first policy
+    auth.uid() != id 
+    AND 
+    -- Check if the profile's school is in user's schools
+    school_id IN (SELECT * FROM public.auth_user_school_ids())
+);
+
+-- Ensure RLS is enabled
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+-- Add helpful comments
+COMMENT ON FUNCTION public.auth_user_school_ids() IS 
+'Security definer function that returns school IDs for the current user. 
+Uses SQL language (not plpgsql) and SECURITY DEFINER to avoid infinite recursion.
+This function executes with elevated privileges and does not trigger RLS policies.';
+
+COMMENT ON POLICY "Users can view own profile" ON profiles IS 
+'Simple policy allowing users to view their own profile without any recursion.';
+
+COMMENT ON POLICY "Users can update own profile" ON profiles IS 
+'Simple policy allowing users to update their own profile without any recursion.';
+
+COMMENT ON POLICY "Users can view profiles in their schools" ON profiles IS 
+'Policy allowing users to view profiles of other users in their schools.
+Uses security definer function to avoid infinite recursion when checking school membership.';

--- a/supabase/migrations/20250827_emergency_fix_profiles_recursion.sql
+++ b/supabase/migrations/20250827_emergency_fix_profiles_recursion.sql
@@ -15,7 +15,7 @@ DROP FUNCTION IF EXISTS public.get_user_school_ids() CASCADE;
 -- Create a SIMPLE, NON-RECURSIVE security definer function
 -- This function runs with elevated privileges to avoid recursion
 CREATE OR REPLACE FUNCTION public.auth_user_school_ids()
-RETURNS TABLE(school_id uuid)
+RETURNS TABLE(school_id varchar)
 LANGUAGE sql
 SECURITY DEFINER
 STABLE

--- a/supabase/migrations/20250827_fix_profiles_rls_conflict.sql
+++ b/supabase/migrations/20250827_fix_profiles_rls_conflict.sql
@@ -10,7 +10,7 @@ DROP FUNCTION IF EXISTS public.get_user_school_ids() CASCADE;
 -- Create the proper security definer function that returns all school IDs for a user
 -- This supports both single school (profiles.school_id) and multiple schools (provider_schools)
 CREATE OR REPLACE FUNCTION public.get_user_school_ids()
-RETURNS TABLE(school_id uuid)
+RETURNS TABLE(school_id varchar)
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = public

--- a/supabase/migrations/20250827_fix_profiles_rls_conflict.sql
+++ b/supabase/migrations/20250827_fix_profiles_rls_conflict.sql
@@ -1,0 +1,58 @@
+-- Fix the conflicting RLS policies and functions from PR 183 and local changes
+-- This migration properly handles users with multiple schools via provider_schools
+
+-- First, drop any existing policies and functions that might conflict
+DROP POLICY IF EXISTS "Users can view team members in same school" ON profiles;
+DROP POLICY IF EXISTS "Users can view team members in their schools" ON profiles;
+DROP FUNCTION IF EXISTS public.get_user_school_id() CASCADE;
+DROP FUNCTION IF EXISTS public.get_user_school_ids() CASCADE;
+
+-- Create the proper security definer function that returns all school IDs for a user
+-- This supports both single school (profiles.school_id) and multiple schools (provider_schools)
+CREATE OR REPLACE FUNCTION public.get_user_school_ids()
+RETURNS TABLE(school_id varchar)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+STABLE
+AS $$
+BEGIN
+    RETURN QUERY
+    -- Get the user's primary school from profiles
+    SELECT p.school_id
+    FROM profiles p
+    WHERE p.id = auth.uid() AND p.school_id IS NOT NULL
+    
+    UNION
+    
+    -- Get additional schools from provider_schools
+    SELECT ps.school_id
+    FROM provider_schools ps
+    WHERE ps.provider_id = auth.uid() AND ps.school_id IS NOT NULL;
+END;
+$$;
+
+-- Grant execute permission to authenticated users
+GRANT EXECUTE ON FUNCTION public.get_user_school_ids() TO authenticated;
+
+-- Create a non-recursive policy that handles both single and multiple schools
+CREATE POLICY "Users can view team members in their schools" 
+ON profiles
+FOR SELECT 
+USING (
+    -- Allow users to view their own profile
+    auth.uid() = id
+    OR
+    -- Allow viewing profiles in any of the user's schools
+    (school_id IS NOT NULL AND school_id IN (SELECT * FROM public.get_user_school_ids()))
+);
+
+-- Ensure the profiles table has RLS enabled
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+-- Add comments for documentation
+COMMENT ON FUNCTION public.get_user_school_ids() IS 
+'Security definer function that returns all school IDs for the current user, including primary school from profiles and additional schools from provider_schools table. This avoids RLS recursion by using SECURITY DEFINER.';
+
+COMMENT ON POLICY "Users can view team members in their schools" ON profiles IS 
+'Non-recursive policy that allows users to view profiles of team members at any school they work at, using a security definer function to avoid infinite recursion when the profiles table references itself in RLS policies.';

--- a/supabase/migrations/20250827_fix_profiles_rls_conflict.sql
+++ b/supabase/migrations/20250827_fix_profiles_rls_conflict.sql
@@ -10,7 +10,7 @@ DROP FUNCTION IF EXISTS public.get_user_school_ids() CASCADE;
 -- Create the proper security definer function that returns all school IDs for a user
 -- This supports both single school (profiles.school_id) and multiple schools (provider_schools)
 CREATE OR REPLACE FUNCTION public.get_user_school_ids()
-RETURNS TABLE(school_id varchar)
+RETURNS TABLE(school_id uuid)
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = public
@@ -33,6 +33,7 @@ END;
 $$;
 
 -- Grant execute permission to authenticated users
+REVOKE ALL ON FUNCTION public.get_user_school_ids() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.get_user_school_ids() TO authenticated;
 
 -- Create a non-recursive policy that handles both single and multiple schools

--- a/supabase/migrations/20250828_add_database_constraints.sql
+++ b/supabase/migrations/20250828_add_database_constraints.sql
@@ -1,0 +1,97 @@
+-- Add comprehensive database constraints for specialist assignments
+-- This migration ensures data integrity between delivered_by and assignee columns
+
+BEGIN;
+
+-- Add check constraints to enforce the invariants between delivered_by and assignee columns
+-- These were identified as missing by code review
+
+-- Drop any existing partial constraints first
+ALTER TABLE schedule_sessions 
+DROP CONSTRAINT IF EXISTS schedule_sessions_delivered_by_assignee_integrity;
+
+-- Add comprehensive constraint to enforce all invariants
+ALTER TABLE schedule_sessions 
+ADD CONSTRAINT schedule_sessions_delivered_by_assignee_integrity
+CHECK (
+  -- Valid delivered_by values
+  delivered_by IN ('provider', 'sea', 'specialist') AND
+  
+  -- Provider delivery means no assignees
+  (delivered_by != 'provider' OR (assigned_to_sea_id IS NULL AND assigned_to_specialist_id IS NULL)) AND
+  
+  -- SEA delivery requires SEA assignee and no specialist assignee
+  (delivered_by != 'sea' OR (assigned_to_sea_id IS NOT NULL AND assigned_to_specialist_id IS NULL)) AND
+  
+  -- Specialist delivery requires specialist assignee and no SEA assignee
+  (delivered_by != 'specialist' OR (assigned_to_specialist_id IS NOT NULL AND assigned_to_sea_id IS NULL))
+);
+
+-- Add foreign key constraints if missing
+ALTER TABLE schedule_sessions
+DROP CONSTRAINT IF EXISTS schedule_sessions_assigned_to_sea_id_fkey;
+
+ALTER TABLE schedule_sessions
+ADD CONSTRAINT schedule_sessions_assigned_to_sea_id_fkey
+FOREIGN KEY (assigned_to_sea_id) 
+REFERENCES profiles(id) 
+ON DELETE SET NULL;
+
+ALTER TABLE schedule_sessions
+DROP CONSTRAINT IF EXISTS schedule_sessions_assigned_to_specialist_id_fkey;
+
+ALTER TABLE schedule_sessions
+ADD CONSTRAINT schedule_sessions_assigned_to_specialist_id_fkey
+FOREIGN KEY (assigned_to_specialist_id) 
+REFERENCES profiles(id) 
+ON DELETE SET NULL;
+
+-- Create trigger to handle FK ON DELETE SET NULL interaction with CHECK constraint
+-- When a specialist or SEA is deleted, we need to update delivered_by to 'provider'
+CREATE OR REPLACE FUNCTION handle_assignee_deletion()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- If assigned_to_sea_id was set to NULL by FK cascade, update delivered_by
+  IF OLD.assigned_to_sea_id IS NOT NULL AND NEW.assigned_to_sea_id IS NULL THEN
+    NEW.delivered_by = 'provider';
+  END IF;
+  
+  -- If assigned_to_specialist_id was set to NULL by FK cascade, update delivered_by
+  IF OLD.assigned_to_specialist_id IS NOT NULL AND NEW.assigned_to_specialist_id IS NULL THEN
+    NEW.delivered_by = 'provider';
+  END IF;
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Drop existing trigger if it exists
+DROP TRIGGER IF EXISTS handle_assignee_deletion_trigger ON schedule_sessions;
+
+-- Create trigger to fire before UPDATE to handle FK cascades
+CREATE TRIGGER handle_assignee_deletion_trigger
+BEFORE UPDATE ON schedule_sessions
+FOR EACH ROW
+WHEN (
+  (OLD.assigned_to_sea_id IS NOT NULL AND NEW.assigned_to_sea_id IS NULL) OR
+  (OLD.assigned_to_specialist_id IS NOT NULL AND NEW.assigned_to_specialist_id IS NULL)
+)
+EXECUTE FUNCTION handle_assignee_deletion();
+
+-- Add indexes for performance
+CREATE INDEX IF NOT EXISTS idx_schedule_sessions_delivered_by 
+ON schedule_sessions(delivered_by);
+
+CREATE INDEX IF NOT EXISTS idx_schedule_sessions_sea_assignment 
+ON schedule_sessions(assigned_to_sea_id) 
+WHERE assigned_to_sea_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_schedule_sessions_specialist_assignment 
+ON schedule_sessions(assigned_to_specialist_id) 
+WHERE assigned_to_specialist_id IS NOT NULL;
+
+-- Add composite index for queries filtering by both delivered_by and assignee
+CREATE INDEX IF NOT EXISTS idx_schedule_sessions_delivery_assignment
+ON schedule_sessions(delivered_by, assigned_to_sea_id, assigned_to_specialist_id);
+
+COMMIT;

--- a/supabase/migrations/20250829_consolidate_profiles_rls.sql
+++ b/supabase/migrations/20250829_consolidate_profiles_rls.sql
@@ -18,7 +18,7 @@ DROP FUNCTION IF EXISTS public.auth_user_school_ids() CASCADE;
 -- Create a single, authoritative security definer function for getting user's schools
 -- This handles both single school (profiles.school_id) and multiple schools (provider_schools)
 CREATE OR REPLACE FUNCTION public.user_accessible_school_ids()
-RETURNS TABLE(school_id uuid)
+RETURNS TABLE(school_id varchar)
 LANGUAGE sql
 SECURITY DEFINER
 STABLE

--- a/supabase/migrations/20250829_consolidate_profiles_rls.sql
+++ b/supabase/migrations/20250829_consolidate_profiles_rls.sql
@@ -1,0 +1,109 @@
+-- Consolidate and fix profile RLS policies to avoid conflicts
+-- This migration ensures a single, consistent set of policies and helper functions
+
+BEGIN;
+
+-- Drop all potentially conflicting policies
+DROP POLICY IF EXISTS "Users can view team members in same school" ON profiles;
+DROP POLICY IF EXISTS "Users can view team members in their schools" ON profiles;
+DROP POLICY IF EXISTS "Users can view profiles in their schools" ON profiles;
+DROP POLICY IF EXISTS "Users can view own profile" ON profiles;
+DROP POLICY IF EXISTS "Users can update own profile" ON profiles;
+
+-- Drop all potentially conflicting functions
+DROP FUNCTION IF EXISTS public.get_user_school_id() CASCADE;
+DROP FUNCTION IF EXISTS public.get_user_school_ids() CASCADE;
+DROP FUNCTION IF EXISTS public.auth_user_school_ids() CASCADE;
+
+-- Create a single, authoritative security definer function for getting user's schools
+-- This handles both single school (profiles.school_id) and multiple schools (provider_schools)
+CREATE OR REPLACE FUNCTION public.user_accessible_school_ids()
+RETURNS TABLE(school_id uuid)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+    SELECT DISTINCT school_id FROM (
+        -- User's primary school from profiles
+        SELECT p.school_id
+        FROM public.profiles p
+        WHERE p.id = auth.uid() 
+        AND p.school_id IS NOT NULL
+        
+        UNION
+        
+        -- Additional schools from provider_schools
+        SELECT ps.school_id
+        FROM public.provider_schools ps
+        WHERE ps.provider_id = auth.uid() 
+        AND ps.school_id IS NOT NULL
+    ) schools
+    WHERE school_id IS NOT NULL;
+$$;
+
+-- Revoke public access and grant to authenticated users only
+REVOKE ALL ON FUNCTION public.user_accessible_school_ids() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.user_accessible_school_ids() TO authenticated;
+
+-- Create consolidated RLS policies for profiles table
+
+-- Policy 1: Users can view their own profile
+CREATE POLICY "profiles_view_own" 
+ON profiles
+FOR SELECT 
+USING (auth.uid() = id);
+
+-- Policy 2: Users can update their own profile
+CREATE POLICY "profiles_update_own" 
+ON profiles
+FOR UPDATE 
+USING (auth.uid() = id)
+WITH CHECK (auth.uid() = id);
+
+-- Policy 3: Users can view profiles of people in their accessible schools
+CREATE POLICY "profiles_view_same_schools" 
+ON profiles
+FOR SELECT 
+USING (
+    auth.uid() != id 
+    AND school_id IN (SELECT * FROM public.user_accessible_school_ids())
+);
+
+-- Policy 4: Users can insert their own profile (for initial setup)
+CREATE POLICY "profiles_insert_own"
+ON profiles
+FOR INSERT
+WITH CHECK (auth.uid() = id);
+
+-- Policy 5: Service role can do everything (for admin operations)
+CREATE POLICY "profiles_service_role_all"
+ON profiles
+USING (auth.role() = 'service_role')
+WITH CHECK (auth.role() = 'service_role');
+
+-- Ensure RLS is enabled
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+-- Add helpful comments
+COMMENT ON FUNCTION public.user_accessible_school_ids() IS 
+'Consolidated security definer function that returns all school IDs accessible to the current user.
+Includes both the primary school from profiles and any additional schools from provider_schools.
+Uses SQL language and SECURITY DEFINER to avoid infinite recursion in RLS policies.';
+
+COMMENT ON POLICY "profiles_view_own" ON profiles IS 
+'Allow users to view their own profile without any school checks.';
+
+COMMENT ON POLICY "profiles_update_own" ON profiles IS 
+'Allow users to update only their own profile with strict checking.';
+
+COMMENT ON POLICY "profiles_view_same_schools" ON profiles IS 
+'Allow users to view profiles of other users in their accessible schools.';
+
+COMMENT ON POLICY "profiles_insert_own" ON profiles IS 
+'Allow users to create their initial profile during signup.';
+
+COMMENT ON POLICY "profiles_service_role_all" ON profiles IS 
+'Allow service role full access for administrative operations.';
+
+COMMIT;


### PR DESCRIPTION
- Add database fields and permissions for specialist assignments
- Update UI to show other specialists in assignment dropdown
- Add visual indicators (purple ring) for specialist-assigned sessions
- Implement same-school validation for specialist assignments
- Update session filters to handle specialist assignments

Implements #80

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Assign sessions to same‑school specialists via a grouped assignee dropdown; new "Specialist Sessions" filter and page footer legend showing SEA and Specialist chips.

- **Style**
  - Visual cues: orange for SEA assignments; purple for Specialist assignments.

- **Improvements**
  - "Mine" filter now includes specialist‑owned sessions where appropriate; Specialist filter shown only to relevant users; clearer, role‑specific permission error messages when assignment is blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->