### PR TITLE
Remove AI lesson creation from Dashboard and Calendar Week view

### DIFF
--- a/app/components/calendar/calendar-week-view.tsx
+++ b/app/components/calendar/calendar-week-view.tsx
@@ -7,7 +7,6 @@ import type { Database } from "../../../src/types/database";
 import { AIContentModal } from "../ai-content-modal";
 import { AIContentModalEnhanced } from "../ai-content-modal-enhanced";
 import { SessionGenerator } from '@/lib/services/session-generator';
-import { LessonTypeModal } from "../modals/lesson-type-modal";
 import { ManualLessonFormModal } from "../modals/manual-lesson-form-modal";
 import { ManualLessonViewModal } from "../modals/manual-lesson-view-modal";
 import { useToast } from "../../contexts/toast-context";
@@ -112,7 +111,6 @@ export function CalendarWeekView({
   const [sessionConflicts, setSessionConflicts] = useState<Record<string, boolean>>({});
   
   // State for manual lesson creation
-  const [showLessonTypeModal, setShowLessonTypeModal] = useState(false);
   const [selectedLessonDate, setSelectedLessonDate] = useState<Date | null>(null);
   const [showManualLessonForm, setShowManualLessonForm] = useState(false);
   const [manualLessons, setManualLessons] = useState<Map<string, ManualLesson[]>>(new Map());
@@ -918,7 +916,7 @@ export function CalendarWeekView({
   const handleCreateDailyLesson = (date: Date, daySessions: ScheduleSession[]) => {
     setSelectedLessonDate(date);
     setSelectedDaySessions(daySessions);
-    setShowLessonTypeModal(true);
+    setShowManualLessonForm(true);
   };
 
   // Handle viewing all AI lessons for a day
@@ -1086,32 +1084,12 @@ export function CalendarWeekView({
     return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:00`;
   };
 
-  // Handler for Create Lesson button
+  // Handler for Create Lesson button - goes directly to manual lesson form
   const handleCreateLesson = (date: Date) => {
     setSelectedLessonDate(date);
-    setShowLessonTypeModal(true);
+    setShowManualLessonForm(true);
   };
 
-  const handleLessonTypeSelect = async (type: 'ai' | 'manual') => {
-    setShowLessonTypeModal(false);
-    
-    if (type === 'ai' && selectedLessonDate) {
-      // Use the sessions that were set when Create Lesson button was clicked
-      const daySessions = selectedDaySessions;
-      
-      if (!daySessions || daySessions.length === 0) {
-        showToast('No sessions scheduled for this day', 'warning');
-        return;
-      }
-
-      // Show subject type popup instead of generating immediately
-      setPendingLessonData({ date: selectedLessonDate, daySessions });
-      setSubjectTypePopupOpen(true);
-      return;
-    } else if (type === 'manual') {
-      setShowManualLessonForm(true);
-    }
-  };
 
   // Function to handle AI lesson generation with subject type
   const generateAILessons = async (date: Date, daySessions: ScheduleSession[], subjectType: 'ela' | 'math') => {
@@ -1788,16 +1766,6 @@ export function CalendarWeekView({
         isViewingSaved={viewingSavedLesson}
       />
 
-      {/* Lesson Type Modal */}
-      <LessonTypeModal
-        isOpen={showLessonTypeModal}
-        onClose={() => {
-          setShowLessonTypeModal(false);
-          setSelectedLessonDate(null);
-        }}
-        onSelectAI={() => handleLessonTypeSelect('ai')}
-        onSelectManual={() => handleLessonTypeSelect('manual')}
-      />
 
       {/* Subject Type Selection Popup */}
       {subjectTypePopupOpen && (

--- a/app/components/group-sessions-widget.tsx
+++ b/app/components/group-sessions-widget.tsx
@@ -538,31 +538,6 @@ export function GroupSessionsWidget() {
                         </div>
                       )}
                     </div>
-
-                    {slotSessions.length > 0 && (
-                      <button
-                        onClick={() =>
-                          handleGenerateAIContent(timeSlot, slotSessions)
-                        }
-                        className="ml-2 bg-purple-500 hover:bg-purple-600 text-white text-xs px-3 py-1.5 rounded-md transition-colors flex items-center gap-1"
-                        title={`Generate AI lesson content for ${slotSessions.length} students`}
-                      >
-                        <svg
-                          className="w-3 h-3"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
-                          />
-                        </svg>
-                        AI Lesson
-                      </button>
-                    )}
                   </div>
                 );
               })}


### PR DESCRIPTION
## Summary
- Removes AI lesson creation options from Dashboard Upcoming Sessions widget and Calendar Week view
- Streamlines the lesson creation flow by going directly to manual lesson creation
- AI lesson creation remains available in the Lessons page via AI Lesson Builder

## Changes Made
1. **Dashboard - Upcoming Sessions Widget**:
   - Removed the purple "AI Lesson" button that appeared next to each time slot

2. **Calendar - Week View**:
   - Modified the "+ Create Lesson" button to skip the lesson type selection modal
   - Now goes directly to the manual lesson creation form
   - Removed unused imports and state variables related to the lesson type modal

## Rationale
Per requirements, the AI lesson creation functionality should only be accessible from the dedicated "AI Lesson Builder" on the Lessons page. This change simplifies the UI and creates a more consistent user experience for lesson creation in the calendar and dashboard views.

## Test Plan
- [x] Verified TypeScript compilation with no errors
- [x] Confirmed that "+ Create Lesson" button in Calendar Week view opens manual lesson form directly
- [x] Verified that AI Lesson button is removed from Dashboard widget
- [x] Ensured AI lesson creation remains functional in Lessons page

🤖 Generated with [Claude Code](https://claude.ai/code)