### PR TITLE
Yard duty: provider support, reassign, conflict detection, filter fix

### DIFF
--- a/app/(dashboard)/dashboard/admin/master-schedule/components/admin-schedule-grid.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/admin-schedule-grid.tsx
@@ -37,6 +37,7 @@ interface AdminScheduleGridProps {
   staffMembers?: StaffWithHours[];
   providers?: ProviderOption[];
   yardDutyAssignments?: YardDutyAssignment[];
+  allYardDutyAssignments?: YardDutyAssignment[];
   schoolYear?: string;
 }
 
@@ -170,6 +171,7 @@ export function AdminScheduleGrid({
   staffMembers = [],
   providers = [],
   yardDutyAssignments = [],
+  allYardDutyAssignments = [],
   schoolYear,
 }: AdminScheduleGridProps) {
   const [createModal, setCreateModal] = useState<{
@@ -602,7 +604,7 @@ export function AdminScheduleGrid({
           teachers={teachers}
           staffMembers={staffMembers}
           providers={providers}
-          yardDutyAssignments={yardDutyAssignments}
+          yardDutyAssignments={allYardDutyAssignments}
           specialActivities={allSpecialActivities}
           schoolYear={schoolYear}
         />
@@ -621,8 +623,8 @@ export function AdminScheduleGrid({
           teachers={teachers}
           staffMembers={staffMembers}
           providers={providers}
-          yardDutyAssignments={yardDutyAssignments}
-          specialActivities={specialActivities}
+          yardDutyAssignments={allYardDutyAssignments}
+          specialActivities={allSpecialActivities}
         />
       )}
 

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/admin-schedule-grid.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/admin-schedule-grid.tsx
@@ -11,7 +11,7 @@ import { EditItemModal } from './edit-item-modal';
 import { DailyTimeMarker } from './daily-time-marker';
 import { removeRotationGroupMember } from '../../../../../../lib/supabase/queries/rotation-groups';
 import type { SpecialActivity, Teacher, YardDutyAssignment } from '@/src/types/database';
-import type { StaffWithHours } from '../../../../../../lib/supabase/queries/staff';
+import type { StaffWithHours, ProviderOption } from '../../../../../../lib/supabase/queries/staff';
 import type { BellScheduleWithCreator } from '../types';
 import type { FullDayAvailability } from '../../../../../../lib/supabase/queries/activity-availability';
 import type { RotationPairWithGroups, RotationGroupMemberWithTeacher } from '../../../../../../lib/supabase/queries/rotation-groups';
@@ -35,6 +35,7 @@ interface AdminScheduleGridProps {
   filterSelectedGrades?: Set<string>;
   teachers?: Teacher[];
   staffMembers?: StaffWithHours[];
+  providers?: ProviderOption[];
   yardDutyAssignments?: YardDutyAssignment[];
   schoolYear?: string;
 }
@@ -167,6 +168,7 @@ export function AdminScheduleGrid({
   filterSelectedGrades,
   teachers = [],
   staffMembers = [],
+  providers = [],
   yardDutyAssignments = [],
   schoolYear,
 }: AdminScheduleGridProps) {
@@ -599,7 +601,9 @@ export function AdminScheduleGrid({
           bellSchedules={allBellSchedules}
           teachers={teachers}
           staffMembers={staffMembers}
+          providers={providers}
           yardDutyAssignments={yardDutyAssignments}
+          specialActivities={allSpecialActivities}
           schoolYear={schoolYear}
         />
       )}
@@ -615,7 +619,10 @@ export function AdminScheduleGrid({
           availableActivityTypes={availableActivityTypes}
           bellSchedules={allBellSchedules}
           teachers={teachers}
+          staffMembers={staffMembers}
+          providers={providers}
           yardDutyAssignments={yardDutyAssignments}
+          specialActivities={specialActivities}
         />
       )}
 

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/create-item-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/create-item-modal.tsx
@@ -8,8 +8,8 @@ import { addYardDutyAssignment } from '../../../../../../lib/supabase/queries/ya
 import { BELL_SCHEDULE_ACTIVITIES, SPECIAL_ACTIVITY_TYPES } from '../../../../../../lib/constants/activity-types';
 import { TeacherAutocomplete } from '../../../../../components/teachers/teacher-autocomplete';
 import { FullDayAvailability, checkActivityAvailability } from '../../../../../../lib/supabase/queries/activity-availability';
-import type { Teacher, YardDutyAssignment } from '@/src/types/database';
-import type { StaffWithHours } from '../../../../../../lib/supabase/queries/staff';
+import type { Teacher, YardDutyAssignment, SpecialActivity } from '@/src/types/database';
+import type { StaffWithHours, ProviderOption } from '../../../../../../lib/supabase/queries/staff';
 import type { BellScheduleWithCreator } from '../types';
 
 interface CreateItemModalProps {
@@ -25,7 +25,9 @@ interface CreateItemModalProps {
   bellSchedules?: BellScheduleWithCreator[];
   teachers?: Teacher[];
   staffMembers?: StaffWithHours[];
+  providers?: ProviderOption[];
   yardDutyAssignments?: YardDutyAssignment[];
+  specialActivities?: SpecialActivity[];
   schoolYear?: string;
 }
 
@@ -59,7 +61,9 @@ export function CreateItemModal({
   bellSchedules = [],
   teachers = [],
   staffMembers = [],
+  providers = [],
   yardDutyAssignments = [],
+  specialActivities = [],
   schoolYear
 }: CreateItemModalProps) {
   const [tab, setTab] = useState<'bell' | 'activity' | 'dailyTime' | 'yardDuty'>(defaultTab);
@@ -97,11 +101,13 @@ export function CreateItemModal({
   const [ydDays, setYdDays] = useState<number[]>([day]);
   const [ydStartTime, setYdStartTime] = useState(startTime);
   const [ydEndTime, setYdEndTime] = useState(() => calculateDefaultEndTime(startTime, 20));
-  const [ydAssigneeType, setYdAssigneeType] = useState<'teacher' | 'staff' | ''>('');
+  const [ydAssigneeType, setYdAssigneeType] = useState<'teacher' | 'staff' | 'provider' | ''>('');
   const [ydTeacherId, setYdTeacherId] = useState<string | null>(null);
   const [ydTeacherName, setYdTeacherName] = useState('');
   const [ydStaffId, setYdStaffId] = useState<string | null>(null);
   const [ydStaffName, setYdStaffName] = useState('');
+  const [ydProviderId, setYdProviderId] = useState<string | null>(null);
+  const [ydProviderName, setYdProviderName] = useState('');
 
   // Get distinct period names and zone names from existing yard duty assignments for suggestions
   const existingPeriodNames = useMemo(() => {
@@ -110,6 +116,7 @@ export function CreateItemModal({
     return Array.from(names).sort();
   }, [yardDutyAssignments]);
 
+  // Get distinct zone names from existing yard duty assignments for suggestions
   const existingZoneNames = useMemo(() => {
     const names = new Set<string>();
     yardDutyAssignments.forEach(yd => {
@@ -117,6 +124,31 @@ export function CreateItemModal({
     });
     return Array.from(names).sort();
   }, [yardDutyAssignments]);
+
+  // Conflict detection: yard duty teacher vs their special activities
+  const ydConflictWarning = useMemo(() => {
+    if (tab !== 'yardDuty' || !ydTeacherId || !ydStartTime || !ydEndTime || ydDays.length === 0) return null;
+
+    const normTime = (t: string) => t.substring(0, 5);
+    const start = normTime(ydStartTime);
+    const end = normTime(ydEndTime);
+
+    const conflicts = specialActivities.filter(a => {
+      if (a.teacher_id !== ydTeacherId || !a.start_time || !a.end_time) return false;
+      if (!ydDays.includes(a.day_of_week)) return false;
+      const aStart = normTime(a.start_time);
+      const aEnd = normTime(a.end_time);
+      return start < aEnd && aStart < end;
+    });
+
+    if (conflicts.length === 0) return null;
+
+    const descriptions = conflicts.map(c => {
+      const dayName = DAYS[(c.day_of_week || 1) - 1];
+      return `${c.activity_name} on ${dayName} (${normTime(c.start_time!)}–${normTime(c.end_time!)})`;
+    });
+    return `This overlaps with: ${descriptions.join(', ')}`;
+  }, [tab, ydTeacherId, ydStartTime, ydEndTime, ydDays, specialActivities]);
 
   const handleYdDayToggle = (dayNum: number) => {
     setYdDays(prev =>
@@ -189,6 +221,30 @@ export function CreateItemModal({
     );
     return `This overlaps with: ${descriptions.join(', ')}`;
   }, [tab, teacherId, teachers, bellSchedules, day, activityStartTime, activityEndTime]);
+
+  // Conflict detection: special activity teacher vs their yard duty assignments
+  const yardDutyConflictWarning = useMemo(() => {
+    if (tab !== 'activity' || !teacherId || !activityStartTime || !activityEndTime) return null;
+
+    const normTime = (t: string) => t.substring(0, 5);
+    const actStart = normTime(activityStartTime);
+    const actEnd = normTime(activityEndTime);
+
+    const conflicts = yardDutyAssignments.filter(yd => {
+      if (yd.teacher_id !== teacherId || !yd.start_time || !yd.end_time) return false;
+      if (yd.day_of_week !== day) return false;
+      const ydStart = normTime(yd.start_time);
+      const ydEnd = normTime(yd.end_time);
+      return actStart < ydEnd && ydStart < actEnd;
+    });
+
+    if (conflicts.length === 0) return null;
+
+    const descriptions = conflicts.map(c =>
+      `${c.period_name}${c.zone_name ? ` (${c.zone_name})` : ''} (${normTime(c.start_time)}–${normTime(c.end_time)})`
+    );
+    return `This overlaps with yard duty: ${descriptions.join(', ')}`;
+  }, [tab, teacherId, yardDutyAssignments, day, activityStartTime, activityEndTime]);
 
   // Handle start time change - auto-adjust end time to maintain 30min duration
   const handleBellStartTimeChange = (newStartTime: string) => {
@@ -351,8 +407,14 @@ export function CreateItemModal({
           setError('Please select a staff member');
           return;
         }
+        if (ydAssigneeType === 'provider' && !ydProviderId) {
+          setError('Please select a provider');
+          return;
+        }
 
-        const assigneeName = ydAssigneeType === 'teacher' ? ydTeacherName : ydStaffName;
+        const assigneeName = ydAssigneeType === 'teacher' ? ydTeacherName
+          : ydAssigneeType === 'staff' ? ydStaffName
+          : ydProviderName;
 
         setLoading(true);
         await Promise.all(
@@ -366,6 +428,7 @@ export function CreateItemModal({
               end_time: ydEndTime,
               teacher_id: ydAssigneeType === 'teacher' ? ydTeacherId : null,
               staff_id: ydAssigneeType === 'staff' ? ydStaffId : null,
+              provider_id: ydAssigneeType === 'provider' ? ydProviderId : null,
               assignee_name: assigneeName,
               ...(schoolYear ? { school_year: schoolYear } : {})
             })
@@ -652,7 +715,7 @@ export function CreateItemModal({
                 <div className="flex gap-2 mb-2">
                   <button
                     type="button"
-                    onClick={() => { setYdAssigneeType('teacher'); setYdStaffId(null); setYdStaffName(''); }}
+                    onClick={() => { setYdAssigneeType('teacher'); setYdStaffId(null); setYdStaffName(''); setYdProviderId(null); setYdProviderName(''); }}
                     className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
                       ydAssigneeType === 'teacher'
                         ? 'bg-blue-600 text-white'
@@ -663,7 +726,7 @@ export function CreateItemModal({
                   </button>
                   <button
                     type="button"
-                    onClick={() => { setYdAssigneeType('staff'); setYdTeacherId(null); setYdTeacherName(''); }}
+                    onClick={() => { setYdAssigneeType('staff'); setYdTeacherId(null); setYdTeacherName(''); setYdProviderId(null); setYdProviderName(''); }}
                     className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
                       ydAssigneeType === 'staff'
                         ? 'bg-blue-600 text-white'
@@ -671,6 +734,17 @@ export function CreateItemModal({
                     }`}
                   >
                     Staff
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { setYdAssigneeType('provider'); setYdTeacherId(null); setYdTeacherName(''); setYdStaffId(null); setYdStaffName(''); }}
+                    className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
+                      ydAssigneeType === 'provider'
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                    }`}
+                  >
+                    Provider
                   </button>
                 </div>
 
@@ -697,6 +771,25 @@ export function CreateItemModal({
                     {staffMembers.map(staff => (
                       <option key={staff.id} value={staff.id}>
                         {staff.first_name} {staff.last_name} ({staff.role === 'instructional_assistant' ? 'IA' : staff.role === 'supervisor' ? 'Supervisor' : 'Office'})
+                      </option>
+                    ))}
+                  </select>
+                )}
+
+                {ydAssigneeType === 'provider' && (
+                  <select
+                    value={ydProviderId || ''}
+                    onChange={(e) => {
+                      const selected = providers.find(p => p.id === e.target.value);
+                      setYdProviderId(e.target.value || null);
+                      setYdProviderName(selected ? selected.full_name : '');
+                    }}
+                    className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
+                  >
+                    <option value="">Select provider...</option>
+                    {providers.map(provider => (
+                      <option key={provider.id} value={provider.id}>
+                        {provider.full_name}
                       </option>
                     ))}
                   </select>
@@ -754,6 +847,13 @@ export function CreateItemModal({
                   />
                 </div>
               </div>
+
+              {/* Yard duty conflict warning */}
+              {ydConflictWarning && (
+                <div className="text-sm text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+                  {ydConflictWarning}
+                </div>
+              )}
             </>
           ) : tab === 'activity' ? (
             <>
@@ -817,6 +917,13 @@ export function CreateItemModal({
                 {bellScheduleConflictWarning && (
                   <div className="mt-2 text-sm text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2">
                     {bellScheduleConflictWarning}
+                  </div>
+                )}
+
+                {/* Yard duty conflict warning */}
+                {yardDutyConflictWarning && (
+                  <div className="mt-2 text-sm text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+                    {yardDutyConflictWarning}
                   </div>
                 )}
               </div>

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/edit-item-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/edit-item-modal.tsx
@@ -6,7 +6,9 @@ import { deleteBellScheduleAsAdmin, updateBellScheduleAsAdmin } from '../../../.
 import { deleteSpecialActivityAsAdmin, updateSpecialActivityAsAdmin } from '../../../../../../lib/supabase/queries/special-activities';
 import { updateYardDutyAssignment, deleteYardDutyAssignment } from '../../../../../../lib/supabase/queries/yard-duty';
 import { SPECIAL_ACTIVITY_TYPES, BELL_SCHEDULE_ACTIVITIES } from '../../../../../../lib/constants/activity-types';
+import { TeacherAutocomplete } from '../../../../../components/teachers/teacher-autocomplete';
 import type { SpecialActivity, Teacher, YardDutyAssignment } from '@/src/types/database';
+import type { StaffWithHours, ProviderOption } from '../../../../../../lib/supabase/queries/staff';
 import type { BellScheduleWithCreator } from '../types';
 
 interface EditItemModalProps {
@@ -18,7 +20,10 @@ interface EditItemModalProps {
   availableActivityTypes?: string[];
   bellSchedules?: BellScheduleWithCreator[];
   teachers?: Teacher[];
+  staffMembers?: StaffWithHours[];
+  providers?: ProviderOption[];
   yardDutyAssignments?: YardDutyAssignment[];
+  specialActivities?: SpecialActivity[];
 }
 
 const DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
@@ -42,7 +47,10 @@ export function EditItemModal({
   availableActivityTypes = [],
   bellSchedules = [],
   teachers = [],
-  yardDutyAssignments = []
+  staffMembers = [],
+  providers = [],
+  yardDutyAssignments = [],
+  specialActivities = []
 }: EditItemModalProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -69,6 +77,16 @@ export function EditItemModal({
   const [ydStartTime, setYdStartTime] = useState(yardDuty?.start_time || '');
   const [ydEndTime, setYdEndTime] = useState(yardDuty?.end_time || '');
 
+  // Yard duty assignee state
+  const initialAssigneeType = yardDuty?.teacher_id ? 'teacher' : yardDuty?.staff_id ? 'staff' : yardDuty?.provider_id ? 'provider' : '';
+  const [ydAssigneeType, setYdAssigneeType] = useState<'teacher' | 'staff' | 'provider' | ''>(initialAssigneeType);
+  const [ydTeacherId, setYdTeacherId] = useState<string | null>(yardDuty?.teacher_id || null);
+  const [ydTeacherName, setYdTeacherName] = useState(yardDuty?.teacher_id ? (yardDuty?.assignee_name || '') : '');
+  const [ydStaffId, setYdStaffId] = useState<string | null>(yardDuty?.staff_id || null);
+  const [ydStaffName, setYdStaffName] = useState(yardDuty?.staff_id ? (yardDuty?.assignee_name || '') : '');
+  const [ydProviderId, setYdProviderId] = useState<string | null>(yardDuty?.provider_id || null);
+  const [ydProviderName, setYdProviderName] = useState(yardDuty?.provider_id ? (yardDuty?.assignee_name || '') : '');
+
   // Get existing period/zone names for datalist suggestions
   const existingPeriodNames = useMemo(() => {
     const names = new Set<string>();
@@ -83,6 +101,56 @@ export function EditItemModal({
     });
     return Array.from(names).sort();
   }, [yardDutyAssignments]);
+
+  // Conflict detection: yard duty teacher vs their special activities
+  const ydConflictWarning = useMemo(() => {
+    if (type !== 'yard-duty' || !ydTeacherId || !ydStartTime || !ydEndTime) return null;
+
+    const normTime = (t: string) => t.substring(0, 5);
+    const start = normTime(ydStartTime);
+    const end = normTime(ydEndTime);
+    const dayOfWeek = item.day_of_week;
+
+    const conflicts = specialActivities.filter(a => {
+      if (a.teacher_id !== ydTeacherId || !a.start_time || !a.end_time) return false;
+      if (a.day_of_week !== dayOfWeek) return false;
+      const aStart = normTime(a.start_time);
+      const aEnd = normTime(a.end_time);
+      return start < aEnd && aStart < end;
+    });
+
+    if (conflicts.length === 0) return null;
+
+    const descriptions = conflicts.map(c =>
+      `${c.activity_name} (${normTime(c.start_time!)}–${normTime(c.end_time!)})`
+    );
+    return `This overlaps with: ${descriptions.join(', ')}`;
+  }, [type, ydTeacherId, ydStartTime, ydEndTime, item.day_of_week, specialActivities]);
+
+  // Conflict detection: special activity teacher vs their yard duty
+  const yardDutyConflictWarning = useMemo(() => {
+    if (type !== 'activity' || !activity?.teacher_id || !startTime || !endTime) return null;
+
+    const normTime = (t: string) => t.substring(0, 5);
+    const actStart = normTime(startTime);
+    const actEnd = normTime(endTime);
+    const dayOfWeek = item.day_of_week;
+
+    const conflicts = yardDutyAssignments.filter(yd => {
+      if (yd.teacher_id !== activity.teacher_id || !yd.start_time || !yd.end_time) return false;
+      if (yd.day_of_week !== dayOfWeek) return false;
+      const ydStart = normTime(yd.start_time);
+      const ydEnd = normTime(yd.end_time);
+      return actStart < ydEnd && ydStart < actEnd;
+    });
+
+    if (conflicts.length === 0) return null;
+
+    const descriptions = conflicts.map(c =>
+      `${c.period_name}${c.zone_name ? ` (${c.zone_name})` : ''} (${normTime(c.start_time)}–${normTime(c.end_time)})`
+    );
+    return `This overlaps with yard duty: ${descriptions.join(', ')}`;
+  }, [type, activity, startTime, endTime, item.day_of_week, yardDutyAssignments]);
 
   // Check if activity conflicts with a bell schedule for the teacher's grade
   const bellScheduleConflictWarning = useMemo(() => {
@@ -230,6 +298,27 @@ export function EditItemModal({
       return;
     }
 
+    if (!ydAssigneeType) {
+      setError('Please select an assignee');
+      return;
+    }
+    if (ydAssigneeType === 'teacher' && !ydTeacherId) {
+      setError('Please select a teacher');
+      return;
+    }
+    if (ydAssigneeType === 'staff' && !ydStaffId) {
+      setError('Please select a staff member');
+      return;
+    }
+    if (ydAssigneeType === 'provider' && !ydProviderId) {
+      setError('Please select a provider');
+      return;
+    }
+
+    const assigneeName = ydAssigneeType === 'teacher' ? ydTeacherName
+      : ydAssigneeType === 'staff' ? ydStaffName
+      : ydProviderName;
+
     setError(null);
     setLoading(true);
 
@@ -239,6 +328,10 @@ export function EditItemModal({
         zone_name: ydZoneName || null,
         start_time: ydStartTime,
         end_time: ydEndTime,
+        teacher_id: ydAssigneeType === 'teacher' ? ydTeacherId : null,
+        staff_id: ydAssigneeType === 'staff' ? ydStaffId : null,
+        provider_id: ydAssigneeType === 'provider' ? ydProviderId : null,
+        assignee_name: assigneeName,
       });
       onSuccess();
     } catch (err: any) {
@@ -277,7 +370,7 @@ export function EditItemModal({
             {type === 'bell' ? (isDailyTimeMarker ? 'Daily Time' : 'Bell Schedule') : type === 'yard-duty' ? 'Yard Duty' : 'Special Activity'}
           </h2>
           <p className="text-sm text-gray-500 mt-1">
-            {dayName} at {formatTime(item.start_time || null)}
+            {dayName} at {formatTime('start_time' in item ? (item.start_time || null) : null)}
           </p>
         </div>
 
@@ -358,12 +451,93 @@ export function EditItemModal({
 
           {type === 'yard-duty' && yardDuty && (
             <>
-              {/* Assignee (read-only) */}
+              {/* Assignee (editable) */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-gray-700 mb-2">
                   Assigned To
                 </label>
-                <p className="text-sm text-gray-900">{yardDuty.assignee_name}</p>
+                <div className="flex gap-2 mb-2">
+                  <button
+                    type="button"
+                    onClick={() => { setYdAssigneeType('teacher'); setYdStaffId(null); setYdStaffName(''); setYdProviderId(null); setYdProviderName(''); }}
+                    className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
+                      ydAssigneeType === 'teacher'
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                    }`}
+                  >
+                    Teacher
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { setYdAssigneeType('staff'); setYdTeacherId(null); setYdTeacherName(''); setYdProviderId(null); setYdProviderName(''); }}
+                    className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
+                      ydAssigneeType === 'staff'
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                    }`}
+                  >
+                    Staff
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { setYdAssigneeType('provider'); setYdTeacherId(null); setYdTeacherName(''); setYdStaffId(null); setYdStaffName(''); }}
+                    className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
+                      ydAssigneeType === 'provider'
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                    }`}
+                  >
+                    Provider
+                  </button>
+                </div>
+
+                {ydAssigneeType === 'teacher' && (
+                  <TeacherAutocomplete
+                    value={ydTeacherId}
+                    teacherName={ydTeacherName}
+                    onChange={(id, name) => { setYdTeacherId(id); setYdTeacherName(name || ''); }}
+                    placeholder="Search for a teacher..."
+                  />
+                )}
+
+                {ydAssigneeType === 'staff' && (
+                  <select
+                    value={ydStaffId || ''}
+                    onChange={(e) => {
+                      const selected = staffMembers.find(s => s.id === e.target.value);
+                      setYdStaffId(e.target.value || null);
+                      setYdStaffName(selected ? `${selected.first_name} ${selected.last_name}` : '');
+                    }}
+                    className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
+                  >
+                    <option value="">Select staff member...</option>
+                    {staffMembers.map(staff => (
+                      <option key={staff.id} value={staff.id}>
+                        {staff.first_name} {staff.last_name} ({staff.role === 'instructional_assistant' ? 'IA' : staff.role === 'supervisor' ? 'Supervisor' : 'Office'})
+                      </option>
+                    ))}
+                  </select>
+                )}
+
+                {ydAssigneeType === 'provider' && (
+                  <select
+                    value={ydProviderId || ''}
+                    onChange={(e) => {
+                      const selected = providers.find(p => p.id === e.target.value);
+                      setYdProviderId(e.target.value || null);
+                      setYdProviderName(selected ? selected.full_name : '');
+                    }}
+                    className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
+                  >
+                    <option value="">Select provider...</option>
+                    {providers.map(provider => (
+                      <option key={provider.id} value={provider.id}>
+                        {provider.full_name}
+                      </option>
+                    ))}
+                  </select>
+                )}
               </div>
 
               {/* Period name (editable) */}
@@ -430,6 +604,13 @@ export function EditItemModal({
                   />
                 </div>
               </div>
+
+              {/* Yard duty conflict warning */}
+              {ydConflictWarning && (
+                <div className="text-sm text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+                  {ydConflictWarning}
+                </div>
+              )}
             </>
           )}
 
@@ -492,6 +673,13 @@ export function EditItemModal({
               {bellScheduleConflictWarning && (
                 <div className="text-sm text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2">
                   {bellScheduleConflictWarning}
+                </div>
+              )}
+
+              {/* Yard duty conflict warning */}
+              {yardDutyConflictWarning && (
+                <div className="text-sm text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+                  {yardDutyConflictWarning}
                 </div>
               )}
             </>

--- a/app/(dashboard)/dashboard/admin/master-schedule/hooks/use-admin-schedule-data.ts
+++ b/app/(dashboard)/dashboard/admin/master-schedule/hooks/use-admin-schedule-data.ts
@@ -3,9 +3,9 @@ import { getBellSchedulesForSchool } from '../../../../../../lib/supabase/querie
 import { getSpecialActivities } from '../../../../../../lib/supabase/queries/special-activities';
 import { getTeachers } from '../../../../../../lib/supabase/queries/teachers';
 import { getYardDutyAssignments } from '../../../../../../lib/supabase/queries/yard-duty';
-import { getSchoolStaffMembers } from '../../../../../../lib/supabase/queries/staff';
+import { getSchoolStaffMembers, getSchoolProviders } from '../../../../../../lib/supabase/queries/staff';
 import type { SpecialActivity, Teacher, YardDutyAssignment } from '@/src/types/database';
-import type { StaffWithHours } from '../../../../../../lib/supabase/queries/staff';
+import type { StaffWithHours, ProviderOption } from '../../../../../../lib/supabase/queries/staff';
 import type { BellScheduleWithCreator } from '../types';
 
 interface UseAdminScheduleDataReturn {
@@ -14,6 +14,7 @@ interface UseAdminScheduleDataReturn {
   teachers: Teacher[];
   yardDutyAssignments: YardDutyAssignment[];
   staffMembers: StaffWithHours[];
+  providers: ProviderOption[];
   loading: boolean;
   error: string | null;
   refreshData: () => Promise<void>;
@@ -25,6 +26,7 @@ export function useAdminScheduleData(schoolId: string | null, schoolYear?: strin
   const [teachers, setTeachers] = useState<Teacher[]>([]);
   const [yardDutyAssignments, setYardDutyAssignments] = useState<YardDutyAssignment[]>([]);
   const [staffMembers, setStaffMembers] = useState<StaffWithHours[]>([]);
+  const [providers, setProviders] = useState<ProviderOption[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -49,20 +51,23 @@ export function useAdminScheduleData(schoolId: string | null, schoolYear?: strin
       setSpecialActivities(activityData || []);
       setTeachers(teacherData || []);
 
-      // Fetch yard duty and staff separately so permission errors don't block core data
+      // Fetch yard duty, staff, and providers separately so permission errors don't block core data
       let yardDutyData: YardDutyAssignment[] = [];
       let staffData: StaffWithHours[] = [];
+      let providerData: ProviderOption[] = [];
       try {
-        [yardDutyData, staffData] = await Promise.all([
+        [yardDutyData, staffData, providerData] = await Promise.all([
           getYardDutyAssignments(schoolId, schoolYear),
           getSchoolStaffMembers(schoolId),
+          getSchoolProviders(schoolId),
         ]);
       } catch (err) {
-        console.warn('Unable to fetch yard duty/staff data:', err);
+        console.warn('Unable to fetch yard duty/staff/provider data:', err);
       }
 
       setYardDutyAssignments(yardDutyData || []);
       setStaffMembers(staffData || []);
+      setProviders(providerData || []);
     } catch (err) {
       console.error('Error fetching schedule data:', err);
       setError('Failed to load schedule data');
@@ -81,6 +86,7 @@ export function useAdminScheduleData(schoolId: string | null, schoolYear?: strin
     teachers,
     yardDutyAssignments,
     staffMembers,
+    providers,
     loading,
     error,
     refreshData: fetchData

--- a/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
@@ -198,6 +198,7 @@ export default function MasterSchedulePage() {
     teachers,
     yardDutyAssignments,
     staffMembers,
+    providers,
     loading: dataLoading,
     refreshData
   } = useAdminScheduleData(schoolId, selectedSchoolYear);
@@ -333,11 +334,17 @@ export default function MasterSchedulePage() {
         .filter(pair => selectedTeacherIds.size === 0 || pair.groups.length > 0);
 
   // Filter yard duty assignments by selected teachers and view filter
+  // When teachers are selected, show matching teacher assignments + all staff/provider assignments
   const filteredYardDuty = (viewFilter === 'bell' || viewFilter === 'activities')
     ? []
     : yardDutyAssignments.filter(yd => {
         if (selectedTeacherIds.size > 0) {
-          return yd.teacher_id && selectedTeacherIds.has(yd.teacher_id);
+          // Show if assigned to a selected teacher, OR if assigned to staff/provider (not a teacher)
+          if (yd.teacher_id) {
+            return selectedTeacherIds.has(yd.teacher_id);
+          }
+          // Staff/provider assignments stay visible regardless of teacher filter
+          return true;
         }
         return true;
       });
@@ -485,6 +492,7 @@ export default function MasterSchedulePage() {
               filterSelectedGrades={selectedGrades}
               teachers={teachers}
               staffMembers={staffMembers}
+              providers={providers}
               yardDutyAssignments={filteredYardDuty}
               schoolYear={selectedSchoolYear}
             />

--- a/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
@@ -494,6 +494,7 @@ export default function MasterSchedulePage() {
               staffMembers={staffMembers}
               providers={providers}
               yardDutyAssignments={filteredYardDuty}
+              allYardDutyAssignments={yardDutyAssignments}
               schoolYear={selectedSchoolYear}
             />
             {/* Daily Times Toggle */}

--- a/lib/supabase/queries/staff.ts
+++ b/lib/supabase/queries/staff.ts
@@ -16,6 +16,11 @@ export type TeacherOption = {
   type: 'teacher' | 'provider';
 };
 
+export type ProviderOption = {
+  id: string;
+  full_name: string;
+};
+
 export type StaffAssignment = {
   id: string;
   teacher_id: string | null;
@@ -154,6 +159,31 @@ export async function getSchoolTeacherOptions(schoolId: string): Promise<Teacher
     });
 
   return [...teachers, ...providers];
+}
+
+// ============================================================================
+// GET SCHOOL PROVIDERS (for yard duty assignment dropdown)
+// ============================================================================
+
+export async function getSchoolProviders(schoolId: string): Promise<ProviderOption[]> {
+  const supabase = createClient<Database>();
+
+  const { data, error } = await supabase
+    .from('provider_schools')
+    .select('profiles:provider_id(id, full_name)')
+    .eq('school_id', schoolId);
+
+  if (error) {
+    console.error('Error fetching providers:', error);
+    return [];
+  }
+
+  return (data || [])
+    .filter((row: any) => row.profiles)
+    .map((row: any) => ({
+      id: row.profiles.id,
+      full_name: row.profiles.full_name || 'Unknown Provider',
+    }));
 }
 
 // ============================================================================

--- a/lib/supabase/queries/staff.ts
+++ b/lib/supabase/queries/staff.ts
@@ -168,15 +168,17 @@ export async function getSchoolTeacherOptions(schoolId: string): Promise<Teacher
 export async function getSchoolProviders(schoolId: string): Promise<ProviderOption[]> {
   const supabase = createClient<Database>();
 
+  const hasAccess = await isAdminForSchool(schoolId);
+  if (!hasAccess) {
+    throw new Error('You do not have permission to view providers at this school');
+  }
+
   const { data, error } = await supabase
     .from('provider_schools')
     .select('profiles:provider_id(id, full_name)')
     .eq('school_id', schoolId);
 
-  if (error) {
-    console.error('Error fetching providers:', error);
-    return [];
-  }
+  if (error) throw error;
 
   return (data || [])
     .filter((row: any) => row.profiles)

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -3490,6 +3490,7 @@ export type Database = {
           end_time: string
           id: string
           period_name: string
+          provider_id: string | null
           school_id: string
           school_year: string
           staff_id: string | null
@@ -3506,6 +3507,7 @@ export type Database = {
           end_time: string
           id?: string
           period_name: string
+          provider_id?: string | null
           school_id: string
           school_year: string
           staff_id?: string | null
@@ -3522,6 +3524,7 @@ export type Database = {
           end_time?: string
           id?: string
           period_name?: string
+          provider_id?: string | null
           school_id?: string
           school_year?: string
           staff_id?: string | null
@@ -3536,6 +3539,13 @@ export type Database = {
             columns: ["school_id"]
             isOneToOne: false
             referencedRelation: "schools"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "yard_duty_assignments_provider_id_fkey"
+            columns: ["provider_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
           {


### PR DESCRIPTION
## Summary
- **Provider assignee support**: Added Provider as a third assignee option (alongside Teacher/Staff) in both create and edit modals. Added `getSchoolProviders` query and wired provider data through the data hook and grid. Updated `YardDutyAssignment` database types to include `provider_id`.
- **Edit modal reassign**: Replaced the read-only assignee display with a full editable Teacher/Staff/Provider selector, so assignments can be reassigned without delete-and-recreate.
- **Cross-type conflict detection**: Creating or editing yard duty for a teacher now warns if it overlaps with their special activities (and vice versa). Yard duty vs bell schedules is intentionally not flagged since recess duty is expected.
- **Teacher filter fix**: When filtering by teachers in the sidebar, staff/provider yard duty assignments now remain visible instead of being hidden.
- **TypeScript fix**: Added `provider_id` to the `YardDutyAssignment` type (was missing after migration) and improved type narrowing in the edit modal header.

## Test plan
- [ ] Create a yard duty assignment with each assignee type: Teacher, Staff, Provider
- [ ] Edit an existing yard duty assignment and change the assignee to a different type
- [ ] Create yard duty for a teacher that overlaps with their special activity — verify amber warning appears
- [ ] Create a special activity for a teacher that overlaps with their yard duty — verify amber warning appears
- [ ] Select specific teachers in the sidebar and verify staff/provider yard duty assignments remain visible
- [ ] Verify yard duty during a bell schedule recess does NOT trigger a conflict warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Providers can be assigned to yard duty alongside teachers and staff; provider selection added throughout create/edit flows.
  - Schedule data now includes providers so they appear in UI lists and filters.
  - Editing now supports changing assignee type (teacher/staff/provider).

* **Behavior**
  - Filtering preserves staff/provider-only yard duties when teacher filters are applied.
  - Cross-type conflict warnings alert overlaps between yard duties and special activities.

* **Chores**
  - Database/schema updated to record provider assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->