### PR TITLE
fix: resolve issue #226 - AI lessons match grade levels and worksheet…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -51,7 +51,9 @@
       "mcp__github__get_issue",
       "Bash(gh repo view:*)",
       "mcp__github__create_issue",
-      "Bash(git fetch:*)"
+      "Bash(git fetch:*)",
+      "Bash(git restore:*)",
+      "mcp__supabase__list_tables"
     ],
     "deny": []
   },

--- a/.replit
+++ b/.replit
@@ -46,3 +46,6 @@ exposeLocalhost = true
 [[ports]]
 localPort = 24282
 externalPort = 5000
+
+[agent]
+expertMode = true

--- a/app/components/calendar/calendar-week-view.tsx
+++ b/app/components/calendar/calendar-week-view.tsx
@@ -128,7 +128,7 @@ export function CalendarWeekView({
   const applyGeneratedLessonsToState = (
     prev: Map<string, any>,
     dateKey: string,
-    lessons: Array<{ timeSlot: string; content: string; prompt: string; lessonId?: string }>
+    lessons: Array<{ timeSlot: string; content: string; prompt: string; lessonId?: string; students?: Array<{ id: string; initials: string; grade_level: string; teacher_name: string }> }>
   ) => {
     const newMap = new Map(prev);
     const dayLessons = { ...(newMap.get(dateKey) || {}) };
@@ -1016,14 +1016,17 @@ export function CalendarWeekView({
         for (const [timeSlot, slotSessions] of timeSlotGroups.entries()) {
           const lessonData = await generateAIContentForTimeSlot(selectedLessonDate, slotSessions, timeSlot);
           if (lessonData) {
-            // Add student information to the lesson data
-            lessonData.students = slotSessions.map(session => ({
-              id: session.student_id || '',
-              initials: students.get(session.student_id || '')?.initials || '',
-              grade_level: students.get(session.student_id || '')?.grade_level || '',
-              teacher_name: ''
-            }));
-            generatedLessons.push(lessonData);
+            // Create a new object with student information
+            const lessonWithStudents = {
+              ...lessonData,
+              students: slotSessions.map(session => ({
+                id: session.student_id || '',
+                initials: students.get(session.student_id || '')?.initials || '',
+                grade_level: students.get(session.student_id || '')?.grade_level || '',
+                teacher_name: ''
+              }))
+            };
+            generatedLessons.push(lessonWithStudents);
           }
         }
         

--- a/lib/ai-lessons/assessment-registry.ts
+++ b/lib/ai-lessons/assessment-registry.ts
@@ -123,6 +123,24 @@ export class AssessmentRegistry {
 
     // Get student details (contains IEP goals, reading level, etc.)
     const supabase = await createClient() as unknown as SupabaseClient;
+    
+    // First get the student's grade level from students table
+    const { data: student } = await supabase
+      .from('students')
+      .select('grade_level')
+      .eq('id', studentId)
+      .single();
+    
+    if (student?.grade_level) {
+      assessments.push({
+        studentId,
+        assessmentType: 'grade_level',
+        data: student.grade_level,
+        collectedAt: new Date(),
+        confidence: 1.0
+      });
+    }
+    
     const { data: studentDetails } = await supabase
       .from('student_details')
       .select('*')

--- a/lib/ai-lessons/lesson-generator.ts
+++ b/lib/ai-lessons/lesson-generator.ts
@@ -181,12 +181,7 @@ export class LessonGenerator {
 
   private async callAIForLesson(prompt: any): Promise<string> {
     if (!this.anthropic) {
-      // Only return mock lesson in non-production environments
-      if (process.env.NODE_ENV !== 'production') {
-        return this.generateMockLesson(prompt);
-      } else {
-        throw new Error('AI client not initialized and running in production. Cannot generate lesson.');
-      }
+      throw new Error('AI service is not configured. Please ensure ANTHROPIC_API_KEY is set.');
     }
 
     try {
@@ -203,87 +198,25 @@ export class LessonGenerator {
       return message.content[0].type === 'text' ? message.content[0].text : '';
     } catch (error) {
       console.error('AI generation error:', error);
-      return this.generateMockLesson(prompt);
+      throw new Error(`Failed to generate lesson: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }
 
-  private generateMockLesson(prompt: any): string {
-    // Generate a structured mock response for testing
-    const isGroup = prompt.userPrompt.includes('group');
-    const studentCount = isGroup ? 3 : 1;
-    
-    return `
-# Lesson Overview
-**Title:** Phonics Practice - Short Vowel Sounds
-**Duration:** 30 minutes
-**Learning Objectives:**
-- Identify short vowel sounds in CVC words
-- Read and write words with short vowels
-- Apply phonics skills to decode new words
-
-**Materials Needed:** All materials included on worksheets - just print!
-
-## Student Materials
-
-${Array.from({ length: studentCount }, (_, i) => `
-### Student ${i + 1} Worksheet
-
-**Title:** Short Vowel Practice - Level ${i + 1}
-**Instructions:** Complete each section. All the help you need is on this paper!
-
-**Section 1: Word Recognition** (with picture supports)
-1. Circle the word that matches the picture:
-   [CAT picture] -> cat / cut / cot
-   [BED picture] -> bad / bed / bid
-   
-**Section 2: Fill in the Vowel**
-Complete each word with the correct vowel (a, e, i, o, u):
-1. c_t (picture of cat)
-2. d_g (picture of dog)
-3. p_n (picture of pen)
-
-**Visual Support Box:**
-Short Vowel Sounds:
-- a as in cat 🐱
-- e as in bed 🛏️
-- i as in pig 🐷
-- o as in dog 🐕
-- u as in sun ☀️
-
-**Exit Ticket:**
-Write one word with each short vowel:
-a: _____ e: _____ i: _____ o: _____ u: _____
-`).join('\n')}
-
-## Teacher Guidance
-
-**Differentiation Notes:**
-- Student 1: Working at grade level, independent work expected
-- Student 2: May need reminder about vowel sounds, check after 10 minutes
-- Student 3: Provide encouragement, may need help with writing formation
-
-**Check-in Priorities:**
-1. Student 3 - after 5 minutes
-2. Student 2 - after 10 minutes  
-3. Student 1 - after 15 minutes
-
-**Expected Completion Times:**
-- Student 1: 20-25 minutes
-- Student 2: 25-30 minutes
-- Student 3: Full 30 minutes
-
-**Support Levels:**
-- Student 1: Independent
-- Student 2: Minimal support
-- Student 3: Moderate support`;
-  }
 
   private parseAIResponse(response: string, request: LessonGenerationRequest): Omit<GeneratedLesson, 'id' | 'worksheetIds' | 'qrCodes'> {
-    // Parse the AI response into structured format
-    // This is simplified - in production, use more robust parsing
+    // Try to parse as JSON first (if AI returns structured JSON)
+    try {
+      const jsonResponse = JSON.parse(response);
+      if (jsonResponse.content && jsonResponse.content.studentMaterials) {
+        return jsonResponse;
+      }
+    } catch {
+      // If not JSON, parse as markdown/text format
+    }
     
+    // Parse the AI response from markdown/text format
     const lines = response.split('\n');
-    const title = lines.find(l => l.includes('Title:'))?.replace(/.*Title:\s*/, '') || 'Lesson';
+    const title = lines.find(l => l.includes('Title:'))?.replace(/.*Title:\s*/, '') || 'AI-Generated Lesson';
     
     const studentMaterials: StudentMaterial[] = [];
     const differentiationMap = new Map<string, DifferentiationData>();

--- a/lib/ai-lessons/prompt-assembler.ts
+++ b/lib/ai-lessons/prompt-assembler.ts
@@ -66,8 +66,8 @@ export class PromptAssembler {
     let totalConfidence = 0;
     let confidenceCount = 0;
 
-    // Build system prompt with constraints
-    const systemPrompt = this.buildSystemPrompt(context.lessonType);
+    // Build system prompt with constraints and subject-specific guidance
+    const systemPrompt = this.buildSystemPrompt(context.lessonType, context.subject);
     
     // Build user prompt with dynamic data
     let userPrompt = '';
@@ -96,12 +96,50 @@ export class PromptAssembler {
     };
   }
 
-  private buildSystemPrompt(lessonType: 'individual' | 'group'): string {
+  private buildSystemPrompt(lessonType: 'individual' | 'group', subject?: string): string {
+    let subjectGuidance = '';
+    
+    if (subject) {
+      const subjectLower = subject.toLowerCase();
+      if (subjectLower === 'math' || subjectLower === 'mathematics') {
+        subjectGuidance = `
+MATH-SPECIFIC REQUIREMENTS:
+- Include number lines, hundreds charts, or visual models for every problem
+- Progress from concrete to abstract representations
+- Include computation practice appropriate for grade level
+- Incorporate word problems with visual supports
+- Use manipulative representations (drawn on worksheet)
+- Include step-by-step examples for new concepts
+`;
+      } else if (subjectLower === 'ela' || subjectLower === 'reading' || subjectLower === 'english' || subjectLower === 'phonics') {
+        subjectGuidance = `
+ELA/READING-SPECIFIC REQUIREMENTS:
+- Match text complexity to student's actual reading level (not just grade level)
+- Include phonics patterns appropriate for developmental level
+- Incorporate sight word practice for younger grades
+- Use picture supports for vocabulary
+- Include comprehension questions at multiple levels (literal, inferential)
+- Provide word banks when appropriate
+- Use larger fonts for younger students
+`;
+      } else if (subjectLower === 'writing') {
+        subjectGuidance = `
+WRITING-SPECIFIC REQUIREMENTS:
+- Provide sentence starters and frames
+- Include word banks with topic-specific vocabulary
+- Use graphic organizers (printed on worksheet)
+- Include lined spaces appropriate for grade level
+- Provide examples of target writing skill
+- Break complex tasks into steps
+`;
+      }
+    }
+    
     return `You are an expert special education teacher creating ${lessonType} lessons with these STRICT requirements:
 
 MATERIAL CONSTRAINTS (ABSOLUTELY REQUIRED):
 ${this.materialConstraints.map(c => `- ${c}`).join('\n')}
-
+${subjectGuidance}
 OUTPUT FORMAT:
 1. Lesson Overview
    - Title
@@ -236,8 +274,19 @@ CRITICAL RULES:
     const assessments = context.assessments.get(studentId) || [];
     const performance = context.performance.get(studentId) || [];
     
-    // Add basic info (would need to fetch from DB in real implementation)
+    // Fetch student's actual grade level from database
+    const { data: student } = await this.supabase!
+      .from('students')
+      .select('grade_level')
+      .eq('id', studentId)
+      .single();
+    
+    // Add basic info
     profile += `- ID Reference: Student${studentNumber}\n`;
+    if (student?.grade_level) {
+      profile += `- Grade Level: ${student.grade_level}\n`;
+      dataUsed.push('grade_level');
+    }
 
     // Add assessment-based information
     if (assessments.length > 0) {

--- a/lib/utils/grade-level.ts
+++ b/lib/utils/grade-level.ts
@@ -1,0 +1,125 @@
+// lib/utils/grade-level.ts
+
+/**
+ * Standardizes grade level format across the system
+ * Converts various grade formats to a consistent format
+ * 
+ * @param grade - The grade level in any format (e.g., "4th Grade", "Grade 4", "4", "fourth")
+ * @returns The standardized grade level (e.g., "4") or null if invalid
+ */
+export function standardizeGradeLevel(grade: string | null | undefined): string | null {
+  if (!grade) return null;
+  
+  const gradeStr = grade.toString().toLowerCase().trim();
+  
+  // Handle kindergarten
+  if (gradeStr.includes('kind') || gradeStr === 'k') {
+    return 'K';
+  }
+  
+  // Handle pre-K
+  if (gradeStr.includes('pre') && (gradeStr.includes('k') || gradeStr.includes('kind'))) {
+    return 'PreK';
+  }
+  
+  // Extract numeric grade
+  const numericMatch = gradeStr.match(/\d+/);
+  if (numericMatch) {
+    const gradeNum = parseInt(numericMatch[0]);
+    if (gradeNum >= 1 && gradeNum <= 12) {
+      return gradeNum.toString();
+    }
+  }
+  
+  // Handle written numbers
+  const writtenNumbers: Record<string, string> = {
+    'first': '1',
+    'second': '2',
+    'third': '3',
+    'fourth': '4',
+    'fifth': '5',
+    'sixth': '6',
+    'seventh': '7',
+    'eighth': '8',
+    'ninth': '9',
+    'tenth': '10',
+    'eleventh': '11',
+    'twelfth': '12'
+  };
+  
+  for (const [written, numeric] of Object.entries(writtenNumbers)) {
+    if (gradeStr.includes(written)) {
+      return numeric;
+    }
+  }
+  
+  return null;
+}
+
+/**
+ * Formats a standardized grade level for display
+ * 
+ * @param standardizedGrade - The standardized grade (e.g., "4", "K")
+ * @returns The formatted grade for display (e.g., "4th Grade", "Kindergarten")
+ */
+export function formatGradeLevel(standardizedGrade: string | null | undefined): string {
+  if (!standardizedGrade) return 'Unknown Grade';
+  
+  if (standardizedGrade === 'K') {
+    return 'Kindergarten';
+  }
+  
+  if (standardizedGrade === 'PreK') {
+    return 'Pre-Kindergarten';
+  }
+  
+  const gradeNum = parseInt(standardizedGrade);
+  if (!isNaN(gradeNum)) {
+    const suffix = getOrdinalSuffix(gradeNum);
+    return `${gradeNum}${suffix} Grade`;
+  }
+  
+  return standardizedGrade;
+}
+
+/**
+ * Gets the ordinal suffix for a number
+ */
+function getOrdinalSuffix(num: number): string {
+  const lastDigit = num % 10;
+  const lastTwoDigits = num % 100;
+  
+  if (lastTwoDigits >= 11 && lastTwoDigits <= 13) {
+    return 'th';
+  }
+  
+  switch (lastDigit) {
+    case 1: return 'st';
+    case 2: return 'nd';
+    case 3: return 'rd';
+    default: return 'th';
+  }
+}
+
+/**
+ * Compares two grade levels
+ * 
+ * @returns negative if grade1 < grade2, positive if grade1 > grade2, 0 if equal
+ */
+export function compareGradeLevels(grade1: string, grade2: string): number {
+  const std1 = standardizeGradeLevel(grade1);
+  const std2 = standardizeGradeLevel(grade2);
+  
+  if (!std1 || !std2) return 0;
+  
+  // Handle special grades
+  const gradeOrder: Record<string, number> = {
+    'PreK': -1,
+    'K': 0
+  };
+  
+  const order1 = gradeOrder[std1] ?? parseInt(std1);
+  const order2 = gradeOrder[std2] ?? parseInt(std2);
+  
+  return order1 - order2;
+}

--- a/lib/utils/grade-level.ts
+++ b/lib/utils/grade-level.ts
@@ -12,14 +12,14 @@ export function standardizeGradeLevel(grade: string | null | undefined): string 
   
   const gradeStr = grade.toString().toLowerCase().trim();
   
+  // Handle pre-K first (must come before kindergarten check)
+  if (gradeStr.includes('pre') && (gradeStr.includes('k') || gradeStr.includes('kind'))) {
+    return 'PreK';
+  }
+  
   // Handle kindergarten
   if (gradeStr.includes('kind') || gradeStr === 'k') {
     return 'K';
-  }
-  
-  // Handle pre-K
-  if (gradeStr.includes('pre') && (gradeStr.includes('k') || gradeStr.includes('kind'))) {
-    return 'PreK';
   }
   
   // Extract numeric grade
@@ -120,6 +120,9 @@ export function compareGradeLevels(grade1: string, grade2: string): number {
   
   const order1 = gradeOrder[std1] ?? parseInt(std1);
   const order2 = gradeOrder[std2] ?? parseInt(std2);
+  
+  // Check for NaN in case of non-numeric standardized grades
+  if (isNaN(order1) || isNaN(order2)) return 0;
   
   return order1 - order2;
 }

--- a/lib/worksheets/worksheet-generator.ts
+++ b/lib/worksheets/worksheet-generator.ts
@@ -1,8 +1,9 @@
 // lib/worksheets/worksheet-generator.ts
-import QRCode from 'qrcode';
+import * as QRCode from 'qrcode';
 import { createClient } from '@/lib/supabase/client';
 import type { Database } from '../../src/types/database';
 import type { LessonResponse, StudentMaterial, WorksheetItem } from '../lessons/schema';
+import { standardizeGradeLevel } from '../utils/grade-level';
 
 interface WorksheetQuestion {
   id: string;
@@ -175,6 +176,12 @@ export function extractWorksheetFromLesson(
   }
   
   // Fallback to grade-appropriate template worksheets if extraction fails
+  // Standardize the grade level first
+  const standardizedGrade = standardizeGradeLevel(gradeLevel);
+  if (!standardizedGrade) {
+    return null;
+  }
+  
   const worksheetTemplates: Record<string, WorksheetContent> = {
     'K': {
       title: 'Letter Recognition Practice',
@@ -237,7 +244,7 @@ export function extractWorksheetFromLesson(
     }
   };
 
-  return worksheetTemplates[gradeLevel] || null;
+  return worksheetTemplates[standardizedGrade] || null;
 }
 
 // Generate printable HTML for worksheet


### PR DESCRIPTION
…s print correctly

- Remove mock lesson generation entirely, throw errors instead
- Add student grade level fetching and inclusion in AI prompts
- Implement subject-specific prompt guidance for Math vs ELA
- Fix worksheet extraction to handle proper JSON format
- Create grade level standardization utility
- Ensure IEP goals and assessments are properly included

Resolves #226

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Grade level is now included in student assessments and profiles, with consistent formatting across the app.
  - AI prompts are tailored by subject for more relevant lesson content.
  - Generated lessons now prioritize structured JSON responses and always produce full per-student materials, guidance, and differentiation.
  - Calendar lessons can include student info per timeslot; worksheets pick better-matched templates by standardized grade.

- Bug Fixes
  - Normalized grade inputs to prevent mismatches and improve title/data consistency when AI responses lack structure.

- Chores
  - System now surfaces configuration errors when AI is not available instead of returning mock lessons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->