### PR TITLE
Refactor schedule page local storage and filtering logic

### DIFF
--- a/app/(dashboard)/dashboard/schedule/page.tsx
+++ b/app/(dashboard)/dashboard/schedule/page.tsx
@@ -48,8 +48,6 @@ const loadVisualFilters = (schoolId?: string | null): VisualFilters => {
 };
 
 const loadSessionTags = (): Record<string, string> => {
-  console.log('[SchedulePage] Initializing sessionTags from localStorage...');
-
   if (typeof window === 'undefined') {
     return {};
   }
@@ -57,16 +55,30 @@ const loadSessionTags = (): Record<string, string> => {
   const savedTags = localStorage.getItem('speddy-session-tags');
 
   if (!savedTags) {
-    console.log('[SchedulePage] No saved tags found, initializing empty');
     return {};
   }
 
   try {
-    const parsedTags = JSON.parse(savedTags);
-    console.log('[SchedulePage] Initialized with tags from localStorage:', parsedTags);
-    return parsedTags;
-  } catch (error) {
-    console.error('[SchedulePage] Failed to parse saved tags:', error);
+    const parsed = JSON.parse(savedTags);
+
+    // Verify parsed value is a non-null object (not an array)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+
+    // Build a clean Record<string, string> from the parsed data
+    const result: Record<string, string> = {};
+
+    for (const key of Object.keys(parsed)) {
+      const value = parsed[key];
+      // Skip keys with undefined or function values
+      if (value !== undefined && typeof value !== 'function') {
+        result[key] = String(value);
+      }
+    }
+
+    return result;
+  } catch {
     return {};
   }
 };


### PR DESCRIPTION
## Summary
- extract helper utilities for loading session tags and visual filters so the schedule page stops duplicating default values
- stabilize visual filter persistence with a ref based debounce and cleanup to avoid stale timers while switching schools
- memoize session filtering logic for consistent reuse across the page and grid interactions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4289a3df8832d8dc1d1f76a037323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual filters are now saved per school and restored when you return.
  * Session tags are remembered between visits.
  * Session list and counts now accurately reflect your selected filters.

* **Bug Fixes**
  * Automatically clears an invalid “special activity teacher” filter when switching schools.
  * Filtering is more consistent with the schedule grid, preventing mismatches and stale states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->