### PR TITLE
CARE: SST badge and unscheduled-SST notice

### DIFF
--- a/app/components/care/case-detail-header.tsx
+++ b/app/components/care/case-detail-header.tsx
@@ -48,6 +48,8 @@ export function CaseDetailHeader({ caseData }: CaseDetailHeaderProps) {
     (s) => s.value === referral.referral_source
   )?.label;
 
+  const showSstBadge = caseData.current_disposition === 'schedule_sst';
+
   return (
     <div className="bg-white border border-gray-200 rounded-lg p-6">
       {/* Back link */}
@@ -80,6 +82,11 @@ export function CaseDetailHeader({ caseData }: CaseDetailHeaderProps) {
           {sourceLabel && (
             <span className="px-3 py-1 text-sm font-medium rounded-full bg-indigo-100 text-indigo-800">
               {sourceLabel}
+            </span>
+          )}
+          {showSstBadge && (
+            <span className="px-3 py-1 text-sm font-medium rounded-full bg-cyan-100 text-cyan-800">
+              SST
             </span>
           )}
         </div>

--- a/app/components/care/referral-card.tsx
+++ b/app/components/care/referral-card.tsx
@@ -52,6 +52,7 @@ export function ReferralCard({
 
   const currentAssignee = caseData?.assigned_user?.full_name || null;
   const currentAssigneeId = caseData?.assigned_to || '';
+  const showSstBadge = caseData?.current_disposition === 'schedule_sst';
 
   const handleAssignChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     e.stopPropagation();
@@ -127,6 +128,11 @@ export function ReferralCard({
           {categoryLabel && categoryColor && (
             <span className={`px-2 py-1 text-xs font-medium rounded-full ${categoryColor}`}>
               {categoryLabel}
+            </span>
+          )}
+          {showSstBadge && (
+            <span className="px-2 py-1 text-xs font-medium rounded-full bg-cyan-100 text-cyan-800">
+              SST
             </span>
           )}
         </div>

--- a/app/components/care/sst-schedule-section.tsx
+++ b/app/components/care/sst-schedule-section.tsx
@@ -126,7 +126,7 @@ export function SstScheduleSection({
         <div className="flex-shrink-0">
           <label htmlFor="sst-date" className="block text-sm font-medium text-gray-700 mb-1">
             Scheduled Date
-            {!scheduledDate && (
+            {!disabled && !scheduledDate && (
               <span className="ml-2 text-xs font-semibold text-red-600">
                 * scheduling required
               </span>

--- a/app/components/care/sst-schedule-section.tsx
+++ b/app/components/care/sst-schedule-section.tsx
@@ -126,6 +126,11 @@ export function SstScheduleSection({
         <div className="flex-shrink-0">
           <label htmlFor="sst-date" className="block text-sm font-medium text-gray-700 mb-1">
             Scheduled Date
+            {!scheduledDate && (
+              <span className="ml-2 text-xs font-semibold text-red-600">
+                * scheduling required
+              </span>
+            )}
           </label>
           <input
             type="date"


### PR DESCRIPTION
## Summary

Two small CARE visibility tweaks so SST work doesn't fall through the cracks:

- **SST badge** — a cyan "SST" badge now shows on the referral card and the case detail header whenever a case's disposition is `schedule_sst`. An SST in progress is visible at a glance without opening the case.
- **Unscheduled-SST notice** — the SST Schedule field shows a red **"* scheduling required"** next to the date label until a date is entered. Selecting the SST disposition but never scheduling the meeting now stands out during review.

No schema or behavior changes — display only.

## Test plan

- [ ] Set a case's disposition to "Schedule SST" — verify the "SST" badge appears on its referral card and on the case detail header.
- [ ] Open that case — verify the SST Schedule field shows the red "* scheduling required" notice while the date is empty.
- [ ] Enter and save an SST date — verify the red notice disappears; the badge remains.
- [ ] Verify cases with any other disposition show no SST badge.

https://claude.ai/code/session_01JdN5ehjdP3L8gY2zq6ZC1s

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdN5ehjdP3L8gY2zq6ZC1s)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * SST badges now display in case detail headers and referral cards when a case is scheduled for SST, making SST status more visible at a glance.
  * Added a visual warning indicator in the SST scheduling section when a scheduled date is required, prompting users to complete scheduling before proceeding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->