### PR TITLE
Refine scheduling types to eliminate unsafe any usage

### DIFF
--- a/app/(dashboard)/dashboard/schedule/components/ConflictFilterPanel.tsx
+++ b/app/(dashboard)/dashboard/schedule/components/ConflictFilterPanel.tsx
@@ -3,12 +3,15 @@
 import React, { useMemo } from 'react';
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
 import { formatTeacherName } from '@/lib/utils/teacher-utils';
+import type { BellSchedule, SpecialActivity, Student, Database } from '@/src/types/database';
+
+type Teacher = Database['public']['Tables']['teachers']['Row'];
 
 interface ConflictFilterPanelProps {
-  bellSchedules: any[];
-  specialActivities: any[];
-  students: any[];
-  teachers?: any[];
+  bellSchedules: BellSchedule[];
+  specialActivities: SpecialActivity[];
+  students: Student[];
+  teachers?: Teacher[];
   selectedFilters: {
     bellScheduleGrade: string | null;
     specialActivityTeacher: string | null;

--- a/app/(dashboard)/dashboard/schedule/components/VisualAvailabilityLayer.tsx
+++ b/app/(dashboard)/dashboard/schedule/components/VisualAvailabilityLayer.tsx
@@ -2,14 +2,21 @@
 
 import React, { useMemo } from 'react';
 import { GRADE_COLOR_MAP } from '@/lib/scheduling/constants';
+import type {
+  BellSchedule,
+  ScheduleSession,
+  SchoolHour,
+  SpecialActivity,
+  Student,
+} from '@/src/types/database';
 
 interface VisualAvailabilityLayerProps {
   day: number;
-  bellSchedules: any[];
-  specialActivities: any[];
-  schoolHours: any[];
-  sessions: any[];
-  students: any[];
+  bellSchedules: BellSchedule[];
+  specialActivities: SpecialActivity[];
+  schoolHours: SchoolHour[];
+  sessions: ScheduleSession[];
+  students: Student[];
   filters: {
     bellScheduleGrade: string | null;
     specialActivityTeacher: string | null;

--- a/app/(dashboard)/dashboard/schedule/hooks/use-schedule-state.tsx
+++ b/app/(dashboard)/dashboard/schedule/hooks/use-schedule-state.tsx
@@ -2,6 +2,13 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { DEFAULT_SCHEDULING_CONFIG } from '../../../../../lib/scheduling/scheduling-config';
+import type { ScheduleSession } from '@/src/types/database';
+
+export interface ScheduleDragPosition {
+  day: number;
+  time: string;
+  pixelY: number;
+}
 
 export interface ScheduleUIState {
   selectedGrades: Set<string>;
@@ -9,14 +16,10 @@ export interface ScheduleUIState {
   selectedDay: number | null;
   highlightedStudentId: string | null;
   sessionFilter: 'all' | 'mine' | 'sea' | 'specialist';
-  draggedSession: any | null;
+  draggedSession: ScheduleSession | null;
   dragOffset: number;
-  dragPosition: {
-    day: number;
-    time: string;
-    pixelY: number;
-  } | null;
-  selectedSession: any | null;
+  dragPosition: ScheduleDragPosition | null;
+  selectedSession: ScheduleSession | null;
   popupPosition: DOMRect | null;
 }
 
@@ -31,16 +34,12 @@ export function useScheduleState() {
   const [sessionFilter, setSessionFilter] = useState<'all' | 'mine' | 'sea' | 'specialist'>('all');
 
   // Drag and drop states
-  const [draggedSession, setDraggedSession] = useState<any | null>(null);
+  const [draggedSession, setDraggedSession] = useState<ScheduleSession | null>(null);
   const [dragOffset, setDragOffset] = useState<number>(0);
-  const [dragPosition, setDragPosition] = useState<{
-    day: number;
-    time: string;
-    pixelY: number;
-  } | null>(null);
+  const [dragPosition, setDragPosition] = useState<ScheduleDragPosition | null>(null);
 
   // Popup states
-  const [selectedSession, setSelectedSession] = useState<any | null>(null);
+  const [selectedSession, setSelectedSession] = useState<ScheduleSession | null>(null);
   const [popupPosition, setPopupPosition] = useState<DOMRect | null>(null);
 
   // Grid configuration from config
@@ -82,12 +81,12 @@ export function useScheduleState() {
   }, []);
 
   // Drag handlers
-  const startDrag = useCallback((session: any, offset: number) => {
+  const startDrag = useCallback((session: ScheduleSession, offset: number) => {
     setDraggedSession(session);
     setDragOffset(offset);
   }, []);
 
-  const updateDragPosition = useCallback((position: { day: number; time: string; pixelY: number } | null) => {
+  const updateDragPosition = useCallback((position: ScheduleDragPosition | null) => {
     setDragPosition(position);
   }, []);
 
@@ -99,7 +98,7 @@ export function useScheduleState() {
 
 
   // Popup handlers
-  const openSessionPopup = useCallback((session: any, triggerRect: DOMRect) => {
+  const openSessionPopup = useCallback((session: ScheduleSession, triggerRect: DOMRect) => {
     setSelectedSession(session);
     setPopupPosition(triggerRect);
   }, []);

--- a/app/(dashboard)/dashboard/schedule/session-assignment-popup.tsx
+++ b/app/(dashboard)/dashboard/schedule/session-assignment-popup.tsx
@@ -3,10 +3,13 @@
 import { useEffect, useRef, useState, useLayoutEffect } from "react";
 import { createClient } from '@/lib/supabase/client';
 import { calculateOptimalModalPosition, getSessionModalDimensions, type ModalPosition } from '@/lib/utils/modal-positioning';
+import type { Database, ScheduleSession, Student } from '@/src/types/database';
+
+type ScheduleSessionUpdate = Database['public']['Tables']['schedule_sessions']['Update'];
 
 interface SessionAssignmentPopupProps {
-  session: any;
-  student: any;
+  session: ScheduleSession;
+  student?: Student;
   triggerRect: DOMRect;
   seaProfiles: Array<{ id: string; full_name: string; is_shared?: boolean }>;
   otherSpecialists: Array<{ id: string; full_name: string; role: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' }>;
@@ -76,7 +79,7 @@ export function SessionAssignmentPopup({
     }
 
     try {
-      const updateData: any = {};
+      const updateData: ScheduleSessionUpdate = {};
 
       if (isSeaAssignment) {
         // Validate assignment ID

--- a/lib/supabase/hooks/use-schedule-data.ts
+++ b/lib/supabase/hooks/use-schedule-data.ts
@@ -6,7 +6,7 @@ import { useSchool } from '../../../app/components/providers/school-context';
 import { getSchoolHours } from '../queries/school-hours';
 import { getUnscheduledSessionsCount } from '../queries/schedule-sessions';
 import { useSchedulingData } from './use-scheduling-data';
-import type { Database } from '../../../src/types/database';
+import type { Database, SchoolHour } from '../../../src/types/database';
 
 type Student = Database['public']['Tables']['students']['Row'];
 type ScheduleSession = Database['public']['Tables']['schedule_sessions']['Row'];
@@ -19,7 +19,7 @@ interface ScheduleData {
   sessions: ScheduleSession[];
   bellSchedules: BellSchedule[];
   specialActivities: SpecialActivity[];
-  schoolHours: any[];
+  schoolHours: SchoolHour[];
   seaProfiles: Array<{ id: string; full_name: string; is_shared?: boolean }>;
   otherSpecialists: Array<{ id: string; full_name: string; role: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' }>;
   unscheduledCount: number;
@@ -193,8 +193,6 @@ export function useScheduleData() {
               code: error.code,
               details: error.details,
               hint: error.hint,
-              status: (error as any).status,
-              statusText: (error as any).statusText
             });
           } else if (schoolSeas) {
             seaProfiles = schoolSeas.map(sea => ({

--- a/lib/supabase/queries/school-hours.ts
+++ b/lib/supabase/queries/school-hours.ts
@@ -1,15 +1,15 @@
 import { createClient } from '@/lib/supabase/client';
-import { buildSchoolFilter, type SchoolIdentifier } from '@/lib/school-helpers';
+import { type SchoolIdentifier } from '@/lib/school-helpers';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
-import type { Database } from '../../../src/types/database';
+import type { Database, SchoolHour } from '../../../src/types/database';
 
-type SchoolHours = Database['public']['Tables']['school_hours']['Insert'];
+type SchoolHoursInput = Database['public']['Tables']['school_hours']['Insert'];
 
 /**
  * Get school hours for the current user and school.
  * Uses intelligent filtering based on available school identifiers.
  */
-export async function getSchoolHours(school?: SchoolIdentifier) {
+export async function getSchoolHours(school?: SchoolIdentifier): Promise<SchoolHour[]> {
   const supabase = createClient<Database>();
   const queryType = school?.school_id ? 'indexed' : 'text-based';
   
@@ -51,7 +51,7 @@ export async function getSchoolHours(school?: SchoolIdentifier) {
  * Stores both structured and text-based school identifiers.
  */
 export async function upsertSchoolHours(
-  hours: Omit<SchoolHours, 'id' | 'created_at' | 'updated_at' | 'provider_id'> & Partial<SchoolIdentifier>
+  hours: Omit<SchoolHoursInput, 'id' | 'created_at' | 'updated_at' | 'provider_id'> & Partial<SchoolIdentifier>
 ) {
   const supabase = createClient<Database>();
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1310,6 +1310,7 @@ export type BellSchedule = Tables<'bell_schedules'>;
 export type SpecialActivity = Tables<'special_activities'>;
 export type ScheduleSession = Tables<'schedule_sessions'>;
 export type Worksheet = Tables<'worksheets'>;
+export type SchoolHour = Tables<'school_hours'>;
 export type WorksheetSubmission = Tables<'worksheet_submissions'>;
 export type State = Tables<'states'>;
 export type District = Tables<'districts'>;


### PR DESCRIPTION
## Summary
- replace schedule UI state and grid props that used `any` with concrete Supabase-derived types for sessions, students, and drag metadata
- add a shared `SchoolHour` type and update Supabase hooks/utilities to return typed data instead of `any`
- harden the session assignment popup update payload and related helpers against unsafe `any` usage

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db12aa4de4832dab43e60f302201a3