### PR TITLE
fix: standardize AI lesson formatting across all modals (Issue #204)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -49,7 +49,8 @@
       "Bash(npm run dev)",
       "Bash(gh pr list --head fix/react-hook-dependencies-build-errors)",
       "mcp__github__get_issue",
-      "Bash(gh repo view:*)"
+      "Bash(gh repo view:*)",
+      "mcp__github__create_issue"
     ],
     "deny": []
   },

--- a/app/api/generate-lesson/route.ts
+++ b/app/api/generate-lesson/route.ts
@@ -584,13 +584,33 @@ Requirements:
 
 CRITICAL: Pay special attention to the "Current Working Skills" for each student. These are the specific skills the teacher has identified as current focus areas. Design activities that directly practice these skills.
 
-Structure the lesson with:
-- Opening (5 min): Multi-sensory warm-up engaging all learning styles
-- Main Instruction (${duration - 10} min): 
-  * Differentiated activities for each ability level
-  * Specific IEP goal practice for each student
-  * Clear instructions for grouping/individual work
-- Closing (5 min): Individual assessment aligned to goals
+MANDATORY FORMAT - You MUST structure the lesson EXACTLY like this:
+
+<h3>Opening ⏱️ 5 minutes</h3>
+[Multi-sensory warm-up content here]
+
+<h3>Main Instruction ⏱️ ${duration - 10} minutes</h3>
+<h4>[Student Initials] (Grade [X])</h4>
+<strong>IEP Goal:</strong> [State the specific goal]
+<strong>Current Working Skills:</strong> [List skills]
+<strong>Focus Areas:</strong> [List areas]
+
+<strong>Activity 1:</strong> [Activity name]
+[Activity description]
+
+<strong>Activity 2:</strong> [Activity name]
+[Activity description]
+
+[Repeat for each student]
+
+<h3>Closing ⏱️ 5 minutes</h3>
+[Assessment activities here]
+
+Use EXACTLY this format with:
+- <h3> for main sections (Opening, Main Instruction, Closing) 
+- ⏱️ emoji for ALL time durations
+- <h4> for student names with grade
+- <strong> for labels like "IEP Goal:", "Activity 1:", etc.
 
 ${profile?.selected_curriculums?.length > 0 ? `
 
@@ -612,7 +632,7 @@ For each activity, specify:
 - Which curriculum/program to use (if applicable)
 - How to assess progress
 
-Format as clean, semantic HTML. Use <h3> for sections, <h4> for activities, <strong> for student names, and clear paragraph structure. Make it immediately actionable for a ${
+IMPORTANT: Follow the MANDATORY FORMAT shown above exactly. Do not deviate from the structure. Make it immediately actionable for a ${
   userRole === 'speech' ? 'speech-language pathologist' :
   userRole === 'ot' ? 'occupational therapist' :
   userRole === 'counseling' ? 'school counselor' :

--- a/app/components/ai-content-modal.tsx
+++ b/app/components/ai-content-modal.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { X, Printer, Save, Check } from "lucide-react";
 import { WorksheetGenerator } from '../../lib/worksheet-generator';
-import { getSanitizedHTML } from '../../lib/sanitize-html';
+import { processAILessonContent, processAILessonContentForPrint } from '../../lib/utils/ai-lesson-formatter';
 
 interface Student {
   id: string;
@@ -42,7 +42,7 @@ export function AIContentModal({
   const [saved, setSaved] = React.useState(false);
   const [notes, setNotes] = React.useState("");
   const [showNotes, setShowNotes] = React.useState(false);
-  const sanitizedContent = content ? getSanitizedHTML(content) : null;
+  const sanitizedContent = content ? processAILessonContent(content, students) : null;
 
   // Escape HTML special characters in user-supplied notes
   function escapeHTML(str: string): string {
@@ -136,6 +136,9 @@ export function AIContentModal({
     const printWindow = window.open('', '_blank');
     if (!printWindow) return;
 
+    // Use the print formatter for consistent print output
+    const printFormattedContent: { __html: string } | null = content ? processAILessonContentForPrint(content, students) : null;
+
     const styles = `
       <style>
         @media print {
@@ -162,7 +165,7 @@ export function AIContentModal({
             <p style="margin: 5px 0;"><strong>Date:</strong> ${new Date().toLocaleDateString()}</p>
             ${notes ? `<p style="margin: 5px 0;"><strong>Notes:</strong> ${escapeHTML(notes)}</p>` : ''}
           </div>
-          ${sanitizedContent ? sanitizedContent.__html : ''}
+          ${printFormattedContent ? printFormattedContent.__html : ''}
         </body>
       </html>
     `);

--- a/lib/utils/ai-lesson-formatter.ts
+++ b/lib/utils/ai-lesson-formatter.ts
@@ -5,6 +5,7 @@
 
 import { getSanitizedHTML } from '../sanitize-html';
 import { formatLessonContent } from './lesson-formatter';
+import { standardizeLessonStructure } from './ai-lesson-standardizer';
 
 interface Student {
   id: string;
@@ -20,8 +21,8 @@ interface Student {
 export function processAILessonContent(content: string, students: Student[] = []): { __html: string } | null {
   if (!content) return null;
   
-  // Start with the base formatting
-  let processedContent = content;
+  // First, standardize the structure
+  let processedContent = standardizeLessonStructure(content);
   
   // Remove redundant headers that are already shown in the UI
   processedContent = processedContent.replace(

--- a/lib/utils/ai-lesson-formatter.ts
+++ b/lib/utils/ai-lesson-formatter.ts
@@ -1,0 +1,148 @@
+/**
+ * Shared utility for formatting AI-generated lesson content
+ * Ensures consistent formatting across all modals and views
+ */
+
+import { getSanitizedHTML } from '../sanitize-html';
+import { formatLessonContent } from './lesson-formatter';
+
+interface Student {
+  id: string;
+  initials: string;
+  grade_level: string;
+  teacher_name: string;
+}
+
+/**
+ * Process AI lesson content with enhanced formatting
+ * This is the main formatter that should be used across all components
+ */
+export function processAILessonContent(content: string, students: Student[] = []): { __html: string } | null {
+  if (!content) return null;
+  
+  // Start with the base formatting
+  let processedContent = content;
+  
+  // Remove redundant headers that are already shown in the UI
+  processedContent = processedContent.replace(
+    /<h1[^>]*>\s*Special Education Lesson Plan\s*<\/h1>/gi,
+    ''
+  );
+  
+  // Remove grade level and duration line (e.g., "Grades 3-4 | 30 Minutes")
+  processedContent = processedContent.replace(
+    /<p[^>]*>\s*Grade[s]?\s+[^<]*\|\s*\d+\s*[Mm]inutes?\s*<\/p>/gi,
+    ''
+  );
+  
+  // Also remove if it's in a heading format
+  processedContent = processedContent.replace(
+    /<h[2-6][^>]*>\s*Grade[s]?\s+[^<]*\|\s*\d+\s*[Mm]inutes?\s*<\/h[2-6]>/gi,
+    ''
+  );
+  
+  // Apply the base lesson formatting (icons, keywords, etc.)
+  processedContent = formatLessonContent(processedContent);
+  
+  // Highlight student names with colored badges
+  if (students && students.length > 0) {
+    students.forEach((student, index) => {
+      const colors = [
+        'from-purple-500 to-pink-500',
+        'from-blue-500 to-cyan-500',
+        'from-green-500 to-emerald-500',
+        'from-orange-500 to-red-500',
+        'from-indigo-500 to-purple-500'
+      ];
+      const colorClass = colors[index % colors.length];
+      
+      // Replace student references with styled badges
+      const studentRegex = new RegExp(`\\b(${student.initials}|Student ${index + 1})\\b`, 'g');
+      processedContent = processedContent.replace(
+        studentRegex,
+        `<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-gradient-to-r ${colorClass} text-white">${student.initials}</span>`
+      );
+    });
+  }
+  
+  // Add activity blocks with better visual separation
+  processedContent = processedContent.replace(
+    /<h3>([^<]*Activity[^<]*)<\/h3>/gi,
+    '</div><div class="activity-block mt-6"><h3 class="flex items-center gap-2"><svg class="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>$1</h3>'
+  );
+  
+  // Clean up any unclosed divs from activity block replacements
+  processedContent = processedContent.replace(
+    /<div class="activity-block/g,
+    '</div><div class="activity-block'
+  ).replace(
+    /^<\/div>/, ''
+  );
+  
+  // Add section dividers for better visual separation
+  processedContent = processedContent.replace(
+    /<h2>/g,
+    '<div class="my-8 border-t-2 border-gray-200"></div><h2>'
+  );
+  
+  // Ensure we wrap the content properly and close any open divs
+  processedContent = `<div class="ai-lesson-content">${processedContent}</div>`;
+  
+  // Sanitize and return the final HTML
+  return getSanitizedHTML(processedContent);
+}
+
+/**
+ * Process AI lesson content for printing
+ * Removes interactive elements and optimizes for paper output
+ */
+export function processAILessonContentForPrint(content: string, students: Student[] = []): { __html: string } | null {
+  if (!content) return null;
+  
+  let processedContent = content;
+  
+  // Remove redundant headers
+  processedContent = processedContent.replace(
+    /<h1[^>]*>\s*Special Education Lesson Plan\s*<\/h1>/gi,
+    ''
+  );
+  
+  processedContent = processedContent.replace(
+    /<p[^>]*>\s*Grade[s]?\s+[^<]*\|\s*\d+\s*[Mm]inutes?\s*<\/p>/gi,
+    ''
+  );
+  
+  processedContent = processedContent.replace(
+    /<h[2-6][^>]*>\s*Grade[s]?\s+[^<]*\|\s*\d+\s*[Mm]inutes?\s*<\/h[2-6]>/gi,
+    ''
+  );
+  
+  // For print, use simpler student name formatting
+  if (students && students.length > 0) {
+    students.forEach((student, index) => {
+      const studentRegex = new RegExp(`\\b(${student.initials}|Student ${index + 1})\\b`, 'g');
+      processedContent = processedContent.replace(
+        studentRegex,
+        `<strong style="text-decoration: underline;">${student.initials}</strong>`
+      );
+    });
+  }
+  
+  // Simple activity headers for print
+  processedContent = processedContent.replace(
+    /<h3>([^<]*Activity[^<]*)<\/h3>/gi,
+    '<h3 style="margin-top: 20px; padding-top: 10px; border-top: 1px solid #ccc;">📌 $1</h3>'
+  );
+  
+  // Add section dividers
+  processedContent = processedContent.replace(
+    /<h2>/g,
+    '<h2 style="margin-top: 30px; padding-top: 15px; border-top: 2px solid #333;">'
+  );
+  
+  // Clean up empty paragraphs
+  processedContent = processedContent.replace(/<p[^>]*>\s*<\/p>/gi, '');
+  
+  // Sanitize and return
+  return getSanitizedHTML(processedContent);
+}

