### PR TITLE
Fix lesson creation issues in week view calendar (Issue #196)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -48,7 +48,8 @@
       "mcp__supabase__execute_sql",
       "Bash(npm run dev)",
       "Bash(gh pr list --head fix/react-hook-dependencies-build-errors)",
-      "mcp__github__get_issue"
+      "mcp__github__get_issue",
+      "Bash(gh repo view:*)"
     ],
     "deny": []
   },

--- a/app/components/ai-content-modal-enhanced.tsx
+++ b/app/components/ai-content-modal-enhanced.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { X, Printer, Save, Check, ChevronLeft, ChevronRight } from "lucide-react";
 import { WorksheetGenerator } from '../../lib/worksheet-generator';
 import { getSanitizedHTML } from '../../lib/sanitize-html';
+import { formatTimeSlot } from '../../lib/utils/date-time';
 
 interface Student {
   id: string;
@@ -63,20 +64,6 @@ export function AIContentModalEnhanced({
       .replace(/'/g, "&#039;");
   }
 
-  const formatTimeSlot = (timeSlot: string) => {
-    const parts = timeSlot.split('-');
-    if (parts.length !== 2) return timeSlot;
-    
-    const formatTime = (time: string) => {
-      const [hours, minutes] = time.split(':');
-      const hour = parseInt(hours);
-      const period = hour >= 12 ? 'PM' : 'AM';
-      const displayHour = hour > 12 ? hour - 12 : hour === 0 ? 12 : hour;
-      return `${displayHour}:${minutes} ${period}`;
-    };
-    
-    return `${formatTime(parts[0])} - ${formatTime(parts[1])}`;
-  };
 
   const handlePrintSingle = () => {
     setPrintMode('single');
@@ -403,7 +390,7 @@ export function AIContentModalEnhanced({
 
         {/* Worksheet Prompt Modal */}
         {showWorksheetPrompt && printMode === 'single' && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-60">
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
             <div className="bg-white rounded-lg p-6 max-w-md">
               <h3 className="text-lg font-semibold mb-4">Print Worksheets?</h3>
               <p className="mb-4">

--- a/app/components/ai-content-modal-enhanced.tsx
+++ b/app/components/ai-content-modal-enhanced.tsx
@@ -1,0 +1,438 @@
+"use client";
+
+import * as React from "react";
+import { X, Printer, Save, Check, ChevronLeft, ChevronRight } from "lucide-react";
+import { WorksheetGenerator } from '../../lib/worksheet-generator';
+import { getSanitizedHTML } from '../../lib/sanitize-html';
+
+interface Student {
+  id: string;
+  initials: string;
+  grade_level: string;
+  teacher_name: string;
+}
+
+interface LessonContent {
+  timeSlot: string;
+  content: string;
+  students: Student[];
+}
+
+interface AIContentModalEnhancedProps {
+  isOpen: boolean;
+  onClose: () => void;
+  lessons: LessonContent[];
+  isLoading: boolean;
+  schoolSite?: string;
+  onSave?: (savedLesson: any) => void;  
+  isViewingSaved?: boolean;
+  hideControls?: boolean;
+  lessonDate: Date;
+}
+
+export function AIContentModalEnhanced({ 
+  isOpen, 
+  onClose, 
+  lessons, 
+  isLoading,
+  schoolSite,
+  onSave,
+  isViewingSaved = false,
+  hideControls = false,
+  lessonDate
+}: AIContentModalEnhancedProps) {
+  const printRef = React.useRef<HTMLDivElement>(null);
+  const [saving, setSaving] = React.useState(false);
+  const [saved, setSaved] = React.useState(false);
+  const [notes, setNotes] = React.useState("");
+  const [showNotes, setShowNotes] = React.useState(false);
+  const [currentLessonIndex, setCurrentLessonIndex] = React.useState(0);
+  const [printMode, setPrintMode] = React.useState<'single' | 'all' | null>(null);
+  const [showWorksheetPrompt, setShowWorksheetPrompt] = React.useState(false);
+
+  const currentLesson = lessons[currentLessonIndex];
+  const sanitizedContent = currentLesson?.content ? getSanitizedHTML(currentLesson.content) : null;
+
+  // Escape HTML special characters
+  function escapeHTML(str: string): string {
+    if (!str) return '';
+    return str.replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
+  const formatTimeSlot = (timeSlot: string) => {
+    const parts = timeSlot.split('-');
+    if (parts.length !== 2) return timeSlot;
+    
+    const formatTime = (time: string) => {
+      const [hours, minutes] = time.split(':');
+      const hour = parseInt(hours);
+      const period = hour >= 12 ? 'PM' : 'AM';
+      const displayHour = hour > 12 ? hour - 12 : hour === 0 ? 12 : hour;
+      return `${displayHour}:${minutes} ${period}`;
+    };
+    
+    return `${formatTime(parts[0])} - ${formatTime(parts[1])}`;
+  };
+
+  const handlePrintSingle = () => {
+    setPrintMode('single');
+    setShowWorksheetPrompt(true);
+  };
+
+  const handlePrintAll = () => {
+    setPrintMode('all');
+    // No worksheet prompt for bulk printing as per requirements
+    printAllLessons();
+  };
+
+  const printSingleLesson = (includeWorksheets: boolean) => {
+    const printContent = printRef.current;
+    if (!printContent || !currentLesson) return;
+
+    const printWindow = window.open('', '_blank');
+    if (!printWindow) return;
+
+    const styles = `
+      <style>
+        @media print {
+          body { margin: 20px; font-family: Arial, sans-serif; }
+          .lesson-plan { max-width: 800px; margin: 0 auto; }
+          h2, h3, h4 { color: #333 !important; }
+          .no-print { display: none !important; }
+          @page { margin: 1in; }
+        }
+      </style>
+    `;
+
+    printWindow.document.write(`
+      <html>
+        <head>
+          <title>Lesson Plan - ${formatTimeSlot(currentLesson.timeSlot)}</title>
+          ${styles}
+        </head>
+        <body>
+          <div class="print-header" style="margin-bottom: 20px; border-bottom: 2px solid #333; padding-bottom: 10px;">
+            <h1 style="margin: 0;">Special Education Lesson Plan</h1>
+            <p style="margin: 5px 0;"><strong>Date:</strong> ${lessonDate.toLocaleDateString()}</p>
+            <p style="margin: 5px 0;"><strong>Time:</strong> ${formatTimeSlot(currentLesson.timeSlot)}</p>
+            <p style="margin: 5px 0;"><strong>Students:</strong> ${currentLesson.students.map(s => `${s.initials} (Grade ${s.grade_level})`).join(', ')}</p>
+            ${notes ? `<p style="margin: 5px 0;"><strong>Notes:</strong> ${escapeHTML(notes)}</p>` : ''}
+          </div>
+          ${sanitizedContent ? sanitizedContent.__html : ''}
+        </body>
+      </html>
+    `);
+
+    printWindow.document.close();
+    printWindow.focus();
+
+    setTimeout(() => {
+      printWindow.print();
+      printWindow.close();
+      
+      // If user chose to include worksheets, generate them
+      if (includeWorksheets) {
+        generateWorksheetsForLesson(currentLesson);
+      }
+    }, 250);
+  };
+
+  const printAllLessons = () => {
+    // Print each lesson as a separate document
+    lessons.forEach((lesson, index) => {
+      setTimeout(() => {
+        const printWindow = window.open('', '_blank');
+        if (!printWindow) return;
+
+        const sanitized = getSanitizedHTML(lesson.content);
+        const styles = `
+          <style>
+            @media print {
+              body { margin: 20px; font-family: Arial, sans-serif; }
+              .lesson-plan { max-width: 800px; margin: 0 auto; }
+              h2, h3, h4 { color: #333 !important; }
+              @page { margin: 1in; }
+            }
+          </style>
+        `;
+
+        printWindow.document.write(`
+          <html>
+            <head>
+              <title>Lesson Plan ${index + 1} - ${formatTimeSlot(lesson.timeSlot)}</title>
+              ${styles}
+            </head>
+            <body>
+              <div class="print-header" style="margin-bottom: 20px; border-bottom: 2px solid #333; padding-bottom: 10px;">
+                <h1 style="margin: 0;">Special Education Lesson Plan</h1>
+                <p style="margin: 5px 0;"><strong>Date:</strong> ${lessonDate.toLocaleDateString()}</p>
+                <p style="margin: 5px 0;"><strong>Time:</strong> ${formatTimeSlot(lesson.timeSlot)}</p>
+                <p style="margin: 5px 0;"><strong>Students:</strong> ${lesson.students.map(s => `${s.initials} (Grade ${s.grade_level})`).join(', ')}</p>
+              </div>
+              ${sanitized ? sanitized.__html : ''}
+            </body>
+          </html>
+        `);
+
+        printWindow.document.close();
+        printWindow.focus();
+
+        setTimeout(() => {
+          printWindow.print();
+          printWindow.close();
+        }, 250);
+      }, index * 500); // Delay between windows to prevent blocking
+    });
+  };
+
+  const generateWorksheetsForLesson = async (lesson: LessonContent) => {
+    // Generate worksheets for each student in the time slot
+    for (const student of lesson.students) {
+      try {
+        const generator = new WorksheetGenerator();
+        
+        // Generate math worksheet
+        const mathPdf = await generator.generateWorksheet({
+          studentName: student.initials,
+          gradeLevel: student.grade_level as any, // Grade level from DB
+          subject: 'math',
+          sessionTime: formatTimeSlot(lesson.timeSlot),
+          sessionDate: lessonDate
+        });
+        
+        // Open math worksheet in new window for printing
+        const mathWindow = window.open('', '_blank');
+        if (mathWindow) {
+          mathWindow.document.write(`
+            <html>
+              <head><title>Math Worksheet - ${student.initials}</title></head>
+              <body style="margin: 0;">
+                <iframe src="${mathPdf}" width="100%" height="100%" style="border: none;"></iframe>
+              </body>
+            </html>
+          `);
+          mathWindow.document.close();
+          setTimeout(() => {
+            mathWindow.print();
+          }, 500);
+        }
+        
+        // Generate ELA worksheet
+        const elaGenerator = new WorksheetGenerator();
+        const elaPdf = await elaGenerator.generateWorksheet({
+          studentName: student.initials,
+          gradeLevel: student.grade_level as any, // Grade level from DB
+          subject: 'ela',
+          sessionTime: formatTimeSlot(lesson.timeSlot),
+          sessionDate: lessonDate
+        });
+        
+        // Open ELA worksheet in new window for printing
+        const elaWindow = window.open('', '_blank');
+        if (elaWindow) {
+          elaWindow.document.write(`
+            <html>
+              <head><title>ELA Worksheet - ${student.initials}</title></head>
+              <body style="margin: 0;">
+                <iframe src="${elaPdf}" width="100%" height="100%" style="border: none;"></iframe>
+              </body>
+            </html>
+          `);
+          elaWindow.document.close();
+          setTimeout(() => {
+            elaWindow.print();
+          }, 500);
+        }
+        
+      } catch (error) {
+        console.error(`Failed to generate worksheets for ${student.initials}:`, error);
+      }
+    }
+  };
+
+  const navigateLesson = (direction: 'prev' | 'next') => {
+    if (direction === 'prev' && currentLessonIndex > 0) {
+      setCurrentLessonIndex(currentLessonIndex - 1);
+    } else if (direction === 'next' && currentLessonIndex < lessons.length - 1) {
+      setCurrentLessonIndex(currentLessonIndex + 1);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg w-full max-w-5xl h-[90vh] flex flex-col">
+        {/* Header with navigation */}
+        <div className="px-6 py-4 border-b flex justify-between items-center bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-t-lg">
+          <div className="flex items-center gap-4">
+            <h2 className="text-xl font-semibold">
+              AI Generated Lessons - {lessonDate.toLocaleDateString()}
+            </h2>
+            {lessons.length > 1 && (
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => navigateLesson('prev')}
+                  disabled={currentLessonIndex === 0}
+                  className="p-1 rounded hover:bg-white/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                  title="Previous time slot"
+                >
+                  <ChevronLeft className="w-5 h-5" />
+                </button>
+                <span className="text-sm">
+                  {currentLessonIndex + 1} / {lessons.length}
+                </span>
+                <button
+                  onClick={() => navigateLesson('next')}
+                  disabled={currentLessonIndex === lessons.length - 1}
+                  className="p-1 rounded hover:bg-white/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                  title="Next time slot"
+                >
+                  <ChevronRight className="w-5 h-5" />
+                </button>
+              </div>
+            )}
+          </div>
+          <button onClick={onClose} className="p-1 hover:bg-white/20 rounded">
+            <X className="w-6 h-6" />
+          </button>
+        </div>
+
+        {/* Time slot tabs */}
+        {lessons.length > 1 && (
+          <div className="px-6 py-2 border-b bg-gray-50">
+            <div className="flex gap-2 overflow-x-auto">
+              {lessons.map((lesson, index) => (
+                <button
+                  key={index}
+                  onClick={() => setCurrentLessonIndex(index)}
+                  className={`px-3 py-1.5 rounded-md text-sm font-medium whitespace-nowrap transition-colors ${
+                    index === currentLessonIndex
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-white text-gray-700 hover:bg-gray-100'
+                  }`}
+                >
+                  {formatTimeSlot(lesson.timeSlot)}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Current time slot info */}
+        {currentLesson && (
+          <div className="px-6 py-3 bg-blue-50 border-b">
+            <div className="flex justify-between items-center">
+              <div>
+                <p className="text-sm font-medium text-gray-700">
+                  Time: {formatTimeSlot(currentLesson.timeSlot)}
+                </p>
+                <p className="text-sm text-gray-600">
+                  Students: {currentLesson.students.map(s => `${s.initials} (Grade ${s.grade_level})`).join(', ')}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Content */}
+        <div className="flex-1 overflow-auto px-6 py-4">
+          {isLoading ? (
+            <div className="flex items-center justify-center h-full">
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+            </div>
+          ) : currentLesson ? (
+            <div ref={printRef}>
+              <div className="prose max-w-none" dangerouslySetInnerHTML={sanitizedContent || { __html: '' }} />
+            </div>
+          ) : (
+            <div className="text-center text-gray-500">No lesson content available</div>
+          )}
+        </div>
+
+        {/* Controls */}
+        {!hideControls && (
+          <div className="px-6 py-4 border-t bg-gray-50 rounded-b-lg">
+            <div className="flex justify-between items-center">
+              <div className="flex gap-2">
+                <button
+                  onClick={handlePrintSingle}
+                  className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 flex items-center gap-2"
+                >
+                  <Printer className="w-4 h-4" />
+                  Print This Lesson
+                </button>
+                {lessons.length > 1 && (
+                  <button
+                    onClick={handlePrintAll}
+                    className="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 flex items-center gap-2"
+                  >
+                    <Printer className="w-4 h-4" />
+                    Print All Lessons
+                  </button>
+                )}
+              </div>
+              <div className="flex gap-2">
+                {onSave && !isViewingSaved && (
+                  <button
+                    onClick={() => {/* Save logic */}}
+                    disabled={saving || saved}
+                    className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50 flex items-center gap-2"
+                  >
+                    {saved ? (
+                      <>
+                        <Check className="w-4 h-4" />
+                        Saved
+                      </>
+                    ) : (
+                      <>
+                        <Save className="w-4 h-4" />
+                        {saving ? 'Saving...' : 'Save'}
+                      </>
+                    )}
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Worksheet Prompt Modal */}
+        {showWorksheetPrompt && printMode === 'single' && (
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-60">
+            <div className="bg-white rounded-lg p-6 max-w-md">
+              <h3 className="text-lg font-semibold mb-4">Print Worksheets?</h3>
+              <p className="mb-4">
+                Would you like to also print worksheets for the students in this time slot?
+              </p>
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={() => {
+                    setShowWorksheetPrompt(false);
+                    printSingleLesson(false);
+                  }}
+                  className="px-4 py-2 bg-gray-300 text-gray-700 rounded-md hover:bg-gray-400"
+                >
+                  No, Just Lesson
+                </button>
+                <button
+                  onClick={() => {
+                    setShowWorksheetPrompt(false);
+                    printSingleLesson(true);
+                  }}
+                  className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+                >
+                  Yes, Include Worksheets
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/ai-content-modal-enhanced.tsx
+++ b/app/components/ai-content-modal-enhanced.tsx
@@ -59,8 +59,29 @@ export function AIContentModalEnhanced({
   const processLessonContent = (content: string) => {
     if (!content) return null;
     
-    // First apply our custom formatting
-    let processedContent = formatLessonContent(content);
+    // Remove redundant headers that are already shown in the UI
+    let processedContent = content;
+    
+    // Remove "Special Education Lesson Plan" title and grade/time subtitle
+    processedContent = processedContent.replace(
+      /<h1[^>]*>\s*Special Education Lesson Plan\s*<\/h1>/gi,
+      ''
+    );
+    
+    // Remove grade level and duration line (e.g., "Grades 3-4 | 30 Minutes")
+    processedContent = processedContent.replace(
+      /<p[^>]*>\s*Grade[s]?\s+[^<]*\|\s*\d+\s*[Mm]inutes?\s*<\/p>/gi,
+      ''
+    );
+    
+    // Also remove if it's in a heading format
+    processedContent = processedContent.replace(
+      /<h[2-6][^>]*>\s*Grade[s]?\s+[^<]*\|\s*\d+\s*[Mm]inutes?\s*<\/h[2-6]>/gi,
+      ''
+    );
+    
+    // Apply our custom formatting
+    processedContent = formatLessonContent(processedContent);
     
     // Additional modal-specific formatting
     
@@ -157,7 +178,7 @@ export function AIContentModalEnhanced({
         </head>
         <body>
           <div class="print-header" style="margin-bottom: 20px; border-bottom: 2px solid #333; padding-bottom: 10px;">
-            <h1 style="margin: 0;">Special Education Lesson Plan</h1>
+            <h1 style="margin: 0;">Lesson Plan</h1>
             <p style="margin: 5px 0;"><strong>Date:</strong> ${lessonDate.toLocaleDateString()}</p>
             <p style="margin: 5px 0;"><strong>Time:</strong> ${formatTimeSlot(currentLesson.timeSlot)}</p>
             <p style="margin: 5px 0;"><strong>Students:</strong> ${currentLesson.students.map(s => `${s.initials} (Grade ${s.grade_level})`).join(', ')}</p>
@@ -209,7 +230,7 @@ export function AIContentModalEnhanced({
             </head>
             <body>
               <div class="print-header" style="margin-bottom: 20px; border-bottom: 2px solid #333; padding-bottom: 10px;">
-                <h1 style="margin: 0;">Special Education Lesson Plan</h1>
+                <h1 style="margin: 0;">Lesson Plan</h1>
                 <p style="margin: 5px 0;"><strong>Date:</strong> ${lessonDate.toLocaleDateString()}</p>
                 <p style="margin: 5px 0;"><strong>Time:</strong> ${formatTimeSlot(lesson.timeSlot)}</p>
                 <p style="margin: 5px 0;"><strong>Students:</strong> ${lesson.students.map(s => `${s.initials} (Grade ${s.grade_level})`).join(', ')}</p>

--- a/app/components/calendar/calendar-week-view.tsx
+++ b/app/components/calendar/calendar-week-view.tsx
@@ -388,6 +388,28 @@ export function CalendarWeekView({
     return date < today;
   };
 
+  // Helper function to group sessions by time slots (using actual start-end times)
+  const groupSessionsByTimeSlot = (sessions: ScheduleSession[]): Map<string, ScheduleSession[]> => {
+    const timeSlotGroups = new Map<string, ScheduleSession[]>();
+    
+    sessions.forEach(session => {
+      if (!session.start_time || !session.end_time) return;
+      
+      // Normalize time format by removing seconds if present
+      const startTime = session.start_time.split(':').slice(0, 2).join(':');
+      const endTime = session.end_time.split(':').slice(0, 2).join(':');
+      const timeSlot = `${startTime}-${endTime}`;
+      
+      if (!timeSlotGroups.has(timeSlot)) {
+        timeSlotGroups.set(timeSlot, []);
+      }
+      timeSlotGroups.get(timeSlot)!.push(session);
+    });
+    
+    // Sort the map by time slot keys
+    return new Map([...timeSlotGroups.entries()].sort());
+  };
+
   // Memoize expensive day color calculations
   const getDayColorData = useMemo(() => {
     const colorMap = new Map<string, string>();
@@ -466,28 +488,6 @@ export function CalendarWeekView({
   const getDayColor = (date: Date) => {
     const dateStr = toLocalDateKey(date);
     return getDayColorData.get(dateStr) || "bg-white border-gray-200";
-  };
-
-  // Helper function to group sessions by time slots (using actual start-end times)
-  const groupSessionsByTimeSlot = (sessions: ScheduleSession[]): Map<string, ScheduleSession[]> => {
-    const timeSlotGroups = new Map<string, ScheduleSession[]>();
-    
-    sessions.forEach(session => {
-      if (!session.start_time || !session.end_time) return;
-      
-      // Normalize time format by removing seconds if present
-      const startTime = session.start_time.split(':').slice(0, 2).join(':');
-      const endTime = session.end_time.split(':').slice(0, 2).join(':');
-      const timeSlot = `${startTime}-${endTime}`;
-      
-      if (!timeSlotGroups.has(timeSlot)) {
-        timeSlotGroups.set(timeSlot, []);
-      }
-      timeSlotGroups.get(timeSlot)!.push(session);
-    });
-    
-    // Sort the map by time slot keys
-    return new Map([...timeSlotGroups.entries()].sort());
   };
 
   const handleGenerateDailyAILesson = async (

--- a/app/styles/lesson-content.css
+++ b/app/styles/lesson-content.css
@@ -1,0 +1,178 @@
+/* Custom styles for AI-generated lesson content */
+
+.lesson-content {
+  @apply text-gray-800;
+}
+
+/* Main headings - Lesson Title */
+.lesson-content h1 {
+  @apply text-2xl font-bold text-gray-900 mb-6 pb-3 border-b-2 border-blue-200;
+}
+
+/* Section headings */
+.lesson-content h2 {
+  @apply text-xl font-semibold text-blue-700 mt-8 mb-4 flex items-center gap-2;
+  position: relative;
+  padding-left: 1.5rem;
+}
+
+.lesson-content h2::before {
+  content: '▸';
+  @apply text-blue-500 absolute left-0;
+}
+
+/* Sub-section headings */
+.lesson-content h3 {
+  @apply text-lg font-semibold text-gray-700 mt-6 mb-3 pl-4 border-l-4 border-green-400;
+}
+
+/* Activity/Student specific headings */
+.lesson-content h4 {
+  @apply text-base font-semibold text-purple-700 mt-4 mb-2 bg-purple-50 px-3 py-2 rounded-lg;
+}
+
+/* Paragraphs */
+.lesson-content p {
+  @apply text-gray-700 leading-relaxed mb-4;
+}
+
+/* Lists */
+.lesson-content ul {
+  @apply space-y-2 mb-4 ml-4;
+}
+
+.lesson-content ul li {
+  @apply pl-6 relative;
+}
+
+.lesson-content ul li::before {
+  content: '✓';
+  @apply absolute left-0 text-green-500 font-bold;
+}
+
+.lesson-content ol {
+  @apply space-y-3 mb-4 ml-4;
+}
+
+.lesson-content ol li {
+  @apply pl-6 relative;
+  counter-increment: item;
+}
+
+.lesson-content ol li::before {
+  content: counter(item);
+  @apply absolute left-0 w-5 h-5 bg-blue-500 text-white text-xs rounded-full flex items-center justify-center font-bold;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Reset counter for each ol */
+.lesson-content ol {
+  counter-reset: item;
+}
+
+/* Strong text (usually for emphasis or labels) */
+.lesson-content strong {
+  @apply font-semibold text-gray-900 bg-yellow-50 px-1 rounded;
+}
+
+/* Activity cards */
+.lesson-content .activity-block {
+  @apply bg-gradient-to-r from-blue-50 to-indigo-50 rounded-lg p-4 mb-4 border border-blue-200 shadow-sm;
+}
+
+/* Materials section */
+.lesson-content .materials-section {
+  @apply bg-green-50 rounded-lg p-4 mb-4 border border-green-300;
+}
+
+/* Objectives section */
+.lesson-content .objectives-section {
+  @apply bg-amber-50 rounded-lg p-4 mb-4 border border-amber-300;
+}
+
+/* Time indicators */
+.lesson-content .time-indicator {
+  @apply inline-block bg-gray-100 text-gray-700 px-2 py-1 rounded text-sm font-medium mr-2;
+}
+
+/* Student names/initials */
+.lesson-content .student-name {
+  @apply inline-block bg-gradient-to-r from-purple-500 to-pink-500 text-white px-2 py-1 rounded text-sm font-bold mr-1;
+}
+
+/* IEP Goals */
+.lesson-content .iep-goal {
+  @apply bg-blue-50 border-l-4 border-blue-500 pl-4 py-2 mb-2 italic text-sm;
+}
+
+/* Dividers between major sections */
+.lesson-content hr {
+  @apply my-8 border-t-2 border-gray-200;
+}
+
+/* Tables for structured content */
+.lesson-content table {
+  @apply w-full border-collapse mb-6;
+}
+
+.lesson-content th {
+  @apply bg-gray-100 px-4 py-2 text-left font-semibold text-gray-700 border border-gray-300;
+}
+
+.lesson-content td {
+  @apply px-4 py-2 border border-gray-300;
+}
+
+.lesson-content tbody tr:nth-child(even) {
+  @apply bg-gray-50;
+}
+
+/* Blockquotes for special notes or tips */
+.lesson-content blockquote {
+  @apply border-l-4 border-yellow-400 bg-yellow-50 pl-4 py-3 mb-4 italic;
+}
+
+/* Code blocks for specific instructions */
+.lesson-content code {
+  @apply bg-gray-100 px-2 py-1 rounded text-sm font-mono text-red-600;
+}
+
+.lesson-content pre {
+  @apply bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto mb-4;
+}
+
+/* Responsive adjustments */
+@media (max-width: 640px) {
+  .lesson-content h1 {
+    @apply text-xl;
+  }
+  
+  .lesson-content h2 {
+    @apply text-lg;
+  }
+  
+  .lesson-content h3 {
+    @apply text-base;
+  }
+}
+
+/* Print styles */
+@media print {
+  .lesson-content {
+    @apply text-black;
+  }
+  
+  .lesson-content h2::before,
+  .lesson-content ul li::before {
+    content: '•';
+    @apply text-black;
+  }
+  
+  .lesson-content .activity-block,
+  .lesson-content .materials-section,
+  .lesson-content .objectives-section {
+    @apply border-2 border-black bg-white;
+  }
+}

--- a/lib/utils/date-time.ts
+++ b/lib/utils/date-time.ts
@@ -1,0 +1,65 @@
+/**
+ * Utilities for date and time formatting
+ */
+
+/**
+ * Convert a Date to a local date key (YYYY-MM-DD) to avoid timezone issues
+ */
+export function toLocalDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Format a time slot range (e.g., "08:15-08:45" to "8:15 AM - 8:45 AM")
+ * Handles both range format and single time format for backward compatibility
+ */
+export function formatTimeSlot(timeSlot: string): string {
+  // Handle time range format (e.g., "08:15-08:45")
+  if (timeSlot.includes('-')) {
+    const parts = timeSlot.split('-').map(p => p.trim());
+    if (parts.length !== 2) return timeSlot;
+    
+    const formatSingleTime = (time: string) => {
+      // Handle HH:MM or HH:MM:SS format
+      const match = /^(\d{1,2}):(\d{2})(?::\d{2})?$/.exec(time);
+      if (!match) return time;
+      
+      const hour = parseInt(match[1], 10);
+      const minutes = match[2];
+      const period = hour >= 12 ? 'PM' : 'AM';
+      const displayHour = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+      return `${displayHour}:${minutes} ${period}`;
+    };
+    
+    return `${formatSingleTime(parts[0])} - ${formatSingleTime(parts[1])}`;
+  }
+  
+  // Handle single time format (legacy)
+  const [hours, minutes] = timeSlot.split(':');
+  const hour = parseInt(hours, 10);
+  const period = hour >= 12 ? 'PM' : 'AM';
+  const displayHour = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+  return `${displayHour}:${minutes} ${period}`;
+}
+
+/**
+ * Calculate duration in minutes from a time slot range
+ */
+export function calculateDurationFromTimeSlot(timeSlot: string): number {
+  if (!timeSlot.includes('-')) {
+    return 30; // Default duration for legacy format
+  }
+  
+  const [startTime, endTime] = timeSlot.split('-').map(t => t.trim());
+  
+  const timeToMinutes = (time: string): number => {
+    const [hours, minutes] = time.split(':').map(Number);
+    return hours * 60 + (minutes || 0);
+  };
+  
+  const duration = timeToMinutes(endTime) - timeToMinutes(startTime);
+  return Math.max(0, duration);
+}

--- a/lib/utils/lesson-formatter.ts
+++ b/lib/utils/lesson-formatter.ts
@@ -1,0 +1,83 @@
+/**
+ * Utilities for formatting lesson content with enhanced visual hierarchy
+ */
+
+export const formatLessonContent = (content: string): string => {
+  if (!content) return '';
+  
+  let formatted = content;
+  
+  // Add icons to main section headers
+  const sectionIcons: Record<string, string> = {
+    'objective': '🎯',
+    'material': '📚',
+    'activity': '🎮',
+    'assessment': '📊',
+    'homework': '📝',
+    'warm-up': '🔥',
+    'introduction': '👋',
+    'closure': '🔚',
+    'differentiation': '🎨',
+    'accommodation': '♿',
+    'modification': '🔧',
+    'extension': '🚀',
+    'vocabulary': '📖',
+    'skill': '💪',
+    'goal': '🎯',
+    'standard': '📏',
+    'note': '📌',
+    'reminder': '⏰',
+    'tip': '💡'
+  };
+  
+  // Add icons to h2 headers
+  Object.entries(sectionIcons).forEach(([keyword, icon]) => {
+    const regex = new RegExp(`<h2>([^<]*${keyword}[^<]*)</h2>`, 'gi');
+    formatted = formatted.replace(regex, `<h2>${icon} $1</h2>`);
+  });
+  
+  // Format time durations with clock icon
+  formatted = formatted.replace(
+    /\((\d+[\s-]*(?:min(?:ute)?s?|hour?s?))\)/gi,
+    '<span class="inline-flex items-center gap-1 text-blue-600 font-medium">⏱️ $1</span>'
+  );
+  
+  // Highlight important keywords
+  const importantKeywords = [
+    'IMPORTANT',
+    'NOTE',
+    'REMINDER',
+    'TIP',
+    'WARNING',
+    'CAUTION'
+  ];
+  
+  importantKeywords.forEach(keyword => {
+    const regex = new RegExp(`\\b(${keyword}:?)\\b`, 'g');
+    formatted = formatted.replace(
+      regex,
+      '<span class="inline-block px-2 py-1 bg-yellow-100 text-yellow-800 font-bold text-xs uppercase rounded">$1</span>'
+    );
+  });
+  
+  // Format numbered steps with better styling
+  formatted = formatted.replace(
+    /<li>(\d+\.?\s*)/g,
+    '<li><span class="font-bold text-blue-600">$1</span>'
+  );
+  
+  // Add visual breaks between major sections
+  formatted = formatted.replace(
+    /(<\/h2>)/g,
+    '$1<hr class="my-4 border-t-2 border-gray-100" />'
+  );
+  
+  // Wrap entire content in a container with proper spacing
+  formatted = `
+    <div class="lesson-content-wrapper space-y-6">
+      ${formatted}
+    </div>
+  `;
+  
+  return formatted;
+};

--- a/lib/utils/lesson-formatter.ts
+++ b/lib/utils/lesson-formatter.ts
@@ -7,6 +7,25 @@ export const formatLessonContent = (content: string): string => {
   
   let formatted = content;
   
+  // Clean up any redundant headers that might still exist
+  // Remove standalone "Special Education" headers
+  formatted = formatted.replace(
+    /<h[1-6][^>]*>\s*Special Education\s*<\/h[1-6]>/gi,
+    ''
+  );
+  
+  // Remove lesson plan headers that are too generic
+  formatted = formatted.replace(
+    /<h1[^>]*>\s*Lesson Plan\s*<\/h1>/gi,
+    ''
+  );
+  
+  // Clean up empty paragraphs that might result from removals
+  formatted = formatted.replace(/<p[^>]*>\s*<\/p>/gi, '');
+  
+  // Remove duplicate line breaks
+  formatted = formatted.replace(/(\n\s*){3,}/g, '\n\n');
+  
   // Add icons to main section headers
   const sectionIcons: Record<string, string> = {
     'objective': '🎯',

--- a/supabase/migrations/20240827_fix_time_slot_length.sql
+++ b/supabase/migrations/20240827_fix_time_slot_length.sql
@@ -1,0 +1,6 @@
+-- Fix time_slot column length to accommodate time ranges like "08:15-08:45"
+ALTER TABLE ai_generated_lessons 
+ALTER COLUMN time_slot TYPE VARCHAR(20);
+
+-- Update the unique constraint if needed (it should remain the same)
+-- The constraint should already be: provider_id, lesson_date, time_slot


### PR DESCRIPTION
- Replaced individual time slot buttons with single "Create Lesson" button per day
- Fixed AI lesson generation to properly handle all time slots in unified workflow
- Added enhanced modal with tabbed interface for multiple time slots
- Implemented smart printing with worksheet prompts for individual lessons
- Fixed state management to prevent phantom lessons after failures
- Added visual improvements with color-coded day indicators for lesson coverage
- Added legend to explain calendar color coding
- Implemented automatic cleanup of legacy lessons without time_slot
- Ensures lesson deletion is day-based only (not individual slots)
- Manual lessons remain day-wide as requested
- Print All creates separate documents without worksheet prompts

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced AI Lessons modal with tabs, navigation, notes, save states, print options, and worksheet generation.
  - Calendar day-level AI workflows: Create/View All/Edit/Delete for a day, per-day progress, summaries, legends, and improved day coloring.
  - Utilities for local date keys, human-friendly time-slot formatting, and duration calculation.
  - Rich lesson content formatting and comprehensive lesson-content styling.

- **Bug Fixes**
  - One-time cleanup of legacy empty slots to prevent missing-slot errors.

- **Chores**
  - Increased time-slot capacity to support precise start–end ranges.
  - Permission allow-list updated to permit GitHub CLI repo view commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->