### PR TITLE
Fix Visual Availability Filters not showing grade options

### DIFF
--- a/app/(dashboard)/dashboard/schedule/components/ConflictFilterPanel.tsx
+++ b/app/(dashboard)/dashboard/schedule/components/ConflictFilterPanel.tsx
@@ -29,8 +29,15 @@ export function ConflictFilterPanel({
   selectedFilters,
   onFilterChange,
 }: ConflictFilterPanelProps) {
-  // Get unique grade levels from bell schedules
-  const gradeLevels = Array.from(new Set(bellSchedules.map(bs => bs.grade_level))).filter(Boolean).sort();
+  // Get unique grade levels from bell schedules, sorted in logical grade order (TK, K, 1, 2, 3...)
+  const gradeLevels = Array.from(new Set(bellSchedules.map(bs => bs.grade_level)))
+    .filter(Boolean)
+    .sort((a, b) => {
+      const gradeOrder: Record<string, number> = { 'TK': 0, 'K': 1 };
+      const orderA = gradeOrder[a] ?? (parseInt(a, 10) + 2);
+      const orderB = gradeOrder[b] ?? (parseInt(b, 10) + 2);
+      return orderA - orderB;
+    });
   
   // Use teachers from the teachers table, with fallback to legacy teacher names
   const teachers = useMemo(() => {
@@ -175,10 +182,10 @@ export function ConflictFilterPanel({
               onChange={(e) => handleGradeChange(e.target.value || null)}
               className="w-full px-3 py-2 pr-8 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none bg-white"
             >
-              <option value="">All Grades</option>
+              <option value="">None</option>
               {gradeLevels.map((grade) => (
                 <option key={grade} value={grade}>
-                  {grade === 'K' ? 'Kindergarten' : `Grade ${grade}`}
+                  {grade === 'TK' ? 'Transitional Kindergarten' : grade === 'K' ? 'Kindergarten' : `Grade ${grade}`}
                 </option>
               ))}
             </select>
@@ -197,7 +204,7 @@ export function ConflictFilterPanel({
               onChange={(e) => handleTeacherChange(e.target.value || null)}
               className="w-full px-3 py-2 pr-8 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none bg-white"
             >
-              <option value="">All Teachers</option>
+              <option value="">None</option>
               {teachers.map((teacher) => {
                 const grade = teacherGrades.get(teacher.id);
                 const displayName = formatTeacherName(teacher) || 'Unknown Teacher';
@@ -218,7 +225,7 @@ export function ConflictFilterPanel({
         <div className="mt-3 flex flex-wrap gap-2">
           {selectedFilters.bellScheduleGrade && (
             <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-blue-100 text-blue-800">
-              Bell: {selectedFilters.bellScheduleGrade === 'K' ? 'Kindergarten' : `Grade ${selectedFilters.bellScheduleGrade}`}
+              Bell: {selectedFilters.bellScheduleGrade === 'TK' ? 'Transitional Kindergarten' : selectedFilters.bellScheduleGrade === 'K' ? 'Kindergarten' : `Grade ${selectedFilters.bellScheduleGrade}`}
             </span>
           )}
           {selectedFilters.specialActivityTeacher && (() => {

--- a/lib/supabase/hooks/use-schedule-data.ts
+++ b/lib/supabase/hooks/use-schedule-data.ts
@@ -120,14 +120,16 @@ export function useScheduleData() {
           return query;
         })(),
         
-        // Bell schedules query - Using school_id
+        // Bell schedules query - School-level (bell schedules are school-wide resources)
         (() => {
           let query = supabase
             .from('bell_schedules')
-            .select('*')
-            .eq('provider_id', user.id);
+            .select('*');
           if (currentSchool.school_id) {
             query = query.eq('school_id', currentSchool.school_id);
+          } else {
+            // Legacy fallback for non-migrated schools
+            query = query.eq('provider_id', user.id);
           }
           return query;
         })(),


### PR DESCRIPTION
## Summary
- Fixed bell schedules query to use `school_id` only (treating bell schedules as school-wide resources)
- Fixed grade sorting to show TK, K, 1, 2, 3... instead of alphabetical order
- Changed "All Grades" and "All Teachers" labels to "None" for clarity

## Problem
In Kim McCorkell's account, the Bell Schedule filter in Visual Availability Filters only showed "All Grades" with no individual grade options. This was because:
1. The query required `provider_id = user.id`, but school-level bell schedules have `provider_id = NULL`
2. When grades did show, they were sorted alphabetically (1, 2, 3... K) instead of logical grade order

## Changes
- `lib/supabase/hooks/use-schedule-data.ts`: Simplified bell schedules query to use `school_id` only
- `app/(dashboard)/dashboard/schedule/components/ConflictFilterPanel.tsx`:
  - Added custom sort for logical grade order (TK, K, 1, 2, 3...)
  - Changed dropdown options from "All Grades/Teachers" to "None"
  - Added TK (Transitional Kindergarten) display label

## Test plan
- [ ] Log in as Kim McCorkell
- [ ] Navigate to Main Schedule
- [ ] Verify Bell Schedule dropdown shows: None, Kindergarten, Grade 1, Grade 2, Grade 3, Grade 4, Grade 5
- [ ] Select a grade and verify visual filter renders correctly
- [ ] Verify Special Activities dropdown shows "None" instead of "All Teachers"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Grade levels now display with descriptive names (Transitional Kindergarten, Kindergarten, Grade 1-12) instead of abbreviations, with improved logical ordering.
  * Filter UI labels clarified for better clarity—empty selections now display "None" instead of "All Grades" or "All Teachers".
  * Schedule filtering logic enhanced to prioritize school-level organization when available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->