--- a/lib/utils/ai-lesson-standardizer.ts
+++ b/lib/utils/ai-lesson-standardizer.ts
@@ -1,0 +1,175 @@
+/**
+ * Standardizes AI-generated lesson content to ensure consistent structure
+ * This post-processes the AI output to enforce a uniform format
+ */
+
+interface ParsedSection {
+  title: string;
+  duration?: string;
+  content: string;
+}
+
+/**
+ * Standardize the structure of AI-generated lesson content
+ * Ensures all lessons follow the same format regardless of how the AI generated them
+ */
+export function standardizeLessonStructure(content: string): string {
+  if (!content) return content;
+  
+  // Remove any existing titles that might be inconsistent
+  let processedContent = content;
+  
+  // Remove various forms of lesson plan titles
+  processedContent = processedContent.replace(
+    /<h1[^>]*>.*?(?:lesson plan|session plan|therapy plan).*?<\/h1>/gi,
+    ''
+  );
+  
+  // Remove standalone headers that are too generic
+  processedContent = processedContent.replace(
+    /^.*?(?:Special Education Lesson Plan|Lesson Plan:|Here is a detailed).*?$/gmi,
+    ''
+  );
+  
+  // Standardize time indicators - ensure they all use the clock emoji format
+  processedContent = processedContent.replace(
+    /\b(\d+\s*(?:min(?:ute)?s?|hour?s?))\s*:/gi,
+    '⏱️ $1:'
+  );
+  
+  // Ensure consistent section headers
+  processedContent = ensureConsistentSections(processedContent);
+  
+  // Standardize student sections
+  processedContent = standardizeStudentSections(processedContent);
+  
+  // Add consistent title structure
+  const title = '<h2 class="lesson-title">Special Education Lesson Plan</h2>\n';
+  
+  // Clean up extra whitespace and empty tags
+  processedContent = processedContent
+    .replace(/<p[^>]*>\s*<\/p>/gi, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+  
+  return title + processedContent;
+}
+
+/**
+ * Ensure main sections (Opening, Main Instruction, Closing) are consistently formatted
+ */
+function ensureConsistentSections(content: string): string {
+  // Define the standard sections we expect
+  const sections = [
+    { pattern: /opening|warm[- ]?up|introduction/i, standard: 'Opening' },
+    { pattern: /main\s*(?:instruction|activity|activities|lesson)|core\s*(?:instruction|content)/i, standard: 'Main Instruction' },
+    { pattern: /closing|conclusion|wrap[- ]?up|assessment|closure/i, standard: 'Closing' }
+  ];
+  
+  let result = content;
+  
+  sections.forEach(section => {
+    // Find and replace various forms of section headers
+    // First try to find h3 headers
+    result = result.replace(
+      new RegExp(`<h3[^>]*>\\s*(?:${section.pattern.source})[^<]*<\\/h3>`, 'gi'),
+      `<h3 class="section-header">${section.standard}</h3>`
+    );
+    
+    // Then try h4 headers
+    result = result.replace(
+      new RegExp(`<h4[^>]*>\\s*(?:${section.pattern.source})[^<]*<\\/h4>`, 'gi'),
+      `<h3 class="section-header">${section.standard}</h3>`
+    );
+    
+    // Also check for bold text that might be acting as headers
+    result = result.replace(
+      new RegExp(`<(?:strong|b)>\\s*(?:${section.pattern.source})[^<]*<\\/(?:strong|b)>`, 'gi'),
+      `<h3 class="section-header">${section.standard}</h3>`
+    );
+  });
+  
+  // Ensure all section headers have consistent h3 tags
+  result = result.replace(
+    /<h3\s+class="section-header">([^<]+)<\/h3>/gi,
+    (match, p1) => {
+      // Extract any time duration from the header
+      const timeMatch = p1.match(/⏱️?\s*(\d+\s*(?:min(?:ute)?s?|hour?s?))/i);
+      if (timeMatch) {
+        const cleanTitle = p1.replace(/⏱️?\s*\d+\s*(?:min(?:ute)?s?|hour?s?):?/i, '').trim();
+        return `<h3 class="section-header">${cleanTitle} <span class="duration">⏱️ ${timeMatch[1]}</span></h3>`;
+      }
+      return `<h3 class="section-header">${p1}</h3>`;
+    }
+  );
+  
+  return result;
+}
+
+/**
+ * Standardize how student-specific content is formatted
+ */
+function standardizeStudentSections(content: string): string {
+  // Look for patterns like "Student Name (Grade X)" or "JW (Grade 3)"
+  const studentPattern = /(?:<(?:h4|strong|b)>)?([A-Z]{1,3})\s*\(Grade\s*(\d+)\)(?:<\/(?:h4|strong|b)>)?/g;
+  
+  let result = content;
+  
+  // Replace student headers with consistent formatting
+  result = result.replace(
+    studentPattern,
+    '<h4 class="student-header"><span class="student-name">$1</span> <span class="grade-level">(Grade $2)</span></h4>'
+  );
+  
+  // Ensure activity labels are consistent
+  result = result.replace(
+    /Activity\s*(\d+)\s*:/gi,
+    '<strong class="activity-label">Activity $1:</strong>'
+  );
+  
+  // Standardize IEP goal references
+  result = result.replace(
+    /IEP\s*Goal\s*:/gi,
+    '<strong class="goal-label">IEP Goal:</strong>'
+  );
+  
+  // Standardize focus areas
+  result = result.replace(
+    /Focus\s*Areas?\s*:/gi,
+    '<strong class="focus-label">Focus Areas:</strong>'
+  );
+  
+  return result;
+}
+
+/**
+ * Extract and structure lesson metadata for consistent display
+ */
+export function extractLessonMetadata(content: string): {
+  gradeLevel?: string;
+  duration?: string;
+  studentCount?: number;
+} {
+  const metadata: any = {};
+  
+  // Extract grade level
+  const gradeMatch = content.match(/Grade[s]?\s+(\d+(?:-\d+)?)/i);
+  if (gradeMatch) {
+    metadata.gradeLevel = gradeMatch[1];
+  }
+  
+  // Extract duration
+  const durationMatch = content.match(/(\d+)\s*minutes?/i);
+  if (durationMatch) {
+    metadata.duration = `${durationMatch[1]} minutes`;
+  }
+  
+  // Count unique students
+  const studentMatches = content.match(/([A-Z]{1,3})\s*\(Grade\s*\d+\)/g);
+  if (studentMatches) {
+    const uniqueStudents = new Set(studentMatches.map(m => m.split('(')[0].trim()));
+    metadata.studentCount = uniqueStudents.size;
+  }
+  
+  return metadata;
+}


### PR DESCRIPTION
- Created shared AI lesson formatter utility for consistent formatting
- Updated both ai-content-modal.tsx and ai-content-modal-enhanced.tsx to use shared formatter
- Ensures uniform formatting for spacing, font sizes, and visual hierarchy
- Added print-specific formatting for consistent printed output
- Resolved issue where same lessons displayed differently in different modals

This ensures all AI-generated lesson plans have consistent formatting regardless of which modal component renders them.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enforced, consistent HTML structure for AI-generated lessons and dedicated print formatting including “Print All.”
- Enhancements
  - Cleaner lesson content: redundant headers and grade/duration lines removed.
  - Consistent section and student formatting; activity sections get visual cues and dividers.
  - Improved student references: colored badges on-screen; print uses underlined initials; empty paragraphs trimmed.
- Chores
  - Added AI permission to allow creating GitHub issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->