### PR TITLE
Fix: Enable specialist assignment across primary and secondary schools

### DIFF
--- a/lib/supabase/hooks/use-schedule-data.ts
+++ b/lib/supabase/hooks/use-schedule-data.ts
@@ -279,103 +279,26 @@ export function useScheduleData() {
           // Get other specialists (resource, speech, ot, counseling, specialist) from the CURRENT school only
           console.log('[useScheduleData] Fetching other specialists for current school:', currentSchool.school_id || currentSchool.school_site);
 
-          // Fetch specialists who work at the current school
-          // This needs to check BOTH:
-          // 1. Specialists whose primary school matches (profiles.school_id)
-          // 2. Specialists who work at multiple schools and have this school in provider_schools
-
+          // Use the database function to get specialists, which handles both primary and secondary schools
           if (currentSchool.school_id) {
-            // Query 1: Get specialists where this is their primary school
-            const { data: primarySchoolSpecialists, error: primaryError } = await supabase
-              .from('profiles')
-              .select('id, full_name, role')
-              .in('role', ['resource', 'speech', 'ot', 'counseling', 'specialist'])
-              .neq('id', user.id)
-              .eq('school_id', currentSchool.school_id);
+            const { data: specialists, error: specialistsError } = await supabase
+              .rpc('get_available_specialists', { current_user_id: user.id });
 
-            // Query 2: Get specialists who work at this school via provider_schools (multi-school staff)
-            const { data: multiSchoolData, error: multiError } = await supabase
-              .from('provider_schools')
-              .select('provider_id, profiles!provider_schools_provider_id_fkey(id, full_name, role)')
-              .eq('school_id', currentSchool.school_id);
-
-            // Check for critical errors - if either query fails completely, log and skip
-            // We need both queries to succeed for complete data
-            if (primaryError || multiError) {
+            if (specialistsError) {
               console.error('[useScheduleData] Error fetching specialists:', {
-                primaryError: primaryError ? {
-                  message: primaryError.message,
-                  code: primaryError.code,
-                  details: primaryError.details
-                } : null,
-                multiError: multiError ? {
-                  message: multiError.message,
-                  code: multiError.code,
-                  details: multiError.details
-                } : null
+                error: specialistsError.message,
+                code: specialistsError.code,
+                details: specialistsError.details
               });
+              otherSpecialists = [];
+            } else if (specialists) {
+              otherSpecialists = specialists.map(s => ({
+                id: s.id,
+                full_name: s.full_name,
+                role: s.role as 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist'
+              }));
 
-              // Only proceed if we have at least one successful query
-              // This prevents showing incomplete data
-              if (primaryError && multiError) {
-                console.warn('[useScheduleData] Both specialist queries failed - no specialists will be shown');
-                otherSpecialists = [];
-              }
-            }
-
-            // Merge results and deduplicate only if we have valid data
-            if (!primaryError || !multiError) {
-              const specialistMap = new Map<string, { id: string; full_name: string; role: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' }>();
-
-              // Add primary school specialists
-              if (primarySchoolSpecialists && !primaryError) {
-                primarySchoolSpecialists.forEach(s => {
-                  if (['resource', 'speech', 'ot', 'counseling', 'specialist'].includes(s.role)) {
-                    specialistMap.set(s.id, {
-                      id: s.id,
-                      full_name: s.full_name,
-                      role: s.role as 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist'
-                    });
-                  }
-                });
-              }
-
-              // Add multi-school specialists with proper type checking
-              if (multiSchoolData && !multiError) {
-                multiSchoolData.forEach(item => {
-                  // Type-safe access to nested profile data
-                  // Supabase returns foreign key joins as nested objects
-                  const profile = item.profiles;
-
-                  // Check if profile exists and has required fields
-                  if (profile &&
-                      typeof profile === 'object' &&
-                      'id' in profile &&
-                      'full_name' in profile &&
-                      'role' in profile) {
-                    const { id, full_name, role } = profile as { id: string; full_name: string; role: string };
-
-                    // Validate role and exclude current user
-                    if (['resource', 'speech', 'ot', 'counseling', 'specialist'].includes(role) &&
-                        id !== user.id) {
-                      specialistMap.set(id, {
-                        id,
-                        full_name,
-                        role: role as 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist'
-                      });
-                    }
-                  }
-                });
-              }
-
-              // Convert to array and sort
-              otherSpecialists = Array.from(specialistMap.values()).sort((a, b) =>
-                a.full_name.localeCompare(b.full_name)
-              );
-
-              const dataSource = !primaryError && !multiError ? 'both queries' :
-                                 primaryError ? 'multi-school query only' : 'primary school query only';
-              console.log(`[useScheduleData] Successfully loaded ${otherSpecialists.length} other specialists from current school (${currentSchool.school_id}) using ${dataSource}: ${otherSpecialists.map(s => `${s.full_name} (${s.role})`).join(', ')}`);
+              console.log(`[useScheduleData] Successfully loaded ${otherSpecialists.length} other specialists from current school (${currentSchool.school_id}): ${otherSpecialists.map(s => `${s.full_name} (${s.role})`).join(', ')}`);
             }
           } else {
             // Legacy schools without school_id - fallback to old logic


### PR DESCRIPTION
## Summary

Fixes an issue where resource specialists at a school could not see or assign sessions to other specialists who have that school as a **secondary** school (instead of primary).

## Problem

The frontend code in `use-schedule-data.ts` was using manual queries to fetch available specialists. While the code attempted to check both:
1. Specialists whose primary school matches (via `profiles.school_id`)
2. Specialists who work at multiple schools (via `provider_schools` table)

The implementation had issues that prevented specialists with secondary school associations from appearing in the dropdown.

## Solution

Replaced the complex manual queries (90+ lines) with a simple RPC call to the `get_available_specialists()` database function, which was specifically created in migration `20251103_fix_multi_school_specialist_assignment.sql` to handle multi-school scenarios correctly.

**Before:** Two separate queries with manual merging and deduplication
**After:** Single database function call that handles all cases

## Changes

- `lib/supabase/hooks/use-schedule-data.ts`: Replaced manual specialist queries with `supabase.rpc('get_available_specialists', { current_user_id: user.id })`
- Removed 92 lines of complex query logic
- Added 15 lines of simple, clean RPC call

## Testing

Verified that when Kim McCorkell (resource specialist, MDE primary) views the "Other Specialists" dropdown, Blair Stewart (resource specialist, MDE secondary) now appears and can be assigned to sessions.

Database test confirmed:
```sql
SELECT * FROM get_available_specialists('3bd096e0-8b12-4b37-ba10-8c75631e0ba8');
-- Returns Blair Stewart and other eligible specialists
```

## Test Plan

- [ ] Verify resource specialists can see and assign to specialists with the school as secondary
- [ ] Verify existing functionality for primary school specialists still works
- [ ] Verify current user is still excluded from their own dropdown
- [ ] Test with both migrated schools (school_id) and legacy schools (school_district + school_site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized specialist availability data loading to use a streamlined request, reducing the number of operations needed.

* **Bug Fixes**
  * Improved error handling for specialist data retrieval to prevent incomplete data from being used in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->