### PR TITLE
Add project onboarding docs and scheduling context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,188 +1,55 @@
-# Supabase CLI
-
-[![Coverage Status](https://coveralls.io/repos/github/supabase/cli/badge.svg?branch=main)](https://coveralls.io/github/supabase/cli?branch=main) [![Bitbucket Pipelines](https://img.shields.io/bitbucket/pipelines/supabase-cli/setup-cli/master?style=flat-square&label=Bitbucket%20Canary)](https://bitbucket.org/supabase-cli/setup-cli/pipelines) [![Gitlab Pipeline Status](https://img.shields.io/gitlab/pipeline-status/sweatybridge%2Fsetup-cli?label=Gitlab%20Canary)
-](https://gitlab.com/sweatybridge/setup-cli/-/pipelines)
-
-[Supabase](https://supabase.io) is an open source Firebase alternative. We're building the features of Firebase using enterprise-grade open source tools.
-
-This repository contains all the functionality for Supabase CLI.
-
-- [x] Running Supabase locally
-- [x] Managing database migrations
-- [x] Creating and deploying Supabase Functions
-- [x] Generating types directly from your database schema
-- [x] Making authenticated HTTP requests to [Management API](https://supabase.com/docs/reference/api/introduction)
-
-## Getting started
-
-### Install the CLI
-
-Available via [NPM](https://www.npmjs.com) as dev dependency. To install:
-
-```bash
-npm i supabase --save-dev
-```
-
-To install the beta release channel:
-
-```bash
-npm i supabase@beta --save-dev
-```
-
-When installing with yarn 4, you need to disable experimental fetch with the following nodejs config.
-
-```
-NODE_OPTIONS=--no-experimental-fetch yarn add supabase
-```
-
-> **Note**
-> For Bun versions below v1.0.17, you must add `supabase` as a [trusted dependency](https://bun.sh/guides/install/trusted) before running `bun add -D supabase`.
-
-<details>
-  <summary><b>macOS</b></summary>
-
-Available via [Homebrew](https://brew.sh). To install:
-
-```sh
-brew install supabase/tap/supabase
-```
-
-To install the beta release channel:
-
-```sh
-brew install supabase/tap/supabase-beta
-brew link --overwrite supabase-beta
-```
-
-To upgrade:
-
-```sh
-brew upgrade supabase
-```
-
-</details>
-
-<details>
-  <summary><b>Windows</b></summary>
-
-Available via [Scoop](https://scoop.sh). To install:
-
-```powershell
-scoop bucket add supabase https://github.com/supabase/scoop-bucket.git
-scoop install supabase
-```
-
-To upgrade:
-
-```powershell
-scoop update supabase
-```
-
-</details>
-
-<details>
-  <summary><b>Linux</b></summary>
-
-Available via [Homebrew](https://brew.sh) and Linux packages.
-
-#### via Homebrew
-
-To install:
-
-```sh
-brew install supabase/tap/supabase
-```
-
-To upgrade:
-
-```sh
-brew upgrade supabase
-```
-
-#### via Linux packages
-
-Linux packages are provided in [Releases](https://github.com/supabase/cli/releases). To install, download the `.apk`/`.deb`/`.rpm`/`.pkg.tar.zst` file depending on your package manager and run the respective commands.
-
-```sh
-sudo apk add --allow-untrusted <...>.apk
-```
-
-```sh
-sudo dpkg -i <...>.deb
-```
-
-```sh
-sudo rpm -i <...>.rpm
-```
-
-```sh
-sudo pacman -U <...>.pkg.tar.zst
-```
-
-</details>
-
-<details>
-  <summary><b>Other Platforms</b></summary>
-
-You can also install the CLI via [go modules](https://go.dev/ref/mod#go-install) without the help of package managers.
-
-```sh
-go install github.com/supabase/cli@latest
-```
-
-Add a symlink to the binary in `$PATH` for easier access:
-
-```sh
-ln -s "$(go env GOPATH)/bin/cli" /usr/bin/supabase
-```
-
-This works on other non-standard Linux distros.
-
-</details>
-
-<details>
-  <summary><b>Community Maintained Packages</b></summary>
-
-Available via [pkgx](https://pkgx.sh/). Package script [here](https://github.com/pkgxdev/pantry/blob/main/projects/supabase.com/cli/package.yml).
-To install in your working directory:
-
-```bash
-pkgx install supabase
-```
-
-Available via [Nixpkgs](https://nixos.org/). Package script [here](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/supabase-cli/default.nix).
-
-</details>
-
-### Run the CLI
-
-```bash
-supabase bootstrap
-```
-
-Or using npx:
-
-```bash
-npx supabase bootstrap
-```
-
-The bootstrap command will guide you through the process of setting up a Supabase project using one of the [starter](https://github.com/supabase-community/supabase-samples/blob/main/samples.json) templates.
-
-## Docs
-
-Command & config reference can be found [here](https://supabase.com/docs/reference/cli/about).
-
-## Breaking changes
-
-We follow semantic versioning for changes that directly impact CLI commands, flags, and configurations.
-
-However, due to dependencies on other service images, we cannot guarantee that schema migrations, seed.sql, and generated types will always work for the same CLI major version. If you need such guarantees, we encourage you to pin a specific version of CLI in package.json.
-
-## Developing
-
-To run from source:
-
-```sh
-# Go >= 1.22
-go run . help
-```
+# Speddy
+
+Speddy is a scheduling and caseload management tool for special education providers. It uses Next.js 14, Supabase, and Tailwind CSS to help providers coordinate student services across schools while enforcing role-based access controls and scheduling constraints.
+
+## Quick start
+
+### Prerequisites
+- Node.js 18+
+- npm 10+
+- Access to a Supabase project with anon and service role keys
+
+### Setup
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Create a `.env.local` file with your Supabase credentials:
+   ```bash
+   NEXT_PUBLIC_SUPABASE_URL=your-url
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+   SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+   ```
+   The service role key is required for data import and migration scripts; the anon key is used by the application and integration tests.
+3. Start the app:
+   ```bash
+   npm run dev
+   ```
+   The app runs at http://localhost:3000.
+
+### Common scripts
+- `npm run dev` – start the Next.js dev server
+- `npm run lint` – lint the codebase
+- `npm run typecheck` – full TypeScript checks
+- `npm run test:basic` – sanity smoke test
+- `npm run test:integration` – integration test suite (requires Supabase env vars)
+- `npm run build` – production build
+
+## Database and migrations
+- SQL migrations are stored in `supabase/migrations/` using the naming convention `YYYYMMDD_description.sql`.
+- Production database changes are applied manually in Supabase; keep migration files committed for history.
+- For local testing you can run `node scripts/run-migrations.js` after setting `NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`.
+
+## Onboarding and workflows
+- New contributors should start with the [onboarding guide](docs/onboarding.md) for step-by-step local setup, Replit tips, and testing expectations.
+- See `speddy-dev-workflow-v3.md` for branch strategy, PR expectations, and background on how the team uses Supabase and Replit.
+
+## Project structure
+- `app/` – Next.js app router pages and UI components
+- `lib/` – scheduling engines, Supabase clients, and shared utilities
+- `supabase/` – database migrations and generated types
+- `scripts/` – data import, migration, and verification scripts
+- `tests/` – integration and end-to-end checks
+
+## Support
+Please open issues or pull requests with detailed context. Include reproduction steps and any relevant logs when reporting bugs.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,54 @@
+# Speddy Onboarding Guide
+
+This guide walks new contributors through setting up Speddy locally and understanding how the team works in Replit and Supabase.
+
+## 1) Local development setup
+1. **Clone the repository** and install dependencies:
+   ```bash
+   npm install
+   ```
+2. **Environment variables** – create `.env.local` in the project root:
+   ```bash
+   NEXT_PUBLIC_SUPABASE_URL=your-url
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+   SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+   ```
+   - `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are required for the Next.js app and integration tests.
+   - `SUPABASE_SERVICE_ROLE_KEY` is required for migration and data-import scripts that need elevated privileges.
+3. **Run the app**:
+   ```bash
+   npm run dev
+   ```
+   The dev server runs on http://localhost:3000.
+4. **Run checks** before opening a PR:
+   ```bash
+   npm run lint
+   npm run typecheck
+   npm run test:basic
+   ```
+   Integration tests (`npm run test:integration`) require a Supabase instance configured with the schema from `supabase/migrations/`.
+
+## 2) Database workflow
+- SQL migrations live in `supabase/migrations/` and follow `YYYYMMDD_description.sql` naming.
+- Apply migrations to a Supabase instance with the service role key via `node scripts/run-migrations.js`.
+- For production, migrations are executed manually in Supabase; keep the migration files committed for traceability.
+- Seed data: use `scripts/seed.js` after setting `NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `SEED_PROVIDER_ID` to load basic fixtures.
+
+## 3) Replit usage
+- Replit is the always-on deployment target; production runs directly from the main branch pulled into Replit.
+- After a PR is merged, refresh Replit with:
+  ```bash
+  git pull origin main
+  npm run dev
+  ```
+- Replit should have the same env vars as `.env.local` to keep behavior consistent.
+
+## 4) Contribution expectations
+- Work on feature branches and open pull requests; direct commits to `main` are avoided.
+- Describe schema changes clearly and add SQL files for any database adjustments, even when applied manually.
+- Provide reproduction steps and screenshots for UI changes when possible to help reviewers.
+
+## 5) Helpful references
+- `speddy-dev-workflow-v3.md` – detailed team workflow, branching strategy, and environment notes.
+- `supabase/migrations/` – current database schema history.
+- `scripts/` – utilities for data import, validation, and migrations.

--- a/lib/scheduling/scheduling-coordinator.ts
+++ b/lib/scheduling/scheduling-coordinator.ts
@@ -1,3 +1,14 @@
+/**
+ * SchedulingCoordinator orchestrates the full scheduling flow:
+ * - Loads student, bell schedule, and provider context through `SchedulingDataManager`
+ * - Validates requested sessions against configurable constraints (max concurrent sessions, grade grouping, etc.)
+ *   via `ConstraintValidator`
+ * - Uses `SchedulingEngine` to pick optimal time slots from availability windows
+ * - Persists sessions and updates in-memory context so subsequent students respect earlier placements
+ *
+ * The coordinator is stateful per provider/school pairing. Call `initialize` before scheduling to ensure
+ * shared caches and the scheduling context are populated.
+ */
 import { createClient } from '@/lib/supabase/client';
 import { SchedulingDataManager } from './scheduling-data-manager';
 import { ConstraintValidator } from './constraint-validator';

--- a/lib/services/manual-placement-service.ts
+++ b/lib/services/manual-placement-service.ts
@@ -1,3 +1,10 @@
+/**
+ * ManualPlacementService lets staff assign sessions directly while still respecting conflicts.
+ * It synthesizes candidate time slots, checks them against existing provider sessions via
+ * `SchedulingDataManager`, and optionally persists placements with conflict details when
+ * overrides are allowed. Use this when a deterministic manual schedule is needed instead of
+ * the automated scheduling engine.
+ */
 import { SupabaseClient } from '@supabase/supabase-js';
 import { SchedulingDataManager } from '../scheduling/scheduling-data-manager';
 import { sessionUpdateService } from './session-update-service';


### PR DESCRIPTION
## Summary
- replace the root README with Speddy-specific overview, setup steps, and common scripts
- add a contributor onboarding guide covering env vars, database workflow, and Replit usage
- document scheduling coordinator and manual placement services with module-level context

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959cbaf07e4832d88250ff4fd115932)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project README with comprehensive Speddy overview and quick start guide
  * Added detailed onboarding guide covering development setup, database workflows, and contribution expectations

* **New Features**
  * Added manual session placement functionality with available slot detection, conflict validation, and placement orchestration capabilities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->