### PR TITLE
CARE module: Lane B compliance lane (intake, detail page, schema)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# SessionStart hook: install dependencies so linters, type checks, and tests
+# work in Claude Code on the web sessions (which start from a fresh clone).
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) environments. Local sessions
+# manage their own node_modules.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Install Node dependencies. npm install is idempotent and lets the cached
+# container state be reused on subsequent runs.
+npm install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,15 @@
 {
-  "enabledPlugins": {}
+  "enabledPlugins": {},
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -89,7 +89,8 @@
       "mcp__52287d5e-942b-4bb1-a760-a897e4851102__list_issue_labels",
       "mcp__52287d5e-942b-4bb1-a760-a897e4851102__save_project",
       "mcp__52287d5e-942b-4bb1-a760-a897e4851102__create_issue_label",
-      "mcp__52287d5e-942b-4bb1-a760-a897e4851102__save_issue"
+      "mcp__52287d5e-942b-4bb1-a760-a897e4851102__save_issue",
+      "Bash(mkdir -p .claude/hooks)"
     ],
     "deny": []
   },

--- a/app/(dashboard)/dashboard/care/[caseId]/page.tsx
+++ b/app/(dashboard)/dashboard/care/[caseId]/page.tsx
@@ -22,6 +22,8 @@ import { InitialAssessmentTracker } from '@/app/components/care/initial-assessme
 import { CaseNotesSection } from '@/app/components/care/case-notes-section';
 import { CaseActionsSection } from '@/app/components/care/case-actions-section';
 import { SstScheduleSection } from '@/app/components/care/sst-schedule-section';
