### PR TITLE
Fix group lesson save and change conflict behavior to mark instead of delete

### DIFF
--- a/app/api/groups/[groupId]/lesson/route.ts
+++ b/app/api/groups/[groupId]/lesson/route.ts
@@ -189,7 +189,7 @@ export async function POST(
         .update({
           lesson_date: existingLesson.lesson_date ?? today,
           title: title || null,
-          content: content || null,
+          content: content || {},
           lesson_source: lesson_source || 'manual',
           subject: subject || null,
           grade_levels: grade_levels || null,
@@ -217,7 +217,7 @@ export async function POST(
           group_id: groupId,
           lesson_date: today,
           title: title || null,
-          content: content || null,
+          content: content || {},
           lesson_source: lesson_source || 'manual',
           subject: subject || null,
           grade_levels: grade_levels || null,

--- a/app/components/bell-schedules/add-bell-schedule-form.tsx
+++ b/app/components/bell-schedules/add-bell-schedule-form.tsx
@@ -116,7 +116,7 @@ export default function AddBellScheduleForm({
         return;
       }
 
-      let totalResolved = 0;
+      let totalMarked = 0;
       let totalFailed = 0;
       const insertErrors: string[] = [];
       const conflictErrors: string[] = [];
@@ -167,7 +167,7 @@ export default function AddBellScheduleForm({
               };
 
               const result = await resolver.resolveBellScheduleConflicts(insertedSchedule);
-              totalResolved += result.resolved;
+              totalMarked += result.marked;
               totalFailed += result.failed;
             } catch (conflictErr) {
               // Schedule was added but conflict check failed - don't count as insert failure
@@ -196,8 +196,8 @@ export default function AddBellScheduleForm({
           ? 'Bell schedule added successfully.'
           : `${successCount} bell schedules added successfully.`;
 
-        if (totalResolved > 0 || totalFailed > 0) {
-          alert(`${message} ${totalResolved} sessions rescheduled, ${totalFailed} could not be rescheduled.`);
+        if (totalMarked > 0) {
+          alert(`${message} ${totalMarked} session${totalMarked > 1 ? 's' : ''} marked as conflicted.`);
         }
 
         // Reset form

--- a/app/components/modals/group-details-modal.tsx
+++ b/app/components/modals/group-details-modal.tsx
@@ -332,7 +332,11 @@ export function GroupDetailsModal({
           body: JSON.stringify(body)
         });
 
-        if (!response.ok) throw new Error('Failed to save lesson');
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          const errorMessage = errorData.error || `Failed to save lesson (${response.status})`;
+          throw new Error(errorMessage);
+        }
 
         const data = await response.json();
         setLesson(data.lesson);
@@ -376,7 +380,8 @@ export function GroupDetailsModal({
       }
     } catch (error) {
       console.error('Error saving lesson:', error);
-      showToast('Failed to save lesson', 'error');
+      const message = error instanceof Error ? error.message : 'Failed to save lesson';
+      showToast(message, 'error');
     }
   };
 

--- a/app/components/special-activities/add-special-activity-form.tsx
+++ b/app/components/special-activities/add-special-activity-form.tsx
@@ -97,6 +97,7 @@ export default function AddSpecialActivityForm({ teacherId: initialTeacherId, te
         const updatedActivity = {
           teacher_id: teacherId,
           teacher_name: teacherName || '',
+          activity_name: activityName,
           day_of_week: parseInt(dayOfWeek),
           start_time: startTime,
           end_time: endTime,
@@ -105,8 +106,8 @@ export default function AddSpecialActivityForm({ teacherId: initialTeacherId, te
 
         const result = await resolver.resolveSpecialActivityConflicts(updatedActivity);
 
-        if (result.resolved > 0 || result.failed > 0) {
-          alert(`Special activity updated. ${result.resolved} sessions rescheduled, ${result.failed} could not be rescheduled.`);
+        if (result.marked > 0) {
+          alert(`Special activity updated. ${result.marked} session${result.marked > 1 ? 's' : ''} marked as conflicted.`);
         }
       } else {
         // Create new activity
@@ -132,6 +133,7 @@ export default function AddSpecialActivityForm({ teacherId: initialTeacherId, te
         const insertedActivity = {
           teacher_id: teacherId,
           teacher_name: teacherName || '',
+          activity_name: activityName,
           day_of_week: parseInt(dayOfWeek),
           start_time: startTime,
           end_time: endTime,
@@ -140,8 +142,8 @@ export default function AddSpecialActivityForm({ teacherId: initialTeacherId, te
 
         const result = await resolver.resolveSpecialActivityConflicts(insertedActivity);
 
-        if (result.resolved > 0 || result.failed > 0) {
-          alert(`Special activity added. ${result.resolved} sessions rescheduled, ${result.failed} could not be rescheduled.`);
+        if (result.marked > 0) {
+          alert(`Special activity added. ${result.marked} session${result.marked > 1 ? 's' : ''} marked as conflicted.`);
         }
       }
 


### PR DESCRIPTION
## Summary
- Fix group lesson saving from Today's Schedule widget (was failing with "content cannot be null")
- Change conflict behavior: when bell schedules or special activities conflict with existing sessions, mark them as conflicted instead of deleting them
- Sessions keep their grade color and show a yellow/amber conflict indicator

## Changes

### Bug Fix: Group Lesson Save
The `content` column in the `lessons` table has a NOT NULL constraint. The API was sending `content: null` which violated this. Changed to `content: {}` (empty object) as fallback.

### Behavior Change: Conflict Resolution
Previously, when adding a special activity or bell schedule that conflicted with existing sessions, the system would **delete** those sessions and attempt to reschedule them (often failing silently).

Now, conflicting sessions are **marked** with:
- `has_conflict: true`
- `conflict_reason: "Conflicts with [activity] (time-time)"`
- `status: 'needs_attention'`

This preserves the session while alerting the user to the conflict.

### Related Issue
See #488 for future refactoring of the conflict status system.

## Test plan
- [x] Save a lesson from a group session in Today's Schedule widget - should succeed
- [ ] Add a special activity that conflicts with an existing session - session should remain but show conflict indicator
- [ ] Add a bell schedule that conflicts with existing sessions - sessions should remain but show conflict indicators
- [ ] Verify conflict indicator shows yellow/amber border, not red background (preserves grade color)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messages when saving lessons now display HTTP status codes and specific error details for better troubleshooting

* **Improvements**
  * Scheduling conflicts are now marked for review instead of being automatically rescheduled
  * Conflict notifications provide enhanced details about affected sessions and reasons for conflicts
  * Activity information is now included in conflict reporting for better visibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->