### PR TITLE
Add settings gear and zone filter to master schedule

### DIFF
--- a/app/(dashboard)/dashboard/admin/master-schedule/components/admin-schedule-grid.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/admin-schedule-grid.tsx
@@ -10,7 +10,7 @@ import { CreateItemModal } from './create-item-modal';
 import { EditItemModal } from './edit-item-modal';
 import { DailyTimeMarker } from './daily-time-marker';
 import { removeRotationGroupMember } from '../../../../../../lib/supabase/queries/rotation-groups';
-import type { SpecialActivity, Teacher, YardDutyAssignment } from '@/src/types/database';
+import type { SpecialActivity, Teacher, YardDutyAssignment, SchoolHour } from '@/src/types/database';
 import type { StaffWithHours, ProviderOption } from '../../../../../../lib/supabase/queries/staff';
 import type { YardDutyZone } from '../../../../../../lib/supabase/queries/yard-duty-zones';
 import type { BellScheduleWithCreator } from '../types';
@@ -41,6 +41,18 @@ interface AdminScheduleGridProps {
   allYardDutyAssignments?: YardDutyAssignment[];
   yardDutyZones?: YardDutyZone[];
   schoolYear?: string;
+  schoolHours?: SchoolHour[];
+}
+
+// Unified daily time marker (from school_hours or legacy bell_schedules)
+interface DailyMarker {
+  id: string;
+  time: string;
+  label: string;
+  periodName: string;
+  color: 'blue' | 'orange';
+  gradeLevel?: string;
+  bellSchedule?: BellScheduleWithCreator; // Present only for legacy bell schedule markers
 }
 
 // Flattened rotation item for grid rendering