+import { ComplianceTimelineSection } from '@/app/components/care/compliance-timeline-section';
+import { EligibilitySection } from '@/app/components/care/eligibility-section';
 import type { CareDisposition } from '@/lib/constants/care';
 
 export default function CaseDetailPage() {
@@ -303,6 +305,19 @@ export default function CaseDetailPage() {
   // Read-only mode for district admins viewing cases
   const readOnly = isDistrictAdmin;
 
+  // Lane / status helpers. status = 'initial' is the compliance lane.
+  const status = caseData.care_referrals.status;
+  const complianceReadOnly = isDistrictAdmin || status === 'closed';
+  const complianceDisabled = isTeacher || complianceReadOnly;
+  const hasComplianceData = !!(
+    caseData.ap_sent_date ||
+    caseData.ap_due_date ||
+    caseData.ap_received_date ||
+    caseData.eligibility_outcome
+  );
+  const showComplianceLayout =
+    status === 'initial' || (status === 'closed' && hasComplianceData);
+
   return (
     <div className="max-w-4xl mx-auto py-8 px-4 space-y-6">
       {/* District admin read-only notice */}
@@ -337,52 +352,90 @@ export default function CaseDetailPage() {
       {/* Header with student info */}
       <CaseDetailHeader caseData={caseData} />
 
-      {/* Initial Assessment Tracking - only show when in 'initial' stage */}
-      {caseData.care_referrals.status === 'initial' && (
-        <InitialAssessmentTracker
-          caseId={caseId}
-          initialData={{
-            ap_received_date: caseData.ap_received_date,
-            iep_due_date: caseData.iep_due_date,
-            academic_testing_completed: caseData.academic_testing_completed ?? false,
-            academic_testing_date: caseData.academic_testing_date,
-            speech_testing_needed: caseData.speech_testing_needed ?? false,
-            speech_testing_completed: caseData.speech_testing_completed ?? false,
-            speech_testing_date: caseData.speech_testing_date,
-            psych_testing_completed: caseData.psych_testing_completed ?? false,
-            psych_testing_date: caseData.psych_testing_date,
-            ot_testing_needed: caseData.ot_testing_needed ?? false,
-            ot_testing_completed: caseData.ot_testing_completed ?? false,
-            ot_testing_date: caseData.ot_testing_date,
-          }}
-          disabled={isTeacher || readOnly}
-          onUpdate={fetchCase}
-        />
+      {/* Discussion lane (active): disposition selector + SST scheduling */}
+      {status === 'active' && (
+        <>
+          <div className="bg-white border border-gray-200 rounded-lg p-4">
+            <DispositionSelector
+              value={caseData.current_disposition}
+              onChange={handleDispositionChange}
+              onMoveToInitials={() => setShowMoveToInitialsModal(true)}
+              showMoveToInitials={!readOnly}
+              onCloseCase={() => setShowCloseCaseModal(true)}
+              showCloseCase={!readOnly}
+              disabled={isTeacher || readOnly}
+            />
+            <StatusHistoryLog caseId={caseId} refreshTrigger={historyRefresh} />
+          </div>
+
+          {caseData.current_disposition === 'schedule_sst' && (
+            <SstScheduleSection
+              initialDate={caseData.sst_scheduled_date}
+              initialLink={caseData.sst_notes_link}
+              onUpdate={handleSstUpdate}
+              onRemove={handleSstRemove}
+              disabled={isTeacher || readOnly}
+            />
+          )}
+        </>
       )}
 
-      {/* Status selector with history - read-only for teachers and district admins */}
-      <div className="bg-white border border-gray-200 rounded-lg p-4">
-        <DispositionSelector
-          value={caseData.current_disposition}
-          onChange={handleDispositionChange}
-          onMoveToInitials={() => setShowMoveToInitialsModal(true)}
-          showMoveToInitials={caseData.care_referrals.status === 'active' && !readOnly}
-          onCloseCase={() => setShowCloseCaseModal(true)}
-          showCloseCase={(caseData.care_referrals.status === 'active' || caseData.care_referrals.status === 'initial') && !readOnly}
-          disabled={isTeacher || readOnly}
-        />
-        <StatusHistoryLog caseId={caseId} refreshTrigger={historyRefresh} />
-      </div>
+      {/* Compliance lane (initial / closed-with-data): timeline, assessment, eligibility */}
+      {showComplianceLayout && (
+        <>
+          <ComplianceTimelineSection
+            caseId={caseId}
+            caseData={caseData}
+            disabled={complianceDisabled}
+            onUpdate={fetchCase}
+          />
 
-      {/* SST Schedule section - only show when disposition is 'schedule_sst' */}
-      {caseData.current_disposition === 'schedule_sst' && (
-        <SstScheduleSection
-          initialDate={caseData.sst_scheduled_date}
-          initialLink={caseData.sst_notes_link}
-          onUpdate={handleSstUpdate}
-          onRemove={handleSstRemove}
-          disabled={isTeacher || readOnly}
-        />
+          <InitialAssessmentTracker
+            caseId={caseId}
+            initialData={{
+              ap_received_date: caseData.ap_received_date,
+              iep_due_date: caseData.iep_due_date,
+              academic_testing_completed: caseData.academic_testing_completed ?? false,
+              academic_testing_date: caseData.academic_testing_date,
+              speech_testing_needed: caseData.speech_testing_needed ?? false,
+              speech_testing_completed: caseData.speech_testing_completed ?? false,
+              speech_testing_date: caseData.speech_testing_date,
+              psych_testing_completed: caseData.psych_testing_completed ?? false,
+              psych_testing_date: caseData.psych_testing_date,
+              ot_testing_needed: caseData.ot_testing_needed ?? false,
+              ot_testing_completed: caseData.ot_testing_completed ?? false,
+              ot_testing_date: caseData.ot_testing_date,
+            }}
+            disabled={complianceDisabled}
+            onUpdate={fetchCase}
+          />
+
+          <EligibilitySection
+            caseId={caseId}
+            caseData={caseData}
+            disabled={complianceDisabled}
+            onUpdate={fetchCase}
+          />
+        </>
+      )}
+
+      {/* Close action for initial-stage cases */}
+      {status === 'initial' && !isTeacher && !isDistrictAdmin && (
+        <div className="bg-white border border-gray-200 rounded-lg p-4 flex justify-end">
+          <button
+            onClick={() => setShowCloseCaseModal(true)}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          >
+            Close Referral
+          </button>
+        </div>
+      )}
+
+      {/* Status history - shown for compliance-lane and closed cases */}
+      {status !== 'active' && (
+        <div className="bg-white border border-gray-200 rounded-lg p-4">
+          <StatusHistoryLog caseId={caseId} refreshTrigger={historyRefresh} />
+        </div>
       )}
 
       {/* Move to Initials confirmation modal */}

--- a/app/(dashboard)/dashboard/care/page.tsx
+++ b/app/(dashboard)/dashboard/care/page.tsx
@@ -6,7 +6,7 @@ import { useSchool } from '@/app/components/providers/school-context';
 import { useCareData } from '@/lib/supabase/hooks/use-care-data';
 import { AddReferralModal } from '@/app/components/care/add-referral-modal';
 import { ReferralList } from '@/app/components/care/referral-list';
-import { CareReferral, getTeacherByAccountId } from '@/lib/supabase/queries/care-referrals';
+import { CareReferral, NewReferralInput, getTeacherByAccountId } from '@/lib/supabase/queries/care-referrals';
 import { getAssignableUsers, updateCase, AssignableUser } from '@/lib/supabase/queries/care-cases';
 import { createClient } from '@/lib/supabase/client';
 import type { CareStatus } from '@/lib/constants/care';
@@ -107,15 +107,10 @@ export default function CareDashboardPage() {
   }, [currentSchool?.school_id]);
 
   const handleAddReferral = useCallback(
-    async (data: {
-      student_name: string;
-      grade: string;
-      referral_reason: string;
-      category?: string;
-    }) => {
+    async (data: NewReferralInput) => {
       setActionError(null);
       try {
-        await addReferral(data as Parameters<typeof addReferral>[0]);
+        await addReferral(data);
       } catch (err) {
         setActionError(err instanceof Error ? err.message : 'Failed to add referral');
         throw err; // Re-throw so the modal knows it failed

--- a/app/components/care/add-referral-modal.tsx
+++ b/app/components/care/add-referral-modal.tsx
@@ -4,19 +4,21 @@ import { useState } from 'react';
 import { Modal } from '@/app/components/ui/modal';
 import { TeacherAutocomplete } from '@/app/components/teachers/teacher-autocomplete';
 import { useSchool } from '@/app/components/providers/school-context';
-import { CARE_CATEGORIES, GRADE_OPTIONS, type CareCategory } from '@/lib/constants/care';
+import {
+  CARE_CATEGORIES,
+  CARE_REFERRAL_SOURCES,
+  COMPLIANCE_LANE_SOURCES,
+  CARE_AP_DUE_DAYS,
+  GRADE_OPTIONS,
+  type CareCategory,
+  type CareReferralSource,
+} from '@/lib/constants/care';
+import type { NewReferralInput } from '@/lib/supabase/queries/care-referrals';
 
 interface AddReferralModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (data: {
-    student_name: string;
-    grade: string;
-    referral_reason: string;
-    category?: CareCategory;
-    teacher_id?: string;
-    teacher_name?: string;
-  }) => Promise<void>;
+  onSubmit: (data: NewReferralInput) => Promise<void>;
   /** When provided, the teacher field is locked to this value (for teacher users) */
   lockedTeacher?: {
     id: string;
@@ -24,18 +26,50 @@ interface AddReferralModalProps {
   };
 }
 
+const inputClass =
+  'w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent';
+
+/** Today as a YYYY-MM-DD string in local time. */
+function todayISO(): string {
+  const n = new Date();
+  return `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, '0')}-${String(n.getDate()).padStart(2, '0')}`;
+}
+
+/** Format an ISO date + offset as a readable due-date hint. */
+function formatDueHint(isoDate: string, days: number): string {
+  const [y, m, d] = isoDate.split('-').map(Number);
+  const due = new Date(y, m - 1, d);
+  due.setDate(due.getDate() + days);
+  return due.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
 export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: AddReferralModalProps) {
   const { currentSchool } = useSchool();
+  const [referralSource, setReferralSource] = useState<CareReferralSource | ''>('');
   const [studentName, setStudentName] = useState('');
   const [grade, setGrade] = useState('');
   const [teacherId, setTeacherId] = useState<string | null>(lockedTeacher?.id ?? null);
   const [teacherName, setTeacherName] = useState<string | null>(lockedTeacher?.name ?? null);
+  const [requestReceivedDate, setRequestReceivedDate] = useState('');
+  const [requestedBy, setRequestedBy] = useState('');
+  const [privateSchoolName, setPrivateSchoolName] = useState('');
   const [referralReason, setReferralReason] = useState('');
   const [category, setCategory] = useState<CareCategory | ''>('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
+  const isComplianceLane =
+    referralSource !== '' && COMPLIANCE_LANE_SOURCES.includes(referralSource);
+  const isPrivateSchool = referralSource === 'private_school';
+  const teacherRequired = referralSource !== '' && !isPrivateSchool;
+
+  const apDueHint =
+    isComplianceLane && requestReceivedDate
+      ? formatDueHint(requestReceivedDate, CARE_AP_DUE_DAYS)
+      : null;
+
   const resetForm = () => {
+    setReferralSource('');
     setStudentName('');
     setGrade('');
     // Keep locked teacher values if teacher is locked
@@ -43,6 +77,9 @@ export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: A
       setTeacherId(null);
       setTeacherName(null);
     }
+    setRequestReceivedDate('');
+    setRequestedBy('');
+    setPrivateSchoolName('');
     setReferralReason('');
     setCategory('');
     setError('');
@@ -53,11 +90,23 @@ export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: A
     onClose();
   };
 
+  const handleSourceChange = (value: CareReferralSource | '') => {
+    setReferralSource(value);
+    // Default the clock-start date to today when entering a compliance-lane source
+    if (value !== '' && COMPLIANCE_LANE_SOURCES.includes(value) && !requestReceivedDate) {
+      setRequestReceivedDate(todayISO());
+    }
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
 
     // Validation
+    if (!referralSource) {
+      setError('Referral source is required');
+      return;
+    }
     if (!studentName.trim()) {
       setError('Student name is required');
       return;
@@ -66,8 +115,16 @@ export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: A
       setError('Grade is required');
       return;
     }
-    if (!teacherId || !teacherName) {
+    if (teacherRequired && (!teacherId || !teacherName)) {
       setError('Teacher is required');
+      return;
+    }
+    if (isPrivateSchool && !privateSchoolName.trim()) {
+      setError('Private school name is required');
+      return;
+    }
+    if (isComplianceLane && !requestReceivedDate) {
+      setError('Date request received is required');
       return;
     }
     if (!referralReason.trim()) {
@@ -80,10 +137,15 @@ export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: A
       await onSubmit({
         student_name: studentName.trim(),
         grade,
-        teacher_id: teacherId,
-        teacher_name: teacherName,
+        teacher_id: isPrivateSchool ? undefined : teacherId ?? undefined,
+        teacher_name: isPrivateSchool ? undefined : teacherName ?? undefined,
         referral_reason: referralReason.trim(),
         category: category || undefined,
+        referral_source: referralSource,
+        request_received_date: isComplianceLane ? requestReceivedDate : undefined,
+        requested_by:
+          isComplianceLane && requestedBy.trim() ? requestedBy.trim() : undefined,
+        private_school_name: isPrivateSchool ? privateSchoolName.trim() : undefined,
       });
       resetForm();
       onClose();
@@ -103,6 +165,32 @@ export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: A
           </div>
         )}
 
+        {/* Referral source drives the rest of the form and the entry lane */}
+        <div>
+          <label htmlFor="referralSource" className="block text-sm font-medium text-gray-700 mb-1">
+            How did this come in? <span className="text-red-500">*</span>
+          </label>
+          <select
+            id="referralSource"
+            value={referralSource}
+            onChange={(e) => handleSourceChange(e.target.value as CareReferralSource | '')}
+            className={inputClass}
+            disabled={loading}
+          >
+            <option value="">Select referral source...</option>
+            {CARE_REFERRAL_SOURCES.map((s) => (
+              <option key={s.value} value={s.value}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+          {isComplianceLane && (
+            <p className="mt-1 text-xs text-blue-600">
+              This referral has a compliance timeline and will be tracked in the Initial stage.
+            </p>
+          )}
+        </div>
+
         <div>
           <label htmlFor="studentName" className="block text-sm font-medium text-gray-700 mb-1">
             Student Name <span className="text-red-500">*</span>
@@ -112,7 +200,7 @@ export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: A
             id="studentName"
             value={studentName}
             onChange={(e) => setStudentName(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            className={inputClass}
             placeholder="Enter student's full name"
             disabled={loading}
           />
@@ -126,7 +214,7 @@ export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: A
             id="grade"
             value={grade}
             onChange={(e) => setGrade(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            className={inputClass}
             disabled={loading}
           >
             <option value="">Select grade...</option>
@@ -138,30 +226,92 @@ export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: A
           </select>
         </div>
 
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Teacher <span className="text-red-500">*</span>
-          </label>
-          {lockedTeacher ? (
-            // Display locked teacher (for teacher users)
-            <div className="w-full px-3 py-2 border border-gray-200 rounded-md bg-gray-50 text-gray-700">
-              {lockedTeacher.name}
-            </div>
-          ) : (
-            <TeacherAutocomplete
-              value={teacherId}
-              teacherName={teacherName || undefined}
-              onChange={(id, name) => {
-                setTeacherId(id);
-                setTeacherName(name);
-              }}
-              placeholder="Search for teacher..."
-              schoolId={currentSchool?.school_id ?? undefined}
+        {/* Private school name replaces the teacher field for private-school referrals */}
+        {isPrivateSchool && (
+          <div>
+            <label htmlFor="privateSchoolName" className="block text-sm font-medium text-gray-700 mb-1">
+              Private School <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              id="privateSchoolName"
+              value={privateSchoolName}
+              onChange={(e) => setPrivateSchoolName(e.target.value)}
+              className={inputClass}
+              placeholder="Name of the private school the student attends"
               disabled={loading}
-              required
             />
-          )}
-        </div>
+          </div>
+        )}
+
+        {!isPrivateSchool && (
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Teacher {teacherRequired && <span className="text-red-500">*</span>}
+            </label>
+            {lockedTeacher ? (
+              // Display locked teacher (for teacher users)
+              <div className="w-full px-3 py-2 border border-gray-200 rounded-md bg-gray-50 text-gray-700">
+                {lockedTeacher.name}
+              </div>
+            ) : (
+              <TeacherAutocomplete
+                value={teacherId}
+                teacherName={teacherName || undefined}
+                onChange={(id, name) => {
+                  setTeacherId(id);
+                  setTeacherName(name);
+                }}
+                placeholder="Search for teacher..."
+                schoolId={currentSchool?.school_id ?? undefined}
+                disabled={loading}
+                required={teacherRequired}
+              />
+            )}
+          </div>
+        )}
+
+        {/* Compliance-lane intake: clock-start date + who requested it */}
+        {isComplianceLane && (
+          <>
+            <div>
+              <label
+                htmlFor="requestReceivedDate"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Date Request Received <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="date"
+                id="requestReceivedDate"
+                value={requestReceivedDate}
+                onChange={(e) => setRequestReceivedDate(e.target.value)}
+                className={inputClass}
+                disabled={loading}
+              />
+              {apDueHint && (
+                <p className="mt-1 text-xs text-blue-600">
+                  Assessment Plan due: {apDueHint}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label htmlFor="requestedBy" className="block text-sm font-medium text-gray-700 mb-1">
+                Requested By
+              </label>
+              <input
+                type="text"
+                id="requestedBy"
+                value={requestedBy}
+                onChange={(e) => setRequestedBy(e.target.value)}
+                className={inputClass}
+                placeholder="Parent/guardian name and relationship"
+                disabled={loading}
+              />
+            </div>
+          </>
+        )}
 
         <div>
           <label htmlFor="category" className="block text-sm font-medium text-gray-700 mb-1">
@@ -171,7 +321,7 @@ export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: A
             id="category"
             value={category}
             onChange={(e) => setCategory(e.target.value as CareCategory | '')}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            className={inputClass}
             disabled={loading}
           >
             <option value="">Select category (optional)...</option>
@@ -192,7 +342,7 @@ export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: A
             value={referralReason}
             onChange={(e) => setReferralReason(e.target.value)}
             rows={4}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+            className={`${inputClass} resize-none`}
             placeholder="Describe the concerns and reasons for this referral..."
             disabled={loading}
           />

--- a/app/components/care/add-referral-modal.tsx
+++ b/app/components/care/add-referral-modal.tsx
@@ -133,6 +133,10 @@ export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: A
       setError('Date request received is required');
       return;
     }
+    if (isComplianceLane && requestReceivedDate > todayISO()) {
+      setError('Date request received cannot be in the future');
+      return;
+    }
     if (!referralReason.trim()) {
       setError('Referral reason is required');
       return;
@@ -292,6 +296,7 @@ export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: A
                 id="requestReceivedDate"
                 value={requestReceivedDate}
                 onChange={(e) => setRequestReceivedDate(e.target.value)}
+                max={todayISO()}
                 className={inputClass}
                 disabled={loading}
               />

--- a/app/components/care/add-referral-modal.tsx
+++ b/app/components/care/add-referral-modal.tsx
@@ -63,6 +63,12 @@ export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: A
   const isPrivateSchool = referralSource === 'private_school';
   const teacherRequired = referralSource !== '' && !isPrivateSchool;
 
+  // Teacher users may only file discussion-lane referrals; compliance-lane
+  // sources (written requests, private-school referrals) are office-handled.
+  const availableSources = lockedTeacher
+    ? CARE_REFERRAL_SOURCES.filter((s) => !COMPLIANCE_LANE_SOURCES.includes(s.value))
+    : CARE_REFERRAL_SOURCES;
+
   const apDueHint =
     isComplianceLane && requestReceivedDate
       ? formatDueHint(requestReceivedDate, CARE_AP_DUE_DAYS)
@@ -178,7 +184,7 @@ export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: A
             disabled={loading}
           >
             <option value="">Select referral source...</option>
-            {CARE_REFERRAL_SOURCES.map((s) => (
+            {availableSources.map((s) => (
               <option key={s.value} value={s.value}>
                 {s.label}
               </option>

--- a/app/components/care/case-detail-header.tsx
+++ b/app/components/care/case-detail-header.tsx
@@ -6,12 +6,23 @@ import {
   CARE_STATUS_COLORS,
   CARE_CATEGORY_COLORS,
   CARE_CATEGORIES,
+  CARE_REFERRAL_SOURCES,
   type CareStatus,
   type CareCategory,
 } from '@/lib/constants/care';
 
 interface CaseDetailHeaderProps {
   caseData: CareCaseWithDetails;
+}
+
+/** Format a YYYY-MM-DD date string for display (parsed in local time). */
+function formatDateOnly(d: string): string {
+  const [y, m, day] = d.split('-').map(Number);
+  return new Date(y, m - 1, day).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
 }
 
 export function CaseDetailHeader({ caseData }: CaseDetailHeaderProps) {
@@ -32,6 +43,10 @@ export function CaseDetailHeader({ caseData }: CaseDetailHeaderProps) {
   });
 
   const referrerName = referral.referring_user?.full_name || 'Unknown';
+
+  const sourceLabel = CARE_REFERRAL_SOURCES.find(
+    (s) => s.value === referral.referral_source
+  )?.label;
 
   return (
     <div className="bg-white border border-gray-200 rounded-lg p-6">
@@ -62,6 +77,11 @@ export function CaseDetailHeader({ caseData }: CaseDetailHeaderProps) {
               {categoryLabel}
             </span>
           )}
+          {sourceLabel && (
+            <span className="px-3 py-1 text-sm font-medium rounded-full bg-indigo-100 text-indigo-800">
+              {sourceLabel}
+            </span>
+          )}
         </div>
       </div>
 
@@ -78,6 +98,22 @@ export function CaseDetailHeader({ caseData }: CaseDetailHeaderProps) {
         {referral.teacher_name && (
           <div>
             <span className="font-medium">Teacher:</span> {referral.teacher_name}
+          </div>
+        )}
+        {referral.private_school_name && (
+          <div>
+            <span className="font-medium">Private school:</span> {referral.private_school_name}
+          </div>
+        )}
+        {referral.requested_by && (
+          <div>
+            <span className="font-medium">Requested by:</span> {referral.requested_by}
+          </div>
+        )}
+        {referral.request_received_date && (
+          <div>
+            <span className="font-medium">Request received:</span>{' '}
+            {formatDateOnly(referral.request_received_date)}
           </div>
         )}
         <div>

--- a/app/components/care/compliance-timeline-section.tsx
+++ b/app/components/care/compliance-timeline-section.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useState, useRef, useCallback } from 'react';
+import { updateCase, type CareCaseWithDetails } from '@/lib/supabase/queries/care-cases';
+
+interface ComplianceTimelineSectionProps {
+  caseId: string;
+  caseData: CareCaseWithDetails;
+  disabled?: boolean;
+  onUpdate?: () => void;
+}
+
+const inputClass =
+  'w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed';
+
+/** Format a YYYY-MM-DD date string for display (parsed in local time). */
+function formatDate(d: string | null): string {
+  if (!d) return '';
+  const [y, m, day] = d.split('-').map(Number);
+  return new Date(y, m - 1, day).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+/** True if a YYYY-MM-DD date is before today. */
+function isPast(d: string): boolean {
+  const [y, m, day] = d.split('-').map(Number);
+  const date = new Date(y, m - 1, day);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return date < today;
+}
+
+export function ComplianceTimelineSection({
+  caseId,
+  caseData,
+  disabled = false,
+  onUpdate,
+}: ComplianceTimelineSectionProps) {
+  const [apSentDate, setApSentDate] = useState(caseData.ap_sent_date ?? '');
+  const [apDueDate, setApDueDate] = useState(caseData.ap_due_date ?? '');
+  const [apDueNote, setApDueNote] = useState(caseData.ap_due_date_note ?? '');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Latest server values, used to revert local state if a save fails.
+  const propsRef = useRef(caseData);
+  propsRef.current = caseData;
+
+  const persist = useCallback(
+    async (updates: {
+      ap_sent_date?: string | null;
+      ap_due_date?: string | null;
+      ap_due_date_note?: string | null;
+    }) => {
+      setSaving(true);
+      setError(null);
+      try {
+        await updateCase(caseId, updates);
+        onUpdate?.();
+      } catch (err) {
+        console.error('Error saving compliance dates:', err);
+        setError('Failed to save changes');
+        setApSentDate(propsRef.current.ap_sent_date ?? '');
+        setApDueDate(propsRef.current.ap_due_date ?? '');
+        setApDueNote(propsRef.current.ap_due_date_note ?? '');
+      } finally {
+        setSaving(false);
+      }
+    },
+    [caseId, onUpdate]
+  );
+
+  // Timeline step derivation -- a step is "done" when its data is present.
+  const apSent = !!caseData.ap_sent_date;
+  const consentReceived = !!caseData.ap_received_date;
+  const testingDone =
+    caseData.academic_testing_completed &&
+    caseData.psych_testing_completed &&
+    (!caseData.speech_testing_needed || caseData.speech_testing_completed) &&
+    (!caseData.ot_testing_needed || caseData.ot_testing_completed);
+  const eligibilityDone = !!caseData.eligibility_outcome;
+
+  const steps = [
+    { label: 'Request received', done: true },
+    { label: 'AP sent', done: apSent },
+    { label: 'Consent received', done: consentReceived },
+    { label: 'Evaluation', done: consentReceived && testingDone },
+    { label: 'Eligibility', done: eligibilityDone },
+  ];
+  const currentIndex = steps.findIndex((s) => !s.done);
+
+  // Next deadline the provider should be watching.
+  let deadline: { label: string; date: string | null } | null = null;
+  if (!apSent) {
+    deadline = { label: 'Assessment Plan due', date: caseData.ap_due_date };
+  } else if (!consentReceived) {
+    deadline = { label: 'Awaiting parent consent', date: null };
+  } else if (!eligibilityDone) {
+    deadline = { label: 'IEP due', date: caseData.iep_due_date };
+  }
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4">
+      <h3 className="text-lg font-medium text-gray-900 mb-4">Compliance Timeline</h3>
+
+      {error && (
+        <div className="mb-4 p-2 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Step strip */}
+      <div className="flex items-start mb-4">
+        {steps.map((step, i) => (
+          <div key={step.label} className="flex-1 flex flex-col items-center relative">
+            {i > 0 && (
+              <div
+                className={`absolute top-3 right-1/2 w-full h-0.5 ${
+                  steps[i - 1].done ? 'bg-blue-600' : 'bg-gray-200'
+                }`}
+              />
+            )}
+            <div
+              className={`relative z-10 w-6 h-6 rounded-full flex items-center justify-center text-xs font-medium ${
+                step.done
+                  ? 'bg-blue-600 text-white'
+                  : i === currentIndex
+                  ? 'bg-white border-2 border-blue-600 text-blue-600'
+                  : 'bg-gray-100 text-gray-400'
+              }`}
+            >
+              {step.done ? '✓' : i + 1}
+            </div>
+            <span
+              className={`mt-1 text-xs text-center ${
+                i === currentIndex ? 'text-blue-700 font-medium' : 'text-gray-500'
+              }`}
+            >
+              {step.label}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Next deadline */}
+      {deadline && (
+        <div className="mb-4 text-sm">
+          <span className="font-medium text-gray-700">Next: </span>
+          <span className="text-gray-700">{deadline.label}</span>
+          {deadline.date && (
+            <span
+              className={`ml-1 font-medium ${
+                isPast(deadline.date) ? 'text-red-600' : 'text-gray-900'
+              }`}
+            >
+              — {formatDate(deadline.date)}
+              {isPast(deadline.date) ? ' (overdue)' : ''}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Assessment Plan dates */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="ap-sent-date" className="block text-sm font-medium text-gray-700 mb-1">
+            Date AP Sent
+          </label>
+          <input
+            id="ap-sent-date"
+            type="date"
+            value={apSentDate}
+            onChange={(e) => {
+              setApSentDate(e.target.value);
+              persist({ ap_sent_date: e.target.value || null });
+            }}
+            disabled={disabled || saving}
+            className={inputClass}
+          />
+        </div>
+        <div>
+          <label htmlFor="ap-due-date" className="block text-sm font-medium text-gray-700 mb-1">
+            AP Due Date
+          </label>
+          <input
+            id="ap-due-date"
+            type="date"
+            value={apDueDate}
+            onChange={(e) => {
+              setApDueDate(e.target.value);
+              persist({ ap_due_date: e.target.value || null });
+            }}
+            disabled={disabled || saving}
+            className={inputClass}
+          />
+        </div>
+      </div>
+
+      <div className="mt-3">
+        <label htmlFor="ap-due-note" className="block text-sm font-medium text-gray-700 mb-1">
+          AP Due Date Note
+        </label>
+        <input
+          id="ap-due-note"
+          type="text"
+          value={apDueNote}
+          onChange={(e) => setApDueNote(e.target.value)}
+          onBlur={() => {
+            if ((apDueNote || '') !== (caseData.ap_due_date_note ?? '')) {
+              persist({ ap_due_date_note: apDueNote || null });
+            }
+          }}
+          disabled={disabled || saving}
+          placeholder="Reason for any adjustment (e.g. winter break 12/22–1/5)"
+          className={inputClass}
+        />
+      </div>
+
+      {saving && <p className="mt-3 text-xs text-gray-500 text-right">Saving...</p>}
+    </div>
+  );
+}

--- a/app/components/care/eligibility-section.tsx
+++ b/app/components/care/eligibility-section.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState, useRef, useCallback } from 'react';
+import { updateCase, type CareCaseWithDetails } from '@/lib/supabase/queries/care-cases';
+import {
+  ELIGIBILITY_OUTCOMES,
+  ELIGIBILITY_CATEGORIES,
+  type EligibilityOutcome,
+  type EligibilityCategory,
+} from '@/lib/constants/care';
+
+interface EligibilitySectionProps {
+  caseId: string;
+  caseData: CareCaseWithDetails;
+  disabled?: boolean;
+  onUpdate?: () => void;
+}
+
+const inputClass =
+  'w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed';
+
+export function EligibilitySection({
+  caseId,
+  caseData,
+  disabled = false,
+  onUpdate,
+}: EligibilitySectionProps) {
+  const [meetingDate, setMeetingDate] = useState(caseData.eligibility_meeting_date ?? '');
+  const [outcome, setOutcome] = useState<EligibilityOutcome | ''>(
+    caseData.eligibility_outcome ?? ''
+  );
+  const [category, setCategory] = useState<EligibilityCategory | ''>(
+    caseData.eligibility_category ?? ''
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Latest server values, used to revert local state if a save fails.
+  const propsRef = useRef(caseData);
+  propsRef.current = caseData;
+
+  const persist = useCallback(
+    async (updates: {
+      eligibility_meeting_date?: string | null;
+      eligibility_outcome?: EligibilityOutcome | null;
+      eligibility_category?: EligibilityCategory | null;
+    }) => {
+      setSaving(true);
+      setError(null);
+      try {
+        await updateCase(caseId, updates);
+        onUpdate?.();
+      } catch (err) {
+        console.error('Error saving eligibility:', err);
+        setError('Failed to save changes');
+        setMeetingDate(propsRef.current.eligibility_meeting_date ?? '');
+        setOutcome(propsRef.current.eligibility_outcome ?? '');
+        setCategory(propsRef.current.eligibility_category ?? '');
+      } finally {
+        setSaving(false);
+      }
+    },
+    [caseId, onUpdate]
+  );
+
+  const isEligible = outcome === 'eligible';
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4">
+      <h3 className="text-lg font-medium text-gray-900 mb-4">Eligibility Determination</h3>
+
+      {error && (
+        <div className="mb-4 p-2 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label
+            htmlFor="elig-meeting-date"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Eligibility Meeting Date
+          </label>
+          <input
+            id="elig-meeting-date"
+            type="date"
+            value={meetingDate}
+            onChange={(e) => {
+              setMeetingDate(e.target.value);
+              persist({ eligibility_meeting_date: e.target.value || null });
+            }}
+            disabled={disabled || saving}
+            className={inputClass}
+          />
+        </div>
+        <div>
+          <label htmlFor="elig-outcome" className="block text-sm font-medium text-gray-700 mb-1">
+            Outcome
+          </label>
+          <select
+            id="elig-outcome"
+            value={outcome}
+            onChange={(e) => {
+              const newOutcome = (e.target.value || '') as EligibilityOutcome | '';
+              setOutcome(newOutcome);
+              const updates: {
+                eligibility_outcome: EligibilityOutcome | null;
+                eligibility_category?: EligibilityCategory | null;
+              } = { eligibility_outcome: newOutcome || null };
+              // A category only applies to an "eligible" outcome.
+              if (newOutcome !== 'eligible' && category) {
+                setCategory('');
+                updates.eligibility_category = null;
+              }
+              persist(updates);
+            }}
+            disabled={disabled || saving}
+            className={inputClass}
+          >
+            <option value="">Not yet determined</option>
+            {ELIGIBILITY_OUTCOMES.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {isEligible && (
+        <div className="mt-3">
+          <label htmlFor="elig-category" className="block text-sm font-medium text-gray-700 mb-1">
+            Disability Category
+          </label>
+          <select
+            id="elig-category"
+            value={category}
+            onChange={(e) => {
+              const newCategory = (e.target.value || '') as EligibilityCategory | '';
+              setCategory(newCategory);
+              persist({ eligibility_category: newCategory || null });
+            }}
+            disabled={disabled || saving}
+            className={inputClass}
+          >
+            <option value="">Select category...</option>
+            {ELIGIBILITY_CATEGORIES.map((c) => (
+              <option key={c.value} value={c.value}>
+                {c.label}
+              </option>
+            ))}
+          </select>
+          {caseData.care_referrals.referral_source === 'private_school' && (
+            <p className="mt-1 text-xs text-gray-500">
+              Private-school students receive a services plan rather than an IEP.
+            </p>
+          )}
+        </div>
+      )}
+
+      {saving && <p className="mt-3 text-xs text-gray-500 text-right">Saving...</p>}
+    </div>
+  );
+}

--- a/lib/constants/care.ts
+++ b/lib/constants/care.ts
@@ -65,3 +65,50 @@ export const GRADE_OPTIONS = [
 ] as const;
 
 export type Grade = (typeof GRADE_OPTIONS)[number];
+
+// Referral source -- how the referral came in; drives intake form and entry lane
+export const CARE_REFERRAL_SOURCES = [
+  { value: 'teacher_concern', label: 'Teacher Concern' },
+  { value: 'parent_concern', label: 'Parent Concern' },
+  { value: 'staff_concern', label: 'Staff Concern' },
+  { value: 'parent_written_request', label: 'Parent Written Request for Evaluation' },
+  { value: 'private_school', label: 'Private School Referral' },
+] as const;
+
+export type CareReferralSource = (typeof CARE_REFERRAL_SOURCES)[number]['value'];
+
+// Sources that enter the compliance lane (Lane B) directly at intake,
+// with a timeline already running. Other sources start in the discussion
+// lane (Lane A) and may be promoted later.
+export const COMPLIANCE_LANE_SOURCES: CareReferralSource[] = [
+  'parent_written_request',
+  'private_school',
+];
+
+// Eligibility determination outcome (result of the compliance-lane process)
+export const ELIGIBILITY_OUTCOMES = [
+  { value: 'eligible', label: 'Eligible' },
+  { value: 'not_eligible', label: 'Not Eligible' },
+  { value: 'eligible_504_only', label: 'Eligible — 504 Only' },
+] as const;
+
+export type EligibilityOutcome = (typeof ELIGIBILITY_OUTCOMES)[number]['value'];
+
+// The 13 federal IDEA disability categories (34 CFR 300.8)
+export const ELIGIBILITY_CATEGORIES = [
+  { value: 'autism', label: 'Autism' },
+  { value: 'deaf_blindness', label: 'Deaf-Blindness' },
+  { value: 'deafness', label: 'Deafness' },
+  { value: 'emotional_disturbance', label: 'Emotional Disturbance' },
+  { value: 'hearing_impairment', label: 'Hearing Impairment' },
+  { value: 'intellectual_disability', label: 'Intellectual Disability' },
+  { value: 'multiple_disabilities', label: 'Multiple Disabilities' },
+  { value: 'orthopedic_impairment', label: 'Orthopedic Impairment' },
+  { value: 'other_health_impairment', label: 'Other Health Impairment' },
+  { value: 'specific_learning_disability', label: 'Specific Learning Disability' },
+  { value: 'speech_language_impairment', label: 'Speech or Language Impairment' },
+  { value: 'traumatic_brain_injury', label: 'Traumatic Brain Injury' },
+  { value: 'visual_impairment', label: 'Visual Impairment' },
+] as const;
+
+export type EligibilityCategory = (typeof ELIGIBILITY_CATEGORIES)[number]['value'];

--- a/lib/constants/care.ts
+++ b/lib/constants/care.ts
@@ -85,6 +85,9 @@ export const COMPLIANCE_LANE_SOURCES: CareReferralSource[] = [
   'private_school',
 ];
 
+// Days from request received to Assessment Plan due (California Ed. Code 56321)
+export const CARE_AP_DUE_DAYS = 15;
+
 // Eligibility determination outcome (result of the compliance-lane process)
 export const ELIGIBILITY_OUTCOMES = [
   { value: 'eligible', label: 'Eligible' },

--- a/lib/supabase/hooks/use-care-data.ts
+++ b/lib/supabase/hooks/use-care-data.ts
@@ -8,8 +8,9 @@ import {
   updateReferralStatus,
   softDeleteReferral,
   CareReferral,
+  NewReferralInput,
 } from '../queries/care-referrals';
-import type { CareCategory, CareStatus } from '@/lib/constants/care';
+import type { CareStatus } from '@/lib/constants/care';
 
 interface CareDataState {
   referrals: {
@@ -30,12 +31,7 @@ interface UseCareDataOptions {
 }
 
 interface UseCareDataReturn extends CareDataState {
-  addReferral: (data: {
-    student_name: string;
-    grade: string;
-    referral_reason: string;
-    category?: CareCategory;
-  }) => Promise<CareReferral>;
+  addReferral: (data: NewReferralInput) => Promise<CareReferral>;
   updateStatus: (referralId: string, status: CareStatus) => Promise<void>;
   deleteReferral: (referralId: string) => Promise<void>;
   refreshData: () => Promise<void>;
@@ -109,14 +105,7 @@ export function useCareData(options?: UseCareDataOptions): UseCareDataReturn {
   }, [fetchData]);
 
   const addReferral = useCallback(
-    async (data: {
-      student_name: string;
-      grade: string;
-      teacher_id?: string;
-      teacher_name?: string;
-      referral_reason: string;
-      category?: CareCategory;
-    }): Promise<CareReferral> => {
+    async (data: NewReferralInput): Promise<CareReferral> => {
       if (!currentSchool?.school_id) {
         throw new Error('No school selected');
       }
@@ -129,15 +118,24 @@ export function useCareData(options?: UseCareDataOptions): UseCareDataReturn {
         state_id: currentSchool.state_id || undefined,
       });
 
-      // Update state only after successful API call
-      setState(prev => ({
-        ...prev,
-        referrals: {
-          ...prev.referrals,
-          pending: [referral, ...prev.referrals.pending],
-          all: [referral, ...prev.referrals.all],
-        },
-      }));
+      // Update state only after successful API call. Compliance-lane referrals
+      // are born into the 'initial' stage; all others start as 'pending'.
+      setState(prev => {
+        const bornInitial = referral.status === 'initial';
+        return {
+          ...prev,
+          referrals: {
+            ...prev.referrals,
+            pending: bornInitial
+              ? prev.referrals.pending
+              : [referral, ...prev.referrals.pending],
+            initial: bornInitial
+              ? [referral, ...prev.referrals.initial]
+              : prev.referrals.initial,
+            all: [referral, ...prev.referrals.all],
+          },
+        };
+      });
 
       return referral;
     },

--- a/lib/supabase/queries/care-cases.ts
+++ b/lib/supabase/queries/care-cases.ts
@@ -1,5 +1,10 @@
 import { createClient } from '@/lib/supabase/client';
-import type { CareDisposition } from '@/lib/constants/care';
+import type {
+  CareDisposition,
+  CareReferralSource,
+  EligibilityOutcome,
+  EligibilityCategory,
+} from '@/lib/constants/care';
 
 export interface CareCaseWithDetails {
   id: string;
@@ -25,6 +30,14 @@ export interface CareCaseWithDetails {
   // SST scheduling fields
   sst_scheduled_date: string | null;
   sst_notes_link: string | null;
+  // Lane B compliance fields
+  ap_sent_date: string | null;
+  ap_due_date: string | null;
+  ap_due_date_note: string | null;
+  iep_due_date_note: string | null;
+  eligibility_meeting_date: string | null;
+  eligibility_outcome: EligibilityOutcome | null;
+  eligibility_category: EligibilityCategory | null;
   // Joined referral data
   care_referrals: {
     id: string;
@@ -37,6 +50,10 @@ export interface CareCaseWithDetails {
     status: string;
     submitted_at: string;
     school_id: string | null;
+    referral_source: CareReferralSource;
+    request_received_date: string | null;
+    requested_by: string | null;
+    private_school_name: string | null;
     referring_user: {
       id: string;
       full_name: string | null;
@@ -118,6 +135,10 @@ export async function getCaseWithDetails(caseId: string): Promise<CareCaseWithDe
         status,
         submitted_at,
         school_id,
+        referral_source,
+        request_received_date,
+        requested_by,
+        private_school_name,
         referring_user:profiles!referring_user_id(id, full_name)
       ),
       assigned_user:profiles!assigned_to(id, full_name),
@@ -171,6 +192,10 @@ export async function getCaseByReferralId(referralId: string): Promise<CareCaseW
         status,
         submitted_at,
         school_id,
+        referral_source,
+        request_received_date,
+        requested_by,
+        private_school_name,
         referring_user:profiles!referring_user_id(id, full_name)
       ),
       assigned_user:profiles!assigned_to(id, full_name),
@@ -209,6 +234,13 @@ export async function updateCase(
     follow_up_date?: string | null;
     sst_scheduled_date?: string | null;
     sst_notes_link?: string | null;
+    ap_sent_date?: string | null;
+    ap_due_date?: string | null;
+    ap_due_date_note?: string | null;
+    iep_due_date_note?: string | null;
+    eligibility_meeting_date?: string | null;
+    eligibility_outcome?: EligibilityOutcome | null;
+    eligibility_category?: EligibilityCategory | null;
   }
 ): Promise<void> {
   const supabase = createClient();

--- a/lib/supabase/queries/care-referrals.ts
+++ b/lib/supabase/queries/care-referrals.ts
@@ -1,5 +1,11 @@
 import { createClient } from '@/lib/supabase/client';
-import type { CareCategory, CareStatus, CareDisposition } from '@/lib/constants/care';
+import type {
+  CareCategory,
+  CareStatus,
+  CareDisposition,
+  CareReferralSource,
+} from '@/lib/constants/care';
+import { COMPLIANCE_LANE_SOURCES, CARE_AP_DUE_DAYS } from '@/lib/constants/care';
 
 export interface CareReferral {
   id: string;
@@ -10,6 +16,10 @@ export interface CareReferral {
   referring_user_id: string;
   referral_reason: string;
   category: CareCategory | null;
+  referral_source: CareReferralSource;
+  request_received_date: string | null;
+  requested_by: string | null;
+  private_school_name: string | null;
   school_id: string | null;
   district_id: string | null;
   state_id: string | null;
@@ -91,19 +101,44 @@ export async function getCareReferrals(
 }
 
 /**
- * Add a new CARE referral
+ * Input shape for creating a new CARE referral, before school context is attached.
  */
-export async function addCareReferral(referral: {
+export interface NewReferralInput {
   student_name: string;
   grade: string;
   teacher_id?: string;
   teacher_name?: string;
   referral_reason: string;
   category?: CareCategory;
-  school_id: string;
-  district_id?: string;
-  state_id?: string;
-}): Promise<CareReferral> {
+  referral_source: CareReferralSource;
+  request_received_date?: string;
+  requested_by?: string;
+  private_school_name?: string;
+}
+
+/** Add N days to an ISO date string (YYYY-MM-DD), returning a YYYY-MM-DD string. */
+function addDaysToISODate(isoDate: string, days: number): string {
+  const [y, m, d] = isoDate.split('-').map(Number);
+  const dt = new Date(y, m - 1, d);
+  dt.setDate(dt.getDate() + days);
+  return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')}`;
+}
+
+/**
+ * Add a new CARE referral.
+ *
+ * Compliance-lane sources (written evaluation requests, private-school
+ * referrals) are born directly into the 'initial' stage with a case created
+ * immediately so the timeline can be tracked. All other sources start as
+ * 'pending' in the discussion lane.
+ */
+export async function addCareReferral(
+  referral: NewReferralInput & {
+    school_id: string;
+    district_id?: string;
+    state_id?: string;
+  }
+): Promise<CareReferral> {
   const supabase = createClient();
 
   // Verify auth
@@ -112,12 +147,15 @@ export async function addCareReferral(referral: {
     throw new Error('User not authenticated');
   }
 
+  const isComplianceLane = COMPLIANCE_LANE_SOURCES.includes(referral.referral_source);
+  const status: CareStatus = isComplianceLane ? 'initial' : 'pending';
+
   const { data, error } = await supabase
     .from('care_referrals')
     .insert({
       ...referral,
       referring_user_id: user.id,
-      status: 'pending',
+      status,
     })
     .select(`
       *,
@@ -132,6 +170,43 @@ export async function addCareReferral(referral: {
   if (error) {
     console.error('Error adding CARE referral:', error);
     throw error;
+  }
+
+  // Lane B referrals need a case immediately so the compliance timeline is
+  // tracked. ap_due_date is pre-filled from the request date and is editable later.
+  if (isComplianceLane) {
+    const apDueDate = referral.request_received_date
+      ? addDaysToISODate(referral.request_received_date, CARE_AP_DUE_DAYS)
+      : null;
+
+    const { error: caseError } = await supabase
+      .from('care_cases')
+      .insert({
+        referral_id: data.id,
+        ap_due_date: apDueDate,
+      });
+
+    // Ignore unique-constraint violations (a concurrent request created the case).
+    if (caseError && caseError.code !== '23505') {
+      console.error('Error creating case for compliance-lane referral:', caseError);
+    }
+
+    const { data: withCase } = await supabase
+      .from('care_referrals')
+      .select(`
+        *,
+        referring_user:profiles!referring_user_id(id, full_name),
+        care_cases(
+          *,
+          assigned_user:profiles!assigned_to(id, full_name)
+        )
+      `)
+      .eq('id', data.id)
+      .single();
+
+    if (withCase) {
+      return withCase as CareReferral;
+    }
   }
 
   return data as CareReferral;

--- a/lib/supabase/queries/care-referrals.ts
+++ b/lib/supabase/queries/care-referrals.ts
@@ -189,6 +189,10 @@ export async function addCareReferral(
     // Ignore unique-constraint violations (a concurrent request created the case).
     if (caseError && caseError.code !== '23505') {
       console.error('Error creating case for compliance-lane referral:', caseError);
+      // Roll back the orphaned referral -- an 'initial' referral with no case
+      // would be unopenable and have no compliance timeline.
+      await supabase.from('care_referrals').delete().eq('id', data.id);
+      throw new Error('Could not create the case for this referral. Please try again.');
     }
 
     const { data: withCase } = await supabase

--- a/supabase/migrations/20260516_care_lane_b_compliance.sql
+++ b/supabase/migrations/20260516_care_lane_b_compliance.sql
@@ -1,0 +1,88 @@
+-- Migration: CARE Lane B (compliance lane) support
+-- Adds referral-source routing + Lane B intake fields to care_referrals,
+-- and the get-to-consent + eligibility-outcome fields to care_cases.
+--
+-- Lane A = discussion lane (teacher/parent/staff concern -> CARE meetings, no clock).
+-- Lane B = compliance lane (written eval request or private-school referral ->
+--          timeline running). status = 'initial' is the compliance-lane marker;
+--          no separate "lane" column is needed.
+
+-- =============================================================
+-- Section A: care_referrals -- referral source + Lane B intake
+-- =============================================================
+
+-- referral_source drives the intake form and the entry lane.
+-- Added nullable first, backfilled, then made NOT NULL.
+ALTER TABLE care_referrals ADD COLUMN referral_source TEXT;
+
+-- Backfill: every existing referral predates this column and went through the
+-- teacher-centric flow, so teacher_concern is the honest default.
+UPDATE care_referrals SET referral_source = 'teacher_concern' WHERE referral_source IS NULL;
+
+ALTER TABLE care_referrals
+  ALTER COLUMN referral_source SET NOT NULL,
+  ADD CONSTRAINT care_referrals_referral_source_check CHECK (referral_source IN (
+    'teacher_concern',
+    'parent_concern',
+    'staff_concern',
+    'parent_written_request',
+    'private_school'
+  ));
+
+-- Lane B intake fields (remain NULL for Lane A referrals).
+ALTER TABLE care_referrals ADD COLUMN request_received_date DATE;
+ALTER TABLE care_referrals ADD COLUMN requested_by TEXT;
+ALTER TABLE care_referrals ADD COLUMN private_school_name TEXT;
+
+COMMENT ON COLUMN care_referrals.referral_source IS 'How the referral came in; drives intake form and entry lane (Lane A discussion vs Lane B compliance)';
+COMMENT ON COLUMN care_referrals.request_received_date IS 'Lane B: date the written evaluation request / private-school referral was received -- start of the 15-day Assessment Plan clock';
+COMMENT ON COLUMN care_referrals.requested_by IS 'Lane B: name/relationship of the person who made the written request (typically a parent/guardian)';
+COMMENT ON COLUMN care_referrals.private_school_name IS 'Lane B: private school the student attends (referral_source = private_school)';
+
+-- =============================================================
+-- Section B: care_cases -- get-to-consent beat + eligibility outcome
+-- =============================================================
+
+-- "Get to consent" beat (precedes the existing ap_received_date).
+-- ap_due_date defaults in-app to request_received_date + 15 days and is
+-- user-editable; ap_due_date_note records any manual adjustment (e.g. breaks).
+ALTER TABLE care_cases ADD COLUMN ap_sent_date DATE;
+ALTER TABLE care_cases ADD COLUMN ap_due_date DATE;
+ALTER TABLE care_cases ADD COLUMN ap_due_date_note TEXT;
+
+-- iep_due_date already exists (= ap_received_date + 60, user-editable);
+-- add its adjustment note for parity with ap_due_date.
+ALTER TABLE care_cases ADD COLUMN iep_due_date_note TEXT;
+
+-- Eligibility outcome -- the result of the compliance-lane process.
+ALTER TABLE care_cases ADD COLUMN eligibility_meeting_date DATE;
+ALTER TABLE care_cases ADD COLUMN eligibility_outcome TEXT
+  CHECK (eligibility_outcome IN ('eligible', 'not_eligible', 'eligible_504_only'));
+ALTER TABLE care_cases ADD COLUMN eligibility_category TEXT
+  CHECK (eligibility_category IN (
+    'autism',
+    'deaf_blindness',
+    'deafness',
+    'emotional_disturbance',
+    'hearing_impairment',
+    'intellectual_disability',
+    'multiple_disabilities',
+    'orthopedic_impairment',
+    'other_health_impairment',
+    'specific_learning_disability',
+    'speech_language_impairment',
+    'traumatic_brain_injury',
+    'visual_impairment'
+  ));
+
+COMMENT ON COLUMN care_cases.ap_sent_date IS 'Date the Assessment Plan was sent to the parent';
+COMMENT ON COLUMN care_cases.ap_due_date IS 'Deadline to send the Assessment Plan (default: request_received_date + 15 days, user-editable)';
+COMMENT ON COLUMN care_cases.ap_due_date_note IS 'Reason for any manual adjustment to ap_due_date (e.g. school break)';
+COMMENT ON COLUMN care_cases.iep_due_date_note IS 'Reason for any manual adjustment to iep_due_date (e.g. school break)';
+COMMENT ON COLUMN care_cases.eligibility_meeting_date IS 'Date of the eligibility determination meeting';
+COMMENT ON COLUMN care_cases.eligibility_outcome IS 'Result of the eligibility determination';
+COMMENT ON COLUMN care_cases.eligibility_category IS 'IDEA disability category when eligibility_outcome = eligible (one of the 13 federal categories)';
+
+-- Note: compliance events (ap_sent, consent_received, eligibility_determined,
+-- due_date_adjusted) are logged into the existing care_case_status_history
+-- table -- its status column is free-text, so no schema change is required.


### PR DESCRIPTION
## Summary

Adds a **compliance lane (Lane B)** to the CARE module. The module now models two lanes off a single referral source field:

- **Lane A — discussion:** teacher/parent/staff concerns → CARE meetings, no legal clock (unchanged behavior).
- **Lane B — compliance:** written evaluation requests and private-school referrals enter the pipeline with a timeline already running. `status = 'initial'` is the compliance lane.

### What's included

- **Schema** (`20260516_care_lane_b_compliance.sql`): `referral_source` + Lane B intake fields (`request_received_date`, `requested_by`, `private_school_name`) on `care_referrals`; get-to-consent and eligibility fields (`ap_sent_date`, `ap_due_date`, `ap_due_date_note`, `iep_due_date_note`, `eligibility_meeting_date`, `eligibility_outcome`, `eligibility_category`) on `care_cases`. Additive only — new nullable columns plus a backfill of existing referrals to `teacher_concern`.
- **Add Referral modal**: leads with a referral-source field and adapts — private-school referrals swap the teacher field for a private-school name; compliance-lane sources collect a request-received date with an Assessment Plan due-date hint. Compliance-lane referrals are created directly in the `initial` stage with a `care_case`, bypassing the discussion-lane disposition flow.
- **Case detail page**: branches by stage. `initial` (compliance) cases show a compliance timeline strip with the next deadline, editable AP sent/due dates, the assessment tracker, and an eligibility-determination section; the disposition selector is hidden. `active` cases keep the existing disposition + SST layout. The header shows a referral-source badge and Lane B intake details.
- **SessionStart hook** (`.claude/hooks/session-start.sh`): installs dependencies in Claude Code on the web sessions so linters/type checks/tests can run from a fresh clone.

> **Note:** the migration has already been applied to the live Speddy Supabase project (verified — additive, no data loss). Merging this PR adds the migration file to the repo for tracking; `supabase db push` should treat it as already applied.

## Test plan

- [ ] Add Referral → pick "Parent written request" — verify the request-received date + AP-due hint appear and teacher stays required.
- [ ] Add Referral → pick "Private school referral" — verify the teacher field is replaced by a private-school name field.
- [ ] Confirm a compliance-lane referral lands in the **Initial** tab (not Pending).
- [ ] Open a Lane B case — verify the compliance timeline strip, editable AP sent/due dates, assessment tracker, and eligibility section render; disposition selector is hidden.
- [ ] Verify an `active` (discussion-lane) case still shows the disposition selector + SST section unchanged.
- [ ] Set an eligibility outcome of "Eligible" — verify the disability-category picker appears.

## Follow-up

The compliance safety net (deadline alerts on Lane B cases) is tracked separately in [SPE-69](https://linear.app/speddy/issue/SPE-69/care-compliance-safety-net-deadline-alerts-for-lane-b-cases).

https://claude.ai/code/session_01JdN5ehjdP3L8gY2zq6ZC1s

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdN5ehjdP3L8gY2zq6ZC1s)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Referral intake now includes a referral-source selector with conditional fields (teacher, private school, compliance).
  * Compliance lane auto-triggers for specified sources and shows a compliance timeline with AP sent/due dates and notes.
  * Eligibility tracking: meeting date, outcome, and IDEA disability category.
  * Intake captures request-received date and requested-by, with validation and due-date hints.
  * Case header and dashboard show referral source and adjusted lane-specific UI and actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->