### PR TITLE
feat: add session details popup to Today's Schedule (#198)

### DIFF
--- a/app/components/session/draggable-session-box.tsx
+++ b/app/components/session/draggable-session-box.tsx
@@ -55,9 +55,17 @@ export function DraggableSessionBox({
   };
 
   const handleDragEnd = () => {
-    setIsDragging(false);
+    // Delay resetting isDragging to prevent click after drag
+    setTimeout(() => setIsDragging(false), 50);
     if (onDragEnd) {
       onDragEnd();
+    }
+  };
+
+  const handleClick = () => {
+    // Prevent click if we're dragging or just finished dragging
+    if (!isDragging && onClick) {
+      onClick();
     }
   };
 
@@ -113,9 +121,15 @@ export function DraggableSessionBox({
       draggable={canEdit}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
-      onClick={onClick}
-      role="button"
-      tabIndex={canEdit ? 0 : -1}
+      onClick={handleClick}
+      onKeyDown={(e) => {
+        if (onClick && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          if (!isDragging) onClick();
+        }
+      }}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick || canEdit ? 0 : -1}
       aria-label={`${isSeaSession ? 'SEA' : 'Provider'} session for ${student.initials}, grade ${student.grade_level}, ${session.service_type} from ${session.start_time} to ${session.end_time}`}
       aria-grabbed={isDragging}
       aria-disabled={!canEdit}

--- a/app/components/session/draggable-session-box.tsx
+++ b/app/components/session/draggable-session-box.tsx
@@ -15,6 +15,7 @@ export interface DraggableSessionBoxProps {
   canEdit: boolean;
   onDragStart?: (session: ScheduleSession, event: DragEvent) => void;
   onDragEnd?: () => void;
+  onClick?: () => void;
   size?: 'small' | 'medium' | 'large';
   variant?: 'box' | 'pill';
   hasConflict?: boolean;
@@ -27,6 +28,7 @@ export function DraggableSessionBox({
   canEdit,
   onDragStart,
   onDragEnd,
+  onClick,
   size = 'medium',
   variant = 'box',
   hasConflict = false
@@ -111,12 +113,14 @@ export function DraggableSessionBox({
       draggable={canEdit}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
+      onClick={onClick}
       role="button"
       tabIndex={canEdit ? 0 : -1}
       aria-label={`${isSeaSession ? 'SEA' : 'Provider'} session for ${student.initials}, grade ${student.grade_level}, ${session.service_type} from ${session.start_time} to ${session.end_time}`}
       aria-grabbed={isDragging}
       aria-disabled={!canEdit}
       title={`${student.initials} - ${session.service_type} (${session.start_time}-${session.end_time})`}
+      style={{ cursor: onClick ? 'pointer' : (canEdit ? 'grab' : 'default') }}
     >
       <span className="select-none">
         {student.initials}

--- a/app/components/session/session-details-popup.tsx
+++ b/app/components/session/session-details-popup.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import { ScheduleSession } from '@/src/types/database';
+import { format } from 'date-fns';
+
+interface SessionDetailsPopupProps {
+  session: ScheduleSession & {
+    session_date?: string;
+  };
+  student: {
+    initials: string;
+    grade_level: string;
+    id: string;
+    teacher_name?: string;
+  };
+  assignedTo?: {
+    full_name: string;
+    role: string;
+  } | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onUpdate?: () => void;
+}
+
+export function SessionDetailsPopup({
+  session,
+  student,
+  assignedTo,
+  isOpen,
+  onClose,
+  onUpdate
+}: SessionDetailsPopupProps) {
+  const [loading, setLoading] = useState(false);
+  const [formData, setFormData] = useState({
+    is_completed: session.is_completed || false,
+    student_absent: session.student_absent || false,
+    outside_schedule_conflict: session.outside_schedule_conflict || false,
+    session_notes: session.session_notes || ''
+  });
+
+  useEffect(() => {
+    setFormData({
+      is_completed: session.is_completed || false,
+      student_absent: session.student_absent || false,
+      outside_schedule_conflict: session.outside_schedule_conflict || false,
+      session_notes: session.session_notes || ''
+    });
+  }, [session]);
+
+  const handleSave = async () => {
+    setLoading(true);
+    const supabase = createClient();
+
+    try {
+      const updateData: any = {
+        ...formData,
+        updated_at: new Date().toISOString()
+      };
+
+      // If marking as completed, set completed_at and completed_by
+      if (formData.is_completed && !session.is_completed) {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (user) {
+          updateData.completed_at = new Date().toISOString();
+          updateData.completed_by = user.id;
+        }
+      } else if (!formData.is_completed && session.is_completed) {
+        // If unchecking completed, clear the timestamps
+        updateData.completed_at = null;
+        updateData.completed_by = null;
+      }
+
+      const { error } = await supabase
+        .from('schedule_sessions')
+        .update(updateData)
+        .eq('id', session.id);
+
+      if (error) throw error;
+
+      if (onUpdate) {
+        onUpdate();
+      }
+      onClose();
+    } catch (error) {
+      console.error('Error updating session details:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  // Format session date if available
+  const sessionDate = session.session_date 
+    ? format(new Date(session.session_date), 'EEEE, MMMM d, yyyy')
+    : 'Today';
+
+  // Format times
+  const startTime = session.start_time ? 
+    format(new Date(`2000-01-01T${session.start_time}`), 'h:mm a') : '';
+  const endTime = session.end_time ? 
+    format(new Date(`2000-01-01T${session.end_time}`), 'h:mm a') : '';
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div 
+        className="fixed inset-0 bg-black bg-opacity-50 z-40"
+        onClick={onClose}
+      />
+      
+      {/* Popup */}
+      <div className="fixed inset-0 flex items-center justify-center z-50 p-4">
+        <div className="bg-white rounded-lg shadow-xl max-w-md w-full max-h-[90vh] overflow-y-auto">
+          {/* Header */}
+          <div className="p-4 border-b">
+            <div className="flex justify-between items-start">
+              <div>
+                <h2 className="text-xl font-semibold">Session Details</h2>
+                <p className="text-sm text-gray-600 mt-1">
+                  {student.initials} - {session.service_type}
+                </p>
+              </div>
+              <button
+                onClick={onClose}
+                className="text-gray-400 hover:text-gray-600"
+              >
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          {/* Content */}
+          <div className="p-4 space-y-4">
+            {/* Session Information */}
+            <div className="space-y-2">
+              <div className="flex justify-between text-sm">
+                <span className="text-gray-600">Date:</span>
+                <span className="font-medium">{sessionDate}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-gray-600">Time:</span>
+                <span className="font-medium">{startTime} - {endTime}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-gray-600">Student:</span>
+                <span className="font-medium">{student.initials} (Grade {student.grade_level})</span>
+              </div>
+              {student.teacher_name && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-gray-600">Teacher:</span>
+                  <span className="font-medium">{student.teacher_name}</span>
+                </div>
+              )}
+              <div className="flex justify-between text-sm">
+                <span className="text-gray-600">Assigned to:</span>
+                <span className="font-medium">
+                  {assignedTo ? `${assignedTo.full_name} (${assignedTo.role})` : 'Not assigned'}
+                </span>
+              </div>
+            </div>
+
+            <hr className="my-4" />
+
+            {/* Checkboxes */}
+            <div className="space-y-3">
+              <label className="flex items-center space-x-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={formData.is_completed}
+                  onChange={(e) => setFormData({ ...formData, is_completed: e.target.checked })}
+                  className="w-4 h-4 text-blue-600 rounded focus:ring-blue-500"
+                  disabled={loading}
+                />
+                <span className="text-sm">Session completed</span>
+              </label>
+
+              <label className="flex items-center space-x-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={formData.student_absent}
+                  onChange={(e) => setFormData({ ...formData, student_absent: e.target.checked })}
+                  className="w-4 h-4 text-blue-600 rounded focus:ring-blue-500"
+                  disabled={loading}
+                />
+                <span className="text-sm">Student was absent</span>
+              </label>
+
+              <label className="flex items-center space-x-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={formData.outside_schedule_conflict}
+                  onChange={(e) => setFormData({ ...formData, outside_schedule_conflict: e.target.checked })}
+                  className="w-4 h-4 text-blue-600 rounded focus:ring-blue-500"
+                  disabled={loading}
+                />
+                <span className="text-sm">Outside schedule conflict</span>
+              </label>
+            </div>
+
+            <hr className="my-4" />
+
+            {/* Notes Section */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Session Notes
+              </label>
+              <textarea
+                value={formData.session_notes}
+                onChange={(e) => setFormData({ ...formData, session_notes: e.target.value })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500 text-sm"
+                rows={3}
+                placeholder="Add any notes about this session..."
+                disabled={loading}
+              />
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="p-4 border-t flex justify-end space-x-3">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
+              disabled={loading}
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              className="px-4 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700 disabled:opacity-50"
+              disabled={loading}
+            >
+              {loading ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -529,6 +529,9 @@ export interface Database {
           session_date: string | null
           session_notes: string | null
           manually_placed: boolean
+          is_completed: boolean
+          student_absent: boolean
+          outside_schedule_conflict: boolean
         }
         Insert: {
           id?: string
@@ -547,6 +550,9 @@ export interface Database {
           session_date?: string | null
           session_notes?: string | null
           manually_placed?: boolean
+          is_completed?: boolean
+          student_absent?: boolean
+          outside_schedule_conflict?: boolean
         }
         Update: {
           id?: string
@@ -565,6 +571,9 @@ export interface Database {
           session_date?: string | null
           session_notes?: string | null
           manually_placed?: boolean
+          is_completed?: boolean
+          student_absent?: boolean
+          outside_schedule_conflict?: boolean
         }
       },
       lessons: {

--- a/supabase/migrations/20250902_session_attendance_tracking.sql
+++ b/supabase/migrations/20250902_session_attendance_tracking.sql
@@ -1,0 +1,10 @@
+-- Add fields for tracking session attendance and conflicts
+ALTER TABLE schedule_sessions
+ADD COLUMN IF NOT EXISTS student_absent BOOLEAN DEFAULT FALSE,
+ADD COLUMN IF NOT EXISTS outside_schedule_conflict BOOLEAN DEFAULT FALSE,
+ADD COLUMN IF NOT EXISTS is_completed BOOLEAN DEFAULT FALSE;
+
+-- Add comment for the new columns
+COMMENT ON COLUMN schedule_sessions.student_absent IS 'Indicates if the student was absent for this session';
+COMMENT ON COLUMN schedule_sessions.outside_schedule_conflict IS 'Indicates if there was a scheduling conflict outside of normal schedule';
+COMMENT ON COLUMN schedule_sessions.is_completed IS 'Indicates if the session was completed (separate from completed_at which is a timestamp)';

--- a/supabase/migrations/20250902_session_attendance_tracking.sql
+++ b/supabase/migrations/20250902_session_attendance_tracking.sql
@@ -1,10 +1,29 @@
 -- Add fields for tracking session attendance and conflicts
+BEGIN;
+
 ALTER TABLE schedule_sessions
-ADD COLUMN IF NOT EXISTS student_absent BOOLEAN DEFAULT FALSE,
-ADD COLUMN IF NOT EXISTS outside_schedule_conflict BOOLEAN DEFAULT FALSE,
-ADD COLUMN IF NOT EXISTS is_completed BOOLEAN DEFAULT FALSE;
+  ADD COLUMN IF NOT EXISTS student_absent BOOLEAN DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS outside_schedule_conflict BOOLEAN DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS is_completed BOOLEAN DEFAULT FALSE;
+
+-- Backfill existing NULLs before enforcing NOT NULL
+UPDATE schedule_sessions SET
+  student_absent = COALESCE(student_absent, FALSE),
+  outside_schedule_conflict = COALESCE(outside_schedule_conflict, FALSE),
+  is_completed = COALESCE(is_completed, FALSE)
+WHERE student_absent IS NULL
+   OR outside_schedule_conflict IS NULL
+   OR is_completed IS NULL;
+
+-- Enforce NOT NULL constraints
+ALTER TABLE schedule_sessions
+  ALTER COLUMN student_absent SET NOT NULL,
+  ALTER COLUMN outside_schedule_conflict SET NOT NULL,
+  ALTER COLUMN is_completed SET NOT NULL;
 
 -- Add comment for the new columns
 COMMENT ON COLUMN schedule_sessions.student_absent IS 'Indicates if the student was absent for this session';
 COMMENT ON COLUMN schedule_sessions.outside_schedule_conflict IS 'Indicates if there was a scheduling conflict outside of normal schedule';
 COMMENT ON COLUMN schedule_sessions.is_completed IS 'Indicates if the session was completed (separate from completed_at which is a timestamp)';
+
+COMMIT;


### PR DESCRIPTION
- Added popup modal for session pills showing:
  - Exact session times
  - Teacher's name
  - Assigned SEA/specialist (if any)
  - Completed checkbox
  - Student absent checkbox
  - Outside schedule conflict checkbox
  - Notes text field
- Added database migration for new tracking fields:
  - is_completed (boolean)
  - student_absent (boolean)
  - outside_schedule_conflict (boolean)
- Updated DraggableSessionBox to support onClick handler
- Integrated popup with session pills in WeeklyView
- Added real-time database updates when session details are saved

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tap a session in Weekly View to open a Session Details popup.
  - View session date/time, student, teacher, and assignee.
  - Update status: completed, student absent, or outside schedule conflict.
  - Add notes and save; changes persist and refresh the schedule.

- Improvements
  - Session tiles show a pointer cursor when clickable.
  - Weekly View refreshes automatically after saving session updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->