@@ -176,6 +188,7 @@ export function AdminScheduleGrid({
   allYardDutyAssignments = [],
   yardDutyZones = [],
   schoolYear,
+  schoolHours = [],
 }: AdminScheduleGridProps) {
   const [createModal, setCreateModal] = useState<{
     day: number;
@@ -196,27 +209,67 @@ export function AdminScheduleGrid({
   // Quick edit modal state for individual rotation schedules
   const [quickEditModal, setQuickEditModal] = useState<RotationGridItem | null>(null);
 
-  // Extract daily time markers from bell schedules (School Start, Dismissal, etc.)
+  // Derive daily time markers from school_hours (preferred) or bell_schedules (legacy fallback)
   const dailyTimeMarkers = useMemo(() => {
-    if (!showDailyTimes) return new Map<number, BellScheduleWithCreator[]>();
+    if (!showDailyTimes) return new Map<number, DailyMarker[]>();
 
-    const markers = new Map<number, BellScheduleWithCreator[]>();
+    const markers = new Map<number, DailyMarker[]>();
+    const addMarker = (day: number, marker: DailyMarker) => {
+      const list = markers.get(day) || [];
+      list.push(marker);
+      markers.set(day, list);
+    };
 
-    allBellSchedules.forEach(schedule => {
-      if (
-        schedule.period_name &&
-        DAILY_TIME_PERIOD_NAMES.includes(schedule.period_name as typeof DAILY_TIME_PERIOD_NAMES[number]) &&
-        schedule.day_of_week &&
-        schedule.start_time
-      ) {
-        const dayMarkers = markers.get(schedule.day_of_week) || [];
-        dayMarkers.push(schedule);
-        markers.set(schedule.day_of_week, dayMarkers);
-      }
-    });
+    // Primary source: school_hours table
+    if (schoolHours.length > 0) {
+      schoolHours.forEach(sh => {
+        if (!sh.day_of_week || !sh.start_time) return;
+        // Map grade_level to a display label (e.g., "K", "TK", "default" → "1-5")
+        const gradeLabel = sh.grade_level === 'default' ? '1-5' : sh.grade_level.toUpperCase();
+        addMarker(sh.day_of_week, {
+          id: `sh-start-${sh.id}`,
+          time: sh.start_time,
+          label: 'Start',
+          periodName: 'School Start',
+          color: 'blue',
+          gradeLevel: gradeLabel,
+        });
+        if (sh.end_time) {
+          addMarker(sh.day_of_week, {
+            id: `sh-end-${sh.id}`,
+            time: sh.end_time,
+            label: 'Dismissal',
+            periodName: 'Dismissal',
+            color: 'orange',
+            gradeLevel: gradeLabel,
+          });
+        }
+      });
+    } else {
+      // Fallback: legacy bell_schedule entries with daily time period names
+      allBellSchedules.forEach(schedule => {
+        if (
+          schedule.period_name &&
+          DAILY_TIME_PERIOD_NAMES.includes(schedule.period_name as typeof DAILY_TIME_PERIOD_NAMES[number]) &&
+          schedule.day_of_week &&
+          schedule.start_time
+        ) {
+          const isStart = schedule.period_name === 'School Start';
+          addMarker(schedule.day_of_week, {
+            id: schedule.id,
+            time: schedule.start_time,
+            label: isStart ? 'Start' : schedule.period_name ?? 'Daily Time',
+            periodName: schedule.period_name,
+            color: isStart ? 'blue' : 'orange',
+            gradeLevel: schedule.grade_level || undefined,
+            bellSchedule: schedule,
+          });
+        }
+      });
+    }
 
     return markers;
-  }, [allBellSchedules, showDailyTimes]);
+  }, [allBellSchedules, schoolHours, showDailyTimes]);
 
   // Flatten rotation pairs into grid items
   const rotationGridItems = useMemo((): RotationGridItem[] => {
@@ -478,21 +531,17 @@ export function AdminScheduleGrid({
                   ))}
 
                   {/* Daily time markers (School Start, Dismissal, etc.) */}
-                  {showDailyTimes && dailyTimeMarkers.get(dayNumber)?.map((marker) => {
-                    if (!marker.start_time) return null;
-                    const isStart = marker.period_name === 'School Start';
-                    return (
-                      <DailyTimeMarker
-                        key={marker.id}
-                        time={marker.start_time}
-                        label={marker.period_name === 'School Start' ? 'Start' : marker.period_name ?? 'Daily Time'}
-                        color={isStart ? 'blue' : 'orange'}
-                        pixelPosition={timeToPixels(marker.start_time)}
-                        gradeLevel={marker.grade_level || undefined}
-                        onClick={() => handleItemClick('bell', marker)}
-                      />
-                    );
-                  })}
+                  {showDailyTimes && dailyTimeMarkers.get(dayNumber)?.map((marker) => (
+                    <DailyTimeMarker
+                      key={marker.id}
+                      time={marker.time}
+                      label={marker.label}
+                      color={marker.color}
+                      pixelPosition={timeToPixels(marker.time)}
+                      gradeLevel={marker.gradeLevel}
+                      onClick={marker.bellSchedule ? () => handleItemClick('bell', marker.bellSchedule!) : undefined}
+                    />
+                  ))}
 
                   {/* Bell schedules */}
                   {dayBellSchedules.map((schedule) => {

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/create-item-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/create-item-modal.tsx
@@ -19,7 +19,7 @@ interface CreateItemModalProps {
   schoolId: string;
   onClose: () => void;
   onSuccess: () => void;
-  defaultTab?: 'bell' | 'activity' | 'dailyTime' | 'yardDuty';
+  defaultTab?: 'bell' | 'activity' | 'yardDuty';
   activityAvailability?: Map<string, FullDayAvailability>;
   availableActivityTypes?: string[];
   filterSelectedGrades?: Set<string>;
@@ -37,7 +37,6 @@ const DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
 const GRADES = ['TK', 'K', '1', '2', '3', '4', '5'];
 const GRADE_ORDER: Record<string, number> = Object.fromEntries(GRADES.map((g, i) => [g, i]));
 const sortGrades = (grades: string[]) => [...grades].sort((a, b) => (GRADE_ORDER[a] ?? 99) - (GRADE_ORDER[b] ?? 99));
-const DAILY_TIME_TYPES = ['School Start', 'Dismissal', 'Early Dismissal'] as const;
 
 /**
  * Calculate a default end time by adding offset minutes to a start time.
@@ -69,7 +68,7 @@ export function CreateItemModal({
   yardDutyZones = [],
   schoolYear
 }: CreateItemModalProps) {
-  const [tab, setTab] = useState<'bell' | 'activity' | 'dailyTime' | 'yardDuty'>(defaultTab);
+  const [tab, setTab] = useState<'bell' | 'activity' | 'yardDuty'>(defaultTab);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const modalRef = useRef<HTMLDivElement>(null);
@@ -83,12 +82,6 @@ export function CreateItemModal({
   const [periodName, setPeriodName] = useState('');
   const [bellStartTime, setBellStartTime] = useState(startTime);
   const [bellEndTime, setBellEndTime] = useState(() => calculateDefaultEndTime(startTime));
-
-  // Daily time form state
-  const [dailyTimeType, setDailyTimeType] = useState<string>('');
-  const [dailyTime, setDailyTime] = useState(startTime);
-  const [dailyTimeDays, setDailyTimeDays] = useState<number[]>([day]);
-  const [dailyTimeGrades, setDailyTimeGrades] = useState<string[]>(GRADES); // Default to all grades
 
   // Activity form state
   const [teacherId, setTeacherId] = useState<string | null>(null);
@@ -373,22 +366,6 @@ export function CreateItemModal({
     );
   };
 
-  const handleDailyTimeDayToggle = (dayNum: number) => {
-    setDailyTimeDays(prev =>
-      prev.includes(dayNum)
-        ? prev.filter(d => d !== dayNum)
-        : [...prev, dayNum].sort((a, b) => a - b)
-    );
-  };
-
-  const handleDailyTimeGradeToggle = (grade: string) => {
-    setDailyTimeGrades(prev =>
-      prev.includes(grade)
-        ? prev.filter(g => g !== grade)
-        : [...prev, grade]
-    );
-  };
-
   const handleTeacherChange = (newTeacherId: string | null, newTeacherName: string | null) => {
     setTeacherId(newTeacherId);
     setTeacherName(newTeacherName || '');
@@ -428,38 +405,6 @@ export function CreateItemModal({
               start_time: bellStartTime,
               end_time: bellEndTime,
               period_name: periodName,
-              school_id: schoolId,
-              ...(schoolYear ? { school_year: schoolYear } : {})
-            }, 'site_admin')
-          )
-        );
-      } else if (tab === 'dailyTime') {
-        // Validate daily time
-        if (!dailyTimeType) {
-          setError('Please select a time type');
-          return;
-        }
-        if (dailyTimeDays.length === 0) {
-          setError('Please select at least one day');
-          return;
-        }
-        if (dailyTimeGrades.length === 0) {
-          setError('Please select at least one grade');
-          return;
-        }
-
-        setLoading(true);
-        // Create a bell schedule entry for each selected day
-        // Add 1 minute to end_time to satisfy check constraint (renders as a line marker anyway)
-        const endTime = calculateDefaultEndTime(dailyTime, 1);
-        await Promise.all(
-          dailyTimeDays.map(selectedDay =>
-            addBellSchedule({
-              grade_level: sortGrades(dailyTimeGrades).join(','),
-              day_of_week: selectedDay,
-              start_time: dailyTime,
-              end_time: endTime,
-              period_name: dailyTimeType,
               school_id: schoolId,
               ...(schoolYear ? { school_year: schoolYear } : {})
             }, 'site_admin')
@@ -629,19 +574,6 @@ export function CreateItemModal({
             onClick={() => setTab('yardDuty')}
           >
             Yard Duty
-          </button>
-          <button
-            role="tab"
-            aria-selected={tab === 'dailyTime'}
-            aria-controls="dailyTime-panel"
-            className={`flex-1 px-4 py-3 text-sm font-medium ${
-              tab === 'dailyTime'
-                ? 'text-blue-600 border-b-2 border-blue-600'
-                : 'text-gray-500 hover:text-gray-700'
-            }`}
-            onClick={() => setTab('dailyTime')}
-          >
-            Daily Time
           </button>
         </div>
 
@@ -1064,98 +996,7 @@ export function CreateItemModal({
                 </div>
               </div>
             </>
-          ) : (
-            <>
-              {/* Daily Time form */}
-              {/* Time type selection */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Time Type
-                </label>
-                <select
-                  value={dailyTimeType}
-                  onChange={(e) => setDailyTimeType(e.target.value)}
-                  className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
-                >
-                  <option value="">Select type...</option>
-                  {DAILY_TIME_TYPES.map((type) => (
-                    <option key={type} value={type}>
-                      {type}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {/* Grade selection */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Grade Level(s)
-                </label>
-                <div className="flex flex-wrap gap-2">
-                  {GRADES.map((grade) => (
-                    <button
-                      key={grade}
-                      type="button"
-                      onClick={() => handleDailyTimeGradeToggle(grade)}
-                      className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
-                        dailyTimeGrades.includes(grade)
-                          ? 'bg-blue-600 text-white'
-                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                      }`}
-                    >
-                      {grade}
-                    </button>
-                  ))}
-                </div>
-                <p className="text-xs text-gray-500 mt-1">
-                  Select specific grades (e.g., TK/K for early dismissal)
-                </p>
-              </div>
-
-              {/* Day selection */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Day(s)
-                </label>
-                <div className="flex flex-wrap gap-2">
-                  {DAYS.map((dayName, index) => {
-                    const dayNum = index + 1;
-                    return (
-                      <button
-                        key={dayName}
-                        type="button"
-                        onClick={() => handleDailyTimeDayToggle(dayNum)}
-                        className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
-                          dailyTimeDays.includes(dayNum)
-                            ? 'bg-blue-600 text-white'
-                            : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                        }`}
-                      >
-                        {dayName.slice(0, 3)}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {/* Time input */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Time
-                </label>
-                <input
-                  type="time"
-                  value={dailyTime}
-                  onChange={(e) => setDailyTime(e.target.value)}
-                  className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
-                />
-              </div>
-
-              <p className="text-xs text-gray-500">
-                Daily times appear as markers on the schedule grid when "Show Daily Times" is enabled.
-              </p>
-            </>
-          )}
+          ) : null}
         </div>
 
         {/* Footer */}

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/master-schedule-settings-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/master-schedule-settings-modal.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import React, { useState, useEffect, useRef } from 'react';
+import { Cog6ToothIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import SchoolHoursForm from '../../../../../components/bell-schedules/school-hours-form';
+import { getYardDutyZones, addYardDutyZone, deleteYardDutyZone, type YardDutyZone } from '../../../../../../lib/supabase/queries/yard-duty-zones';
+
+interface MasterScheduleSettingsModalProps {
+  schoolId: string;
+  onClose: () => void;
+  onZonesChanged: () => void;
+  onSchoolHoursChanged: () => void;
+}
+
+type SettingsTab = 'daily-times' | 'zones';
+
+export function MasterScheduleSettingsModal({
+  schoolId,
+  onClose,
+  onZonesChanged,
+  onSchoolHoursChanged,
+}: MasterScheduleSettingsModalProps) {
+  const [tab, setTab] = useState<SettingsTab>('daily-times');
+  const [zoneCount, setZoneCount] = useState(0);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // Fetch zone count for badge
+  useEffect(() => {
+    getYardDutyZones(schoolId)
+      .then((zones) => setZoneCount(zones.length))
+      .catch(() => {});
+  }, [schoolId]);
+
+  // Close on escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  // Close on backdrop click
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={handleBackdropClick}
+    >
+      <div
+        ref={modalRef}
+        className="bg-white rounded-xl shadow-xl w-full max-w-2xl max-h-[85vh] flex flex-col"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <div className="flex items-center gap-2">
+            <Cog6ToothIcon className="w-5 h-5 text-gray-500" />
+            <h2 className="text-lg font-semibold text-gray-900">
+              Schedule Settings
+            </h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <XMarkIcon className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex border-b border-gray-200" role="tablist">
+          <button
+            role="tab"
+            aria-selected={tab === 'daily-times'}
+            className={`flex-1 px-4 py-3 text-sm font-medium transition-colors ${
+              tab === 'daily-times'
+                ? 'text-blue-600 border-b-2 border-blue-600'
+                : 'text-gray-500 hover:text-gray-700'
+            }`}
+            onClick={() => setTab('daily-times')}
+          >
+            Daily Times
+          </button>
+          <button
+            role="tab"
+            aria-selected={tab === 'zones'}
+            className={`flex-1 px-4 py-3 text-sm font-medium transition-colors ${
+              tab === 'zones'
+                ? 'text-blue-600 border-b-2 border-blue-600'
+                : 'text-gray-500 hover:text-gray-700'
+            }`}
+            onClick={() => setTab('zones')}
+          >
+            Zone Settings
+            {zoneCount > 0 && (
+              <span className="ml-1.5 text-xs text-gray-400">({zoneCount})</span>
+            )}
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-6 py-5">
+          {tab === 'daily-times' ? (
+            <div>
+              <p className="text-sm text-gray-500 mb-4">
+                Configure school start and end times by grade level. These times are used for daily time markers on the schedule grid.
+              </p>
+              <SchoolHoursForm
+                onSuccess={() => {
+                  onSchoolHoursChanged();
+                }}
+              />
+            </div>
+          ) : (
+            <div>
+              <p className="text-sm text-gray-500 mb-4">
+                Manage yard duty zones for your school site. Zones can be assigned when creating yard duty entries.
+              </p>
+              <InlineZoneSettings
+                schoolId={schoolId}
+                onZonesChanged={() => {
+                  onZonesChanged();
+                  getYardDutyZones(schoolId)
+                    .then((zones) => setZoneCount(zones.length))
+                    .catch(() => {});
+                }}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Inline zone settings (not a separate modal, rendered directly in the settings panel)
+ */
+function InlineZoneSettings({
+  schoolId,
+  onZonesChanged,
+}: {
+  schoolId: string;
+  onZonesChanged: () => void;
+}) {
+  const [zones, setZones] = useState<YardDutyZone[]>([]);
+  const [newZoneName, setNewZoneName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchZones = async () => {
+    try {
+      const data = await getYardDutyZones(schoolId);
+      setZones(data);
+    } catch (err) {
+      console.error('Error fetching zones:', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchZones();
+  }, [schoolId]);
+
+  const handleAddZone = async () => {
+    const name = newZoneName.trim();
+    if (!name) return;
+
+    setLoading(true);
+    setError(null);
+    try {
+      await addYardDutyZone(schoolId, name);
+      setNewZoneName('');
+      await fetchZones();
+      onZonesChanged();
+    } catch (err: any) {
+      setError(err.message || 'Failed to add zone');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDeleteZone = async (zoneId: string) => {
+    try {
+      await deleteYardDutyZone(zoneId);
+      await fetchZones();
+      onZonesChanged();
+    } catch (err: any) {
+      setError(err.message || 'Failed to delete zone');
+    }
+  };
+
+  // Auto-dismiss error
+  useEffect(() => {
+    if (error) {
+      const timer = setTimeout(() => setError(null), 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [error]);
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-3 py-2 rounded text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Add zone */}
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={newZoneName}
+          onChange={(e) => setNewZoneName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              handleAddZone();
+            }
+          }}
+          placeholder="New zone name..."
+          className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
+        />
+        <button
+          onClick={handleAddZone}
+          disabled={loading || !newZoneName.trim()}
+          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          Add
+        </button>
+      </div>
+
+      {/* Zone list */}
+      <div className="space-y-1 max-h-64 overflow-y-auto">
+        {zones.length === 0 ? (
+          <p className="text-sm text-gray-400 py-3 text-center">
+            No zones configured yet
+          </p>
+        ) : (
+          zones.map((zone) => (
+            <div
+              key={zone.id}
+              className="flex items-center justify-between px-3 py-2 rounded-md hover:bg-gray-50 group"
+            >
+              <span className="text-sm text-gray-700">{zone.zone_name}</span>
+              <button
+                onClick={() => handleDeleteZone(zone.id)}
+                className="text-gray-300 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-all text-sm"
+              >
+                Remove
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/master-schedule-settings-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/master-schedule-settings-modal.tsx
@@ -23,6 +23,7 @@ export function MasterScheduleSettingsModal({
   const [tab, setTab] = useState<SettingsTab>('daily-times');
   const [zoneCount, setZoneCount] = useState(0);
   const modalRef = useRef<HTMLDivElement>(null);
+  const headingId = 'master-schedule-settings-heading';
 
   // Fetch zone count for badge
   useEffect(() => {
@@ -30,6 +31,11 @@ export function MasterScheduleSettingsModal({
       .then((zones) => setZoneCount(zones.length))
       .catch(() => {});
   }, [schoolId]);
+
+  // Focus the modal on mount
+  useEffect(() => {
+    modalRef.current?.focus();
+  }, []);
 
   // Close on escape
   useEffect(() => {
@@ -54,18 +60,23 @@ export function MasterScheduleSettingsModal({
     >
       <div
         ref={modalRef}
-        className="bg-white rounded-xl shadow-xl w-full max-w-2xl max-h-[85vh] flex flex-col"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        tabIndex={-1}
+        className="bg-white rounded-xl shadow-xl w-full max-w-2xl max-h-[85vh] flex flex-col outline-none"
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
           <div className="flex items-center gap-2">
             <Cog6ToothIcon className="w-5 h-5 text-gray-500" />
-            <h2 className="text-lg font-semibold text-gray-900">
+            <h2 id={headingId} className="text-lg font-semibold text-gray-900">
               Schedule Settings
             </h2>
           </div>
           <button
             onClick={onClose}
+            aria-label="Close schedule settings"
             className="text-gray-400 hover:text-gray-600 transition-colors"
           >
             <XMarkIcon className="w-5 h-5" />

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/zone-filter.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/zone-filter.tsx
@@ -39,6 +39,7 @@ export function ZoneFilter({
             <button
               key={zone}
               onClick={() => onToggleZone(zone)}
+              aria-pressed={isSelected}
               className={`
                 px-2 py-0.5 text-xs font-medium rounded transition-all
                 ${isSelected
@@ -55,6 +56,7 @@ export function ZoneFilter({
         {hasUnzoned && (
           <button
             onClick={() => onToggleZone(ZONE_OTHER)}
+            aria-pressed={selectedZones.has(ZONE_OTHER)}
             className={`
               px-2 py-0.5 text-xs font-medium rounded italic transition-all
               ${selectedZones.has(ZONE_OTHER)

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/zone-filter.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/zone-filter.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import React from 'react';
+
+export const ZONE_OTHER = '__other__';
+
+interface ZoneFilterProps {
+  selectedZones: Set<string>;
+  availableZones: string[];
+  hasUnzoned: boolean;
+  onToggleZone: (zone: string) => void;
+  onClearAll: () => void;
+  onSelectAll: () => void;
+}
+
+export function ZoneFilter({
+  selectedZones,
+  availableZones,
+  hasUnzoned,
+  onToggleZone,
+  onClearAll,
+  onSelectAll,
+}: ZoneFilterProps) {
+  // Total count includes "Other" if there are unzoned assignments
+  const totalCount = availableZones.length + (hasUnzoned ? 1 : 0);
+  const allSelected = selectedZones.size === totalCount;
+  const noneSelected = selectedZones.size === 0;
+
+  if (totalCount === 0) return null;
+
+  return (
+    <div className="flex items-center gap-2 bg-gray-200 rounded-full px-3 py-1.5">
+      <span className="text-xs font-medium text-gray-700">Zone:</span>
+      <div className="flex items-center gap-1 flex-wrap">
+        {availableZones.map((zone) => {
+          const isSelected = selectedZones.has(zone);
+
+          return (
+            <button
+              key={zone}
+              onClick={() => onToggleZone(zone)}
+              className={`
+                px-2 py-0.5 text-xs font-medium rounded transition-all
+                ${isSelected
+                  ? 'bg-amber-200 border-2 border-gray-900 text-gray-900'
+                  : 'bg-amber-50 border border-amber-300 text-gray-600 opacity-60 hover:opacity-100'
+                }
+              `}
+              title={`${isSelected ? 'Hide' : 'Show'} zone: ${zone}`}
+            >
+              {zone}
+            </button>
+          );
+        })}
+        {hasUnzoned && (
+          <button
+            onClick={() => onToggleZone(ZONE_OTHER)}
+            className={`
+              px-2 py-0.5 text-xs font-medium rounded italic transition-all
+              ${selectedZones.has(ZONE_OTHER)
+                ? 'bg-amber-200 border-2 border-gray-900 text-gray-900'
+                : 'bg-amber-50 border border-amber-300 text-gray-600 opacity-60 hover:opacity-100'
+              }
+            `}
+            title={`${selectedZones.has(ZONE_OTHER) ? 'Hide' : 'Show'} assignments without a zone`}
+          >
+            Other
+          </button>
+        )}
+      </div>
+      <div className="flex items-center gap-1 ml-2 border-l border-gray-200 pl-2">
+        <button
+          onClick={onSelectAll}
+          disabled={allSelected}
+          className={`text-xs px-2 py-1 rounded transition-colors ${
+            allSelected
+              ? 'text-gray-400 cursor-not-allowed'
+              : 'text-blue-600 hover:bg-blue-50'
+          }`}
+        >
+          All
+        </button>
+        <button
+          onClick={onClearAll}
+          disabled={noneSelected}
+          className={`text-xs px-2 py-1 rounded transition-colors ${
+            noneSelected
+              ? 'text-gray-400 cursor-not-allowed'
+              : 'text-blue-600 hover:bg-blue-50'
+          }`}
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/admin/master-schedule/hooks/use-admin-schedule-data.ts
+++ b/app/(dashboard)/dashboard/admin/master-schedule/hooks/use-admin-schedule-data.ts
@@ -4,7 +4,8 @@ import { getSpecialActivities } from '../../../../../../lib/supabase/queries/spe
 import { getTeachers } from '../../../../../../lib/supabase/queries/teachers';
 import { getYardDutyAssignments } from '../../../../../../lib/supabase/queries/yard-duty';
 import { getSchoolStaffMembers, getSchoolProviders } from '../../../../../../lib/supabase/queries/staff';
-import type { SpecialActivity, Teacher, YardDutyAssignment } from '@/src/types/database';
+import { getSchoolHoursBySchoolId } from '../../../../../../lib/supabase/queries/school-hours';
+import type { SpecialActivity, Teacher, YardDutyAssignment, SchoolHour } from '@/src/types/database';
 import type { StaffWithHours, ProviderOption } from '../../../../../../lib/supabase/queries/staff';
 import type { BellScheduleWithCreator } from '../types';
 
@@ -15,6 +16,7 @@ interface UseAdminScheduleDataReturn {
   yardDutyAssignments: YardDutyAssignment[];
   staffMembers: StaffWithHours[];
   providers: ProviderOption[];
+  schoolHours: SchoolHour[];
   loading: boolean;
   error: string | null;
   refreshData: () => Promise<void>;
@@ -27,6 +29,7 @@ export function useAdminScheduleData(schoolId: string | null, schoolYear?: strin
   const [yardDutyAssignments, setYardDutyAssignments] = useState<YardDutyAssignment[]>([]);
   const [staffMembers, setStaffMembers] = useState<StaffWithHours[]>([]);
   const [providers, setProviders] = useState<ProviderOption[]>([]);
+  const [schoolHours, setSchoolHours] = useState<SchoolHour[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -51,15 +54,17 @@ export function useAdminScheduleData(schoolId: string | null, schoolYear?: strin
       setSpecialActivities(activityData || []);
       setTeachers(teacherData || []);
 
-      // Fetch yard duty, staff, and providers separately so permission errors don't block core data
+      // Fetch yard duty, staff, providers, and school hours separately so permission errors don't block core data
       let yardDutyData: YardDutyAssignment[] = [];
       let staffData: StaffWithHours[] = [];
       let providerData: ProviderOption[] = [];
+      let schoolHoursData: SchoolHour[] = [];
       try {
-        [yardDutyData, staffData, providerData] = await Promise.all([
+        [yardDutyData, staffData, providerData, schoolHoursData] = await Promise.all([
           getYardDutyAssignments(schoolId, schoolYear),
           getSchoolStaffMembers(schoolId),
           getSchoolProviders(schoolId),
+          getSchoolHoursBySchoolId(schoolId),
         ]);
       } catch (err) {
         console.warn('Unable to fetch yard duty/staff/provider data:', err);
@@ -68,6 +73,7 @@ export function useAdminScheduleData(schoolId: string | null, schoolYear?: strin
       setYardDutyAssignments(yardDutyData || []);
       setStaffMembers(staffData || []);
       setProviders(providerData || []);
+      setSchoolHours(schoolHoursData || []);
     } catch (err) {
       console.error('Error fetching schedule data:', err);
       setError('Failed to load schedule data');
@@ -87,6 +93,7 @@ export function useAdminScheduleData(schoolId: string | null, schoolYear?: strin
     yardDutyAssignments,
     staffMembers,
     providers,
+    schoolHours,
     loading,
     error,
     refreshData: fetchData

--- a/app/(dashboard)/dashboard/admin/master-schedule/hooks/use-admin-schedule-data.ts
+++ b/app/(dashboard)/dashboard/admin/master-schedule/hooks/use-admin-schedule-data.ts
@@ -59,16 +59,24 @@ export function useAdminScheduleData(schoolId: string | null, schoolYear?: strin
       let staffData: StaffWithHours[] = [];
       let providerData: ProviderOption[] = [];
       let schoolHoursData: SchoolHour[] = [];
-      try {
-        [yardDutyData, staffData, providerData, schoolHoursData] = await Promise.all([
-          getYardDutyAssignments(schoolId, schoolYear),
-          getSchoolStaffMembers(schoolId),
-          getSchoolProviders(schoolId),
-          getSchoolHoursBySchoolId(schoolId),
-        ]);
-      } catch (err) {
-        console.warn('Unable to fetch yard duty/staff/provider data:', err);
-      }
+      const results = await Promise.allSettled([
+        getYardDutyAssignments(schoolId, schoolYear),
+        getSchoolStaffMembers(schoolId),
+        getSchoolProviders(schoolId),
+        getSchoolHoursBySchoolId(schoolId),
+      ]);
+
+      if (results[0].status === 'fulfilled') yardDutyData = results[0].value;
+      else console.warn('Unable to fetch yard duty assignments:', results[0].reason);
+
+      if (results[1].status === 'fulfilled') staffData = results[1].value;
+      else console.warn('Unable to fetch staff members:', results[1].reason);
+
+      if (results[2].status === 'fulfilled') providerData = results[2].value;
+      else console.warn('Unable to fetch providers:', results[2].reason);
+
+      if (results[3].status === 'fulfilled') schoolHoursData = results[3].value;
+      else console.warn('Unable to fetch school hours:', results[3].reason);
 
       setYardDutyAssignments(yardDutyData || []);
       setStaffMembers(staffData || []);

--- a/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
@@ -254,6 +254,7 @@ export default function MasterSchedulePage() {
     yardDutyAssignments,
     staffMembers,
     providers,
+    schoolHours,
     loading: dataLoading,
     refreshData
   } = useAdminScheduleData(schoolId, selectedSchoolYear);
@@ -643,6 +644,7 @@ export default function MasterSchedulePage() {
               allYardDutyAssignments={yardDutyAssignments}
               yardDutyZones={yardDutyZones}
               schoolYear={selectedSchoolYear}
+              schoolHours={schoolHours}
             />
             {/* Daily Times Toggle */}
             <div className="flex items-center gap-2 mt-3">

--- a/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { getCurrentAdminPermissions } from '../../../../../lib/supabase/queries/admin-accounts';
 import { AdminScheduleGrid } from './components/admin-schedule-grid';
 import { TeacherPanel } from './components/teacher-panel';
@@ -73,6 +73,8 @@ export default function MasterSchedulePage() {
 
   // Zone filter state
   const [selectedZones, setSelectedZones] = useState<Set<string>>(new Set());
+  const previousZoneKeysRef = useRef<Set<string>>(new Set());
+  const zoneSelectionInitializedRef = useRef(false);
 
   const fetchZones = useCallback(async () => {
     if (!schoolId) return;
@@ -314,9 +316,25 @@ export default function MasterSchedulePage() {
     return keys;
   }, [availableZones, hasUnzonedAssignments]);
 
-  // Initialize selected zones to all when available zones change
+  // Initialize selected zones to all on first load; preserve user selection on refresh
   useEffect(() => {
-    setSelectedZones(new Set(allZoneKeys));
+    setSelectedZones(prev => {
+      if (!zoneSelectionInitializedRef.current) {
+        zoneSelectionInitializedRef.current = true;
+        previousZoneKeysRef.current = new Set(allZoneKeys);
+        return new Set(allZoneKeys);
+      }
+
+      // If user had all selected, keep all selected (including any new zones)
+      const hadAllSelected =
+        prev.size === previousZoneKeysRef.current.size &&
+        [...previousZoneKeysRef.current].every(zone => prev.has(zone));
+
+      previousZoneKeysRef.current = new Set(allZoneKeys);
+      return hadAllSelected
+        ? new Set(allZoneKeys)
+        : new Set([...prev].filter(zone => allZoneKeys.has(zone)));
+    });
   }, [allZoneKeys]);
 
   const toggleZone = useCallback((zone: string) => {
@@ -550,6 +568,7 @@ export default function MasterSchedulePage() {
               onClick={() => setShowSettingsModal(true)}
               className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
               title="Schedule Settings"
+              aria-label="Schedule settings"
             >
               <Cog6ToothIcon className="w-5 h-5" />
             </button>

--- a/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/page.tsx
@@ -10,6 +10,7 @@ import { RotationGroupsPanel } from './components/rotation-groups-panel';
 import { RotationGroupModal } from './components/rotation-group-modal';
 import { GradeFilter } from './components/grade-filter';
 import { ActivityTypeFilter } from './components/activity-type-filter';
+import { ZoneFilter, ZONE_OTHER } from './components/zone-filter';
 import { useAdminScheduleData } from './hooks/use-admin-schedule-data';
 import { useAdminScheduleState } from './hooks/use-admin-schedule-state';
 import { getActivityAvailabilityWithTimeRanges, getConfiguredActivityTypes, FullDayAvailability } from '../../../../../lib/supabase/queries/activity-availability';
@@ -19,6 +20,7 @@ import { checkYearActivated, activateSchoolYear, copyScheduleToNextYear } from '
 import { SchoolYearToggle } from './components/school-year-toggle';
 import { YearActivationDialog } from './components/year-activation-dialog';
 import { YardDutyZonesModal } from './components/yard-duty-zones-modal';
+import { MasterScheduleSettingsModal } from './components/master-schedule-settings-modal';
 import { getYardDutyZones, type YardDutyZone } from '../../../../../lib/supabase/queries/yard-duty-zones';
 import { Cog6ToothIcon } from '@heroicons/react/24/outline';
 
@@ -65,6 +67,12 @@ export default function MasterSchedulePage() {
   // Yard duty zones state
   const [yardDutyZones, setYardDutyZones] = useState<YardDutyZone[]>([]);
   const [showZonesModal, setShowZonesModal] = useState(false);
+
+  // Settings modal state
+  const [showSettingsModal, setShowSettingsModal] = useState(false);
+
+  // Zone filter state
+  const [selectedZones, setSelectedZones] = useState<Set<string>>(new Set());
 
   const fetchZones = useCallback(async () => {
     if (!schoolId) return;
@@ -284,6 +292,50 @@ export default function MasterSchedulePage() {
     return types;
   }, [specialActivities, rotationPairs]);
 
+  // Derive available zones from configured zones + zones used in assignments
+  const availableZones = useMemo(() => {
+    const zones = new Set<string>();
+    yardDutyZones.forEach(z => zones.add(z.zone_name));
+    yardDutyAssignments.forEach(yd => {
+      if (yd.zone_name) zones.add(yd.zone_name);
+    });
+    return Array.from(zones).sort();
+  }, [yardDutyZones, yardDutyAssignments]);
+
+  // Check if any yard duty assignments have no zone
+  const hasUnzonedAssignments = useMemo(() => {
+    return yardDutyAssignments.some(yd => !yd.zone_name);
+  }, [yardDutyAssignments]);
+
+  // Build the full set of zone filter keys (named zones + __other__ if applicable)
+  const allZoneKeys = useMemo(() => {
+    const keys = new Set(availableZones);
+    if (hasUnzonedAssignments) keys.add(ZONE_OTHER);
+    return keys;
+  }, [availableZones, hasUnzonedAssignments]);
+
+  // Initialize selected zones to all when available zones change
+  useEffect(() => {
+    setSelectedZones(new Set(allZoneKeys));
+  }, [allZoneKeys]);
+
+  const toggleZone = useCallback((zone: string) => {
+    setSelectedZones(prev => {
+      const next = new Set(prev);
+      if (next.has(zone)) next.delete(zone);
+      else next.add(zone);
+      return next;
+    });
+  }, []);
+
+  const selectAllZones = useCallback(() => {
+    setSelectedZones(new Set(allZoneKeys));
+  }, [allZoneKeys]);
+
+  const clearZones = useCallback(() => {
+    setSelectedZones(new Set());
+  }, []);
+
   // UI state management hook
   const {
     selectedTeacherIds,
@@ -382,10 +434,19 @@ export default function MasterSchedulePage() {
         })
         .filter(pair => selectedTeacherIds.size === 0 || pair.groups.length > 0);
 
-  // Filter yard duty assignments by selected teachers/providers/staff and view filter
+  // Filter yard duty assignments by selected teachers/providers/staff, zones, and view filter
   const filteredYardDuty = (viewFilter === 'bell' || viewFilter === 'activities')
     ? []
     : yardDutyAssignments.filter(yd => {
+        // Filter by zone
+        if (yd.zone_name) {
+          if (!selectedZones.has(yd.zone_name)) return false;
+        } else {
+          // Unzoned assignment — check if "Other" is selected
+          if (!selectedZones.has(ZONE_OTHER)) return false;
+        }
+
+        // Filter by person
         if (!hasAnyPersonFilter) return true;
         if (yd.teacher_id && selectedTeacherIds.has(yd.teacher_id)) return true;
         if (yd.provider_id && selectedProviderIds.has(yd.provider_id)) return true;
@@ -483,6 +544,15 @@ export default function MasterSchedulePage() {
                 Yard Duty
               </button>
             </div>
+
+            {/* Settings Gear */}
+            <button
+              onClick={() => setShowSettingsModal(true)}
+              className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
+              title="Schedule Settings"
+            >
+              <Cog6ToothIcon className="w-5 h-5" />
+            </button>
             </div>
           </div>
 
@@ -514,20 +584,18 @@ export default function MasterSchedulePage() {
               />
             )}
 
-            {/* Yard Duty Zone Settings - right-aligned */}
-            {viewFilter === 'yard-duty' && (
-              <button
-                onClick={() => setShowZonesModal(true)}
-                className="ml-auto flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
-                title="Configure yard duty zones"
-              >
-                <Cog6ToothIcon className="w-4 h-4" />
-                <span>Zone Settings</span>
-                {yardDutyZones.length > 0 && (
-                  <span className="text-xs text-gray-400">({yardDutyZones.length})</span>
-                )}
-              </button>
+            {/* Zone Filter - for yard duty */}
+            {(viewFilter === 'yard-duty' || viewFilter === 'all') && (availableZones.length > 0 || hasUnzonedAssignments) && (
+              <ZoneFilter
+                selectedZones={selectedZones}
+                availableZones={availableZones}
+                hasUnzoned={hasUnzonedAssignments}
+                onToggleZone={toggleZone}
+                onClearAll={clearZones}
+                onSelectAll={selectAllZones}
+              />
             )}
+
           </div>
         </div>
 
@@ -631,6 +699,16 @@ export default function MasterSchedulePage() {
           schoolId={schoolId}
           onClose={() => setShowZonesModal(false)}
           onZonesChanged={fetchZones}
+        />
+      )}
+
+      {/* Schedule Settings Modal */}
+      {showSettingsModal && schoolId && (
+        <MasterScheduleSettingsModal
+          schoolId={schoolId}
+          onClose={() => setShowSettingsModal(false)}
+          onZonesChanged={fetchZones}
+          onSchoolHoursChanged={refreshData}
         />
       )}
     </div>

--- a/app/(dashboard)/dashboard/schedule/components/schedule-grid.tsx
+++ b/app/(dashboard)/dashboard/schedule/components/schedule-grid.tsx
@@ -45,7 +45,7 @@ interface ScheduleGridProps {
   selectedSession: ScheduleSession | null;
   popupPosition: DOMRect | null;
   seaProfiles: Array<{ id: string; full_name: string; is_shared?: boolean }>;
-  otherSpecialists: Array<{ id: string; full_name: string; role: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' }>;
+  otherSpecialists: Array<{ id: string; full_name: string; role: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' | 'intervention' }>;
   providerRole: string;
   currentUserId: string | null;
   sessionTags: Record<string, string>;

--- a/app/(dashboard)/dashboard/schedule/session-assignment-popup.tsx
+++ b/app/(dashboard)/dashboard/schedule/session-assignment-popup.tsx
@@ -14,7 +14,7 @@ interface SessionAssignmentPopupProps {
   student?: Student;
   triggerRect: DOMRect;
   seaProfiles: Array<{ id: string; full_name: string; is_shared?: boolean }>;
-  otherSpecialists: Array<{ id: string; full_name: string; role: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' }>;
+  otherSpecialists: Array<{ id: string; full_name: string; role: 'resource' | 'speech' | 'ot' | 'counseling' | 'specialist' | 'intervention' }>;
   sessionTags: Record<string, string>;
   setSessionTags: React.Dispatch<React.SetStateAction<Record<string, string>>>;
   onClose: () => void;
@@ -268,7 +268,8 @@ export function SessionAssignmentPopup({
                   'speech': 'Speech',
                   'ot': 'OT',
                   'counseling': 'Counseling',
-                  'specialist': 'Specialist'
+                  'specialist': 'Specialist',
+                  'intervention': 'Intervention'
                 }[specialist.role] || specialist.role;
                 
                 return (

--- a/app/api/admin/district/providers/[providerId]/route.ts
+++ b/app/api/admin/district/providers/[providerId]/route.ts
@@ -59,7 +59,7 @@ async function verifyAdminAccess(
     if (profile.district_id !== districtPerm.district_id) {
       return { allowed: false, error: 'Provider is not in your district' };
     }
-    return { allowed: true, districtId: districtPerm.district_id };
+    return { allowed: true, districtId: districtPerm.district_id ?? undefined };
   }
 
   // Site admin: verify provider is at their school
@@ -77,7 +77,7 @@ async function verifyAdminAccess(
         return { allowed: false, error: 'Provider is not at your school' };
       }
     }
-    return { allowed: true, districtId: profile.district_id || undefined, siteAdminSchoolId: sitePerm.school_id };
+    return { allowed: true, districtId: profile.district_id ?? undefined, siteAdminSchoolId: sitePerm.school_id ?? undefined };
   }
 
   return { allowed: false, error: 'Access denied' };

--- a/lib/supabase/queries/school-hours.ts
+++ b/lib/supabase/queries/school-hours.ts
@@ -47,6 +47,58 @@ export async function getSchoolHours(school?: SchoolIdentifier): Promise<SchoolH
 }
 
 /**
+ * Get school hours for a school by school_id (for admin views).
+ * Returns the most recently updated set of hours per grade_level + day_of_week.
+ */
+export async function getSchoolHoursBySchoolId(schoolId: string): Promise<SchoolHour[]> {
+  const supabase = createClient<Database>();
+
+  // Try by school_id first
+  let { data, error } = await supabase
+    .from('school_hours')
+    .select('*')
+    .eq('school_id', schoolId)
+    .order('day_of_week')
+    .order('grade_level');
+
+  if (error) throw error;
+
+  // If no results by school_id, try matching by school name via the schools table
+  if (!data || data.length === 0) {
+    const { data: school } = await supabase
+      .from('schools')
+      .select('name')
+      .eq('id', schoolId)
+      .single();
+
+    if (school?.name) {
+      const { data: siteData, error: siteError } = await supabase
+        .from('school_hours')
+        .select('*')
+        .eq('school_site', school.name)
+        .order('day_of_week')
+        .order('grade_level');
+
+      if (siteError) throw siteError;
+      data = siteData;
+    }
+  }
+
+  if (!data || data.length === 0) return [];
+
+  // Deduplicate: keep only the most recently updated row per grade_level + day_of_week
+  const keyMap = new Map<string, SchoolHour>();
+  for (const row of data) {
+    const key = `${row.grade_level}:${row.day_of_week}`;
+    const existing = keyMap.get(key);
+    if (!existing || (row.updated_at && (!existing.updated_at || row.updated_at > existing.updated_at))) {
+      keyMap.set(key, row);
+    }
+  }
+  return Array.from(keyMap.values());
+}
+
+/**
  * Upsert school hours (insert or update).
  * Stores both structured and text-based school identifiers.
  */

--- a/supabase/migrations/20260410_z_normalize_bancroft_yard_duty_periods.sql
+++ b/supabase/migrations/20260410_z_normalize_bancroft_yard_duty_periods.sql
@@ -1,0 +1,27 @@
+-- Normalize yard duty period names for Bancroft Elementary to match
+-- the new bell-schedule-based format: "{grade_level} {period_name}"
+-- e.g., "TK Recess", "K Lunch Recess", "2,3 Recess"
+
+UPDATE yard_duty_assignments
+SET period_name = CASE period_name
+  WHEN 'TK Recess'           THEN 'TK Recess'
+  WHEN 'PM TK Recess'        THEN 'TK Recess'
+  WHEN 'Kinder Recess'       THEN 'K Recess'
+  WHEN 'PM Kinder Recess'    THEN 'K Recess'
+  WHEN '1st Grade Recess'    THEN '1 Recess'
+  WHEN 'PM 1st Grade Recess' THEN '1 Recess'
+  WHEN '2nd & 3rd Recess'    THEN '2,3 Recess'
+  WHEN 'PM 2nd & 3rd Recess' THEN '2,3 Recess'
+  WHEN '4th & 5th Recess'    THEN '4,5 Recess'
+  WHEN 'Dismissal'           THEN 'After School'
+  ELSE period_name
+END
+WHERE school_id = '062271002457'
+  AND period_name IN (
+    'TK Recess', 'PM TK Recess',
+    'Kinder Recess', 'PM Kinder Recess',
+    '1st Grade Recess', 'PM 1st Grade Recess',
+    '2nd & 3rd Recess', 'PM 2nd & 3rd Recess',
+    '4th & 5th Recess',
+    'Dismissal'
+  );


### PR DESCRIPTION
## Summary
- Adds a **settings gear icon** to the right of the `All | Bell Schedules | Special Activities | Yard Duty` toggles, opening a modal with two tabs: **Daily Times** (school hours config) and **Zone Settings** (yard duty zones)
- Removes the Daily Time tab from the "Add to Schedule" modal and the Zone Settings button from the secondary filters — both are now consolidated into the settings gear
- Adds a **zone filter bar** (visible on Yard Duty and All views) with selectable zone tags and an "Other" tag for assignments without a zone

## Test plan
- [ ] Verify the gear icon appears to the right of the view filter toggles
- [ ] Open the settings modal and confirm Daily Times tab loads the school hours form correctly
- [ ] Confirm Zone Settings tab allows adding/removing zones
- [ ] Verify the "Add to Schedule" modal no longer has a Daily Time tab
- [ ] Verify the old Zone Settings button no longer appears in secondary filters when Yard Duty is selected
- [ ] Toggle to Yard Duty view and confirm zone filter capsules appear
- [ ] Create yard duty assignments with and without zones, confirm "Other" tag appears for unzoned
- [ ] Toggle individual zones on/off and verify grid filtering works correctly
- [ ] Test All/Clear buttons on zone filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Master Schedule Settings modal to manage Daily Times and Zone Settings.
  * Inline Zone Filter UI for selecting/clearing yard-duty zones.
  * School hours endpoint surfaced to UI; "Intervention" added as a specialist role.

* **Changes**
  * Removed Daily Time flow from the item-creation modal (now managed in Settings).
  * Schedule grid and data hooks now use school hours for daily-time markers.
  * Database migration to normalize legacy yard-duty period names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->