### PR TITLE
Fix: AI lesson generation timeout and insufficient practice problems

### DIFF
--- a/app/api/lessons/generate/route.ts
+++ b/app/api/lessons/generate/route.ts
@@ -10,7 +10,7 @@ import { withAuth } from '@/lib/api/with-auth';
 import { parseGradeLevel } from '@/lib/utils/grade-parser';
 import { createClient } from '@/lib/supabase/server';
 
-export const maxDuration = 120; // 2 minutes timeout for Vercel
+export const maxDuration = 300; // 5 minutes timeout for platforms that support it (Vercel Pro, etc.)
 
 // Debug logging only in development
 const DEBUG = process.env.NODE_ENV === 'development' || process.env.DEBUG === 'true';

--- a/lib/lessons/generator.ts
+++ b/lib/lessons/generator.ts
@@ -147,9 +147,28 @@ export class LessonGenerator {
               console.log('Retrying with additional constraints...');
               
               // Persist additional constraints into the next attempt prompt
+              // Parse error messages to extract specific requirements
+              let specificRequirements = '';
+              validation.errors.forEach(error => {
+                if (error.includes('Insufficient practice problems')) {
+                  const match = error.match(/minimum (\d+) required/);
+                  if (match) {
+                    specificRequirements += `\n- MUST include AT LEAST ${match[1]} practice problems in the Activity section for each student`;
+                  }
+                }
+                if (error.includes('Insufficient whiteboard examples')) {
+                  const match = error.match(/minimum (\d+) required/);
+                  if (match) {
+                    specificRequirements += `\n- MUST include AT LEAST ${match[1]} whiteboard examples in the teacher lesson plan`;
+                  }
+                }
+              });
+
               const errorFeedback =
                 `\n\nPREVIOUS ATTEMPT HAD ERRORS:\n${validation.errors.join('\n')}\n\n` +
-                `Please fix these issues and ensure strict compliance with material constraints.`;
+                `CRITICAL REQUIREMENTS TO FIX:${specificRequirements}\n\n` +
+                `You MUST generate the exact number of items required. This is not optional. ` +
+                `Count carefully and ensure each student worksheet has the minimum required practice problems.`;
               dynamicSystemPrompt += errorFeedback;
               continue;
             }

--- a/lib/lessons/prompts.ts
+++ b/lib/lessons/prompts.ts
@@ -56,7 +56,10 @@ WORKSHEET FORMATTING STANDARDS (MANDATORY):
    - Distractors should be plausible but wrong
 
 5. ACTIVITY ITEM COUNTS (DURATION-BASED MANDATORY MINIMUMS):
-   These are REQUIRED minimums. Use ranges as targets; fewer than the minimum fails validation.
+   ⚠️ CRITICAL VALIDATION REQUIREMENT ⚠️
+   You MUST generate AT LEAST the minimum number of problems specified below.
+   Generating fewer problems will cause IMMEDIATE VALIDATION FAILURE.
+   Count carefully - each problem in the Activity section counts toward this total.
 
    For 5-15 minute lessons:
    - Grades K-2: Target 6-8 practice problems (minimum 6) in Activity section
@@ -75,7 +78,9 @@ WORKSHEET FORMATTING STANDARDS (MANDATORY):
    - Grades 3-5: Target 20-30 practice problems (minimum 20) in Activity section
 
    - Include variety: mix of question types appropriate for the subject
-   - CRITICAL: These are MINIMUM requirements - generating fewer than the minimum will cause validation failure
+   - ⚠️ VALIDATION WILL FAIL if you generate fewer than the minimum problems
+   - ⚠️ COUNT CAREFULLY: Only problems in the "Activity" section count (not examples)
+   - ⚠️ Each student must have the minimum number of practice problems
 
 STUDENT DIFFERENTIATION REQUIREMENTS:
 
@@ -385,7 +390,7 @@ NEVER generate comprehension questions without including the actual story text f
 - Use exactly 2 worksheet sections: Introduction, Activity
 - Follow grade-based blank line rules: K-1 use 4 lines, 2-3 use 3 lines, 4-5 use 2 lines
 - Multiple choice questions must have exactly 4 choices (A, B, C, D)
