### PR TITLE
Add inline absence reason entry to attendance widget

### DIFF
--- a/app/api/attendance/summary/route.ts
+++ b/app/api/attendance/summary/route.ts
@@ -39,7 +39,8 @@ export async function GET(request: NextRequest) {
   }
 
   // Get today's date for filtering unmarked sessions (don't show future sessions as unmarked)
-  const today = new Date().toISOString().split('T')[0];
+  // Use local date format to match session_date storage format
+  const today = new Intl.DateTimeFormat('en-CA').format(new Date());
 
   try {
     const { data: sessions, error: sessionsError } = await supabase

--- a/app/api/sessions/[sessionId]/attendance/route.ts
+++ b/app/api/sessions/[sessionId]/attendance/route.ts
@@ -181,8 +181,8 @@ export async function PUT(
     const body = await request.json();
     const { student_id, session_date, present, absence_reason } = body;
 
-    if (!student_id || !session_date || present === undefined) {
-      return NextResponse.json({ error: 'student_id, session_date, and present are required' }, { status: 400 });
+    if (!student_id || !session_date || typeof present !== 'boolean') {
+      return NextResponse.json({ error: 'student_id, session_date, and present (boolean) are required' }, { status: 400 });
     }
 
     const serviceClient = createServiceClient();
@@ -212,7 +212,7 @@ export async function PUT(
         student_id,
         session_date,
         present,
-        absence_reason: present ? null : (absence_reason || null),
+        absence_reason: present ? null : (absence_reason?.trim() || null),
         marked_by: user.id
       }, {
         onConflict: 'session_id,student_id,session_date'

--- a/app/components/dashboard/attendance-widget.tsx
+++ b/app/components/dashboard/attendance-widget.tsx
@@ -94,7 +94,7 @@ export function AttendanceWidget() {
           student_id: session.studentId,
           session_date: session.date,
           present,
-          absence_reason: present ? null : (reason || null)
+          absence_reason: present ? null : (reason?.trim() || null)
         })
       });
 


### PR DESCRIPTION
## Summary
- Add inline reason input when marking a student absent (replaces immediate mark with text entry flow)
- Simplify widget by removing attendance rate bar and recent absences section
- Only show unmarked sessions for today or past dates (future sessions no longer shown as unmarked)
- Add PUT handler to attendance API for single-student quick-marking with optional reason

## Changes
- `app/components/dashboard/attendance-widget.tsx` - Inline absence reason UI
- `app/api/sessions/[sessionId]/attendance/route.ts` - New PUT handler
- `app/api/attendance/summary/route.ts` - Filter future sessions from unmarked list

## Test plan
- [ ] Click red X on unmarked session → should show inline input with back arrow and blue confirm
- [ ] Type reason and press Enter → should mark absent with reason and show toast
- [ ] Click back arrow → should return to green/red buttons
- [ ] Press Escape in input → should cancel and return to buttons
- [ ] Verify future sessions don't appear in unmarked list

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Inline reason entry when marking a student absent.
  - Quick mark option to update a single student's attendance.

* **Bug Fixes**
  - Attendance summary no longer shows future unmarked sessions.

* **Style**
  - Updated attendance widget UI; removed inline attendance rate and recent-absences sections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->