### PR TITLE
Fix exit ticket print formatting to match AI worksheets

### DIFF
--- a/app/(dashboard)/dashboard/lessons/components/exit-ticket-builder.tsx
+++ b/app/(dashboard)/dashboard/lessons/components/exit-ticket-builder.tsx
@@ -187,6 +187,9 @@ export default function ExitTicketBuilder() {
           <label className="block text-sm font-medium text-gray-700 mb-2">
             Select Students (max 7)
           </label>
+          <p className="text-xs text-gray-500 mb-2 italic">
+            *Students without IEP goals saved will not be shown.
+          </p>
 
           <div ref={dropdownRef} className="relative">
             <button

--- a/app/(dashboard)/dashboard/lessons/components/exit-ticket-display.tsx
+++ b/app/(dashboard)/dashboard/lessons/components/exit-ticket-display.tsx
@@ -36,6 +36,13 @@ export default function ExitTicketDisplay({ tickets, onBack }: ExitTicketDisplay
           </div>
 
           <div class="content">
+            ${ticket.content.passage ? `
+              <div class="passage-section">
+                <div class="passage-header">Read the following passage:</div>
+                <div class="passage-text">${ticket.content.passage}</div>
+                <div class="passage-divider"></div>
+              </div>
+            ` : ''}
             ${ticket.content.problems ?
               ticket.content.problems.map((problem: any, pIndex: number) => {
                 let problemHTML = `<div class="problem">
@@ -174,6 +181,31 @@ export default function ExitTicketDisplay({ tickets, onBack }: ExitTicketDisplay
             .content {
               flex: 1;
               padding: 10px 0;
+            }
+
+            .passage-section {
+              margin-bottom: 25px;
+              padding: 15px;
+              background: #f8f9fa;
+              border: 1px solid #dee2e6;
+              border-radius: 4px;
+            }
+
+            .passage-header {
+              font-weight: bold;
+              margin-bottom: 10px;
+              font-size: 12pt;
+            }
+
+            .passage-text {
+              line-height: 1.8;
+              font-size: 13pt;
+              padding: 10px 0;
+            }
+
+            .passage-divider {
+              border-bottom: 2px solid #dee2e6;
+              margin-top: 15px;
             }
 
             .problem {
@@ -427,6 +459,17 @@ export default function ExitTicketDisplay({ tickets, onBack }: ExitTicketDisplay
               </div>
               <div className="border-b-2 border-gray-400 mb-4"></div>
             </div>
+
+            {/* Reading Passage (if present) */}
+            {ticket.content.passage && (
+              <div className="mb-6 p-4 bg-gray-50 border border-gray-200 rounded">
+                <h3 className="font-semibold text-sm mb-2">Read the following passage:</h3>
+                <div className="text-gray-800 leading-relaxed">
+                  {ticket.content.passage}
+                </div>
+                <div className="border-b-2 border-gray-300 mt-4"></div>
+              </div>
+            )}
 
             {/* Problems */}
             <div className="exit-ticket-content">

--- a/app/(dashboard)/dashboard/lessons/components/exit-ticket-display.tsx
+++ b/app/(dashboard)/dashboard/lessons/components/exit-ticket-display.tsx
@@ -69,10 +69,25 @@ export default function ExitTicketDisplay({ tickets, onBack }: ExitTicketDisplay
                     ` : ''}
                   `;
                 } else if (problem.type === 'short_answer' || problem.type === 'fill_in_blank') {
-                  problemHTML += `
-                    <div class="problem-text">${problem.question || problem.prompt || problem.problem || problem.text}</div>
-                    <div class="answer-line"></div>
-                  `;
+                  const answerFormat = problem.answer_format || {};
+                  const lineCount = answerFormat.lines || 2;
+
+                  problemHTML += `<div class="problem-text">${problem.question || problem.prompt || problem.problem || problem.text}</div>`;
+
+                  // Add drawing space if requested
+                  if (answerFormat.drawing_space) {
+                    problemHTML += `
+                      <div class="drawing-box">
+                        <div class="drawing-label">Drawing Space</div>
+                      </div>
+                    `;
+                  }
+
+                  // Add answer lines
+                  for (let i = 0; i < lineCount; i++) {
+                    problemHTML += `<div class="answer-line"></div>`;
+                  }
+                  problemHTML += ``;
                 } else if (problem.type === 'word_problem' || problem.type === 'problem') {
                   problemHTML += `
                     <div class="problem-text">${problem.question || problem.prompt || problem.problem}</div>
@@ -255,6 +270,24 @@ export default function ExitTicketDisplay({ tickets, onBack }: ExitTicketDisplay
               margin: 10px 0;
             }
 
+            .drawing-box {
+              border: 2px solid #666;
+              height: 3in;
+              margin: 10px 0;
+              position: relative;
+              background: white;
+            }
+
+            .drawing-label {
+              position: absolute;
+              top: 2px;
+              left: 50%;
+              transform: translateX(-50%);
+              font-size: 10pt;
+              color: #999;
+              text-align: center;
+            }
+
             .footer {
               margin-top: auto;
               padding-top: 20px;
@@ -386,10 +419,25 @@ export default function ExitTicketDisplay({ tickets, onBack }: ExitTicketDisplay
     }
 
     if (problem.type === 'short_answer' || problem.type === 'fill_in_blank') {
+      const answerFormat = problem.answer_format || {};
+      const lineCount = answerFormat.lines || 2; // Default to 2 lines
+
       return (
         <div className="mb-6">
           <div className="mb-2">{problem.question || problem.prompt || problem.problem || problem.text}</div>
-          <div className="border-b-2 border-gray-300 h-8"></div>
+
+          {/* Drawing space if requested */}
+          {answerFormat.drawing_space && (
+            <div className="border-2 border-gray-400 h-32 mb-3 bg-white"
+                 style={{ minHeight: '3in' }}>
+              <div className="text-xs text-gray-400 text-center mt-1">Drawing Space</div>
+            </div>
+          )}
+
+          {/* Answer lines */}
+          {Array.from({ length: lineCount }, (_, i) => (
+            <div key={i} className="border-b-2 border-gray-300 h-8 mb-1"></div>
+          ))}
         </div>
       );
     }

--- a/app/(dashboard)/dashboard/lessons/components/exit-ticket-display.tsx
+++ b/app/(dashboard)/dashboard/lessons/components/exit-ticket-display.tsx
@@ -70,7 +70,7 @@ export default function ExitTicketDisplay({ tickets, onBack }: ExitTicketDisplay
                   `;
                 } else if (problem.type === 'short_answer' || problem.type === 'fill_in_blank') {
                   problemHTML += `
-                    <div class="problem-text">${problem.question || problem.prompt}</div>
+                    <div class="problem-text">${problem.question || problem.prompt || problem.problem || problem.text}</div>
                     <div class="answer-line"></div>
                   `;
                 } else if (problem.type === 'word_problem' || problem.type === 'problem') {
@@ -388,7 +388,7 @@ export default function ExitTicketDisplay({ tickets, onBack }: ExitTicketDisplay
     if (problem.type === 'short_answer' || problem.type === 'fill_in_blank') {
       return (
         <div className="mb-6">
-          <div className="mb-2">{problem.question || problem.prompt}</div>
+          <div className="mb-2">{problem.question || problem.prompt || problem.problem || problem.text}</div>
           <div className="border-b-2 border-gray-300 h-8"></div>
         </div>
       );

--- a/lib/exit-tickets/generator.ts
+++ b/lib/exit-tickets/generator.ts
@@ -16,6 +16,7 @@ interface ExitTicketProblem {
 }
 
 interface ExitTicketContent {
+  passage?: string; // Optional reading passage for comprehension questions
   problems: ExitTicketProblem[];
 }
 
@@ -42,23 +43,43 @@ Requirements:
 5. Language should be clear and grade-appropriate
 6. For multiple choice, provide 3-4 options
 
+SPECIAL INSTRUCTIONS FOR READING COMPREHENSION:
+- If the IEP goal involves reading comprehension, include a "passage" field with a short text (3-5 sentences)
+- The passage should be appropriate for grade ${request.gradeLevel}
+- All comprehension questions should reference "the passage above"
+- Make the passage interesting and engaging for students
+
+FOR OTHER GOALS:
+- Each problem must be completely self-contained with all needed information
+- Math word problems must include all numbers and context
+- Never reference external materials
+
 Return the response in this exact JSON format:
+
+For reading comprehension goals:
 {
+  "passage": "A short reading passage here (3-5 sentences for grade ${request.gradeLevel})",
   "problems": [
     {
       "type": "multiple_choice",
-      "question": "Problem text here",
+      "question": "Based on the passage above, what...",
       "options": ["A) Option 1", "B) Option 2", "C) Option 3", "D) Option 4"],
       "answer": "A"
     },
     {
       "type": "short_answer",
-      "question": "Problem text here",
+      "question": "According to the passage, why did...",
       "answer": "Expected answer"
-    },
+    }
+  ]
+}
+
+For other goals (no passage needed):
+{
+  "problems": [
     {
       "type": "problem",
-      "problem": "Math problem or word problem here",
+      "problem": "Complete self-contained problem with all information",
       "answer": "Solution"
     }
   ]
@@ -68,7 +89,8 @@ Important:
 - Keep problems concise and focused on the IEP goal
 - Ensure all problems are solvable with paper and pencil only
 - Do not include images or complex diagrams
-- Make sure the difficulty is appropriate for independent work`;
+- Make sure the difficulty is appropriate for independent work
+- For reading comprehension, use the "passage" field once, then reference it in questions`;
 
   try {
     const completion = await openai.chat.completions.create({

--- a/lib/exit-tickets/generator.ts
+++ b/lib/exit-tickets/generator.ts
@@ -6,6 +6,11 @@ interface ExitTicketRequest {
   iepGoal: string;
 }
 
+interface AnswerFormat {
+  drawing_space?: boolean;
+  lines?: number;
+}
+
 interface ExitTicketProblem {
   type: 'multiple_choice' | 'short_answer' | 'problem' | 'fill_in_blank';
   question?: string;
@@ -13,6 +18,7 @@ interface ExitTicketProblem {
   problem?: string;
   options?: string[];
   answer?: string;
+  answer_format?: AnswerFormat;
 }
 
 interface ExitTicketContent {
@@ -54,6 +60,22 @@ FOR OTHER GOALS:
 - Math word problems must include all numbers and context
 - Never reference external materials
 
+ANSWER FORMAT SPECIFICATIONS:
+For short_answer and fill_in_blank problems, include an "answer_format" object when needed:
+- If the problem asks for drawing/sketching: add "drawing_space": true
+- Specify "lines" based on expected response:
+  - 1 line for single words or numbers
+  - 2 lines for one sentence
+  - 3 lines for multiple sentences (e.g., "write 3 sentences")
+  - 5-6 lines for a paragraph
+  - If both drawing and writing are needed, include both fields
+
+Examples:
+- "Draw a picture and write 2 sentences" → {"drawing_space": true, "lines": 2}
+- "Write a paragraph about..." → {"lines": 5}
+- "Write three facts about..." → {"lines": 3}
+- "What is 5 + 3?" → {"lines": 1} or omit answer_format
+
 Return the response in this exact JSON format:
 
 For reading comprehension goals:
@@ -69,7 +91,8 @@ For reading comprehension goals:
     {
       "type": "short_answer",
       "question": "According to the passage, why did...",
-      "answer": "Expected answer"
+      "answer": "Expected answer",
+      "answer_format": {"lines": 2}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Replaced window.print() with isolated iframe printing (same approach as AI worksheets)
- Exit tickets now print as clean, professional worksheets without any UI elements
- Each ticket fits on exactly one page

## Changes
- Updated `exit-ticket-display.tsx` to generate complete HTML documents for printing
- Added inline styles for consistent formatting across all browsers
- Optimized spacing to ensure content fits on letter-sized pages
- Added clarification note in `exit-ticket-builder.tsx` about students without IEP goals

## Testing
- Exit tickets now print cleanly without navigation bars or dashboard UI
- Professional worksheet appearance matching AI Lesson Builder output
- Proper page breaks between multiple student tickets

Fixes #300

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Programmatic, print-friendly multi-ticket workflow with per-ticket headers, dates, consistent styling and browser-print fallback.
  - Reading-comprehension support: optional passage field and in-app rendering of passage + instructions when present.

- Improvements
  - Enhanced question rendering for short-answer and fill-in-the-blank with configurable answer lines and optional drawing space; preserves existing types handling.

- Style
  - Small italic note under Student Selection clarifying students without saved IEP goals aren’t shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->