### PR TITLE
Enhance yard duty: bell schedule integration & zone consolidation

### DIFF
--- a/app/(dashboard)/dashboard/admin/master-schedule/components/create-item-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/create-item-modal.tsx
@@ -112,12 +112,58 @@ export function CreateItemModal({
   const [ydProviderId, setYdProviderId] = useState<string | null>(null);
   const [ydProviderName, setYdProviderName] = useState('');
 
-  // Get distinct period names and zone names from existing yard duty assignments for suggestions
-  const existingPeriodNames = useMemo(() => {
-    const names = new Set<string>();
-    yardDutyAssignments.forEach(yd => names.add(yd.period_name));
-    return Array.from(names).sort();
-  }, [yardDutyAssignments]);
+  // Build duty period options from bell schedules that overlap selected time/days
+  const availableDutyPeriods = useMemo(() => {
+    const normTime = (t: string) => t.substring(0, 5);
+    const fmtTime = (t: string) => {
+      const [h, m] = normTime(t).split(':').map(Number);
+      const ampm = h >= 12 ? 'PM' : 'AM';
+      const hr = h > 12 ? h - 12 : h === 0 ? 12 : h;
+      return `${hr}:${m.toString().padStart(2, '0')} ${ampm}`;
+    };
+    const start = normTime(ydStartTime);
+    const end = normTime(ydEndTime);
+    const dailyTimeNames = ['School Start', 'Dismissal', 'Early Dismissal'];
+
+    // Find bell schedules that overlap with selected time on any selected day
+    const overlapping = bellSchedules.filter(bs => {
+      if (!bs.period_name || !bs.start_time || !bs.end_time) return false;
+      if (dailyTimeNames.includes(bs.period_name)) return false;
+      if (!ydDays.includes(bs.day_of_week ?? 0)) return false;
+      const bsStart = normTime(bs.start_time);
+      const bsEnd = normTime(bs.end_time);
+      return start < bsEnd && bsStart < end;
+    });
+
+    const hasOverlap = overlapping.length > 0;
+    const source = hasOverlap
+      ? overlapping
+      : bellSchedules.filter(bs => bs.period_name && !dailyTimeNames.includes(bs.period_name));
+
+    // Deduplicate by grade_level + period_name
+    const seen = new Map<string, { value: string; label: string; sortTime: string }>();
+    for (const bs of source) {
+      if (!bs.period_name || !bs.grade_level || !bs.start_time || !bs.end_time) continue;
+      const value = `${bs.grade_level} ${bs.period_name}`;
+      if (!seen.has(value)) {
+        seen.set(value, {
+          value,
+          label: `${bs.grade_level} ${bs.period_name} (${fmtTime(bs.start_time)}–${fmtTime(bs.end_time)})`,
+          sortTime: bs.start_time,
+        });
+      }
+    }
+
+    const options = Array.from(seen.values()).sort((a, b) => a.sortTime.localeCompare(b.sortTime));
+
+    // When no overlap, include Before School / After School as static options
+    if (!hasOverlap) {
+      options.unshift({ value: 'Before School', label: 'Before School', sortTime: '00:00' });
+      options.push({ value: 'After School', label: 'After School', sortTime: '99:99' });
+    }
+
+    return options;
+  }, [bellSchedules, ydDays, ydStartTime, ydEndTime]);
 
   // Get distinct zone names from existing yard duty assignments for suggestions
   const existingZoneNames = useMemo(() => {
@@ -152,6 +198,41 @@ export function CreateItemModal({
     });
     return `This overlaps with: ${descriptions.join(', ')}`;
   }, [tab, ydTeacherId, ydStartTime, ydEndTime, ydDays, specialActivities]);
+
+  // Conflict detection: yard duty assignee vs their other yard duty assignments
+  const ydDoubleBookWarning = useMemo(() => {
+    if (tab !== 'yardDuty' || !ydStartTime || !ydEndTime || ydDays.length === 0) return null;
+
+    const assigneeId = ydAssigneeType === 'teacher' ? ydTeacherId
+      : ydAssigneeType === 'staff' ? ydStaffId
+      : ydAssigneeType === 'provider' ? ydProviderId
+      : null;
+    if (!assigneeId) return null;
+
+    const normTime = (t: string) => t.substring(0, 5);
+    const start = normTime(ydStartTime);
+    const end = normTime(ydEndTime);
+
+    const conflicts = yardDutyAssignments.filter(yd => {
+      // Match on the same assignee type
+      const matchesAssignee = (ydAssigneeType === 'teacher' && yd.teacher_id === assigneeId)
+        || (ydAssigneeType === 'staff' && yd.staff_id === assigneeId)
+        || (ydAssigneeType === 'provider' && yd.provider_id === assigneeId);
+      if (!matchesAssignee || !yd.start_time || !yd.end_time) return false;
+      if (!ydDays.includes(yd.day_of_week)) return false;
+      const ydStart = normTime(yd.start_time);
+      const ydEnd = normTime(yd.end_time);
+      return start < ydEnd && ydStart < end;
+    });
+
+    if (conflicts.length === 0) return null;
+
+    const descriptions = conflicts.map(c => {
+      const dayName = DAYS[(c.day_of_week || 1) - 1];
+      return `${c.period_name}${c.zone_name ? ` (${c.zone_name})` : ''} on ${dayName} (${normTime(c.start_time)}–${normTime(c.end_time)})`;
+    });
+    return `This assignee already has yard duty: ${descriptions.join(', ')}`;
+  }, [tab, ydAssigneeType, ydTeacherId, ydStaffId, ydProviderId, ydStartTime, ydEndTime, ydDays, yardDutyAssignments]);
 
   const handleYdDayToggle = (dayNum: number) => {
     setYdDays(prev =>
@@ -675,19 +756,21 @@ export function CreateItemModal({
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   Duty Period
                 </label>
-                <input
-                  type="text"
+                <select
                   value={ydPeriodName}
                   onChange={(e) => setYdPeriodName(e.target.value)}
-                  placeholder="e.g., TK Recess, Before School Duty"
-                  list="period-suggestions"
                   className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
-                />
-                <datalist id="period-suggestions">
-                  {existingPeriodNames.map(name => (
-                    <option key={name} value={name} />
+                >
+                  <option value="">Select duty period...</option>
+                  {ydPeriodName && !availableDutyPeriods.some(o => o.value === ydPeriodName) && (
+                    <option value={ydPeriodName}>{ydPeriodName}</option>
+                  )}
+                  {availableDutyPeriods.map(option => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
                   ))}
-                </datalist>
+                </select>
               </div>
 
               {/* Zone name (optional) */}
@@ -868,10 +951,17 @@ export function CreateItemModal({
                 </div>
               </div>
 
-              {/* Yard duty conflict warning */}
+              {/* Yard duty conflict warning (vs special activities) */}
               {ydConflictWarning && (
                 <div className="text-sm text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2">
                   {ydConflictWarning}
+                </div>
+              )}
+
+              {/* Yard duty double-booking warning (vs other yard duty) */}
+              {ydDoubleBookWarning && (
+                <div className="text-sm text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+                  {ydDoubleBookWarning}
                 </div>
               )}
             </>

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/edit-item-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/edit-item-modal.tsx
@@ -387,6 +387,11 @@ export function EditItemModal({
   const handleYardDutyUpdate = async () => {
     if (type !== 'yard-duty') return;
 
+    if (!ydPeriodName.trim()) {
+      setError('Please select a duty period');
+      return;
+    }
+
     if (ydStartTime && ydEndTime && ydStartTime >= ydEndTime) {
       setError('End time must be after start time');
       return;

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/edit-item-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/edit-item-modal.tsx
@@ -90,12 +90,58 @@ export function EditItemModal({
   const [ydProviderId, setYdProviderId] = useState<string | null>(yardDuty?.provider_id || null);
   const [ydProviderName, setYdProviderName] = useState(yardDuty?.provider_id ? (yardDuty?.assignee_name || '') : '');
 
-  // Get existing period/zone names for datalist suggestions
-  const existingPeriodNames = useMemo(() => {
-    const names = new Set<string>();
-    yardDutyAssignments.forEach(yd => names.add(yd.period_name));
-    return Array.from(names).sort();
-  }, [yardDutyAssignments]);
+  // Build duty period options from bell schedules that overlap this item's time
+  const availableDutyPeriods = useMemo(() => {
+    if (type !== 'yard-duty') return [];
+
+    const normTime = (t: string) => t.substring(0, 5);
+    const fmtTime = (t: string) => {
+      const [h, m] = normTime(t).split(':').map(Number);
+      const ampm = h >= 12 ? 'PM' : 'AM';
+      const hr = h > 12 ? h - 12 : h === 0 ? 12 : h;
+      return `${hr}:${m.toString().padStart(2, '0')} ${ampm}`;
+    };
+    const start = normTime(ydStartTime);
+    const end = normTime(ydEndTime);
+    const dayOfWeek = item.day_of_week;
+    const dailyTimeNames = ['School Start', 'Dismissal', 'Early Dismissal'];
+
+    const overlapping = bellSchedules.filter(bs => {
+      if (!bs.period_name || !bs.start_time || !bs.end_time) return false;
+      if (dailyTimeNames.includes(bs.period_name)) return false;
+      if (bs.day_of_week !== dayOfWeek) return false;
+      const bsStart = normTime(bs.start_time);
+      const bsEnd = normTime(bs.end_time);
+      return start < bsEnd && bsStart < end;
+    });
+
+    const hasOverlap = overlapping.length > 0;
+    const source = hasOverlap
+      ? overlapping
+      : bellSchedules.filter(bs => bs.period_name && !dailyTimeNames.includes(bs.period_name));
+
+    const seen = new Map<string, { value: string; label: string; sortTime: string }>();
+    for (const bs of source) {
+      if (!bs.period_name || !bs.grade_level || !bs.start_time || !bs.end_time) continue;
+      const value = `${bs.grade_level} ${bs.period_name}`;
+      if (!seen.has(value)) {
+        seen.set(value, {
+          value,
+          label: `${bs.grade_level} ${bs.period_name} (${fmtTime(bs.start_time)}–${fmtTime(bs.end_time)})`,
+          sortTime: bs.start_time,
+        });
+      }
+    }
+
+    const options = Array.from(seen.values()).sort((a, b) => a.sortTime.localeCompare(b.sortTime));
+
+    if (!hasOverlap) {
+      options.unshift({ value: 'Before School', label: 'Before School', sortTime: '00:00' });
+      options.push({ value: 'After School', label: 'After School', sortTime: '99:99' });
+    }
+
+    return options;
+  }, [type, bellSchedules, item.day_of_week, ydStartTime, ydEndTime]);
 
   const existingZoneNames = useMemo(() => {
     const names = new Set<string>();
@@ -129,6 +175,41 @@ export function EditItemModal({
     );
     return `This overlaps with: ${descriptions.join(', ')}`;
   }, [type, ydTeacherId, ydStartTime, ydEndTime, item.day_of_week, specialActivities]);
+
+  // Conflict detection: yard duty assignee vs their other yard duty assignments
+  const ydDoubleBookWarning = useMemo(() => {
+    if (type !== 'yard-duty' || !ydStartTime || !ydEndTime) return null;
+
+    const assigneeId = ydAssigneeType === 'teacher' ? ydTeacherId
+      : ydAssigneeType === 'staff' ? ydStaffId
+      : ydAssigneeType === 'provider' ? ydProviderId
+      : null;
+    if (!assigneeId) return null;
+
+    const normTime = (t: string) => t.substring(0, 5);
+    const start = normTime(ydStartTime);
+    const end = normTime(ydEndTime);
+    const dayOfWeek = item.day_of_week;
+
+    const conflicts = yardDutyAssignments.filter(yd => {
+      if (yd.id === item.id) return false; // Exclude current item
+      const matchesAssignee = (ydAssigneeType === 'teacher' && yd.teacher_id === assigneeId)
+        || (ydAssigneeType === 'staff' && yd.staff_id === assigneeId)
+        || (ydAssigneeType === 'provider' && yd.provider_id === assigneeId);
+      if (!matchesAssignee || !yd.start_time || !yd.end_time) return false;
+      if (yd.day_of_week !== dayOfWeek) return false;
+      const ydStart = normTime(yd.start_time);
+      const ydEnd = normTime(yd.end_time);
+      return start < ydEnd && ydStart < end;
+    });
+
+    if (conflicts.length === 0) return null;
+
+    const descriptions = conflicts.map(c =>
+      `${c.period_name}${c.zone_name ? ` (${c.zone_name})` : ''} (${normTime(c.start_time)}–${normTime(c.end_time)})`
+    );
+    return `This assignee already has yard duty: ${descriptions.join(', ')}`;
+  }, [type, ydAssigneeType, ydTeacherId, ydStaffId, ydProviderId, ydStartTime, ydEndTime, item.day_of_week, item.id, yardDutyAssignments]);
 
   // Conflict detection: special activity teacher vs their yard duty
   const yardDutyConflictWarning = useMemo(() => {
@@ -263,6 +344,16 @@ export function EditItemModal({
   // Check if this is a daily time marker
   const isDailyTimeMarker = bellPeriodName && DAILY_TIME_PERIOD_NAMES.includes(bellPeriodName as typeof DAILY_TIME_PERIOD_NAMES[number]);
 
+  // Count yard duty assignments matching this bell schedule's derived period name and day
+  const yardDutyCoverageCount = useMemo(() => {
+    if (type !== 'bell' || !bellSchedule?.grade_level || !bellSchedule?.period_name) return 0;
+    const derivedName = `${bellSchedule.grade_level} ${bellSchedule.period_name}`;
+    const dayOfWeek = item.day_of_week;
+    return yardDutyAssignments.filter(
+      yd => yd.period_name === derivedName && yd.day_of_week === dayOfWeek
+    ).length;
+  }, [type, bellSchedule, item.day_of_week, yardDutyAssignments]);
+
   const handleBellUpdate = async () => {
     if (type !== 'bell') return;
 
@@ -387,12 +478,19 @@ export function EditItemModal({
 
           {type === 'bell' && bellSchedule && (
             <>
-              {/* Grade Level (read-only - defines the schedule slot) */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Grade Level
-                </label>
-                <p className="text-sm text-gray-900">{bellSchedule.grade_level || 'Not specified'}</p>
+              {/* Grade Level + Yard Duty Coverage */}
+              <div className="flex items-start justify-between">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Grade Level
+                  </label>
+                  <p className="text-sm text-gray-900">{bellSchedule.grade_level || 'Not specified'}</p>
+                </div>
+                {!isDailyTimeMarker && (
+                  <div className="text-sm text-amber-700 bg-amber-100 border border-amber-300 rounded px-3 py-1.5">
+                    Yard Duty Coverage: <span className="font-medium">{yardDutyCoverageCount}</span>
+                  </div>
+                )}
               </div>
 
               {/* Activity/Type (editable) */}
@@ -449,6 +547,7 @@ export function EditItemModal({
                   </div>
                 )}
               </div>
+
             </>
           )}
 
@@ -548,18 +647,21 @@ export function EditItemModal({
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   Duty Period
                 </label>
-                <input
-                  type="text"
+                <select
                   value={ydPeriodName}
                   onChange={(e) => setYdPeriodName(e.target.value)}
-                  list="edit-period-suggestions"
                   className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
-                />
-                <datalist id="edit-period-suggestions">
-                  {existingPeriodNames.map(name => (
-                    <option key={name} value={name} />
+                >
+                  <option value="">Select duty period...</option>
+                  {ydPeriodName && !availableDutyPeriods.some(o => o.value === ydPeriodName) && (
+                    <option value={ydPeriodName}>{ydPeriodName}</option>
+                  )}
+                  {availableDutyPeriods.map(option => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
                   ))}
-                </datalist>
+                </select>
               </div>
 
               {/* Zone name (editable) */}
@@ -629,10 +731,17 @@ export function EditItemModal({
                 </div>
               </div>
 
-              {/* Yard duty conflict warning */}
+              {/* Yard duty conflict warning (vs special activities) */}
               {ydConflictWarning && (
                 <div className="text-sm text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2">
                   {ydConflictWarning}
+                </div>
+              )}
+
+              {/* Yard duty double-booking warning (vs other yard duty) */}
+              {ydDoubleBookWarning && (
+                <div className="text-sm text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+                  {ydDoubleBookWarning}
                 </div>
               )}
             </>

--- a/supabase/migrations/20260410_consolidate_bancroft_yard_duty_zones.sql
+++ b/supabase/migrations/20260410_consolidate_bancroft_yard_duty_zones.sql
@@ -1,0 +1,35 @@
+-- Consolidate manually-entered yard duty zone names for Bancroft Elementary
+-- and populate the yard_duty_zones settings table with the canonical zone list.
+
+-- Step 1: Consolidate zone names on existing assignments
+
+-- Basketball variants -> "Basketball & Blacktop"
+UPDATE yard_duty_assignments
+SET zone_name = 'Basketball & Blacktop'
+WHERE school_id = '062271002457'
+  AND zone_name IN ('Basketball', 'Basketball & Back Blacktop', 'Basketball & Blacktop Area');
+
+-- "Swings, Bikes, Grass Area" -> "Swings, Bikes & Grass Area"
+UPDATE yard_duty_assignments
+SET zone_name = 'Swings, Bikes & Grass Area'
+WHERE school_id = '062271002457'
+  AND zone_name = 'Swings, Bikes, Grass Area';
+
+-- "Yard Duty" -> NULL (generic label, not a real zone)
+UPDATE yard_duty_assignments
+SET zone_name = NULL
+WHERE school_id = '062271002457'
+  AND zone_name = 'Yard Duty';
+
+-- Step 2: Insert the 8 consolidated zones into yard_duty_zones settings
+INSERT INTO yard_duty_zones (school_id, zone_name)
+VALUES
+  ('062271002457', 'Basketball & Blacktop'),
+  ('062271002457', 'Car Lane'),
+  ('062271002457', 'Handball & Restrooms'),
+  ('062271002457', 'Kinder Transition'),
+  ('062271002457', 'Kinder Yard'),
+  ('062271002457', 'Playstructure & Balls'),
+  ('062271002457', 'Playstructure & Swings'),
+  ('062271002457', 'Swings, Bikes & Grass Area')
+ON CONFLICT (school_id, zone_name) DO NOTHING;

--- a/supabase/migrations/20260410_normalize_bancroft_yard_duty_periods.sql
+++ b/supabase/migrations/20260410_normalize_bancroft_yard_duty_periods.sql
@@ -1,0 +1,27 @@
+-- Normalize yard duty period names for Bancroft Elementary to match
+-- the new bell-schedule-based format: "{grade_level} {period_name}"
+-- e.g., "TK Recess", "K Lunch Recess", "2,3 Recess"
+
+UPDATE yard_duty_assignments
+SET period_name = CASE period_name
+  WHEN 'TK Recess'           THEN 'TK Recess'
+  WHEN 'PM TK Recess'        THEN 'TK Recess'
+  WHEN 'Kinder Recess'       THEN 'K Recess'
+  WHEN 'PM Kinder Recess'    THEN 'K Recess'
+  WHEN '1st Grade Recess'    THEN '1 Recess'
+  WHEN 'PM 1st Grade Recess' THEN '1 Recess'
+  WHEN '2nd & 3rd Recess'    THEN '2,3 Recess'
+  WHEN 'PM 2nd & 3rd Recess' THEN '2,3 Recess'
+  WHEN '4th & 5th Recess'    THEN '4,5 Recess'
+  WHEN 'Dismissal'           THEN 'After School'
+  ELSE period_name
+END
+WHERE school_id = '062271002457'
+  AND period_name IN (
+    'TK Recess', 'PM TK Recess',
+    'Kinder Recess', 'PM Kinder Recess',
+    '1st Grade Recess', 'PM 1st Grade Recess',
+    '2nd & 3rd Recess', 'PM 2nd & 3rd Recess',
+    '4th & 5th Recess',
+    'Dismissal'
+  );

--- a/supabase/migrations/20260410_z_consolidate_bancroft_yard_duty_zones.sql
+++ b/supabase/migrations/20260410_z_consolidate_bancroft_yard_duty_zones.sql
@@ -1,0 +1,37 @@
+-- Consolidate manually-entered yard duty zone names for Bancroft Elementary
+-- and populate the yard_duty_zones settings table with the canonical zone list.
+
+-- Step 1: Consolidate zone names on existing assignments
+
+-- Basketball variants -> "Basketball & Blacktop"
+UPDATE yard_duty_assignments
+SET zone_name = 'Basketball & Blacktop'
+WHERE school_id = '062271002457'
+  AND zone_name IN ('Basketball', 'Basketball & Back Blacktop', 'Basketball & Blacktop Area');
+
+-- "Swings, Bikes, Grass Area" -> "Swings, Bikes & Grass Area"
+UPDATE yard_duty_assignments
+SET zone_name = 'Swings, Bikes & Grass Area'
+WHERE school_id = '062271002457'
+  AND zone_name = 'Swings, Bikes, Grass Area';
+
+-- "Yard Duty" -> NULL (generic label, not a real zone)
+UPDATE yard_duty_assignments
+SET zone_name = NULL
+WHERE school_id = '062271002457'
+  AND zone_name = 'Yard Duty';
+
+-- Step 2: Replace all existing Bancroft zones with the 8 canonical zones
+DELETE FROM yard_duty_zones
+WHERE school_id = '062271002457';
+
+INSERT INTO yard_duty_zones (school_id, zone_name)
+VALUES
+  ('062271002457', 'Basketball & Blacktop'),
+  ('062271002457', 'Car Lane'),
+  ('062271002457', 'Handball & Restrooms'),
+  ('062271002457', 'Kinder Transition'),
+  ('062271002457', 'Kinder Yard'),
+  ('062271002457', 'Playstructure & Balls'),
+  ('062271002457', 'Playstructure & Swings'),
+  ('062271002457', 'Swings, Bikes & Grass Area');


### PR DESCRIPTION
## Summary
- **Duty Period dropdown**: Replaced free-text input with a dropdown sourced from bell schedule items that overlap the selected time range. Falls back to showing all bell schedule items plus Before School / After School when no overlap exists.
- **Double-booking warning**: Added amber warning when the selected assignee (teacher, staff, or provider) already has an overlapping yard duty assignment on the same day(s).
- **Yard Duty Coverage badge**: Bell schedule edit modal now shows an amber badge with the count of yard duty assignments linked to that period/day.
- **Zone consolidation migration**: Consolidates Bancroft's 11 manual zone names into 8 canonical zones in the `yard_duty_zones` settings table.
- **Period name normalization migration**: Updates Bancroft's existing period names to match the new bell-schedule-derived format (e.g., "1st Grade Recess" → "1 Recess").

## Test plan
- [ ] Open Master Schedule, switch to Yard Duty view
- [ ] Click on grid to create a new yard duty — verify Duty Period shows overlapping bell schedule items in 12hr format
- [ ] Set time to early morning (e.g., 7:00–7:30) — verify dropdown shows all items plus Before School / After School
- [ ] Assign a teacher who already has yard duty at an overlapping time — verify amber double-book warning appears
- [ ] Click on a bell schedule item (e.g., Recess) — verify Yard Duty Coverage count appears in amber next to Grade Level
- [ ] Verify Zone Settings shows 8 consolidated zones for Bancroft after migration runs
- [ ] Edit an existing yard duty assignment — verify legacy period names still appear in dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warns when a staff member is double-booked for yard duty.
  * Shows yard duty coverage counts in schedule headers.
  * Duty period selector now preserves custom entries and provides contextual "Before School"/"After School" options when no matches.

* **Bug Fixes**
  * Improved duty-period suggestions to match bell-schedule availability.
  * Normalized and consolidated yard-duty zone and period data via migrations.
  * Replaced free-text period input with a dropdown and added save-time validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->