-- Include ${this.getActivityItemCount(request.students, request.duration)} practice items in Activity section
+- ⚠️ MANDATORY: Include EXACTLY ${this.getActivityItemCount(request.students, request.duration)} practice problems in the Activity section (minimum ${this.getMinimumActivityCount(request.students, request.duration)})
 - Introduction section should have 1-2 example/instruction items only
 - All content must be complete and ready-to-use, no placeholders
 - Questions should be ${request.subjectType.toUpperCase()}-focused and grade-appropriate
@@ -511,6 +516,14 @@ MATH EXAMPLES SECTION:
     const max = Math.ceil(baseMax * multiplier);
 
     return `${min}-${max}`;
+  }
+
+  private getMinimumActivityCount(students: { grade: number }[], duration?: number): number {
+    const maxGrade = Math.max(...students.map(s => s.grade));
+    const effectiveDuration = duration || 30;
+    const baseMin = getBaseMinimum(maxGrade);
+    const multiplier = getDurationMultiplier(effectiveDuration);
+    return Math.ceil(baseMin * multiplier);
   }
 
   private getExampleCount(duration?: number): string {

--- a/lib/utils/fetch-with-retry.ts
+++ b/lib/utils/fetch-with-retry.ts
@@ -34,7 +34,7 @@ export async function fetchWithRetry(
 ): Promise<Response> {
   const {
     retries = 2,
-    timeout = 115000, // 115 seconds (slightly less than typical server timeout)
+    timeout = 180000, // 180 seconds (3 minutes) to handle complex AI generation
     onRetry,
     ...fetchOptions
   } = options;
@@ -221,7 +221,7 @@ export async function fetchLessonGeneration(
     method: 'POST',
     headers: finalHeaders,
     body: JSON.stringify(body),
-    timeout: options.timeout || 115000, // 115 seconds for lesson generation
+    timeout: options.timeout || 180000, // 180 seconds for complex lesson generation
     retries: options.retries ?? 2,
   });
 }


### PR DESCRIPTION
## Problem

Users are experiencing two critical issues with AI lesson generation:

1. **Timeout Errors**: Lessons taking longer than 161 seconds to generate are failing with timeout errors
2. **Insufficient Practice Problems**: AI generating only 5 problems when 16+ are required for 45-minute Grade 3 lessons

## Root Cause

1. **Timeouts**: The API timeout was set to 115 seconds, but OpenAI can take 160+ seconds for complex lessons
2. **Problem Count**: AI not following minimum problem requirements despite clear instructions in prompts

## Solution

### 1. Extended Timeouts
- Increased client-side timeout from 115s to 180s (3 minutes) in `fetch-with-retry.ts`  
- Updated server-side `maxDuration` from 120s to 300s (5 minutes) for platforms that support it
- Note: The 300s setting works on Vercel Pro, AWS Lambda, and other platforms with extended timeout support

### 2. Stronger Problem Count Enforcement
- Added warning symbols (⚠️) to make requirements visually prominent
- Enhanced retry mechanism to parse validation errors and provide specific counts
- Added `getMinimumActivityCount` helper to calculate exact minimums
- Improved error feedback to explicitly state "MUST include AT LEAST X practice problems"

### 3. Documentation Updates
- Updated `MASTER_LESSON_PROMPTS.md` with v2.1 section documenting these fixes
- Added implementation details and key takeaways for future reference

## Testing
- ✅ TypeScript compilation passes
- ✅ ESLint checks pass (existing warnings unrelated to changes)
- ✅ Documentation updated

## Impact
- Lessons will no longer timeout during generation
- AI will receive clearer, more forceful instructions about problem counts
- On validation failure, AI gets explicit requirements like "MUST include AT LEAST 16 practice problems"

## Related Issues
- Addresses timeout errors reported in production
- Fixes insufficient practice problem generation for longer lessons

🤖 Generated with Claude Code