### PR TITLE
Add marketing landing page with Supabase-backed signup

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -92,7 +92,8 @@
       "mcp__52287d5e-942b-4bb1-a760-a897e4851102__save_issue",
       "Bash(mkdir -p .claude/hooks)",
       "mcp__playwright__browser_resize",
-      "mcp__playwright__browser_navigate"
+      "mcp__playwright__browser_navigate",
+      "mcp__982db5fb-7af6-4bff-9a32-9574894b8fe9__execute_sql"
     ],
     "deny": []
   },

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -92,8 +92,7 @@
       "mcp__52287d5e-942b-4bb1-a760-a897e4851102__save_issue",
       "Bash(mkdir -p .claude/hooks)",
       "mcp__playwright__browser_resize",
-      "mcp__playwright__browser_navigate",
-      "mcp__982db5fb-7af6-4bff-9a32-9574894b8fe9__execute_sql"
+      "mcp__playwright__browser_navigate"
     ],
     "deny": []
   },

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -90,7 +90,9 @@
       "mcp__52287d5e-942b-4bb1-a760-a897e4851102__save_project",
       "mcp__52287d5e-942b-4bb1-a760-a897e4851102__create_issue_label",
       "mcp__52287d5e-942b-4bb1-a760-a897e4851102__save_issue",
-      "Bash(mkdir -p .claude/hooks)"
+      "Bash(mkdir -p .claude/hooks)",
+      "mcp__playwright__browser_resize",
+      "mcp__playwright__browser_navigate"
     ],
     "deny": []
   },

--- a/app/api/landing-signup/route.ts
+++ b/app/api/landing-signup/route.ts
@@ -1,7 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createServiceClient } from '@/lib/supabase/server';
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Linear-time email sanity check. Avoids a single regex over user input,
+// which can backtrack quadratically (ReDoS) when segments overlap.
+function isLikelyEmail(value: string): boolean {
+  if (value.length < 3 || value.length > 254) return false;
+  if (/\s/.test(value)) return false;
+  const at = value.indexOf('@');
+  if (at <= 0 || at !== value.lastIndexOf('@') || at === value.length - 1) return false;
+  const domain = value.slice(at + 1);
+  const dot = domain.indexOf('.');
+  return dot > 0 && dot < domain.length - 1;
+}
 
 // Receives email captures from the marketing landing page and stores them in
 // the landing_signups table. Writes use the service-role key so the table can
