### PR TITLE
Add yard duty zone settings modal and dropdown

### DIFF
--- a/app/(dashboard)/dashboard/admin/master-schedule/components/admin-schedule-grid.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/admin-schedule-grid.tsx
@@ -12,6 +12,7 @@ import { DailyTimeMarker } from './daily-time-marker';
 import { removeRotationGroupMember } from '../../../../../../lib/supabase/queries/rotation-groups';
 import type { SpecialActivity, Teacher, YardDutyAssignment } from '@/src/types/database';
 import type { StaffWithHours, ProviderOption } from '../../../../../../lib/supabase/queries/staff';
+import type { YardDutyZone } from '../../../../../../lib/supabase/queries/yard-duty-zones';
 import type { BellScheduleWithCreator } from '../types';
 import type { FullDayAvailability } from '../../../../../../lib/supabase/queries/activity-availability';
 import type { RotationPairWithGroups, RotationGroupMemberWithTeacher } from '../../../../../../lib/supabase/queries/rotation-groups';
@@ -38,6 +39,7 @@ interface AdminScheduleGridProps {
   providers?: ProviderOption[];
   yardDutyAssignments?: YardDutyAssignment[];
   allYardDutyAssignments?: YardDutyAssignment[];
+  yardDutyZones?: YardDutyZone[];
   schoolYear?: string;
 }
 
