### PR TITLE
feat: add edit functionality for special activities

### DIFF
--- a/app/(dashboard)/dashboard/special-activities/page.tsx
+++ b/app/(dashboard)/dashboard/special-activities/page.tsx
@@ -29,6 +29,7 @@ interface EditableActivity extends SpecialActivity {
   teacher_id?: string | null;
   created_by_id?: string | null;
   provider_id?: string | null;
+  school_id?: string | null;
 }
 
 export default function SpecialActivitiesPage() {
@@ -61,7 +62,7 @@ export default function SpecialActivitiesPage() {
       // Exclude soft-deleted activities
       let query = supabase
         .from('special_activities')
-        .select('*, created_by_id, teacher_id, provider_id')
+        .select('*')
         .is('deleted_at', null);
 
       if (currentSchool.school_id) {
@@ -409,14 +410,17 @@ export default function SpecialActivitiesPage() {
                                 Edit
                               </Button>
                             )}
-                            <Button
-                              variant="danger"
-                              size="sm"
-                              onClick={() => handleDelete(activity.id, activity.activity_name)}
-                              disabled={deletingId === activity.id}
-                            >
-                              {deletingId === activity.id ? 'Deleting...' : 'Delete'}
-                            </Button>
+                            {(activity.created_by_id === currentUserId ||
+                              (!activity.created_by_id && activity.provider_id === currentUserId)) && (
+                              <Button
+                                variant="danger"
+                                size="sm"
+                                onClick={() => handleDelete(activity.id, activity.activity_name)}
+                                disabled={deletingId === activity.id}
+                              >
+                                {deletingId === activity.id ? 'Deleting...' : 'Delete'}
+                              </Button>
+                            )}
                           </div>
                         </TableActionCell>
                       </TableRow>

--- a/app/components/special-activities/add-special-activity-form.tsx
+++ b/app/components/special-activities/add-special-activity-form.tsx
@@ -18,6 +18,7 @@ interface EditActivity {
   day_of_week: number;
   start_time: string;
   end_time: string;
+  school_id?: string | null;
 }
 
 interface Props {
@@ -64,13 +65,8 @@ export default function AddSpecialActivityForm({ teacherId: initialTeacherId, te
       return;
     }
 
-    if (!activityName || !startTime || !endTime) {
+    if (!teacherId || !activityName || !startTime || !endTime) {
       setError('All fields are required');
-      return;
-    }
-
-    if (!teacherId) {
-      setError('Teacher is required');
       return;
     }
 
@@ -96,7 +92,7 @@ export default function AddSpecialActivityForm({ teacherId: initialTeacherId, te
           end_time: endTime
         });
 
-        // Check for conflicts after update
+        // Check for conflicts after update - use activity's school_id
         const resolver = new ConflictResolver(user.user.id);
         const updatedActivity = {
           teacher_id: teacherId,
@@ -104,7 +100,7 @@ export default function AddSpecialActivityForm({ teacherId: initialTeacherId, te
           day_of_week: parseInt(dayOfWeek),
           start_time: startTime,
           end_time: endTime,
-          school_id: currentSchool?.school_id ?? null
+          school_id: activity.school_id ?? null
         };
 
         const result = await resolver.resolveSpecialActivityConflicts(updatedActivity);


### PR DESCRIPTION
## Summary
- Add Edit button to special activities table (visible only for activities you created)
- Support editing all fields: teacher, activity type, day, start/end time
- Handle legacy records where `created_by_id` is null (falls back to `provider_id` ownership check)
- Normalize time format for proper dropdown pre-selection
- Trigger conflict resolution after updates to reschedule affected sessions

## Test plan
- [x] Verify Edit button appears for activities you created
- [ ] Verify Edit button does NOT appear for activities created by others
- [x] Test editing an activity - all fields should pre-populate correctly
- [x] Test changing the teacher assignment
- [ ] Verify conflict resolution runs after saving changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit Special Activity: users can edit activities they created or provide; edit form pre-fills details and hides add/import while editing.
  * Server-side edit & delete: updates and deletions are validated on the backend to enforce ownership/permission rules.

* **Improvements**
  * Unified create/update form with clearer labels, normalized time inputs, and improved messages.
  * Activity controls: Edit shown conditionally for owners/providers; Delete preserves confirmation and refreshes the list after removal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->