@@ -19,7 +29,7 @@ export async function POST(request: NextRequest) {
   const audience =
     raw.audience === 'provider' || raw.audience === 'admin' ? raw.audience : null;
 
-  if (!EMAIL_RE.test(email) || email.length > 254) {
+  if (!isLikelyEmail(email)) {
     return NextResponse.json({ error: 'Please enter a valid email address.' }, { status: 400 });
   }
 

--- a/app/api/landing-signup/route.ts
+++ b/app/api/landing-signup/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServiceClient } from '@/lib/supabase/server';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Receives email captures from the marketing landing page and stores them in
+// the landing_signups table. Writes use the service-role key so the table can
+// stay locked down with no public RLS policies.
+export async function POST(request: NextRequest) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+
+  const raw = (body as { email?: unknown; audience?: unknown }) ?? {};
+  const email = typeof raw.email === 'string' ? raw.email.trim().toLowerCase() : '';
+  const audience =
+    raw.audience === 'provider' || raw.audience === 'admin' ? raw.audience : null;
+
+  if (!EMAIL_RE.test(email) || email.length > 254) {
+    return NextResponse.json({ error: 'Please enter a valid email address.' }, { status: 400 });
+  }
+
+  try {
+    const supabase = createServiceClient();
+    const { error } = await supabase.from('landing_signups').insert({ email, audience });
+
+    if (error) {
+      console.error('landing-signup insert failed:', error.message);
+      return NextResponse.json({ error: 'Something went wrong. Please try again.' }, { status: 500 });
+    }
+  } catch (err) {
+    console.error('landing-signup error:', err);
+    return NextResponse.json({ error: 'Something went wrong. Please try again.' }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from 'next/navigation';
+
+// Friendly entry point for the app. Unauthenticated visitors are sent to
+// /login by middleware; authenticated visitors land on the dashboard, where
+// role-based routing takes over.
+export default function AppEntry() {
+  redirect('/dashboard');
+}

--- a/app/components/landing/clean-landing.tsx
+++ b/app/components/landing/clean-landing.tsx
@@ -1,0 +1,618 @@
+'use client';
+
+// Speddy landing page — "Clean (B)" design direction.
+
+import { useState } from 'react';
+import Link from 'next/link';
+import {
+  AudienceToggle,
+  EmailSignup,
+  MockMasterScheduleCard,
+  MockMinutesCard,
+  MockScheduleCard,
+  SpeddyMark,
+  type Audience,
+} from './landing-shared';
+
+const PROVIDER_COPY = {
+  eyebrow: 'For SpEd providers',
+  headline: 'Your weekly schedule,',
+  headlineEm: 'finally in one place.',
+  sub: 'Speddy organizes every session, every student, and every service minute so you can focus on the work that matters.',
+  cta: 'Get started',
+  placeholder: 'you@school.edu',
+};
+const ADMIN_COPY = {
+  eyebrow: 'For school admins',
+  headline: 'Your whole school’s schedule,',
+  headlineEm: 'in one source of truth.',
+  sub: 'Build bell schedules, special activities, yard duty, and SpEd services across every grade — then keep them all in sync as the year evolves.',
+  cta: 'Get started',
+  placeholder: 'admin@district.edu',
+};
+
+export default function CleanLanding() {
+  const [audience, setAudience] = useState<Audience>('provider');
+  const copy = audience === 'provider' ? PROVIDER_COPY : ADMIN_COPY;
+  const isAdmin = audience === 'admin';
+
+  return (
+    <div
+      style={{
+        fontFamily: 'var(--font-dm-sans), system-ui, sans-serif',
+        color: '#0F172A',
+        background: '#F3F5F8',
+        minHeight: '100%',
+        width: '100%',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Nav */}
+      <nav
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '24px 64px',
+          background: '#FFF',
+          borderBottom: '1px solid rgba(15,23,42,0.06)',
+        }}
+      >
+        <SpeddyMark size={34} />
+        <Link
+          href="/login"
+          style={{
+            fontSize: 15,
+            fontWeight: 600,
+            color: '#0F172A',
+            textDecoration: 'none',
+          }}
+        >
+          Sign in
+        </Link>
+      </nav>
+
+      {/* Hero */}
+      <section style={{ padding: '72px 64px 56px', textAlign: 'center', background: '#FFF' }}>
+        <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 24 }}>
+          <AudienceToggle value={audience} onChange={setAudience} />
+        </div>
+        <div
+          style={{
+            fontSize: 14,
+            fontWeight: 600,
+            color: '#F26B5E',
+            letterSpacing: '0.02em',
+            marginBottom: 16,
+          }}
+        >
+          {copy.eyebrow}
+        </div>
+        <h1
+          style={{
+            fontSize: 64,
+            lineHeight: 1.05,
+            fontWeight: 700,
+            letterSpacing: '-0.03em',
+            margin: 0,
+            color: '#0F172A',
+            maxWidth: 820,
+            marginLeft: 'auto',
+            marginRight: 'auto',
+            textWrap: 'balance',
+          }}
+        >
+          {copy.headline} <span style={{ color: '#2452F5' }}>{copy.headlineEm}</span>
+        </h1>
+        <p
+          style={{
+            fontSize: 19,
+            lineHeight: 1.5,
+            margin: '24px auto 36px',
+            color: 'rgba(15,23,42,0.65)',
+            maxWidth: 620,
+          }}
+        >
+          {copy.sub}
+        </p>
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <EmailSignup cta={copy.cta} placeholder={copy.placeholder} />
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            gap: 24,
+            marginTop: 20,
+            fontSize: 13,
+            color: 'rgba(15,23,42,0.55)',
+          }}
+        >
+          <span>✓ FERPA-compliant</span>
+          <span>✓ Built with SpEd providers</span>
+          <span>✓ Set up in an afternoon</span>
+        </div>
+
+        {/* Hero product card */}
+        <div style={{ margin: '64px auto 0', maxWidth: 980, position: 'relative' }}>
+          <div
+            style={{
+              position: 'absolute',
+              inset: '20px -8px -8px',
+              background: 'linear-gradient(180deg, rgba(36,82,245,0.12), rgba(36,82,245,0))',
+              borderRadius: 24,
+              zIndex: 0,
+            }}
+          ></div>
+          <div
+            style={{
+              position: 'relative',
+              background: '#FFF',
+              borderRadius: 20,
+              border: '1px solid rgba(15,23,42,0.08)',
+              boxShadow:
+                '0 40px 80px -40px rgba(15,23,42,0.25), 0 12px 24px -12px rgba(15,23,42,0.08)',
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                padding: '12px 16px',
+                borderBottom: '1px solid rgba(15,23,42,0.06)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+              }}
+            >
+              <span
+                style={{ width: 11, height: 11, borderRadius: 999, background: '#F26B5E' }}
+              ></span>
+              <span
+                style={{ width: 11, height: 11, borderRadius: 999, background: '#FBBF24' }}
+              ></span>
+              <span
+                style={{ width: 11, height: 11, borderRadius: 999, background: '#22C55E' }}
+              ></span>
+              <div
+                style={{
+                  flex: 1,
+                  textAlign: 'center',
+                  fontSize: 12,
+                  color: 'rgba(15,23,42,0.45)',
+                }}
+              >
+                speddy.xyz / schedule
+              </div>
+            </div>
+            <div
+              style={{
+                background: '#F3F5F8',
+                padding: 24,
+                display: 'grid',
+                gridTemplateColumns: '1.4fr 1fr',
+                gap: 20,
+                alignItems: 'start',
+              }}
+            >
+              {isAdmin ? (
+                <MockMasterScheduleCard width="100%" />
+              ) : (
+                <MockScheduleCard width="100%" />
+              )}
+              <MockMinutesCard width="100%" />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Pain points */}
+      <section style={{ padding: '96px 64px' }}>
+        <div style={{ textAlign: 'center', marginBottom: 56 }}>
+          <div
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: '#F26B5E',
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+            }}
+          >
+            Before &amp; after
+          </div>
+          <h2
+            style={{
+              fontSize: 44,
+              fontWeight: 700,
+              letterSpacing: '-0.025em',
+              margin: '12px 0 0',
+              color: '#0F172A',
+            }}
+          >
+            {isAdmin
+              ? 'From scattered spreadsheets to one schedule.'
+              : 'From spreadsheets to one source of truth.'}
+          </h2>
+        </div>
+
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gap: 24,
+            maxWidth: 1080,
+            margin: '0 auto',
+          }}
+        >
+          {/* Before */}
+          <div
+            style={{
+              background: '#FFF',
+              border: '1px solid rgba(15,23,42,0.08)',
+              borderRadius: 16,
+              padding: 32,
+            }}
+          >
+            <div
+              style={{
+                fontSize: 12,
+                fontWeight: 700,
+                color: 'rgba(15,23,42,0.5)',
+                letterSpacing: '0.08em',
+                marginBottom: 12,
+              }}
+            >
+              BEFORE
+            </div>
+            <h3 style={{ fontSize: 22, fontWeight: 700, margin: '0 0 20px', color: '#0F172A' }}>
+              {isAdmin
+                ? 'A folder of spreadsheets nobody trusts'
+                : 'Friday afternoon, three tabs deep'}
+            </h3>
+            {(isAdmin
+              ? [
+                  'Bell schedules in one doc, special activities in another',
+                  'Yard-duty rotations on a printout in the front office',
+                  'Every reorg means re-pasting cells for hours',
+                  'No way to see if Music and Library overlap',
+                ]
+              : [
+                  'Hand-built spreadsheets that break every reorg',
+                  'Service-minute tallying on the back of an envelope',
+                  'Scheduling a student the same time as another provider',
+                  'Constantly asking teachers when to pull students',
+                ]
+            ).map((t, i) => (
+              <div
+                key={i}
+                style={{ display: 'flex', gap: 12, padding: '10px 0', alignItems: 'flex-start' }}
+              >
+                <span
+                  style={{
+                    width: 20,
+                    height: 20,
+                    borderRadius: 999,
+                    flexShrink: 0,
+                    marginTop: 1,
+                    background: '#FEE2E2',
+                    color: '#DC2626',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: 12,
+                    fontWeight: 700,
+                  }}
+                >
+                  ×
+                </span>
+                <span style={{ fontSize: 15, lineHeight: 1.5, color: 'rgba(15,23,42,0.7)' }}>
+                  {t}
+                </span>
+              </div>
+            ))}
+          </div>
+          {/* After */}
+          <div
+            style={{
+              background: '#FFF',
+              border: '1px solid #2452F5',
+              borderRadius: 16,
+              padding: 32,
+              boxShadow: '0 20px 40px -20px rgba(36,82,245,0.18)',
+            }}
+          >
+            <div
+              style={{
+                fontSize: 12,
+                fontWeight: 700,
+                color: '#2452F5',
+                letterSpacing: '0.08em',
+                marginBottom: 12,
+              }}
+            >
+              WITH SPEDDY
+            </div>
+            <h3 style={{ fontSize: 22, fontWeight: 700, margin: '0 0 20px', color: '#0F172A' }}>
+              {isAdmin ? 'One master schedule. Always current.' : 'One view. Everything current.'}
+            </h3>
+            {(isAdmin
+              ? [
+                  'Bell schedules, special activities & yard duty in one view',
+                  'Filter by grade, activity, or zone in a click',
+                  'Conflict detection across the whole school',
+                  'Roll a schedule forward to next year in seconds',
+                ]
+              : [
+                  'Visual weekly schedule, color-coded by grade',
+                  'Live service-minute tracking per student',
+                  'Conflict detection before you commit',
+                  'Assign sessions to a SEA',
+                ]
+            ).map((t, i) => (
+              <div
+                key={i}
+                style={{ display: 'flex', gap: 12, padding: '10px 0', alignItems: 'flex-start' }}
+              >
+                <span
+                  style={{
+                    width: 20,
+                    height: 20,
+                    borderRadius: 999,
+                    flexShrink: 0,
+                    marginTop: 1,
+                    background: '#DCFCE7',
+                    color: '#15803D',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: 11,
+                    fontWeight: 700,
+                  }}
+                >
+                  ✓
+                </span>
+                <span style={{ fontSize: 15, lineHeight: 1.5, color: 'rgba(15,23,42,0.7)' }}>
+                  {t}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Feature grid */}
+      <section
+        style={{
+          padding: '96px 64px',
+          background: '#FFF',
+          borderTop: '1px solid rgba(15,23,42,0.06)',
+        }}
+      >
+        <div style={{ maxWidth: 720, margin: '0 auto 64px', textAlign: 'center' }}>
+          <h2
+            style={{
+              fontSize: 44,
+              fontWeight: 700,
+              letterSpacing: '-0.025em',
+              margin: 0,
+              color: '#0F172A',
+            }}
+          >
+            {isAdmin
+              ? 'Everything a principal needs, in one tab.'
+              : 'The help your SpEd team is missing.'}
+          </h2>
+        </div>
+
+        <div style={{ maxWidth: 1180, margin: '0 auto' }}>
+          <div
+            style={{
+              background: '#F3F5F8',
+              border: '1px solid rgba(15,23,42,0.06)',
+              borderRadius: 20,
+              padding: 40,
+              display: 'grid',
+              gridTemplateColumns: '0.9fr 1.1fr',
+              gap: 48,
+              alignItems: 'center',
+            }}
+          >
+            <div>
+              <div
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  padding: '6px 12px',
+                  background: '#EFF5FF',
+                  borderRadius: 999,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  color: '#2452F5',
+                  letterSpacing: '0.06em',
+                  textTransform: 'uppercase',
+                  marginBottom: 16,
+                }}
+              >
+                <span
+                  style={{ width: 6, height: 6, borderRadius: 999, background: '#2452F5' }}
+                ></span>
+                {isAdmin ? 'Master schedule' : 'Visual scheduler'}
+              </div>
+              <h3
+                style={{
+                  fontSize: 32,
+                  fontWeight: 700,
+                  margin: '0 0 16px',
+                  letterSpacing: '-0.02em',
+                  color: '#0F172A',
+                  lineHeight: 1.15,
+                }}
+              >
+                {isAdmin ? (
+                  <>
+                    Bell schedules,
+                    <br />
+                    special activities,
+                    <br />
+                    yard duty — one view.
+                  </>
+                ) : (
+                  <>
+                    See your whole week.
+                    <br />
+                    Catch the conflicts.
+                  </>
+                )}
+              </h3>
+              <p
+                style={{
+                  fontSize: 16,
+                  lineHeight: 1.55,
+                  color: 'rgba(15,23,42,0.65)',
+                  margin: '0 0 24px',
+                }}
+              >
+                {isAdmin
+                  ? 'Build your whole school year in Speddy. Stack Music, Library, STEAM, Garden and recess against grade-level bell schedules and yard-duty rotations — then filter by grade, activity, or zone instantly.'
+                  : "Drag, drop, color-code by grade. Speddy spots when two sessions overlap, when an SEA isn't free, and when a student's pulled out of their favorite class — then offers a fix before you commit."}
+              </p>
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: '1fr 1fr',
+                  gap: 8,
+                  maxWidth: 360,
+                }}
+              >
+                {(isAdmin
+                  ? [
+                      'Bell schedule builder',
+                      'Special activities',
+                      'Yard-duty rotations',
+                      'Zone management',
+                      'Whole-school conflicts',
+                      'Year-over-year copy',
+                    ]
+                  : [
+                      'Conflict detection',
+                      'Drag & drop',
+                      'Auto-schedule',
+                      'Print-friendly',
+                      'SEA availability',
+                      'Pull-out tracking',
+                    ]
+                ).map((t) => (
+                  <div
+                    key={t}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 8,
+                      fontSize: 13,
+                      color: 'rgba(15,23,42,0.75)',
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 16,
+                        height: 16,
+                        borderRadius: 999,
+                        background: '#DCFCE7',
+                        color: '#15803D',
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontSize: 9,
+                        fontWeight: 700,
+                        flexShrink: 0,
+                      }}
+                    >
+                      ✓
+                    </span>
+                    {t}
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div
+              style={{
+                background: '#FFF',
+                borderRadius: 12,
+                padding: 12,
+                border: '1px solid rgba(15,23,42,0.06)',
+              }}
+            >
+              {isAdmin ? (
+                <MockMasterScheduleCard width="100%" />
+              ) : (
+                <MockScheduleCard width="100%" />
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section
+        style={{ padding: '96px 64px', background: '#0F172A', color: '#FFF', textAlign: 'center' }}
+      >
+        <h2
+          style={{ fontSize: 48, fontWeight: 700, letterSpacing: '-0.025em', margin: '0 0 12px' }}
+        >
+          Make your SpEd life easier.
+        </h2>
+        <p style={{ fontSize: 18, color: 'rgba(255,255,255,0.7)', margin: '0 0 36px' }}>
+          Set up in an afternoon. Designed alongside real SpEd providers.
+        </p>
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <div style={{ background: '#FFF', padding: 8, borderRadius: 14, maxWidth: 580, width: '100%' }}>
+            <EmailSignup cta="Get started" />
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer
+        style={{
+          padding: '32px 64px',
+          background: '#0F172A',
+          borderTop: '1px solid rgba(255,255,255,0.08)',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <SpeddyMark size={26} color="#FFF" />
+          <span style={{ fontSize: 13, color: 'rgba(255,255,255,0.55)' }}>
+            Made by SpEd people, for SpEd people.
+          </span>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            gap: 24,
+            fontSize: 13,
+            color: 'rgba(255,255,255,0.55)',
+          }}
+        >
+          <Link href="/privacy" style={{ color: 'inherit', textDecoration: 'none' }}>
+            Privacy
+          </Link>
+          <Link href="/terms" style={{ color: 'inherit', textDecoration: 'none' }}>
+            Terms
+          </Link>
+          <Link href="/ferpa" style={{ color: 'inherit', textDecoration: 'none' }}>
+            FERPA
+          </Link>
+          <a
+            href="mailto:help@speddy.xyz"
+            style={{ color: 'inherit', textDecoration: 'none' }}
+          >
+            Contact
+          </a>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/app/components/landing/clean-landing.tsx
+++ b/app/components/landing/clean-landing.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 // Speddy landing page — "Clean (B)" design direction.
+// Responsive: clamp() handles type/spacing, flex-wrap handles rows, and a
+// small media-query block collapses the two-column grids on narrow screens.
 
 import { useState } from 'react';
 import Link from 'next/link';
@@ -31,6 +33,17 @@ const ADMIN_COPY = {
   placeholder: 'admin@district.edu',
 };
 
+const SECTION_X = 'clamp(20px, 5vw, 64px)';
+
+const RESPONSIVE_CSS = `
+.sp-hero-grid { display: grid; grid-template-columns: 1.4fr 1fr; gap: 20px; align-items: start; }
+.sp-2col { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.sp-feature-grid { display: grid; grid-template-columns: 0.9fr 1.1fr; gap: clamp(24px, 4vw, 48px); align-items: center; }
+@media (max-width: 768px) {
+  .sp-hero-grid, .sp-2col, .sp-feature-grid { grid-template-columns: 1fr; }
+}
+`;
+
 export default function CleanLanding() {
   const [audience, setAudience] = useState<Audience>('provider');
   const copy = audience === 'provider' ? PROVIDER_COPY : ADMIN_COPY;
@@ -44,16 +57,18 @@ export default function CleanLanding() {
         background: '#F3F5F8',
         minHeight: '100%',
         width: '100%',
-        overflow: 'hidden',
+        overflowX: 'hidden',
       }}
     >
+      <style>{RESPONSIVE_CSS}</style>
+
       {/* Nav */}
       <nav
         style={{
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
-          padding: '24px 64px',
+          padding: `clamp(16px, 4vw, 24px) ${SECTION_X}`,
           background: '#FFF',
           borderBottom: '1px solid rgba(15,23,42,0.06)',
         }}
@@ -73,7 +88,13 @@ export default function CleanLanding() {
       </nav>
 
       {/* Hero */}
-      <section style={{ padding: '72px 64px 56px', textAlign: 'center', background: '#FFF' }}>
+      <section
+        style={{
+          padding: `clamp(40px, 7vw, 72px) ${SECTION_X} clamp(36px, 6vw, 56px)`,
+          textAlign: 'center',
+          background: '#FFF',
+        }}
+      >
         <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 24 }}>
           <AudienceToggle value={audience} onChange={setAudience} />
         </div>
@@ -90,7 +111,7 @@ export default function CleanLanding() {
         </div>
         <h1
           style={{
-            fontSize: 64,
+            fontSize: 'clamp(34px, 7vw, 64px)',
             lineHeight: 1.05,
             fontWeight: 700,
             letterSpacing: '-0.03em',
@@ -106,7 +127,7 @@ export default function CleanLanding() {
         </h1>
         <p
           style={{
-            fontSize: 19,
+            fontSize: 'clamp(16px, 2.2vw, 19px)',
             lineHeight: 1.5,
             margin: '24px auto 36px',
             color: 'rgba(15,23,42,0.65)',
@@ -116,13 +137,14 @@ export default function CleanLanding() {
           {copy.sub}
         </p>
         <div style={{ display: 'flex', justifyContent: 'center' }}>
-          <EmailSignup cta={copy.cta} placeholder={copy.placeholder} />
+          <EmailSignup cta={copy.cta} placeholder={copy.placeholder} audience={audience} />
         </div>
         <div
           style={{
             display: 'flex',
+            flexWrap: 'wrap',
             justifyContent: 'center',
-            gap: 24,
+            gap: '8px 24px',
             marginTop: 20,
             fontSize: 13,
             color: 'rgba(15,23,42,0.55)',
@@ -185,14 +207,8 @@ export default function CleanLanding() {
               </div>
             </div>
             <div
-              style={{
-                background: '#F3F5F8',
-                padding: 24,
-                display: 'grid',
-                gridTemplateColumns: '1.4fr 1fr',
-                gap: 20,
-                alignItems: 'start',
-              }}
+              className="sp-hero-grid"
+              style={{ background: '#F3F5F8', padding: 'clamp(14px, 3vw, 24px)' }}
             >
               {isAdmin ? (
                 <MockMasterScheduleCard width="100%" />
@@ -206,7 +222,7 @@ export default function CleanLanding() {
       </section>
 
       {/* Pain points */}
-      <section style={{ padding: '96px 64px' }}>
+      <section style={{ padding: `clamp(56px, 9vw, 96px) ${SECTION_X}` }}>
         <div style={{ textAlign: 'center', marginBottom: 56 }}>
           <div
             style={{
@@ -221,7 +237,7 @@ export default function CleanLanding() {
           </div>
           <h2
             style={{
-              fontSize: 44,
+              fontSize: 'clamp(26px, 5vw, 44px)',
               fontWeight: 700,
               letterSpacing: '-0.025em',
               margin: '12px 0 0',
@@ -234,22 +250,14 @@ export default function CleanLanding() {
           </h2>
         </div>
 
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: '1fr 1fr',
-            gap: 24,
-            maxWidth: 1080,
-            margin: '0 auto',
-          }}
-        >
+        <div className="sp-2col" style={{ maxWidth: 1080, margin: '0 auto' }}>
           {/* Before */}
           <div
             style={{
               background: '#FFF',
               border: '1px solid rgba(15,23,42,0.08)',
               borderRadius: 16,
-              padding: 32,
+              padding: 'clamp(22px, 4vw, 32px)',
             }}
           >
             <div
@@ -316,7 +324,7 @@ export default function CleanLanding() {
               background: '#FFF',
               border: '1px solid #2452F5',
               borderRadius: 16,
-              padding: 32,
+              padding: 'clamp(22px, 4vw, 32px)',
               boxShadow: '0 20px 40px -20px rgba(36,82,245,0.18)',
             }}
           >
@@ -382,7 +390,7 @@ export default function CleanLanding() {
       {/* Feature grid */}
       <section
         style={{
-          padding: '96px 64px',
+          padding: `clamp(56px, 9vw, 96px) ${SECTION_X}`,
           background: '#FFF',
           borderTop: '1px solid rgba(15,23,42,0.06)',
         }}
@@ -390,7 +398,7 @@ export default function CleanLanding() {
         <div style={{ maxWidth: 720, margin: '0 auto 64px', textAlign: 'center' }}>
           <h2
             style={{
-              fontSize: 44,
+              fontSize: 'clamp(26px, 5vw, 44px)',
               fontWeight: 700,
               letterSpacing: '-0.025em',
               margin: 0,
@@ -405,15 +413,12 @@ export default function CleanLanding() {
 
         <div style={{ maxWidth: 1180, margin: '0 auto' }}>
           <div
+            className="sp-feature-grid"
             style={{
               background: '#F3F5F8',
               border: '1px solid rgba(15,23,42,0.06)',
               borderRadius: 20,
-              padding: 40,
-              display: 'grid',
-              gridTemplateColumns: '0.9fr 1.1fr',
-              gap: 48,
-              alignItems: 'center',
+              padding: 'clamp(22px, 4vw, 40px)',
             }}
           >
             <div>
@@ -440,7 +445,7 @@ export default function CleanLanding() {
               </div>
               <h3
                 style={{
-                  fontSize: 32,
+                  fontSize: 'clamp(24px, 3.5vw, 32px)',
                   fontWeight: 700,
                   margin: '0 0 16px',
                   letterSpacing: '-0.02em',
@@ -554,19 +559,35 @@ export default function CleanLanding() {
 
       {/* Final CTA */}
       <section
-        style={{ padding: '96px 64px', background: '#0F172A', color: '#FFF', textAlign: 'center' }}
+        style={{
+          padding: `clamp(56px, 9vw, 96px) ${SECTION_X}`,
+          background: '#0F172A',
+          color: '#FFF',
+          textAlign: 'center',
+        }}
       >
         <h2
-          style={{ fontSize: 48, fontWeight: 700, letterSpacing: '-0.025em', margin: '0 0 12px' }}
+          style={{
+            fontSize: 'clamp(30px, 6vw, 48px)',
+            fontWeight: 700,
+            letterSpacing: '-0.025em',
+            margin: '0 0 12px',
+          }}
         >
           Make your SpEd life easier.
         </h2>
-        <p style={{ fontSize: 18, color: 'rgba(255,255,255,0.7)', margin: '0 0 36px' }}>
+        <p
+          style={{
+            fontSize: 'clamp(15px, 2vw, 18px)',
+            color: 'rgba(255,255,255,0.7)',
+            margin: '0 0 36px',
+          }}
+        >
           Set up in an afternoon. Designed alongside real SpEd providers.
         </p>
         <div style={{ display: 'flex', justifyContent: 'center' }}>
           <div style={{ background: '#FFF', padding: 8, borderRadius: 14, maxWidth: 580, width: '100%' }}>
-            <EmailSignup cta="Get started" />
+            <EmailSignup cta="Get started" audience={audience} />
           </div>
         </div>
       </section>
@@ -574,10 +595,12 @@ export default function CleanLanding() {
       {/* Footer */}
       <footer
         style={{
-          padding: '32px 64px',
+          padding: `clamp(24px, 4vw, 32px) ${SECTION_X}`,
           background: '#0F172A',
           borderTop: '1px solid rgba(255,255,255,0.08)',
           display: 'flex',
+          flexWrap: 'wrap',
+          gap: 16,
           justifyContent: 'space-between',
           alignItems: 'center',
         }}
@@ -591,6 +614,7 @@ export default function CleanLanding() {
         <div
           style={{
             display: 'flex',
+            flexWrap: 'wrap',
             gap: 24,
             fontSize: 13,
             color: 'rgba(255,255,255,0.55)',

--- a/app/components/landing/landing-shared.tsx
+++ b/app/components/landing/landing-shared.tsx
@@ -1,0 +1,835 @@
+'use client';
+
+// Building blocks for the Speddy landing page, ported from the chosen
+// "Clean (B)" design direction. Inline-styled and self-contained.
+
+import { useState } from 'react';
+
+export type Audience = 'provider' | 'admin';
+
+export const GRADE_COLORS = {
+  tk: '#F472B6',
+  k: '#A78BFA',
+  g1: '#3B82F6',
+  g2: '#22D3EE',
+  g3: '#22C55E',
+  g4: '#F59E0B',
+  g5: '#EF4444',
+};
+
+export const GRADE_LIST = [
+  { l: 'TK', c: GRADE_COLORS.tk },
+  { l: 'K', c: GRADE_COLORS.k },
+  { l: '1st', c: GRADE_COLORS.g1 },
+  { l: '2nd', c: GRADE_COLORS.g2 },
+  { l: '3rd', c: GRADE_COLORS.g3 },
+  { l: '4th', c: GRADE_COLORS.g4 },
+  { l: '5th', c: GRADE_COLORS.g5 },
+];
+
+// "Speddy" wordmark — Pacifico script, matches the in-app logo.
+export function SpeddyMark({
+  size = 36,
+  color = '#0F172A',
+  style,
+}: {
+  size?: number;
+  color?: string;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <span
+      style={{
+        fontFamily: 'var(--font-logo), cursive',
+        fontSize: size,
+        lineHeight: 1,
+        color,
+        letterSpacing: '-0.01em',
+        ...style,
+      }}
+    >
+      Speddy
+    </span>
+  );
+}
+
+// Two-tab audience selector (clean theme).
+export function AudienceToggle({
+  value,
+  onChange,
+}: {
+  value: Audience;
+  onChange: (v: Audience) => void;
+}) {
+  const tabs: { key: Audience; label: string }[] = [
+    { key: 'provider', label: 'For SpEd providers' },
+    { key: 'admin', label: 'For school admins' },
+  ];
+  return (
+    <div
+      style={{
+        display: 'inline-flex',
+        padding: 4,
+        background: '#EEF2F7',
+        borderRadius: 999,
+        gap: 2,
+      }}
+    >
+      {tabs.map((t) => {
+        const active = value === t.key;
+        return (
+          <button
+            key={t.key}
+            onClick={() => onChange(t.key)}
+            style={{
+              border: 0,
+              padding: '8px 16px',
+              borderRadius: 999,
+              fontSize: 14,
+              fontWeight: 600,
+              fontFamily: 'inherit',
+              cursor: 'pointer',
+              background: active ? '#FFFFFF' : 'transparent',
+              color: active ? '#0F172A' : 'rgba(15,23,42,0.55)',
+              boxShadow: active
+                ? '0 1px 2px rgba(15,23,42,0.08), 0 0 0 1px rgba(15,23,42,0.04)'
+                : 'none',
+              transition: 'all .15s',
+            }}
+          >
+            {t.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// Email-only signup (clean theme). Shows an inline thank-you on submit.
+export function EmailSignup({
+  placeholder = 'you@school.edu',
+  cta = 'Get started',
+}: {
+  placeholder?: string;
+  cta?: string;
+}) {
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  if (submitted) {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 14,
+          padding: '18px 22px',
+          background: '#EFF5FF',
+          border: '1.5px solid #2452F5',
+          borderRadius: 14,
+          color: '#1A3DB8',
+          maxWidth: 560,
+        }}
+      >
+        <span
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: 999,
+            background: '#2452F5',
+            color: '#FFF',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+          }}
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </span>
+        <div>
+          <div style={{ fontWeight: 700, fontSize: 16, marginBottom: 2 }}>
+            Thanks — we&apos;ll be in touch!
+          </div>
+          <div style={{ fontSize: 14, opacity: 0.85 }}>
+            A real SpEd person will email <strong>{email || 'you'}</strong> within a day.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!email.includes('@')) return;
+    setSubmitted(true);
+  };
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      style={{ display: 'flex', flexDirection: 'row', gap: 8, maxWidth: 560, width: '100%' }}
+    >
+      <input
+        type="email"
+        required
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder={placeholder}
+        style={{
+          flex: 1,
+          minWidth: 0,
+          padding: '14px 18px',
+          fontSize: 16,
+          fontFamily: 'inherit',
+          background: '#FFF',
+          border: '1.5px solid #D8DEE8',
+          borderRadius: 12,
+          outline: 'none',
+          color: '#0F172A',
+        }}
+        onFocus={(e) => (e.target.style.borderColor = '#2452F5')}
+        onBlur={(e) => (e.target.style.borderColor = '#D8DEE8')}
+      />
+      <button
+        type="submit"
+        style={{
+          border: 0,
+          padding: '14px 22px',
+          fontSize: 16,
+          fontWeight: 700,
+          fontFamily: 'inherit',
+          background: '#2452F5',
+          color: '#FFF',
+          borderRadius: 12,
+          cursor: 'pointer',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {cta} →
+      </button>
+    </form>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Mock UI cards — recreations of the in-app screens.
+// ────────────────────────────────────────────────────────────────────
+
+type Slot = {
+  day: number;
+  top: number;
+  h: number;
+  c: string;
+  code: string;
+  conflict?: boolean;
+  off?: number;
+};
+
+export function MockScheduleCard({ width = 520 }: { width?: string | number }) {
+  const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+  const slots: Slot[] = [
+    { day: 0, top: 0, h: 8, c: GRADE_COLORS.g3, code: 'JW' },
+    { day: 0, top: 8, h: 8, c: GRADE_COLORS.g3, code: 'SP', conflict: true },
+    { day: 1, top: 0, h: 8, c: GRADE_COLORS.g3, code: 'SP' },
+    { day: 1, top: 8, h: 8, c: GRADE_COLORS.g3, code: 'JW' },
+    { day: 2, top: 4, h: 8, c: GRADE_COLORS.g3, code: 'SP' },
+    { day: 3, top: 0, h: 8, c: GRADE_COLORS.g3, code: 'JW' },
+    { day: 3, top: 8, h: 8, c: GRADE_COLORS.g3, code: 'SP' },
+    { day: 4, top: 4, h: 8, c: GRADE_COLORS.g3, code: 'SP' },
+
+    { day: 0, top: 22, h: 8, c: GRADE_COLORS.g4, code: 'AC' },
+    { day: 0, top: 22, h: 8, c: GRADE_COLORS.g4, code: 'MM', off: 1 },
+    { day: 0, top: 22, h: 16, c: GRADE_COLORS.g5, code: 'DGI', off: 2 },
+    { day: 0, top: 30, h: 8, c: GRADE_COLORS.g4, code: 'MFI' },
+    { day: 1, top: 22, h: 8, c: GRADE_COLORS.g4, code: 'MM' },
+    { day: 1, top: 22, h: 16, c: GRADE_COLORS.g5, code: 'DGI', off: 1 },
+    { day: 1, top: 30, h: 8, c: GRADE_COLORS.g4, code: 'MFI' },
+    { day: 2, top: 22, h: 16, c: GRADE_COLORS.g5, code: 'DGI' },
+    { day: 2, top: 22, h: 8, c: GRADE_COLORS.g4, code: 'MFI', off: 1 },
+    { day: 3, top: 22, h: 8, c: GRADE_COLORS.g4, code: 'MFI' },
+    { day: 3, top: 22, h: 16, c: GRADE_COLORS.g5, code: 'DGI', off: 1 },
+    { day: 4, top: 22, h: 16, c: GRADE_COLORS.g5, code: 'DGI' },
+    { day: 4, top: 22, h: 8, c: GRADE_COLORS.g4, code: 'MFI', off: 1 },
+
+    { day: 0, top: 60, h: 8, c: GRADE_COLORS.g5, code: 'ER' },
+    { day: 0, top: 60, h: 16, c: GRADE_COLORS.g5, code: 'DGI', off: 1 },
+    { day: 1, top: 60, h: 8, c: GRADE_COLORS.g5, code: 'ER' },
+    { day: 1, top: 60, h: 16, c: GRADE_COLORS.g5, code: 'DGI', off: 1 },
+    { day: 2, top: 60, h: 16, c: GRADE_COLORS.g5, code: 'DGI' },
+    { day: 3, top: 60, h: 8, c: GRADE_COLORS.g5, code: 'ER' },
+    { day: 3, top: 60, h: 16, c: GRADE_COLORS.g5, code: 'DGI', off: 1 },
+    { day: 4, top: 60, h: 8, c: GRADE_COLORS.g5, code: 'ER' },
+    { day: 4, top: 60, h: 16, c: GRADE_COLORS.g5, code: 'DGI', off: 1 },
+  ];
+
+  return (
+    <div
+      style={{
+        width,
+        background: '#FFF',
+        borderRadius: 16,
+        border: '1px solid rgba(15,23,42,0.08)',
+        boxShadow:
+          '0 24px 60px -20px rgba(15,23,42,0.18), 0 8px 18px -8px rgba(15,23,42,0.08)',
+        overflow: 'hidden',
+        fontFamily: 'inherit',
+      }}
+    >
+      <div
+        style={{
+          padding: '16px 20px',
+          borderBottom: '1px solid rgba(15,23,42,0.06)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <div>
+          <div style={{ fontSize: 13, color: 'rgba(15,23,42,0.55)', fontWeight: 500 }}>
+            Main Schedule
+          </div>
+          <div style={{ fontSize: 18, color: '#0F172A', fontWeight: 700, marginTop: 2 }}>
+            This week
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 6 }}>
+          {GRADE_LIST.map((g) => (
+            <span
+              key={g.l}
+              style={{
+                fontSize: 10,
+                fontWeight: 600,
+                padding: '3px 7px',
+                borderRadius: 999,
+                background: g.c + '22',
+                color: g.c,
+              }}
+            >
+              {g.l}
+            </span>
+          ))}
+        </div>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: '44px repeat(5, 1fr)', position: 'relative' }}>
+        <div></div>
+        {days.map((d) => (
+          <div
+            key={d}
+            style={{
+              padding: '10px 8px',
+              fontSize: 11,
+              fontWeight: 700,
+              color: '#0F172A',
+              borderBottom: '1px solid rgba(15,23,42,0.06)',
+              textAlign: 'center',
+            }}
+          >
+            {d}
+          </div>
+        ))}
+        {['8:00', '9:00', '10:00', '11:00'].map((t, i) => (
+          <div
+            key={t}
+            style={{
+              gridColumn: '1 / 2',
+              gridRow: `${i + 2} / span 1`,
+              height: 56,
+              padding: '6px 8px',
+              fontSize: 10,
+              color: 'rgba(15,23,42,0.5)',
+              borderTop: i === 0 ? 'none' : '1px dashed rgba(15,23,42,0.06)',
+            }}
+          >
+            {t}
+          </div>
+        ))}
+        {days.map((_, di) => (
+          <div
+            key={di}
+            style={{
+              gridColumn: `${di + 2} / span 1`,
+              gridRow: '2 / span 4',
+              height: 224,
+              position: 'relative',
+              borderLeft: '1px solid rgba(15,23,42,0.06)',
+            }}
+          >
+            {slots
+              .filter((s) => s.day === di)
+              .map((s, i) => (
+                <div
+                  key={i}
+                  style={{
+                    position: 'absolute',
+                    top: `${(s.top / 80) * 100}%`,
+                    height: `${(s.h / 80) * 100}%`,
+                    left: `${4 + (s.off || 0) * 26}px`,
+                    width: s.code === 'DGI' ? 26 : 22,
+                    background: s.c,
+                    border: '1.5px solid #FFF',
+                    borderRadius: 5,
+                    color: '#FFF',
+                    fontSize: 8,
+                    fontWeight: 700,
+                    padding: '3px 2px 0',
+                    lineHeight: 1.1,
+                    boxShadow: '0 1px 2px rgba(15,23,42,0.18)',
+                  }}
+                >
+                  {s.code}
+                  {s.conflict && (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        bottom: 2,
+                        right: 2,
+                        width: 9,
+                        height: 9,
+                        borderRadius: 2,
+                        background: '#F59E0B',
+                        border: '1px solid #FFF',
+                        fontSize: 7,
+                        lineHeight: '8px',
+                        textAlign: 'center',
+                        color: '#FFF',
+                        fontWeight: 700,
+                      }}
+                    >
+                      !
+                    </div>
+                  )}
+                </div>
+              ))}
+          </div>
+        ))}
+      </div>
+      <div
+        style={{
+          margin: '12px 16px 16px',
+          padding: '10px 14px',
+          background: '#FFF7E6',
+          border: '1px solid #FCD34D',
+          borderRadius: 10,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          fontSize: 13,
+          color: '#92400E',
+        }}
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+          <line x1="12" y1="9" x2="12" y2="13" />
+          <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+        <span>
+          <strong>2 conflicts found</strong> · Mon 8:15 AM · JW / SP overlap
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function MockMinutesCard({ width = 420 }: { width?: string | number }) {
+  const students = [
+    { initials: 'AC', name: 'A. Chen', goal: 120, used: 118, c: GRADE_COLORS.g3 },
+    { initials: 'MM', name: 'M. Mendez', goal: 90, used: 92, c: GRADE_COLORS.g4 },
+    { initials: 'DG', name: 'D. Garza', goal: 180, used: 142, c: GRADE_COLORS.g5 },
+    { initials: 'JW', name: 'J. Wilson', goal: 60, used: 60, c: GRADE_COLORS.g3 },
+    { initials: 'ER', name: 'E. Rivera', goal: 90, used: 71, c: GRADE_COLORS.g5 },
+  ];
+  return (
+    <div
+      style={{
+        width,
+        background: '#FFF',
+        borderRadius: 16,
+        border: '1px solid rgba(15,23,42,0.08)',
+        boxShadow:
+          '0 24px 60px -20px rgba(15,23,42,0.18), 0 8px 18px -8px rgba(15,23,42,0.08)',
+        overflow: 'hidden',
+        fontFamily: 'inherit',
+      }}
+    >
+      <div style={{ padding: '16px 20px', borderBottom: '1px solid rgba(15,23,42,0.06)' }}>
+        <div style={{ fontSize: 13, color: 'rgba(15,23,42,0.55)', fontWeight: 500 }}>
+          Service minutes · this month
+        </div>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginTop: 4 }}>
+          <div
+            style={{ fontSize: 26, fontWeight: 800, color: '#0F172A', letterSpacing: '-0.02em' }}
+          >
+            92%
+          </div>
+          <div style={{ fontSize: 13, color: '#22C55E', fontWeight: 600 }}>on track</div>
+        </div>
+      </div>
+      <div style={{ padding: '8px 12px' }}>
+        {students.map((s, i) => {
+          const pct = Math.min(100, (s.used / s.goal) * 100);
+          const over = s.used > s.goal;
+          const full = s.used === s.goal;
+          const barColor = over ? '#EF4444' : full ? '#22C55E' : s.c;
+          return (
+            <div
+              key={i}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                padding: '10px 8px',
+                borderRadius: 10,
+              }}
+            >
+              <div
+                style={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: 999,
+                  background: s.c + '22',
+                  color: s.c,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 11,
+                  fontWeight: 700,
+                  flexShrink: 0,
+                }}
+              >
+                {s.initials}
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'baseline',
+                    marginBottom: 4,
+                  }}
+                >
+                  <span style={{ fontSize: 13, fontWeight: 600, color: '#0F172A' }}>
+                    {s.name}
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 11,
+                      color: 'rgba(15,23,42,0.55)',
+                      fontVariantNumeric: 'tabular-nums',
+                    }}
+                  >
+                    <strong style={{ color: over ? '#EF4444' : '#0F172A' }}>{s.used}</strong>/
+                    {s.goal} min
+                  </span>
+                </div>
+                <div
+                  style={{
+                    height: 6,
+                    background: 'rgba(15,23,42,0.06)',
+                    borderRadius: 999,
+                    overflow: 'hidden',
+                  }}
+                >
+                  <div
+                    style={{
+                      height: '100%',
+                      width: `${pct}%`,
+                      background: barColor,
+                      borderRadius: 999,
+                      transition: 'width .4s',
+                    }}
+                  ></div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+type MasterEvent = { d: number; t: number; h: number; col: number; k: string };
+
+export function MockMasterScheduleCard({ width = 540 }: { width?: string | number }) {
+  const ACT: Record<string, { name: string; c: string; bg: string }> = {
+    garden: { name: 'Garden', c: '#22C55E', bg: '#DCFCE7' },
+    library: { name: 'Library', c: '#3B82F6', bg: '#DBEAFE' },
+    music: { name: 'Music', c: '#A78BFA', bg: '#EDE9FE' },
+    steam: { name: 'STEAM', c: '#F97316', bg: '#FFEDD5' },
+    recess: { name: 'Recess', c: '#F59E0B', bg: '#FEF3C7' },
+    lunch: { name: 'Lunch', c: '#94A3B8', bg: '#E2E8F0' },
+  };
+  const events: MasterEvent[] = [
+    { d: 0, t: 0, h: 6, col: 0, k: 'recess' },
+    { d: 0, t: 0, h: 6, col: 1, k: 'recess' },
+    { d: 0, t: 0, h: 6, col: 2, k: 'recess' },
+    { d: 0, t: 7, h: 12, col: 0, k: 'music' },
+    { d: 0, t: 7, h: 12, col: 1, k: 'library' },
+    { d: 0, t: 21, h: 14, col: 0, k: 'recess' },
+    { d: 0, t: 21, h: 14, col: 1, k: 'recess' },
+    { d: 0, t: 21, h: 14, col: 2, k: 'recess' },
+    { d: 0, t: 21, h: 14, col: 3, k: 'recess' },
+    { d: 0, t: 38, h: 12, col: 0, k: 'library' },
+    { d: 0, t: 38, h: 12, col: 1, k: 'music' },
+    { d: 0, t: 52, h: 10, col: 0, k: 'lunch' },
+    { d: 0, t: 52, h: 10, col: 1, k: 'lunch' },
+    { d: 0, t: 64, h: 14, col: 0, k: 'music' },
+    { d: 0, t: 64, h: 14, col: 1, k: 'library' },
+    { d: 0, t: 80, h: 8, col: 0, k: 'recess' },
+    { d: 0, t: 80, h: 8, col: 1, k: 'recess' },
+    { d: 0, t: 80, h: 8, col: 2, k: 'recess' },
+    { d: 1, t: 0, h: 6, col: 0, k: 'recess' },
+    { d: 1, t: 0, h: 6, col: 1, k: 'recess' },
+    { d: 1, t: 7, h: 12, col: 0, k: 'garden' },
+    { d: 1, t: 7, h: 12, col: 1, k: 'steam' },
+    { d: 1, t: 21, h: 14, col: 0, k: 'recess' },
+    { d: 1, t: 21, h: 14, col: 1, k: 'recess' },
+    { d: 1, t: 21, h: 14, col: 2, k: 'recess' },
+    { d: 1, t: 38, h: 12, col: 0, k: 'steam' },
+    { d: 1, t: 38, h: 12, col: 1, k: 'garden' },
+    { d: 1, t: 52, h: 10, col: 0, k: 'lunch' },
+    { d: 1, t: 52, h: 10, col: 1, k: 'lunch' },
+    { d: 1, t: 64, h: 14, col: 0, k: 'library' },
+    { d: 1, t: 64, h: 14, col: 1, k: 'music' },
+    { d: 1, t: 80, h: 8, col: 0, k: 'recess' },
+    { d: 2, t: 0, h: 6, col: 0, k: 'recess' },
+    { d: 2, t: 0, h: 6, col: 1, k: 'recess' },
+    { d: 2, t: 7, h: 12, col: 0, k: 'steam' },
+    { d: 2, t: 7, h: 12, col: 1, k: 'steam' },
+    { d: 2, t: 21, h: 14, col: 0, k: 'recess' },
+    { d: 2, t: 21, h: 14, col: 1, k: 'recess' },
+    { d: 2, t: 21, h: 14, col: 2, k: 'recess' },
+    { d: 2, t: 38, h: 12, col: 0, k: 'garden' },
+    { d: 2, t: 38, h: 12, col: 1, k: 'garden' },
+    { d: 2, t: 52, h: 10, col: 0, k: 'lunch' },
+    { d: 2, t: 52, h: 10, col: 1, k: 'lunch' },
+    { d: 2, t: 64, h: 14, col: 0, k: 'music' },
+    { d: 2, t: 64, h: 14, col: 1, k: 'music' },
+    { d: 3, t: 0, h: 6, col: 0, k: 'recess' },
+    { d: 3, t: 0, h: 6, col: 1, k: 'recess' },
+    { d: 3, t: 0, h: 6, col: 2, k: 'recess' },
+    { d: 3, t: 7, h: 12, col: 0, k: 'music' },
+    { d: 3, t: 7, h: 12, col: 1, k: 'steam' },
+    { d: 3, t: 21, h: 14, col: 0, k: 'recess' },
+    { d: 3, t: 21, h: 14, col: 1, k: 'recess' },
+    { d: 3, t: 21, h: 14, col: 2, k: 'recess' },
+    { d: 3, t: 38, h: 12, col: 0, k: 'library' },
+    { d: 3, t: 38, h: 12, col: 1, k: 'steam' },
+    { d: 3, t: 52, h: 10, col: 0, k: 'lunch' },
+    { d: 3, t: 52, h: 10, col: 1, k: 'lunch' },
+    { d: 3, t: 64, h: 14, col: 0, k: 'garden' },
+    { d: 3, t: 64, h: 14, col: 1, k: 'library' },
+    { d: 3, t: 80, h: 8, col: 0, k: 'recess' },
+    { d: 3, t: 80, h: 8, col: 1, k: 'recess' },
+    { d: 4, t: 0, h: 6, col: 0, k: 'recess' },
+    { d: 4, t: 0, h: 6, col: 1, k: 'recess' },
+    { d: 4, t: 7, h: 12, col: 0, k: 'library' },
+    { d: 4, t: 38, h: 12, col: 0, k: 'music' },
+    { d: 4, t: 38, h: 12, col: 1, k: 'library' },
+    { d: 4, t: 21, h: 14, col: 0, k: 'recess' },
+    { d: 4, t: 21, h: 14, col: 1, k: 'recess' },
+    { d: 4, t: 52, h: 10, col: 0, k: 'lunch' },
+    { d: 4, t: 52, h: 10, col: 1, k: 'lunch' },
+    { d: 4, t: 64, h: 14, col: 0, k: 'steam' },
+    { d: 4, t: 64, h: 14, col: 1, k: 'garden' },
+  ];
+  const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+  const zones = ['Basketball', 'Kinder Yard', 'Playstructure', 'Grass Area'];
+
+  return (
+    <div
+      style={{
+        width,
+        background: '#FFF',
+        borderRadius: 16,
+        border: '1px solid rgba(15,23,42,0.08)',
+        boxShadow:
+          '0 24px 60px -20px rgba(15,23,42,0.18), 0 8px 18px -8px rgba(15,23,42,0.08)',
+        overflow: 'hidden',
+        fontFamily: 'inherit',
+      }}
+    >
+      <div style={{ padding: '14px 18px 12px', borderBottom: '1px solid rgba(15,23,42,0.06)' }}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            marginBottom: 12,
+          }}
+        >
+          <div>
+            <div style={{ fontSize: 16, fontWeight: 700, color: '#0F172A' }}>Master Schedule</div>
+            <div style={{ fontSize: 11, color: 'rgba(15,23,42,0.55)', marginTop: 2 }}>
+              School year 2025–2026
+            </div>
+          </div>
+          <div
+            style={{ display: 'flex', gap: 4, padding: 3, background: '#F3F5F8', borderRadius: 8 }}
+          >
+            {['All', 'Bell', 'Special', 'Yard'].map((t, i) => (
+              <span
+                key={t}
+                style={{
+                  fontSize: 10,
+                  fontWeight: 600,
+                  padding: '4px 9px',
+                  borderRadius: 6,
+                  background: i === 0 ? '#FFF' : 'transparent',
+                  color: i === 0 ? '#0F172A' : 'rgba(15,23,42,0.55)',
+                  boxShadow: i === 0 ? '0 1px 2px rgba(15,23,42,0.08)' : 'none',
+                }}
+              >
+                {t}
+              </span>
+            ))}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {Object.entries(ACT)
+            .slice(0, 4)
+            .map(([k, v]) => (
+              <span
+                key={k}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 5,
+                  padding: '3px 8px',
+                  borderRadius: 999,
+                  background: v.bg,
+                  color: v.c,
+                  fontSize: 10,
+                  fontWeight: 700,
+                }}
+              >
+                <span
+                  style={{ width: 6, height: 6, borderRadius: 999, background: v.c }}
+                ></span>
+                {v.name}
+              </span>
+            ))}
+        </div>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 8 }}>
+          {zones.map((z) => (
+            <span
+              key={z}
+              style={{
+                padding: '3px 8px',
+                borderRadius: 6,
+                background: '#FEF3C7',
+                color: '#92400E',
+                fontSize: 10,
+                fontWeight: 600,
+                border: '1px solid #FCD34D',
+              }}
+            >
+              {z}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div
+        style={{ display: 'grid', gridTemplateColumns: '40px repeat(5, 1fr)', position: 'relative' }}
+      >
+        <div></div>
+        {days.map((d) => (
+          <div
+            key={d}
+            style={{
+              padding: '8px 4px',
+              fontSize: 10,
+              fontWeight: 700,
+              color: '#0F172A',
+              borderBottom: '1px solid rgba(15,23,42,0.06)',
+              textAlign: 'center',
+            }}
+          >
+            {d}
+          </div>
+        ))}
+        {['8AM', '10AM', '12PM', '2PM'].map((t, i) => (
+          <div
+            key={t}
+            style={{
+              gridColumn: '1 / 2',
+              gridRow: `${i + 2} / span 1`,
+              height: 70,
+              padding: '4px 6px',
+              fontSize: 9,
+              color: 'rgba(15,23,42,0.5)',
+              borderTop: i === 0 ? 'none' : '1px dashed rgba(15,23,42,0.06)',
+            }}
+          >
+            {t}
+          </div>
+        ))}
+        {days.map((_, di) => (
+          <div
+            key={di}
+            style={{
+              gridColumn: `${di + 2} / span 1`,
+              gridRow: '2 / span 4',
+              height: 280,
+              position: 'relative',
+              borderLeft: '1px solid rgba(15,23,42,0.06)',
+              padding: '0 2px',
+            }}
+          >
+            {events
+              .filter((e) => e.d === di)
+              .map((e, i) => {
+                const act = ACT[e.k];
+                return (
+                  <div
+                    key={i}
+                    style={{
+                      position: 'absolute',
+                      top: `${e.t}%`,
+                      height: `${e.h}%`,
+                      left: `${2 + e.col * 24}%`,
+                      width: '22%',
+                      background: act.bg,
+                      borderLeft: `2.5px solid ${act.c}`,
+                      borderRadius: 3,
+                      padding: '2px 3px',
+                      fontSize: 7,
+                      fontWeight: 700,
+                      color: act.c,
+                      lineHeight: 1,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {act.name[0]}
+                  </div>
+                );
+              })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/components/landing/landing-shared.tsx
+++ b/app/components/landing/landing-shared.tsx
@@ -105,18 +105,22 @@ export function AudienceToggle({
   );
 }
 
-// Email-only signup (clean theme). Shows an inline thank-you on submit.
+// Email-only signup (clean theme). Posts to /api/landing-signup and shows an
+// inline thank-you on success.
 export function EmailSignup({
   placeholder = 'you@school.edu',
   cta = 'Get started',
+  audience,
 }: {
   placeholder?: string;
   cta?: string;
+  audience?: Audience;
 }) {
   const [email, setEmail] = useState('');
-  const [submitted, setSubmitted] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'done' | 'error'>('idle');
+  const [error, setError] = useState('');
 
-  if (submitted) {
+  if (status === 'done') {
     return (
       <div
         style={{
@@ -169,56 +173,91 @@ export function EmailSignup({
     );
   }
 
-  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!email.includes('@')) return;
-    setSubmitted(true);
+    if (status === 'loading') return;
+    if (!email.includes('@')) {
+      setError('Please enter a valid email address.');
+      setStatus('error');
+      return;
+    }
+    setStatus('loading');
+    setError('');
+    try {
+      const res = await fetch('/api/landing-signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, audience }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(data.error || 'Something went wrong. Please try again.');
+        setStatus('error');
+        return;
+      }
+      setStatus('done');
+    } catch {
+      setError('Network error. Please try again.');
+      setStatus('error');
+    }
   };
 
+  const loading = status === 'loading';
+
   return (
-    <form
-      onSubmit={onSubmit}
-      style={{ display: 'flex', flexDirection: 'row', gap: 8, maxWidth: 560, width: '100%' }}
-    >
-      <input
-        type="email"
-        required
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        placeholder={placeholder}
-        style={{
-          flex: 1,
-          minWidth: 0,
-          padding: '14px 18px',
-          fontSize: 16,
-          fontFamily: 'inherit',
-          background: '#FFF',
-          border: '1.5px solid #D8DEE8',
-          borderRadius: 12,
-          outline: 'none',
-          color: '#0F172A',
-        }}
-        onFocus={(e) => (e.target.style.borderColor = '#2452F5')}
-        onBlur={(e) => (e.target.style.borderColor = '#D8DEE8')}
-      />
-      <button
-        type="submit"
-        style={{
-          border: 0,
-          padding: '14px 22px',
-          fontSize: 16,
-          fontWeight: 700,
-          fontFamily: 'inherit',
-          background: '#2452F5',
-          color: '#FFF',
-          borderRadius: 12,
-          cursor: 'pointer',
-          whiteSpace: 'nowrap',
-        }}
+    <div style={{ maxWidth: 560, width: '100%' }}>
+      <form
+        onSubmit={onSubmit}
+        style={{ display: 'flex', flexWrap: 'wrap', gap: 8, width: '100%' }}
       >
-        {cta} →
-      </button>
-    </form>
+        <input
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder={placeholder}
+          style={{
+            flex: '1 1 200px',
+            minWidth: 0,
+            padding: '14px 18px',
+            fontSize: 16,
+            fontFamily: 'inherit',
+            background: '#FFF',
+            border: '1.5px solid #D8DEE8',
+            borderRadius: 12,
+            outline: 'none',
+            color: '#0F172A',
+          }}
+          onFocus={(e) => (e.target.style.borderColor = '#2452F5')}
+          onBlur={(e) => (e.target.style.borderColor = '#D8DEE8')}
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          style={{
+            flex: '1 1 140px',
+            border: 0,
+            padding: '14px 22px',
+            fontSize: 16,
+            fontWeight: 700,
+            fontFamily: 'inherit',
+            background: '#2452F5',
+            color: '#FFF',
+            borderRadius: 12,
+            cursor: loading ? 'default' : 'pointer',
+            opacity: loading ? 0.7 : 1,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {loading ? 'Sending…' : `${cta} →`}
+        </button>
+      </form>
+      {status === 'error' && error && (
+        <div style={{ marginTop: 8, fontSize: 13, color: '#DC2626', textAlign: 'left' }}>
+          {error}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -303,7 +342,7 @@ export function MockScheduleCard({ width = 520 }: { width?: string | number }) {
             This week
           </div>
         </div>
-        <div style={{ display: 'flex', gap: 6 }}>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
           {GRADE_LIST.map((g) => (
             <span
               key={g.l}

--- a/app/components/landing/landing-shared.tsx
+++ b/app/components/landing/landing-shared.tsx
@@ -80,6 +80,8 @@ export function AudienceToggle({
         return (
           <button
             key={t.key}
+            type="button"
+            aria-pressed={active}
             onClick={() => onChange(t.key)}
             style={{
               border: 0,
@@ -123,6 +125,8 @@ export function EmailSignup({
   if (status === 'done') {
     return (
       <div
+        role="status"
+        aria-live="polite"
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -253,7 +257,10 @@ export function EmailSignup({
         </button>
       </form>
       {status === 'error' && error && (
-        <div style={{ marginTop: 8, fontSize: 13, color: '#DC2626', textAlign: 'left' }}>
+        <div
+          role="alert"
+          style={{ marginTop: 8, fontSize: 13, color: '#DC2626', textAlign: 'left' }}
+        >
           {error}
         </div>
       )}

--- a/app/components/providers/auth-provider.tsx
+++ b/app/components/providers/auth-provider.tsx
@@ -65,8 +65,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   useEffect(() => {
-    // Only check session if we're not on a public route
-    const isPublicRoute = PUBLIC_ROUTES.some(route => pathname?.startsWith(route));
+    // Only check session if we're not on a public route. '/' is the marketing
+    // landing page and is matched exactly (startsWith('/') would match all).
+    const isPublicRoute =
+      pathname === '/' || PUBLIC_ROUTES.some(route => pathname?.startsWith(route));
 
     if (!isPublicRoute && !initialized) {
       checkSession();

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Inter, Pacifico } from "next/font/google";
+import { Inter, Pacifico, DM_Sans } from "next/font/google";
 import Script from 'next/script';
 import "./globals.css";
 import { AuthProvider } from "./components/providers/auth-provider";
@@ -10,10 +10,16 @@ const inter = Inter({
   display: 'swap',
 });
 
-const pacifico = Pacifico({ 
+const pacifico = Pacifico({
   subsets: ["latin"],
   weight: "400",
   variable: '--font-logo',
+  display: 'swap',
+});
+
+const dmSans = DM_Sans({
+  subsets: ["latin"],
+  variable: '--font-dm-sans',
   display: 'swap',
 });
 
@@ -28,7 +34,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${inter.variable} ${pacifico.variable}`}>
+    <html lang="en" className={`${inter.variable} ${pacifico.variable} ${dmSans.variable}`}>
       <body className={`${inter.className || 'font-sans'}`}>
         <AuthProvider>
           {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,12 @@
-import { redirect } from 'next/navigation'
+import type { Metadata } from 'next';
+import CleanLanding from './components/landing/clean-landing';
+
+export const metadata: Metadata = {
+  title: 'Speddy — The friendly elementary SpEd platform',
+  description:
+    'Speddy organizes every session, every student, and every service minute so SpEd providers and school admins can focus on the work that matters.',
+};
 
 export default function Home() {
-  redirect('/login')
+  return <CleanLanding />;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -6,19 +6,13 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
   // Define public routes that don't require authentication
-  const publicRoutes = ['/login', '/signup', '/terms', '/privacy', '/ferpa']
+  // '/' is the marketing landing page and is open to everyone.
+  const publicRoutes = ['/', '/login', '/signup', '/terms', '/privacy', '/ferpa']
   const isPublicRoute = publicRoutes.some(route => pathname === route)
 
   // Routes allowed for users who must change their password
   const passwordChangeRoutes = ['/change-password']
   const isPasswordChangeRoute = passwordChangeRoutes.some(route => pathname === route)
-
-  // If at root, redirect to login
-  if (pathname === '/') {
-    const redirectUrl = request.nextUrl.clone()
-    redirectUrl.pathname = '/login'
-    return NextResponse.redirect(redirectUrl)
-  }
 
   // Allow public routes
   if (isPublicRoute) {

--- a/supabase/migrations/20260519_create_landing_signups_table.sql
+++ b/supabase/migrations/20260519_create_landing_signups_table.sql
@@ -6,7 +6,9 @@ create table if not exists public.landing_signups (
   id uuid primary key default gen_random_uuid(),
   email text not null,
   audience text,
-  created_at timestamptz not null default now()
+  created_at timestamptz not null default now(),
+  constraint landing_signups_email_not_blank check (length(trim(email)) > 0),
+  constraint landing_signups_audience_check check (audience is null or audience in ('provider', 'admin'))
 );
 
 alter table public.landing_signups enable row level security;

--- a/supabase/migrations/20260519_create_landing_signups_table.sql
+++ b/supabase/migrations/20260519_create_landing_signups_table.sql
@@ -1,0 +1,14 @@
+-- Email captures from the marketing landing page signup form.
+-- Writes go through the /api/landing-signup route using the service role key;
+-- the table stays locked down with RLS enabled and no public policies.
+
+create table if not exists public.landing_signups (
+  id uuid primary key default gen_random_uuid(),
+  email text not null,
+  audience text,
+  created_at timestamptz not null default now()
+);
+
+alter table public.landing_signups enable row level security;
+
+comment on table public.landing_signups is 'Email captures from the marketing landing page signup form. Writes go through the /api/landing-signup route using the service role key; no public RLS policies.';


### PR DESCRIPTION
## Summary

Wires up the marketing landing page so `speddy.xyz` can serve both the site and the app from one domain (replacing the Replit deployment).

- **Landing page at `/`** — ports the chosen "Clean (B)" design direction. Audience toggle (providers / admins), mock product cards, and footer links to the existing legal pages. `app/page.tsx` now renders it and middleware no longer forces `/` → `/login`.
- **App keeps its current paths** — `/login`, `/dashboard`, etc. are unchanged. A new `/app` route is added as a friendly entry point: signed-in users go to their dashboard, everyone else to login.
- **Signup → Supabase** — the email form POSTs to a new `/api/landing-signup` route, which stores entries in a new `landing_signups` table (id, email, audience, created_at) via the service-role key. RLS is enabled with no public policies, so the table stays locked down. The form has loading / success / error states and records which audience tab the visitor used.
- **Responsive** — `clamp()` scales type and spacing, `flex-wrap` stacks the signup form and footer, and the two-column grids collapse to one column under 768px. Verified at 390px with zero horizontal overflow.

## Deployment notes (Vercel)

- Set environment variables in Vercel, including `SUPABASE_SERVICE_ROLE_KEY` (already in `.env.example`) — the signup route needs it. `RESEND_API_KEY` is also required for the build (existing `/api/email-webhook` route).
- Point `speddy.xyz` DNS at Vercel (apex `A` → `76.76.21.21`, `www` `CNAME` → `cname.vercel-dns.com`); remove the old Replit records.
- Update Supabase Auth → URL Configuration to `https://speddy.xyz` once the domain is live.
- The `landing_signups` migration has been applied to the live database and added to `supabase/migrations/`.

Check signups in the Supabase dashboard → Table Editor → `landing_signups`.

## Test plan

- [ ] `/` serves the landing page; `/login`, `/dashboard`, `/privacy` etc. unaffected
- [ ] `/app` redirects to login when signed out, dashboard when signed in
- [ ] Signup form: invalid email shows inline error; valid email writes a row to `landing_signups` with the correct `audience`
- [ ] Layout looks correct on desktop and mobile (no horizontal scroll)
- [ ] Audience toggle swaps copy and the provider/admin mock cards

https://claude.ai/code/session_01GtdhBzenrRHdu8HQSwYqHt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtdhBzenrRHdu8HQSwYqHt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched a new marketing landing page with audience-specific copy, toggleable mock previews, and updated home page to show the landing instead of redirecting to login.
  * Added email signup UI that posts to a new signup API and shows inline success/error states.
  * Root route (/) is now treated as public so unauthenticated visitors can view the landing.

* **Chores**
  * Added database migration to store landing signups.
  * Included additional web fonts for the layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->