@@ -172,6 +174,7 @@ export function AdminScheduleGrid({
   providers = [],
   yardDutyAssignments = [],
   allYardDutyAssignments = [],
+  yardDutyZones = [],
   schoolYear,
 }: AdminScheduleGridProps) {
   const [createModal, setCreateModal] = useState<{
@@ -606,6 +609,7 @@ export function AdminScheduleGrid({
           providers={providers}
           yardDutyAssignments={allYardDutyAssignments}
           specialActivities={allSpecialActivities}
+          yardDutyZones={yardDutyZones}
           schoolYear={schoolYear}
         />
       )}
@@ -625,6 +629,7 @@ export function AdminScheduleGrid({
           providers={providers}
           yardDutyAssignments={allYardDutyAssignments}
           specialActivities={allSpecialActivities}
+          yardDutyZones={yardDutyZones}
         />
       )}
 

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/create-item-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/create-item-modal.tsx
@@ -10,6 +10,7 @@ import { TeacherAutocomplete } from '../../../../../components/teachers/teacher-
 import { FullDayAvailability, checkActivityAvailability } from '../../../../../../lib/supabase/queries/activity-availability';
 import type { Teacher, YardDutyAssignment, SpecialActivity } from '@/src/types/database';
 import type { StaffWithHours, ProviderOption } from '../../../../../../lib/supabase/queries/staff';
+import type { YardDutyZone } from '../../../../../../lib/supabase/queries/yard-duty-zones';
 import type { BellScheduleWithCreator } from '../types';
 
 interface CreateItemModalProps {
@@ -28,6 +29,7 @@ interface CreateItemModalProps {
   providers?: ProviderOption[];
   yardDutyAssignments?: YardDutyAssignment[];
   specialActivities?: SpecialActivity[];
+  yardDutyZones?: YardDutyZone[];
   schoolYear?: string;
 }
 
@@ -64,6 +66,7 @@ export function CreateItemModal({
   providers = [],
   yardDutyAssignments = [],
   specialActivities = [],
+  yardDutyZones = [],
   schoolYear
 }: CreateItemModalProps) {
   const [tab, setTab] = useState<'bell' | 'activity' | 'dailyTime' | 'yardDuty'>(defaultTab);
@@ -692,19 +695,36 @@ export function CreateItemModal({
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   Zone / Location <span className="text-gray-400 font-normal">(optional)</span>
                 </label>
-                <input
-                  type="text"
-                  value={ydZoneName}
-                  onChange={(e) => setYdZoneName(e.target.value)}
-                  placeholder="e.g., Basketball & Blacktop, Playstructure"
-                  list="zone-suggestions"
-                  className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
-                />
-                <datalist id="zone-suggestions">
-                  {existingZoneNames.map(name => (
-                    <option key={name} value={name} />
-                  ))}
-                </datalist>
+                {yardDutyZones.length > 0 ? (
+                  <select
+                    value={ydZoneName}
+                    onChange={(e) => setYdZoneName(e.target.value)}
+                    className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
+                  >
+                    <option value="">No zone selected</option>
+                    {yardDutyZones.map(zone => (
+                      <option key={zone.id} value={zone.zone_name}>
+                        {zone.zone_name}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    type="text"
+                    value={ydZoneName}
+                    onChange={(e) => setYdZoneName(e.target.value)}
+                    placeholder="e.g., Basketball & Blacktop, Playstructure"
+                    list="zone-suggestions"
+                    className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
+                  />
+                )}
+                {yardDutyZones.length === 0 && (
+                  <datalist id="zone-suggestions">
+                    {existingZoneNames.map(name => (
+                      <option key={name} value={name} />
+                    ))}
+                  </datalist>
+                )}
               </div>
 
               {/* Assignee type selection */}

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/edit-item-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/edit-item-modal.tsx
@@ -9,6 +9,7 @@ import { SPECIAL_ACTIVITY_TYPES, BELL_SCHEDULE_ACTIVITIES } from '../../../../..
 import { TeacherAutocomplete } from '../../../../../components/teachers/teacher-autocomplete';
 import type { SpecialActivity, Teacher, YardDutyAssignment } from '@/src/types/database';
 import type { StaffWithHours, ProviderOption } from '../../../../../../lib/supabase/queries/staff';
+import type { YardDutyZone } from '../../../../../../lib/supabase/queries/yard-duty-zones';
 import type { BellScheduleWithCreator } from '../types';
 
 interface EditItemModalProps {
@@ -24,6 +25,7 @@ interface EditItemModalProps {
   providers?: ProviderOption[];
   yardDutyAssignments?: YardDutyAssignment[];
   specialActivities?: SpecialActivity[];
+  yardDutyZones?: YardDutyZone[];
 }
 
 const DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
@@ -50,7 +52,8 @@ export function EditItemModal({
   staffMembers = [],
   providers = [],
   yardDutyAssignments = [],
-  specialActivities = []
+  specialActivities = [],
+  yardDutyZones = []
 }: EditItemModalProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -564,19 +567,40 @@ export function EditItemModal({
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   Zone / Location
                 </label>
-                <input
-                  type="text"
-                  value={ydZoneName}
-                  onChange={(e) => setYdZoneName(e.target.value)}
-                  placeholder="Optional"
-                  list="edit-zone-suggestions"
-                  className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
-                />
-                <datalist id="edit-zone-suggestions">
-                  {existingZoneNames.map(name => (
-                    <option key={name} value={name} />
-                  ))}
-                </datalist>
+                {yardDutyZones.length > 0 ? (
+                  <select
+                    value={ydZoneName}
+                    onChange={(e) => setYdZoneName(e.target.value)}
+                    className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
+                  >
+                    <option value="">No zone selected</option>
+                    {/* Include current value if it doesn't match a configured zone (legacy data) */}
+                    {ydZoneName && !yardDutyZones.some(z => z.zone_name === ydZoneName) && (
+                      <option value={ydZoneName}>{ydZoneName}</option>
+                    )}
+                    {yardDutyZones.map(zone => (
+                      <option key={zone.id} value={zone.zone_name}>
+                        {zone.zone_name}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    type="text"
+                    value={ydZoneName}
+                    onChange={(e) => setYdZoneName(e.target.value)}
+                    placeholder="Optional"
+                    list="edit-zone-suggestions"
+                    className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
+                  />
+                )}
+                {yardDutyZones.length === 0 && (
+                  <datalist id="edit-zone-suggestions">
+                    {existingZoneNames.map(name => (
+                      <option key={name} value={name} />
+                    ))}
+                  </datalist>
+                )}
               </div>
 
               {/* Times (editable) */}

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/yard-duty-zones-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/yard-duty-zones-modal.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import React, { useState, useEffect, useRef } from 'react';
+import { Button } from '../../../../../components/ui/button';
+import { TrashIcon } from '@heroicons/react/24/outline';
+import {
+  getYardDutyZones,
+  addYardDutyZone,
+  deleteYardDutyZone,
+  type YardDutyZone,
+} from '../../../../../../lib/supabase/queries/yard-duty-zones';
+
+interface YardDutyZonesModalProps {
+  schoolId: string;
+  onClose: () => void;
+  onZonesChanged: () => void;
+}
+
+export function YardDutyZonesModal({
+  schoolId,
+  onClose,
+  onZonesChanged,
+}: YardDutyZonesModalProps) {
+  const [zones, setZones] = useState<YardDutyZone[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newZoneName, setNewZoneName] = useState('');
+  const [adding, setAdding] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    fetchZones();
+  }, [schoolId]);
+
+  useEffect(() => {
+    modalRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const fetchZones = async () => {
+    try {
+      setLoading(true);
+      const data = await getYardDutyZones(schoolId);
+      setZones(data);
+    } catch (err) {
+      console.error('Error fetching zones:', err);
+      setError('Failed to load zones');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAdd = async () => {
+    const name = newZoneName.trim();
+    if (!name) return;
+
+    setError(null);
+    setAdding(true);
+    try {
+      await addYardDutyZone(schoolId, name);
+      setNewZoneName('');
+      await fetchZones();
+      onZonesChanged();
+      inputRef.current?.focus();
+    } catch (err: any) {
+      setError(err.message || 'Failed to add zone');
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleDelete = async (zone: YardDutyZone) => {
+    setError(null);
+    setDeleting(zone.id);
+    try {
+      await deleteYardDutyZone(zone.id);
+      await fetchZones();
+      onZonesChanged();
+    } catch (err: any) {
+      setError(err.message || 'Failed to delete zone');
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !adding) {
+      e.preventDefault();
+      handleAdd();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="zones-modal-heading"
+    >
+      <div
+        ref={modalRef}
+        className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4"
+        tabIndex={-1}
+      >
+        {/* Header */}
+        <div className="border-b border-gray-200 px-6 py-4">
+          <h2 id="zones-modal-heading" className="text-lg font-semibold text-gray-900">
+            Yard Duty Zones
+          </h2>
+          <p className="text-sm text-gray-500 mt-1">
+            Define the zones/locations used for yard duty assignments.
+          </p>
+        </div>
+
+        {/* Content */}
+        <div className="px-6 py-4">
+          {error && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-3 py-2 rounded text-sm mb-4">
+              {error}
+            </div>
+          )}
+
+          {/* Add new zone */}
+          <div className="flex gap-2 mb-4">
+            <input
+              ref={inputRef}
+              type="text"
+              value={newZoneName}
+              onChange={(e) => setNewZoneName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="e.g., Basketball & Blacktop"
+              className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
+              disabled={adding}
+            />
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleAdd}
+              disabled={adding || !newZoneName.trim()}
+            >
+              {adding ? 'Adding...' : 'Add'}
+            </Button>
+          </div>
+
+          {/* Zone list */}
+          {loading ? (
+            <div className="py-8 text-center text-gray-500 text-sm">Loading zones...</div>
+          ) : zones.length === 0 ? (
+            <div className="py-8 text-center text-gray-500 text-sm">
+              No zones configured yet. Add your first zone above.
+            </div>
+          ) : (
+            <div className="space-y-1 max-h-64 overflow-y-auto">
+              {zones.map((zone) => (
+                <div
+                  key={zone.id}
+                  className="flex items-center justify-between p-2 rounded hover:bg-gray-50 group"
+                >
+                  <span className="text-sm text-gray-900">{zone.zone_name}</span>
+                  <button
+                    onClick={() => handleDelete(zone)}
+                    disabled={deleting === zone.id}
+                    className="p-1 rounded opacity-0 group-hover:opacity-100 hover:bg-red-100 text-gray-400 hover:text-red-600 transition-all"
+                    title={`Delete ${zone.zone_name}`}
+                  >
+                    {deleting === zone.id ? (
+                      <div className="w-4 h-4 border-2 border-gray-400 border-t-transparent rounded-full animate-spin" />
+                    ) : (
+                      <TrashIcon className="w-4 h-4" />
+                    )}
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-gray-200 px-6 py-4 flex justify-end">
+          <Button variant="secondary" onClick={onClose}>
+            Done
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
@@ -486,6 +486,23 @@ export default function MasterSchedulePage() {
             </div>
           </div>
 
+          {/* Yard Duty Zone Settings - right-aligned under the toggle */}
+          {viewFilter === 'yard-duty' && (
+            <div className="flex justify-end mt-2">
+              <button
+                onClick={() => setShowZonesModal(true)}
+                className="flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+                title="Configure yard duty zones"
+              >
+                <Cog6ToothIcon className="w-4 h-4" />
+                <span>Zone Settings</span>
+                {yardDutyZones.length > 0 && (
+                  <span className="text-xs text-gray-400">({yardDutyZones.length})</span>
+                )}
+              </button>
+            </div>
+          )}
+
           {/* Secondary Filters */}
           <div className={`mt-4 pt-4 border-t border-gray-200 flex gap-6 ${
             viewFilter === 'all' ? 'flex-row flex-wrap items-center' : 'flex-col'
@@ -514,20 +531,6 @@ export default function MasterSchedulePage() {
               />
             )}
 
-            {/* Yard Duty Zones Settings */}
-            {viewFilter === 'yard-duty' && (
-              <button
-                onClick={() => setShowZonesModal(true)}
-                className="flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
-                title="Configure yard duty zones"
-              >
-                <Cog6ToothIcon className="w-4 h-4" />
-                <span>Zone Settings</span>
-                {yardDutyZones.length > 0 && (
-                  <span className="text-xs text-gray-400">({yardDutyZones.length})</span>
-                )}
-              </button>
-            )}
           </div>
         </div>
 

--- a/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
@@ -18,6 +18,9 @@ import { getCurrentSchoolYear, getNextSchoolYear } from '../../../../../lib/scho
 import { checkYearActivated, activateSchoolYear, copyScheduleToNextYear } from '../../../../../lib/supabase/queries/school-year-copy';
 import { SchoolYearToggle } from './components/school-year-toggle';
 import { YearActivationDialog } from './components/year-activation-dialog';
+import { YardDutyZonesModal } from './components/yard-duty-zones-modal';
+import { getYardDutyZones, type YardDutyZone } from '../../../../../lib/supabase/queries/yard-duty-zones';
+import { Cog6ToothIcon } from '@heroicons/react/24/outline';
 
 type ViewFilter = 'all' | 'bell' | 'activities' | 'yard-duty';
 
@@ -58,6 +61,24 @@ export default function MasterSchedulePage() {
   const [nextYearActivated, setNextYearActivated] = useState(false);
   const [showActivationDialog, setShowActivationDialog] = useState(false);
   const [activating, setActivating] = useState(false);
+
+  // Yard duty zones state
+  const [yardDutyZones, setYardDutyZones] = useState<YardDutyZone[]>([]);
+  const [showZonesModal, setShowZonesModal] = useState(false);
+
+  const fetchZones = useCallback(async () => {
+    if (!schoolId) return;
+    try {
+      const data = await getYardDutyZones(schoolId);
+      setYardDutyZones(data);
+    } catch (err) {
+      console.warn('Unable to fetch yard duty zones:', err);
+    }
+  }, [schoolId]);
+
+  useEffect(() => {
+    if (schoolId) fetchZones();
+  }, [schoolId, fetchZones]);
 
   // Rotation groups state
   const [rotationPairs, setRotationPairs] = useState<RotationPairWithGroups[]>([]);
@@ -492,6 +513,21 @@ export default function MasterSchedulePage() {
                 inUseActivityTypes={inUseActivityTypes}
               />
             )}
+
+            {/* Yard Duty Zones Settings */}
+            {viewFilter === 'yard-duty' && (
+              <button
+                onClick={() => setShowZonesModal(true)}
+                className="flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+                title="Configure yard duty zones"
+              >
+                <Cog6ToothIcon className="w-4 h-4" />
+                <span>Zone Settings</span>
+                {yardDutyZones.length > 0 && (
+                  <span className="text-xs text-gray-400">({yardDutyZones.length})</span>
+                )}
+              </button>
+            )}
           </div>
         </div>
 
@@ -518,6 +554,7 @@ export default function MasterSchedulePage() {
               providers={providers}
               yardDutyAssignments={filteredYardDuty}
               allYardDutyAssignments={yardDutyAssignments}
+              yardDutyZones={yardDutyZones}
               schoolYear={selectedSchoolYear}
             />
             {/* Daily Times Toggle */}
@@ -585,6 +622,15 @@ export default function MasterSchedulePage() {
           onClose={handleRotationModalClose}
           onSuccess={handleRotationModalSuccess}
           schoolYear={selectedSchoolYear}
+        />
+      )}
+
+      {/* Yard Duty Zones Modal */}
+      {showZonesModal && schoolId && (
+        <YardDutyZonesModal
+          schoolId={schoolId}
+          onClose={() => setShowZonesModal(false)}
+          onZonesChanged={fetchZones}
         />
       )}
     </div>

--- a/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
@@ -486,23 +486,6 @@ export default function MasterSchedulePage() {
             </div>
           </div>
 
-          {/* Yard Duty Zone Settings - right-aligned under the toggle */}
-          {viewFilter === 'yard-duty' && (
-            <div className="flex justify-end mt-2">
-              <button
-                onClick={() => setShowZonesModal(true)}
-                className="flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
-                title="Configure yard duty zones"
-              >
-                <Cog6ToothIcon className="w-4 h-4" />
-                <span>Zone Settings</span>
-                {yardDutyZones.length > 0 && (
-                  <span className="text-xs text-gray-400">({yardDutyZones.length})</span>
-                )}
-              </button>
-            </div>
-          )}
-
           {/* Secondary Filters */}
           <div className={`mt-4 pt-4 border-t border-gray-200 flex gap-6 ${
             viewFilter === 'all' ? 'flex-row flex-wrap items-center' : 'flex-col'
@@ -531,6 +514,20 @@ export default function MasterSchedulePage() {
               />
             )}
 
+            {/* Yard Duty Zone Settings - right-aligned */}
+            {viewFilter === 'yard-duty' && (
+              <button
+                onClick={() => setShowZonesModal(true)}
+                className="ml-auto flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+                title="Configure yard duty zones"
+              >
+                <Cog6ToothIcon className="w-4 h-4" />
+                <span>Zone Settings</span>
+                {yardDutyZones.length > 0 && (
+                  <span className="text-xs text-gray-400">({yardDutyZones.length})</span>
+                )}
+              </button>
+            )}
           </div>
         </div>
 

--- a/lib/supabase/queries/yard-duty-zones.ts
+++ b/lib/supabase/queries/yard-duty-zones.ts
@@ -1,0 +1,71 @@
+import { createClient } from '@/lib/supabase/client';
+
+export interface YardDutyZone {
+  id: string;
+  school_id: string;
+  zone_name: string;
+  created_at: string | null;
+}
+
+/**
+ * Fetch all yard duty zones for a school.
+ */
+export async function getYardDutyZones(schoolId: string): Promise<YardDutyZone[]> {
+  const supabase = createClient();
+
+  const { data, error } = await supabase
+    .from('yard_duty_zones')
+    .select('*')
+    .eq('school_id', schoolId)
+    .order('zone_name');
+
+  if (error) {
+    console.error('Error fetching yard duty zones:', error);
+    throw error;
+  }
+
+  return data || [];
+}
+
+/**
+ * Add a new yard duty zone for a school.
+ */
+export async function addYardDutyZone(
+  schoolId: string,
+  zoneName: string
+): Promise<YardDutyZone> {
+  const supabase = createClient();
+
+  const { data, error } = await supabase
+    .from('yard_duty_zones')
+    .insert({ school_id: schoolId, zone_name: zoneName.trim() })
+    .select()
+    .single();
+
+  if (error) {
+    if (error.code === '23505') {
+      throw new Error(`Zone "${zoneName.trim()}" already exists`);
+    }
+    console.error('Error adding yard duty zone:', error);
+    throw error;
+  }
+
+  return data;
+}
+
+/**
+ * Delete a yard duty zone by id.
+ */
+export async function deleteYardDutyZone(id: string): Promise<void> {
+  const supabase = createClient();
+
+  const { error } = await supabase
+    .from('yard_duty_zones')
+    .delete()
+    .eq('id', id);
+
+  if (error) {
+    console.error('Error deleting yard duty zone:', error);
+    throw error;
+  }
+}

--- a/supabase/migrations/20260410_create_yard_duty_zones.sql
+++ b/supabase/migrations/20260410_create_yard_duty_zones.sql
@@ -16,14 +16,14 @@ CREATE POLICY "Site admins can view zones"
     USING (
         EXISTS (
             SELECT 1 FROM public.admin_permissions ap
-            WHERE ap.user_id = auth.uid()
+            WHERE ap.admin_id = auth.uid()
             AND ap.school_id = yard_duty_zones.school_id
             AND ap.role IN ('site_admin', 'specialist')
         )
         OR
         EXISTS (
             SELECT 1 FROM public.admin_permissions ap
-            WHERE ap.user_id = auth.uid()
+            WHERE ap.admin_id = auth.uid()
             AND ap.role = 'district_admin'
         )
     );
@@ -33,7 +33,7 @@ CREATE POLICY "Site admins can insert zones"
     WITH CHECK (
         EXISTS (
             SELECT 1 FROM public.admin_permissions ap
-            WHERE ap.user_id = auth.uid()
+            WHERE ap.admin_id = auth.uid()
             AND ap.school_id = yard_duty_zones.school_id
             AND ap.role = 'site_admin'
         )
@@ -44,7 +44,7 @@ CREATE POLICY "Site admins can delete zones"
     USING (
         EXISTS (
             SELECT 1 FROM public.admin_permissions ap
-            WHERE ap.user_id = auth.uid()
+            WHERE ap.admin_id = auth.uid()
             AND ap.school_id = yard_duty_zones.school_id
             AND ap.role = 'site_admin'
         )

--- a/supabase/migrations/20260410_create_yard_duty_zones.sql
+++ b/supabase/migrations/20260410_create_yard_duty_zones.sql
@@ -2,7 +2,7 @@
 CREATE TABLE IF NOT EXISTS public.yard_duty_zones (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     school_id text NOT NULL REFERENCES public.schools(id) ON DELETE CASCADE,
-    zone_name text NOT NULL,
+    zone_name text NOT NULL CHECK (length(btrim(zone_name)) > 0),
     created_at timestamptz DEFAULT now(),
     UNIQUE(school_id, zone_name)
 );

--- a/supabase/migrations/20260410_create_yard_duty_zones.sql
+++ b/supabase/migrations/20260410_create_yard_duty_zones.sql
@@ -18,13 +18,15 @@ CREATE POLICY "Site admins can view zones"
             SELECT 1 FROM public.admin_permissions ap
             WHERE ap.admin_id = auth.uid()
             AND ap.school_id = yard_duty_zones.school_id
-            AND ap.role IN ('site_admin', 'specialist')
+            AND ap.role = 'site_admin'
         )
         OR
         EXISTS (
             SELECT 1 FROM public.admin_permissions ap
+            JOIN public.schools s ON s.id = yard_duty_zones.school_id
             WHERE ap.admin_id = auth.uid()
             AND ap.role = 'district_admin'
+            AND ap.district_id = s.district_id
         )
     );
 

--- a/supabase/migrations/20260410_create_yard_duty_zones.sql
+++ b/supabase/migrations/20260410_create_yard_duty_zones.sql
@@ -1,0 +1,51 @@
+-- Simple zone list per school for yard duty assignments
+CREATE TABLE IF NOT EXISTS public.yard_duty_zones (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    school_id text NOT NULL REFERENCES public.schools(id) ON DELETE CASCADE,
+    zone_name text NOT NULL,
+    created_at timestamptz DEFAULT now(),
+    UNIQUE(school_id, zone_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_yard_duty_zones_school_id ON public.yard_duty_zones(school_id);
+
+ALTER TABLE public.yard_duty_zones ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Site admins can view zones"
+    ON public.yard_duty_zones FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.admin_permissions ap
+            WHERE ap.user_id = auth.uid()
+            AND ap.school_id = yard_duty_zones.school_id
+            AND ap.role IN ('site_admin', 'specialist')
+        )
+        OR
+        EXISTS (
+            SELECT 1 FROM public.admin_permissions ap
+            WHERE ap.user_id = auth.uid()
+            AND ap.role = 'district_admin'
+        )
+    );
+
+CREATE POLICY "Site admins can insert zones"
+    ON public.yard_duty_zones FOR INSERT
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM public.admin_permissions ap
+            WHERE ap.user_id = auth.uid()
+            AND ap.school_id = yard_duty_zones.school_id
+            AND ap.role = 'site_admin'
+        )
+    );
+
+CREATE POLICY "Site admins can delete zones"
+    ON public.yard_duty_zones FOR DELETE
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.admin_permissions ap
+            WHERE ap.user_id = auth.uid()
+            AND ap.school_id = yard_duty_zones.school_id
+            AND ap.role = 'site_admin'
+        )
+    );

--- a/supabase/migrations/20260410_fix_yard_duty_zones_policies.sql
+++ b/supabase/migrations/20260410_fix_yard_duty_zones_policies.sql
@@ -1,6 +1,11 @@
--- Fix yard_duty_zones RLS policies:
+-- Fix yard_duty_zones:
 -- 1. Remove invalid 'specialist' role from SELECT policy
 -- 2. Scope district admin SELECT to their district
+-- 3. Add CHECK constraint to prevent blank zone names
+
+ALTER TABLE public.yard_duty_zones
+    ADD CONSTRAINT yard_duty_zones_zone_name_not_blank
+    CHECK (length(btrim(zone_name)) > 0);
 
 DROP POLICY IF EXISTS "Site admins can view zones" ON public.yard_duty_zones;
 

--- a/supabase/migrations/20260410_fix_yard_duty_zones_policies.sql
+++ b/supabase/migrations/20260410_fix_yard_duty_zones_policies.sql
@@ -1,0 +1,24 @@
+-- Fix yard_duty_zones RLS policies:
+-- 1. Remove invalid 'specialist' role from SELECT policy
+-- 2. Scope district admin SELECT to their district
+
+DROP POLICY IF EXISTS "Site admins can view zones" ON public.yard_duty_zones;
+
+CREATE POLICY "Site admins can view zones"
+    ON public.yard_duty_zones FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.admin_permissions ap
+            WHERE ap.admin_id = auth.uid()
+            AND ap.school_id = yard_duty_zones.school_id
+            AND ap.role = 'site_admin'
+        )
+        OR
+        EXISTS (
+            SELECT 1 FROM public.admin_permissions ap
+            JOIN public.schools s ON s.id = yard_duty_zones.school_id
+            WHERE ap.admin_id = auth.uid()
+            AND ap.role = 'district_admin'
+            AND ap.district_id = s.district_id
+        )
+    );


### PR DESCRIPTION
## Summary
- **Zone settings modal**: Gear icon appears next to "Zone Settings" label when the Yard Duty tab is active (in the secondary filters area). Opens a modal where site admins can add/delete zones for their school.
- **Zone dropdown in create/edit**: When zones are configured, the free-text zone input becomes a dropdown populated from the configured zones. Falls back to free-text with datalist suggestions if no zones exist.
- **Database**: New `yard_duty_zones` table with school-scoped unique constraint and RLS policies for site admin access.
- **Legacy support**: Edit modal preserves existing zone values that don't match a configured zone (shown as an extra option in the dropdown).

## Test plan
- [ ] Click the Yard Duty tab — verify "Zone Settings" gear icon appears in the secondary filters area
- [ ] Open zone settings modal — add a few zones, verify they appear in the list
- [ ] Delete a zone from the modal — verify it's removed
- [ ] Create a new yard duty item — verify the zone field is a dropdown with configured zones
- [ ] Edit an existing yard duty item with a legacy zone name — verify it's still shown/selectable
- [ ] Remove all zones — verify the zone field falls back to free-text input

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage yard duty zones via a new modal: add/delete zones, keyboard accessible, shows loading/error states; changes persist to the backend.
  * Zone Settings button in yard-duty view with count badge and modal launcher; schedule UI now receives zone data.

* **Behavior Changes**
  * Zone/Location inputs switch to a dropdown when zones exist; otherwise they fall back to free-text with suggestions.

* **Chores**
  * Persistent per-school storage and access controls added for yard duty zones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->