### PR TITLE
Fix: Display all worksheet problems in teacher lesson plan

### DIFF
--- a/lib/lessons/renderer.ts
+++ b/lib/lessons/renderer.ts
@@ -176,7 +176,7 @@ export class WorksheetRenderer {
 <body>
   <h1>${this.escapeHtml(plan.title)}</h1>
   
-  ${this.renderTeacherLessonPlan(plan)}
+  ${this.renderTeacherLessonPlan(plan, lesson)}
   
   ${!plan.teacherLessonPlan ? `
   <div class="section">
@@ -696,9 +696,9 @@ export class WorksheetRenderer {
 </html>`;
   }
 
-  private renderTeacherLessonPlan(plan: any): string {
+  private renderTeacherLessonPlan(plan: any, fullLesson?: LessonResponse): string {
     if (!plan.teacherLessonPlan) return '';
-    
+
     const tlp = plan.teacherLessonPlan;
     
     return `
@@ -752,34 +752,86 @@ export class WorksheetRenderer {
       
       <div style="margin: 20px 0;">
         <h3>📝 Student Worksheet Problems</h3>
-        ${tlp.studentProblems?.map((studentSet: any) => `
-          <div class="student-problems">
-            <h4>Student: ${this.escapeHtml(studentSet.studentInitials || '')}</h4>
-            <ol>
-              ${studentSet.problems?.map((problem: any) => `
-                <li>
-                  <strong>Problem ${this.escapeHtml(problem.number || '')}:</strong> 
-                  ${this.escapeHtml(problem.question || '')}
-                  ${problem.choices ? `
-                    <ul style="list-style-type: upper-alpha;">
-                      ${problem.choices.map((choice: string) => 
-                        `<li>${this.escapeHtml(choice)}</li>`
-                      ).join('')}
-                    </ul>
-                  ` : ''}
-                  <span class="problem-answer">Answer: ${this.escapeHtml(problem.answer || '')}</span>
-                  ${problem.commonErrors?.length ? `
-                    <div style="margin-top: 5px; color: #dc3545;">
-                      ⚠️ Common errors: ${problem.commonErrors.map((err: string) => 
-                        this.escapeHtml(err)
-                      ).join(', ')}
+        ${(() => {
+          // If we have the full lesson with studentMaterials, show all problems
+          if (fullLesson && fullLesson.studentMaterials && fullLesson.studentMaterials.length > 0) {
+            return fullLesson.studentMaterials.map((material: any) => {
+              const studentInitials = material.studentId ?
+                (tlp.studentInitials?.find((init: string, idx: number) =>
+                  fullLesson.studentMaterials[idx]?.studentId === material.studentId
+                ) || 'Student') : 'Student';
+
+              return `
+                <div class="student-problems">
+                  <h4>Student: ${this.escapeHtml(studentInitials)}</h4>
+                  ${material.worksheet?.sections?.map((section: any) => `
+                    <div style="margin: 15px 0;">
+                      <h5 style="color: #007bff;">${this.escapeHtml(section.title || 'Section')}</h5>
+                      ${section.instructions ? `<p style="font-style: italic; color: #666;">${this.escapeHtml(section.instructions)}</p>` : ''}
+                      <ol>
+                        ${section.items?.map((item: any, index: number) => {
+                          // Skip examples and text-only items in the problem list
+                          if (item.type === 'example' || item.type === 'text' || item.type === 'passage') {
+                            return `<div style="margin: 10px 0; padding: 8px; background: #f8f9fa; border-left: 3px solid #6c757d;">
+                              <strong>Example/Instructions:</strong> ${this.escapeHtml(item.content)}
+                            </div>`;
+                          }
+
+                          return `
+                            <li style="margin: 10px 0;">
+                              <strong>${this.escapeHtml(item.content)}</strong>
+                              ${item.type === 'multiple-choice' && item.choices ? `
+                                <ul style="list-style-type: upper-alpha; margin-top: 5px;">
+                                  ${item.choices.map((choice: string) =>
+                                    `<li>${this.escapeHtml(String(choice).replace(/^\s*[A-H]\s*[\\.\\)\\:]\s*/i, ''))}</li>`
+                                  ).join('')}
+                                </ul>
+                              ` : ''}
+                              <div style="color: #28a745; margin-top: 5px;">
+                                <em>Type: ${this.escapeHtml(item.type || 'unknown')}</em>
+                                ${item.blankLines ? ` | Lines: ${item.blankLines}` : ''}
+                              </div>
+                            </li>
+                          `;
+                        }).join('') || ''}
+                      </ol>
                     </div>
-                  ` : ''}
-                </li>
-              `).join('') || ''}
-            </ol>
-          </div>
-        `).join('') || ''}
+                  `).join('') || ''}
+                </div>
+              `;
+            }).join('') || '';
+          }
+
+          // Fallback to original sample problems if no full lesson data
+          return tlp.studentProblems?.map((studentSet: any) => `
+            <div class="student-problems">
+              <h4>Student: ${this.escapeHtml(studentSet.studentInitials || '')}</h4>
+              <ol>
+                ${studentSet.problems?.map((problem: any) => `
+                  <li>
+                    <strong>Problem ${this.escapeHtml(problem.number || '')}:</strong>
+                    ${this.escapeHtml(problem.question || '')}
+                    ${problem.choices ? `
+                      <ul style="list-style-type: upper-alpha;">
+                        ${problem.choices.map((choice: string) =>
+                          `<li>${this.escapeHtml(choice)}</li>`
+                        ).join('')}
+                      </ul>
+                    ` : ''}
+                    <span class="problem-answer">Answer: ${this.escapeHtml(problem.answer || '')}</span>
+                    ${problem.commonErrors?.length ? `
+                      <div style="margin-top: 5px; color: #dc3545;">
+                        ⚠️ Common errors: ${problem.commonErrors.map((err: string) =>
+                          this.escapeHtml(err)
+                        ).join(', ')}
+                      </div>
+                    ` : ''}
+                  </li>
+                `).join('') || ''}
+              </ol>
+            </div>
+          `).join('') || '';
+        })()}
       </div>
       
       ${tlp.teachingNotes ? `


### PR DESCRIPTION
## Summary
- Fixed issue where teacher lesson plans only showed 2 sample problems per student instead of all worksheet items
- Teachers now have full visibility of all 13+ problems/questions their students are working on
- Maintains proper formatting and question types (multiple-choice, short-answer, fill-in-blank, etc.)

## Problem
The teacher lesson plan was only displaying 2 sample problems from `teacherLessonPlan.studentProblems`, while the actual student worksheets contained 13+ items including examples, short answers, fill-in-blanks, multiple-choice questions, and long answer prompts.

## Solution
Modified the `WorksheetRenderer` to:
1. Pass the full lesson response to `renderTeacherLessonPlan` method
2. Display ALL items from `studentMaterials` in the teacher view
3. Show complete questions with their types and formatting
4. Maintain proper sequential numbering
5. Fall back to sample problems if full lesson data is unavailable

## Testing
- TypeScript compilation passes without errors
- Code maintains backward compatibility with fallback to original behavior

## Result
Teachers can now see everything their students are working on directly in the lesson plan view, providing better oversight and preparation for the lesson.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enriched teacher lesson plans that use full lesson data when available.
  * Per-student worksheet rendering with named student sections and customized numbering.
  * Expanded problem rendering supporting multiple item types (multiple-choice, short/long answer), options, and cleaner formatting.
  * Smarter filtering of non-problem content (examples, passages) from main problem lists.
  * Graceful fallback to existing problem lists when enriched data is unavailable, preserving current UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->