### PR TITLE
Add full Lessons page access for SEAs with student filtering

### DIFF
--- a/app/(dashboard)/dashboard/lessons/components/exit-ticket-builder.tsx
+++ b/app/(dashboard)/dashboard/lessons/components/exit-ticket-builder.tsx
@@ -6,6 +6,7 @@ import ExitTicketDisplay from './exit-ticket-display';
 import { createClient } from '@/lib/supabase/client';
 import { useSchool } from '@/app/components/providers/school-context';
 import { ChevronDownIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { loadStudentsForUser, getUserRole } from '@/lib/supabase/queries/sea-students';
 
 interface Student {
   id: string;
@@ -57,23 +58,20 @@ export default function ExitTicketBuilder() {
     const { data: { user } } = await supabase.auth.getUser();
 
     if (user && currentSchool) {
-      let query = supabase
-        .from('students')
-        .select(`
-          id,
-          initials,
-          grade_level,
-          school_id,
-          student_details(iep_goals)
-        `)
-        .eq('provider_id', user.id)
-        .order('initials');
+      // Get user role to determine how to filter students
+      const userRole = await getUserRole(user.id);
 
-      if (currentSchool.school_id) {
-        query = query.eq('school_id', currentSchool.school_id);
+      if (!userRole) {
+        console.error('Failed to get user role');
+        showToast('Failed to load students', 'error');
+        return;
       }
 
-      const { data, error } = await query;
+      // Load students based on role (SEAs see only assigned students)
+      const { data, error } = await loadStudentsForUser(user.id, userRole, {
+        currentSchool,
+        includeIEPGoals: true
+      });
 
       if (error) {
         console.error('Error loading students:', error);
@@ -84,14 +82,14 @@ export default function ExitTicketBuilder() {
       if (data) {
         // Filter to only show students with IEP goals
         const studentsWithGoals = data.filter(s => {
-          const details = s.student_details as any;
-          return details &&
-            details.iep_goals &&
-            Array.isArray(details.iep_goals) &&
-            details.iep_goals.length > 0;
+          // Handle both formats: nested student_details or direct iep_goals
+          const iepGoals = s.iep_goals ||
+                          (Array.isArray(s.student_details) ? s.student_details[0]?.iep_goals : s.student_details?.iep_goals) ||
+                          [];
+          return Array.isArray(iepGoals) && iepGoals.length > 0;
         });
         console.log(`Found ${studentsWithGoals.length} students with IEP goals out of ${data.length} total students`);
-        setStudents(studentsWithGoals);
+        setStudents(studentsWithGoals as Student[]);
       }
     }
   }

--- a/app/(dashboard)/dashboard/lessons/components/progress-check.tsx
+++ b/app/(dashboard)/dashboard/lessons/components/progress-check.tsx
@@ -6,6 +6,7 @@ import ProgressCheckWorksheet from './progress-check-worksheet';
 import { createClient } from '@/lib/supabase/client';
 import { useSchool } from '@/app/components/providers/school-context';
 import { ChevronDownIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { loadStudentsForUser, getUserRole } from '@/lib/supabase/queries/sea-students';
 
 interface Student {
   id: string;
@@ -68,26 +69,34 @@ export default function ProgressCheck() {
     const { data: { user } } = await supabase.auth.getUser();
 
     if (user && currentSchool) {
-      let query = supabase
-        .from('students')
-        .select('id, initials, grade_level, school_id, student_details(iep_goals)')
-        .eq('provider_id', user.id)
-        .order('initials');
+      // Get user role to determine how to filter students
+      const userRole = await getUserRole(user.id);
 
-      if (currentSchool.school_id) {
-        query = query.eq('school_id', currentSchool.school_id);
+      if (!userRole) {
+        console.error('[Progress Check] Failed to get user role');
+        return;
       }
 
-      const { data } = await query;
+      // Load students based on role (SEAs see only assigned students)
+      const { data, error } = await loadStudentsForUser(user.id, userRole, {
+        currentSchool,
+        includeIEPGoals: true
+      });
+
+      if (error) {
+        console.error('[Progress Check] Error loading students:', error);
+        return;
+      }
 
       if (data) {
         // Filter to only show students with IEP goals
         const studentsWithGoals = data.filter(student => {
+          // Handle both formats: nested student_details or direct iep_goals
           const studentDetails = Array.isArray(student.student_details)
             ? student.student_details[0]
             : student.student_details;
-          const iepGoals = studentDetails?.iep_goals || [];
-          return iepGoals.length > 0;
+          const iepGoals = student.iep_goals || studentDetails?.iep_goals || [];
+          return Array.isArray(iepGoals) && iepGoals.length > 0;
         });
 
         console.log(`[Progress Check] Found ${studentsWithGoals.length} students with IEP goals out of ${data.length} total students`);

--- a/app/components/navigation/navbar.tsx
+++ b/app/components/navigation/navbar.tsx
@@ -66,9 +66,10 @@ export default function Navbar() {
     ];
 
     if (role === 'sea') {
-      // SEAs only see their dashboard
+      // SEAs see their dashboard and lessons
       return [
         { name: 'Dashboard', href: '/dashboard/sea' },
+        { name: 'Lessons', href: '/dashboard/lessons' },
       ];
       
     } else if (role === 'resource') {

--- a/lib/supabase/queries/sea-students.ts
+++ b/lib/supabase/queries/sea-students.ts
@@ -1,0 +1,121 @@
+import { createClient } from '@/lib/supabase/client';
+
+export interface StudentData {
+  id: string;
+  initials: string;
+  grade_level: string | number;
+  school_id?: string;
+  provider_id?: string;
+  student_details?: Array<{ iep_goals?: string[] }> | { iep_goals?: string[] };
+  iep_goals?: string[];
+}
+
+export interface LoadStudentsOptions {
+  includeIEPGoals?: boolean;
+  currentSchool?: { school_id?: string } | null;
+}
+
+/**
+ * Load students based on user role
+ * - For SEAs: Returns only students assigned to them via schedule_sessions
+ * - For other roles: Returns all students where provider_id matches
+ */
+export async function loadStudentsForUser(
+  userId: string,
+  userRole: string,
+  options: LoadStudentsOptions = {}
+): Promise<{ data: StudentData[] | null; error: any }> {
+  const supabase = createClient();
+  const { includeIEPGoals = false, currentSchool = null } = options;
+
+  try {
+    if (userRole === 'sea') {
+      // For SEAs, use the RPC function to get only assigned students
+      const { data, error } = await supabase
+        .rpc('get_sea_students', { sea_user_id: userId });
+
+      if (error) {
+        console.error('Error loading SEA students:', error);
+
+        // Provide helpful error message if function doesn't exist
+        if (error.message?.includes('function') || error.code === '42883') {
+          console.error(
+            'Database function "get_sea_students" not found. ' +
+            'Please run the migration: supabase/migrations/20251006_add_sea_students_function.sql'
+          );
+        }
+
+        return { data: null, error };
+      }
+
+      // Transform the data to match the expected format
+      const transformedData = (data || []).map((student: any) => ({
+        id: student.id,
+        initials: student.initials,
+        grade_level: student.grade_level,
+        school_id: student.school_id,
+        provider_id: student.provider_id,
+        iep_goals: student.iep_goals || [],
+        student_details: includeIEPGoals ? { iep_goals: student.iep_goals || [] } : undefined,
+      }));
+
+      // Filter by school if specified
+      if (currentSchool?.school_id) {
+        const filtered = transformedData.filter(
+          (s: StudentData) => s.school_id === currentSchool.school_id
+        );
+        return { data: filtered, error: null };
+      }
+
+      return { data: transformedData, error: null };
+    } else {
+      // For non-SEA roles, use the standard query
+      let query = supabase
+        .from('students')
+        .select(
+          includeIEPGoals
+            ? 'id, initials, grade_level, school_id, student_details(iep_goals)'
+            : 'id, initials, grade_level, school_id'
+        )
+        .eq('provider_id', userId)
+        .order('initials');
+
+      // Filter by current school if available
+      if (currentSchool?.school_id) {
+        query = query.eq('school_id', currentSchool.school_id);
+      }
+
+      const { data, error } = await query;
+
+      if (error) {
+        console.error('Error loading provider students:', error);
+        return { data: null, error };
+      }
+
+      return { data: data as StudentData[], error: null };
+    }
+  } catch (error) {
+    console.error('Unexpected error loading students:', error);
+    return { data: null, error };
+  }
+}
+
+/**
+ * Get user role from profiles table
+ */
+export async function getUserRole(userId: string): Promise<string | null> {
+  const supabase = createClient();
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', userId)
+    .single();
+
+  if (error) {
+    console.error('Error fetching user role:', error);
+    return null;
+  }
+
+  return data?.role || null;
+}

--- a/supabase/migrations/20251006_add_sea_students_function.sql
+++ b/supabase/migrations/20251006_add_sea_students_function.sql
@@ -1,0 +1,42 @@
+-- Add function to get students assigned to an SEA
+-- This allows SEAs to see only the students they have sessions with
+
+CREATE OR REPLACE FUNCTION public.get_sea_students(sea_user_id UUID)
+RETURNS TABLE(
+  id UUID,
+  initials TEXT,
+  grade_level TEXT,
+  school_id VARCHAR,
+  provider_id UUID,
+  iep_goals TEXT[]
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+BEGIN
+  -- Return unique students that have sessions assigned to this SEA
+  -- Joins with student_details to include IEP goals for Exit Tickets and Progress Checks
+  RETURN QUERY
+  SELECT DISTINCT
+    s.id,
+    s.initials,
+    s.grade_level,
+    s.school_id,
+    s.provider_id,
+    COALESCE(sd.iep_goals, '{}'::TEXT[]) as iep_goals
+  FROM students s
+  INNER JOIN schedule_sessions ss ON ss.student_id = s.id
+  LEFT JOIN student_details sd ON sd.student_id = s.id
+  WHERE ss.assigned_to_sea_id = sea_user_id
+    AND ss.delivered_by = 'sea'
+  ORDER BY s.initials;
+END;
+$$;
+
+-- Grant execute permission to authenticated users
+GRANT EXECUTE ON FUNCTION public.get_sea_students(uuid) TO authenticated;
+
+-- Add comment for documentation
+COMMENT ON FUNCTION public.get_sea_students(uuid) IS
+  'Returns all unique students that have sessions assigned to the specified SEA user. Used in Lessons page to filter student dropdowns for SEAs.';


### PR DESCRIPTION
## Summary

Enables SEAs (Special Education Assistants) to access the complete Lessons page with proper student filtering:
- ✅ AI Lesson Builder
- ✅ Exit Tickets  
- ✅ Progress Checks

SEAs now see **only the students assigned to them** via schedule sessions in all lesson component dropdowns.

## Changes

### Database
- **New migration**: `20251006_add_sea_students_function.sql`
- **New function**: `get_sea_students()` - Returns students assigned to SEA via schedule_sessions

### Backend
- **New utility**: `lib/supabase/queries/sea-students.ts`
  - `loadStudentsForUser()` - Smart student loading based on user role
  - `getUserRole()` - Fetches user role from profiles

### Frontend
- **Navigation**: Added "Lessons" link to SEA navbar
- **Lesson Builder**: Updated to use role-based student filtering
- **Exit Ticket Builder**: Updated to use role-based student filtering
- **Progress Check**: Updated to use role-based student filtering

## How It Works

### For SEAs:
- Student dropdowns show only students they have sessions assigned to
- Fetches via `get_sea_students()` RPC function
- Filters by `schedule_sessions.assigned_to_sea_id = sea_user_id`

### For Resource Specialists & Other Roles:
- Student dropdowns show all their students (existing behavior)
- No changes to their experience
- Uses standard `provider_id` query

## Testing Required

### SEA Account Testing:
- [ ] SEA sees "Lessons" link in navigation
- [ ] AI Lesson Builder shows only assigned students
- [ ] Exit Tickets shows only assigned students with IEP goals
- [ ] Progress Check shows only assigned students with IEP goals
- [ ] Can generate lessons for selected students
- [ ] Can generate exit tickets for selected students
- [ ] Can generate progress checks for selected students

### Regression Testing:
- [ ] Resource Specialists still see all their students
- [ ] All lesson generation features work normally for non-SEA roles

## Migration Instructions

**IMPORTANT**: Before deploying, run the database migration:

```bash
# Via Supabase Dashboard SQL Editor
# Copy/paste: supabase/migrations/20251006_add_sea_students_function.sql

# OR via Supabase CLI
supabase db push
```

## Related Issues

Addresses SEA functionality enhancement request - enables SEAs to prepare materials and track student progress independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)