### PR TITLE
Fix: Convert IEP goal validation to warning in AI Lesson Builder

### DIFF
--- a/app/(dashboard)/dashboard/lessons/sample/sample-lesson-form.tsx
+++ b/app/(dashboard)/dashboard/lessons/sample/sample-lesson-form.tsx
@@ -20,6 +20,7 @@ export default function SampleLessonForm({ onGenerate }: SampleLessonFormProps) 
   const [generateLessonPlan, setGenerateLessonPlan] = useState(false);  // Default to unchecked
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
 
   // Student selection state
   const [students, setStudents] = useState<StudentData[]>([]);
@@ -108,6 +109,7 @@ export default function SampleLessonForm({ onGenerate }: SampleLessonFormProps) 
     e.preventDefault();
     setLoading(true);
     setError(null);
+    setWarning(null);
 
     // Client-side validation
     if (!grade && selectedStudentIds.length === 0) {
@@ -138,6 +140,12 @@ export default function SampleLessonForm({ onGenerate }: SampleLessonFormProps) 
       }
 
       const result = await response.json();
+
+      // Check for IEP goal warning in response
+      if (result.warning) {
+        setWarning(result.warning);
+      }
+
       onGenerate(result);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error');
@@ -301,6 +309,13 @@ export default function SampleLessonForm({ onGenerate }: SampleLessonFormProps) 
           </p>
         </div>
       </div>
+
+      {/* Warning Display */}
+      {warning && (
+        <div className="bg-amber-50 border border-amber-200 rounded-md p-3">
+          <p className="text-sm text-amber-800">{warning}</p>
+        </div>
+      )}
 
       {/* Error Display */}
       {error && (

--- a/app/api/lessons/v2/generate/route.ts
+++ b/app/api/lessons/v2/generate/route.ts
@@ -149,7 +149,8 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Validate that students have matching goals for the subject (when no grade is provided)
+    // Check for matching goals and create warning if needed (when no grade is provided)
+    let iepGoalWarning: string | undefined;
     if (students && students.length > 0 && !body.grade) {
       // Check if any student has IEP goals
       const hasAnyGoals = students.some(s => s.iepGoals && s.iepGoals.length > 0);
@@ -162,12 +163,8 @@ export async function POST(request: NextRequest) {
           const subjectName = body.subjectType === 'ela' ? 'ELA/Reading' : 'Math';
           const studentWord = students.length === 1 ? 'student doesn\'t' : 'students don\'t';
 
-          return NextResponse.json(
-            {
-              error: `Cannot generate ${subjectName} lesson. The selected ${studentWord} have any ${subjectName} goals in their IEP. Please either:\n• Select a grade level to generate a standard lesson\n• Choose students with ${subjectName} goals\n• Generate a lesson for a different subject that matches their IEP goals`
-            },
-            { status: 400 }
-          );
+          iepGoalWarning = `Note: The selected ${studentWord} have ${subjectName} keywords in their IEP goals. The lesson has been generated, but please verify it aligns with the students' actual IEP objectives.`;
+          console.log('[V2 API] IEP goal mismatch warning:', iepGoalWarning);
         }
       }
     }
@@ -333,6 +330,7 @@ export async function POST(request: NextRequest) {
       lessonPlan,
       metadata: combinedMetadata,
       lessonId: savedLessonId,  // Include lessonId (though UI won't use it)
+      warning: iepGoalWarning,  // Include IEP goal warning if present
     });
   } catch (error) {
     console.error('V2 generation error:', error);


### PR DESCRIPTION
## Summary
- Fixes issue where SEAs couldn't generate lessons when selecting students whose IEP goals don't contain exact keyword matches
- Converts blocking error to warning message, allowing lesson generation to proceed
- Adds warning display in frontend to inform users about potential IEP goal mismatches

## Problem
SEAs like Pallavi Shandilya at Bancroft Elementary were unable to generate ELA lessons when selecting multiple students from different teachers. The system was blocking generation if students' IEP goals didn't contain specific keywords like "reading", "comprehension", "phonics", etc.

## Solution
Changed the validation logic from a hard block to a soft warning:
- API endpoint now generates lessons even when IEP goals don't match keywords
- Warning message is included in API response
- Frontend displays warning in amber alert box
- Users are advised to verify the lesson aligns with actual IEP objectives

## Changes
- `app/api/lessons/v2/generate/route.ts`: Modified validation to create warning instead of returning 400 error
- `app/(dashboard)/dashboard/lessons/sample/sample-lesson-form.tsx`: Added warning state and display component

## Test Plan
- ✅ Build passes successfully
- ✅ TypeScript compilation passes
- ✅ Lint passes
- Manual testing needed: Verify warning displays correctly when generating lessons with non-matching IEP goals

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lesson generation now proceeds with warnings instead of stopping when goal conflicts occur
  * Transparent warning system alerts users of potential issues during creation

* **UI Updates**
  * Added warning banner in lesson form to display relevant alerts during the generation process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->