### PR TITLE
fix: filter out orphaned sessions in calendar views (#224)

### DIFF
--- a/app/components/calendar/calendar-today-view-dragversion.tsx
+++ b/app/components/calendar/calendar-today-view-dragversion.tsx
@@ -121,7 +121,7 @@ export function CalendarTodayView({
   // Filter sessions for the selected date (based on day_of_week)
   const selectedDayOfWeek = currentDate.getDay();
   const adjustedDayOfWeek = selectedDayOfWeek === 0 ? 7 : selectedDayOfWeek; // Convert Sunday (0) to 7
-  const todaySessions = sessions.filter(s => s.day_of_week === adjustedDayOfWeek);
+  const todaySessions = sessions.filter(s => s.day_of_week === adjustedDayOfWeek && students.has(s.student_id));
 
   // Sort sessions by start time
   const sortedSessions = [...todaySessions].sort((a, b) => 
@@ -457,7 +457,7 @@ export function CalendarTodayView({
                               <DraggableSessionBox
                                 session={currentSession}
                                 student={{
-                                  initials: student?.initials || 'S',
+                                  initials: student?.initials || '?',
                                   grade_level: student?.grade_level || '',
                                   id: session.student_id
                                 }}

--- a/app/components/calendar/calendar-today-view.tsx
+++ b/app/components/calendar/calendar-today-view.tsx
@@ -360,12 +360,13 @@ export function CalendarTodayView({
       {!isHoliday() && (
         <div className="bg-white rounded-lg shadow-sm border border-gray-200">
           <div className="divide-y divide-gray-100">
-            {sessionsState.length === 0 ? (
+            {sessionsState.filter((session) => students.has(session.student_id)).length === 0 ? (
               <div className="p-4 text-center text-gray-500">
                 No sessions scheduled for today
               </div>
             ) : (
               sessionsState
+                .filter((session) => students.has(session.student_id))
                 .sort((a, b) => a.start_time.localeCompare(b.start_time))
                 .map((session) => {
                   const student = students.get(session.student_id);
@@ -378,7 +379,7 @@ export function CalendarTodayView({
                             {formatTime(session.start_time)} - {formatTime(session.end_time)}
                           </div>
                           <div className="text-sm font-semibold text-gray-900">
-                            {student?.initials || 'S'}
+                            {student?.initials || '?'}
                           </div>
                         </div>
 

--- a/app/components/calendar/calendar-week-view-dragversion.tsx
+++ b/app/components/calendar/calendar-week-view-dragversion.tsx
@@ -722,17 +722,19 @@ export function CalendarWeekView({
     }
   };
 
-  // Group sessions by day
-  const sessionsByDay = sessionsState.reduce(
-    (acc, session) => {
-      if (!acc[session.day_of_week]) {
-        acc[session.day_of_week] = [];
-      }
-      acc[session.day_of_week].push(session);
-      return acc;
-    },
-    {} as Record<number, ScheduleSession[]>,
-  );
+  // Group sessions by day, filtering out sessions without valid students
+  const sessionsByDay = sessionsState
+    .filter((session) => students.has(session.student_id))
+    .reduce(
+      (acc, session) => {
+        if (!acc[session.day_of_week]) {
+          acc[session.day_of_week] = [];
+        }
+        acc[session.day_of_week].push(session);
+        return acc;
+      },
+      {} as Record<number, ScheduleSession[]>,
+    );
 
   // Sort sessions within each day
   Object.keys(sessionsByDay).forEach((day) => {
@@ -1226,7 +1228,7 @@ export function CalendarWeekView({
                           )}
                         >
                           <span className="select-none">
-                            {student?.initials || 'S'}
+                            {student?.initials || '?'}
                           </span>
                         </div>
                         <div className="flex-1 text-xs">

--- a/app/components/calendar/calendar-week-view.tsx
+++ b/app/components/calendar/calendar-week-view.tsx
@@ -902,7 +902,7 @@ export function CalendarWeekView({
     return weekDates.map((date, index) => {
       const dayOfWeek = index + 1; // 1-5 for Monday-Friday
       const daySessions = weekSessions.filter(
-        (s) => s.day_of_week === dayOfWeek
+        (s) => s.day_of_week === dayOfWeek && students.has(s.student_id)
       );
       const isHolidayDay = isHoliday(date);
       const holidayName = isHolidayDay ? getHolidayName(date) : null;
@@ -1290,7 +1290,7 @@ export function CalendarWeekView({
                                 {formatTime(session.start_time)}
                               </div>
                               <div className={session.delivered_by === 'sea' ? 'text-green-600' : 'text-gray-700'}>
-                                {student?.initials || 'S'}
+                                {student?.initials || '?'}
                                 {session.delivered_by === 'sea' && (
                                   <div className="text-green-600 text-xs">SEA</div>
                                 )}


### PR DESCRIPTION
Remove sessions without valid students from all calendar views instead of displaying them with placeholder initials. This fixes the issue where school filtering was creating orphaned sessions that showed as 'S' or '?' in the UI.

Changes:
- Filter sessions to only include those with valid students in students Map
- Update empty state checks to account for filtered sessions
- Apply filtering consistently across all 4 calendar view components

This ensures data consistency when school filtering is active and prevents confusing placeholder displays for sessions with missing student data.

🤖 Generated with [Claude Code](https://claude.ai/code)