### PR TITLE
fix: resolve AI lesson generation material validation failures (issue…

### DIFF
--- a/__tests__/unit/lib/lessons/validator.test.ts
+++ b/__tests__/unit/lib/lessons/validator.test.ts
@@ -145,5 +145,55 @@ describe('MaterialsValidator', () => {
       expect(result.isValid).toBe(true);
       expect(result.errors).toEqual([]);
     });
+
+    it('should accept hyphenated "dry-erase markers"', () => {
+      const lesson = createMockLesson(
+        'Worksheets, pencils, whiteboard and markers only',
+        ['dry-erase markers']
+      );
+      const result = validator.validateLesson(lesson as any);
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should accept hyphenated compound "whiteboard-and-markers"', () => {
+      const lesson = createMockLesson(
+        'Worksheets, pencils, whiteboard-and-markers only',
+        []
+      );
+      const result = validator.validateLesson(lesson as any);
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should reject materials string missing the word "only"', () => {
+      const lesson = createMockLesson(
+        'Worksheets, pencils, whiteboard and markers',
+        []
+      );
+      const result = validator.validateLesson(lesson as any);
+      expect(result.isValid).toBe(false);
+      expect(result.errors.join(' ')).toMatch(/must specify "only"/i);
+    });
+
+    it('should correctly split "pencils and paper" after removing compound phrases', () => {
+      const lesson = createMockLesson(
+        'pencils and paper only',
+        ['pencils', 'paper']
+      );
+      const result = validator.validateLesson(lesson as any);
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should handle mixed regular and compound materials with "and"', () => {
+      const lesson = createMockLesson(
+        'whiteboard and markers, pencils and paper only',
+        ['whiteboard and markers', 'pencils', 'paper']
+      );
+      const result = validator.validateLesson(lesson as any);
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
   });
 });

--- a/lib/lessons/schema.ts
+++ b/lib/lessons/schema.ts
@@ -146,10 +146,13 @@ export const ALLOWED_MATERIALS = [
   'pencil',
   'whiteboard',
   'dry erase marker',
+  'dry-erase marker',
   'dry erase markers',
+  'dry-erase markers',
   'marker',
   'markers',
   'whiteboard and markers',
+  'whiteboard-and-markers',
   'paper'
 ];
 


### PR DESCRIPTION
… #234)

- Add support for compound phrase "whiteboard and markers" in ALLOWED_MATERIALS
- Update material parsing to preserve compound phrases before splitting
- Add plural forms "markers" and "dry erase markers" to allowed list
- Prevent false positive validation failures when AI generates valid materials
- Add comprehensive test coverage for material validation logic

This fix eliminates unnecessary validation retries during AI lesson generation, reducing generation time from 40+ seconds to normal speeds.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved materials parsing to recognize compound phrases, hyphenated/spaced variants, capitalization, and plurals.
  - Expanded allowed materials to include whiteboard and markers, dry erase markers, markers, and hyphenated variants.
  - Prevents splitting compound items; handles repeated “only” more robustly; clearer errors for unknown or forbidden items.

- Tests
  - Added comprehensive unit tests covering diverse materials parsing and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->