### PR TITLE
fix: Remove duplicate subject selector in AI Lesson Builder

### DIFF
--- a/app/(dashboard)/dashboard/lessons/components/lesson-builder.tsx
+++ b/app/(dashboard)/dashboard/lessons/components/lesson-builder.tsx
@@ -9,8 +9,7 @@ import { ChevronDownIcon, XMarkIcon } from '@heroicons/react/24/outline';
 
 interface FormData {
   studentIds: string[];
-  subject: string;
-  subjectType: 'ela' | 'math';
+  subjectType: 'ela' | 'math' | '';
   topic: string;
   timeDuration: string;
 }
@@ -29,21 +28,6 @@ interface GeneratedLesson {
   lessonId?: string;
 }
 
-const subjectOptions = [
-  'Math',
-  'English Language Arts',
-  'Science',
-  'Social Studies',
-  'Reading',
-  'Writing',
-  'History',
-  'Geography',
-  'Life Skills',
-  'Art',
-  'Music',
-  'Physical Education',
-];
-
 const timeDurationOptions = [
   '5 minutes',
   '10 minutes',
@@ -59,8 +43,7 @@ export default function LessonBuilder() {
   const { currentSchool } = useSchool();
   const [formData, setFormData] = useState<FormData>({
     studentIds: [],
-    subject: '',
-    subjectType: 'ela',
+    subjectType: '',
     topic: '',
     timeDuration: '15 minutes',
   });
@@ -150,11 +133,10 @@ export default function LessonBuilder() {
       return;
     }
 
-    if (!formData.subject) {
-      showToast('Please select a subject', 'error');
+    if (!formData.subjectType) {
+      showToast('Please select a subject type', 'error');
       return;
     }
-
 
     if (!formData.topic.trim()) {
       showToast('Please enter a topic', 'error');
@@ -165,7 +147,10 @@ export default function LessonBuilder() {
     try {
       // Get selected student details
       const selectedStudents = students.filter(s => formData.studentIds.includes(s.id));
-      
+
+      // Derive subject from subjectType
+      const subject = formData.subjectType === 'ela' ? 'English Language Arts' : 'Math';
+
       // Use the unified lessons API with actual student data
       const response = await fetch('/api/lessons/generate', {
         method: 'POST',
@@ -175,7 +160,7 @@ export default function LessonBuilder() {
             id: s.id,
             grade: s.grade_level
           })),
-          subject: formData.subject,
+          subject: subject,
           subjectType: formData.subjectType,
           topic: formData.topic,
           duration: parseInt(formData.timeDuration) || 15,
@@ -294,29 +279,11 @@ export default function LessonBuilder() {
             Subject *
           </label>
           <select
-            value={formData.subject}
-            onChange={(e) => handleInputChange('subject', e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
-            <option value="">Select a subject</option>
-            {subjectOptions.map(option => (
-              <option key={option} value={option}>{option}</option>
-            ))}
-          </select>
-        </div>
-
-        {/* Subject Type Selection */}
-        <div className="mb-6">
-          <label className="block text-sm font-medium text-gray-700 mb-2">
-            Subject Type * 
-            <span className="text-xs text-gray-500 ml-1">(Required for enhanced lesson generation)</span>
-          </label>
-          <select
             value={formData.subjectType}
             onChange={(e) => handleInputChange('subjectType', e.target.value)}
             className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
-            <option value="">Select subject type</option>
+            <option value="">Select a subject</option>
             <option value="ela">ELA (English Language Arts)</option>
             <option value="math">Math</option>
           </select>

--- a/app/(dashboard)/dashboard/lessons/components/lesson-preview-modal.tsx
+++ b/app/(dashboard)/dashboard/lessons/components/lesson-preview-modal.tsx
@@ -16,7 +16,7 @@ interface LessonPreviewModalProps {
     title: string;
     formData: {
       studentIds: string[];
-      subject: string;
+      subjectType?: 'ela' | 'math' | '';
       topic: string;
       timeDuration: string;
     };
@@ -321,26 +321,27 @@ export default function LessonPreviewModal({
         return;
       }
 
+      // Derive subject from subjectType
+      const subject = formData.subjectType === 'ela' ? 'ELA' : formData.subjectType === 'math' ? 'Math' : 'Lesson';
+
       // Generate unique worksheet ID
-      const worksheetId = generateWorksheetId(studentId, formData.subject);
-      
+      const worksheetId = generateWorksheetId(studentId, subject);
+
       // Get student initials (for now using Student # as we don't have the actual initials in this context)
       const studentInitials = `Student ${studentIdx + 1}`;
-      
+
       // Generate HTML for the worksheet with subject handling
-      const subjectType = formData.subject?.toLowerCase().includes('math') ? 'math' : 
-                         formData.subject?.toLowerCase().includes('english') || 
-                         formData.subject?.toLowerCase().includes('ela') ? 'ela' : undefined;
-      
+      const subjectType = formData.subjectType as 'math' | 'ela' | undefined;
+
       const html = await generateAIWorksheetHtml(
         studentMaterial,
         studentInitials,
         worksheetId,
-        subjectType as 'math' | 'ela' | undefined
+        subjectType
       );
 
       if (html) {
-        printHtmlWorksheet(html, `${studentInitials}_${formData.subject}_Worksheet`);
+        printHtmlWorksheet(html, `${studentInitials}_${subject}_Worksheet`);
       } else {
         showToast('Failed to generate worksheet', 'error');
       }
@@ -531,8 +532,8 @@ export default function LessonPreviewModal({
                     {/* Lesson Details */}
                     <div className="mt-4 bg-blue-50 p-3 rounded-lg">
                       <p className="text-sm text-gray-700">
-                        <strong>Subject:</strong> {formData.subject} | 
-                        <strong> Topic:</strong> {formData.topic} | 
+                        <strong>Subject:</strong> {formData.subjectType === 'ela' ? 'ELA' : formData.subjectType === 'math' ? 'Math' : 'N/A'} |
+                        <strong> Topic:</strong> {formData.topic} |
                         <strong> Duration:</strong> {formData.timeDuration}
                       </p>
                       <p className="text-sm text-gray-700 mt-1">


### PR DESCRIPTION
- Removed the first subject selector with 12 options (Math, Science, etc.)
- Kept only the ELA/Math subject selector
- Updated FormData interface to remove redundant 'subject' field
- Modified API call to derive subject from subjectType
- Updated lesson preview modal to work with subjectType only
- No breaking changes - API still receives subject field (now derived)

This simplifies the UI by removing redundant subject selection and provides a cleaner user experience.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified subject selection to a single Subject Type dropdown (ELA or Math) with a blank default; users must explicitly choose a subject type.
  - Updated validation to require a subject type and show “Please select a subject type.”
  - Lesson Preview now displays Subject as ELA, Math, or N/A based on selection.
  - Worksheet IDs and printed filenames use the selected subject type (e.g., ELA/Math) for clearer labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->