### PR TITLE
perf: pass curriculum data via props to avoid redundant API calls

### DIFF
--- a/app/components/calendar/calendar-week-view.tsx
+++ b/app/components/calendar/calendar-week-view.tsx
@@ -2273,6 +2273,10 @@ export function CalendarWeekView({
           groupName={selectedGroupName}
           sessions={selectedGroupSessions}
           students={allStudents}
+          initialCurriculum={(() => {
+            const sessionWithCurriculum = selectedGroupSessions.find(s => s.curriculum_tracking && s.curriculum_tracking.length > 0);
+            return sessionWithCurriculum ? getFirstCurriculum(sessionWithCurriculum.curriculum_tracking) : null;
+          })()}
         />
       )}
 
@@ -2286,6 +2290,7 @@ export function CalendarWeekView({
           }}
           session={selectedSession}
           student={selectedSession.student_id ? allStudents.get(selectedSession.student_id) : undefined}
+          initialCurriculum={getFirstCurriculum(selectedSession.curriculum_tracking)}
         />
       )}
     </div>

--- a/app/components/weekly-view.tsx
+++ b/app/components/weekly-view.tsx
@@ -910,6 +910,10 @@ return (
           groupName={selectedGroupName}
           sessions={selectedGroupSessions}
           students={new Map(Object.entries(students))}
+          initialCurriculum={(() => {
+            const sessionWithCurriculum = selectedGroupSessions.find(s => s.curriculum_tracking && s.curriculum_tracking.length > 0);
+            return sessionWithCurriculum ? getFirstCurriculum(sessionWithCurriculum.curriculum_tracking) : null;
+          })()}
         />
       )}
 
@@ -927,6 +931,7 @@ return (
             initials: selectedStudent.initials,
             grade_level: selectedStudent.grade_level || '',
           }}
+          initialCurriculum={getFirstCurriculum(selectedSession.curriculum_tracking)}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- Curriculum data is already fetched by the schedule view along with sessions
- Previously, modals were making a second API call to fetch the same data
- This change passes curriculum data via props, eliminating redundant network requests

## Changes
- Add `initialCurriculum` prop to session-details-modal and group-details-modal
- Pass curriculum data from weekly-view and calendar-week-view to modals
- Skip API fetch in modals when curriculum is provided via props

## Test plan
- [ ] Open a session modal on the weekly schedule view
- [ ] Verify curriculum data loads instantly (no loading state visible)
- [ ] Open a group session modal
- [ ] Verify curriculum data loads instantly
- [ ] Test the same on calendar week view
- [ ] Verify modifying curriculum still saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance of group and session detail modals by streamlining how curriculum information is initialized and displayed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->