### PR TITLE
Persist onboarding banner dismissals on the user profile

### DIFF
--- a/app/components/onboarding/onboarding-notifications.tsx
+++ b/app/components/onboarding/onboarding-notifications.tsx
@@ -15,17 +15,25 @@ export function OnboardingNotifications() {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return;
 
-      // Check if user has dismissed banners (stored in localStorage)
+      // Setup banner dismissal still lives in localStorage; only the
+      // multi-school banner has been migrated to durable per-user storage.
       const dismissedSetup = localStorage.getItem(`dismissed-setup-banner-${user.id}`);
-      const dismissedMultiSchool = localStorage.getItem(`dismissed-multi-school-banner-${user.id}`);
 
-      // Check if user works at multiple schools
-      const { data: providerSchools } = await supabase
-        .from('provider_schools')
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('works_at_multiple_schools, multi_school_banner_dismissed')
+        .eq('id', user.id)
+        .single();
+
+      // If the user has saved any per-site work schedule rows, treat the
+      // multi-school banner's call to action as complete and hide it.
+      const { data: siteSchedules } = await supabase
+        .from('user_site_schedules')
         .select('id')
-        .eq('provider_id', user.id);
+        .eq('user_id', user.id)
+        .limit(1);
 
-      const worksAtMultipleSchools = providerSchools && providerSchools.length > 1;
+      const hasSiteSchedule = !!siteSchedules && siteSchedules.length > 0;
 
       // Check if user has students
       const { data: students } = await supabase
@@ -49,8 +57,8 @@ export function OnboardingNotifications() {
         .limit(1);
 
       // Determine if user needs setup (no students, bell schedules, or special activities)
-      const needsSetup = (!students || students.length === 0) || 
-                        (!bellSchedules || bellSchedules.length === 0) || 
+      const needsSetup = (!students || students.length === 0) ||
+                        (!bellSchedules || bellSchedules.length === 0) ||
                         (!specialActivities || specialActivities.length === 0);
 
       // Show setup banner if needed and not dismissed
@@ -58,8 +66,11 @@ export function OnboardingNotifications() {
         setShowSetupBanner(true);
       }
 
-      // Show multi-school banner if applicable and not dismissed
-      if (worksAtMultipleSchools && !dismissedMultiSchool) {
+      if (
+        profile?.works_at_multiple_schools &&
+        !profile.multi_school_banner_dismissed &&
+        !hasSiteSchedule
+      ) {
         setShowMultiSchoolBanner(true);
       }
     } catch (error) {
@@ -68,7 +79,7 @@ export function OnboardingNotifications() {
       setLoading(false);
     }
   }, [supabase]);
-  
+
   useEffect(() => {
     checkOnboardingStatus();
   }, [checkOnboardingStatus]);
@@ -83,9 +94,18 @@ export function OnboardingNotifications() {
 
   const handleDismissMultiSchoolBanner = async () => {
     const { data: { user } } = await supabase.auth.getUser();
-    if (user) {
-      localStorage.setItem(`dismissed-multi-school-banner-${user.id}`, 'true');
-      setShowMultiSchoolBanner(false);
+    if (!user) return;
+
+    setShowMultiSchoolBanner(false);
+
+    const { error } = await supabase
+      .from('profiles')
+      .update({ multi_school_banner_dismissed: true })
+      .eq('id', user.id);
+
+    if (error) {
+      console.error('Error persisting multi-school banner dismissal:', error);
+      setShowMultiSchoolBanner(true);
     }
   };
 

--- a/app/components/onboarding/onboarding-notifications.tsx
+++ b/app/components/onboarding/onboarding-notifications.tsx
@@ -15,13 +15,9 @@ export function OnboardingNotifications() {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return;
 
-      // Setup banner dismissal still lives in localStorage; only the
-      // multi-school banner has been migrated to durable per-user storage.
-      const dismissedSetup = localStorage.getItem(`dismissed-setup-banner-${user.id}`);
-
       const { data: profile } = await supabase
         .from('profiles')
-        .select('works_at_multiple_schools, multi_school_banner_dismissed')
+        .select('works_at_multiple_schools, multi_school_banner_dismissed, setup_banner_dismissed')
         .eq('id', user.id)
         .single();
 
@@ -61,8 +57,7 @@ export function OnboardingNotifications() {
                         (!bellSchedules || bellSchedules.length === 0) ||
                         (!specialActivities || specialActivities.length === 0);
 
-      // Show setup banner if needed and not dismissed
-      if (needsSetup && !dismissedSetup) {
+      if (needsSetup && !profile?.setup_banner_dismissed) {
         setShowSetupBanner(true);
       }
 
@@ -86,9 +81,18 @@ export function OnboardingNotifications() {
 
   const handleDismissSetupBanner = async () => {
     const { data: { user } } = await supabase.auth.getUser();
-    if (user) {
-      localStorage.setItem(`dismissed-setup-banner-${user.id}`, 'true');
-      setShowSetupBanner(false);
+    if (!user) return;
+
+    setShowSetupBanner(false);
+
+    const { error } = await supabase
+      .from('profiles')
+      .update({ setup_banner_dismissed: true })
+      .eq('id', user.id);
+
+    if (error) {
+      console.error('Error persisting setup banner dismissal:', error);
+      setShowSetupBanner(true);
     }
   };
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1763,6 +1763,7 @@ export type Database = {
           full_name: string
           id: string
           is_speddy_admin: boolean | null
+          multi_school_banner_dismissed: boolean
           must_change_password: boolean | null
           password_reset_requested_at: string | null
           role: string
@@ -1787,6 +1788,7 @@ export type Database = {
           full_name: string
           id: string
           is_speddy_admin?: boolean | null
+          multi_school_banner_dismissed?: boolean
           must_change_password?: boolean | null
           password_reset_requested_at?: string | null
           role: string
@@ -1811,6 +1813,7 @@ export type Database = {
           full_name?: string
           id?: string
           is_speddy_admin?: boolean | null
+          multi_school_banner_dismissed?: boolean
           must_change_password?: boolean | null
           password_reset_requested_at?: string | null
           role?: string

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1773,6 +1773,7 @@ export type Database = {
           school_site: string
           school_site_original: string | null
           selected_curriculums: string[] | null
+          setup_banner_dismissed: boolean
           shared_at_school: boolean | null
           state: string | null
           state_id: string | null
@@ -1798,6 +1799,7 @@ export type Database = {
           school_site: string
           school_site_original?: string | null
           selected_curriculums?: string[] | null
+          setup_banner_dismissed?: boolean
           shared_at_school?: boolean | null
           state?: string | null
           state_id?: string | null
@@ -1823,6 +1825,7 @@ export type Database = {
           school_site?: string
           school_site_original?: string | null
           selected_curriculums?: string[] | null
+          setup_banner_dismissed?: boolean
           shared_at_school?: boolean | null
           state?: string | null
           state_id?: string | null

--- a/supabase/migrations/20260519_add_multi_school_banner_dismissed_to_profiles.sql
+++ b/supabase/migrations/20260519_add_multi_school_banner_dismissed_to_profiles.sql
@@ -1,0 +1,9 @@
+-- Persist dismissal of the "we noticed you work at multiple schools" onboarding
+-- banner on the user's profile, so the banner stays dismissed across devices and
+-- browsers instead of only being remembered in localStorage.
+
+alter table public.profiles
+  add column if not exists multi_school_banner_dismissed boolean not null default false;
+
+comment on column public.profiles.multi_school_banner_dismissed is
+  'Set to true when the user dismisses the multi-school onboarding banner via the X button. Persists dismissal across devices/browsers.';

--- a/supabase/migrations/20260519_add_setup_banner_dismissed_to_profiles.sql
+++ b/supabase/migrations/20260519_add_setup_banner_dismissed_to_profiles.sql
@@ -1,0 +1,9 @@
+-- Persist dismissal of the onboarding setup banner on the user's profile, so
+-- the banner stays dismissed across devices and browsers instead of only being
+-- remembered in localStorage.
+
+alter table public.profiles
+  add column if not exists setup_banner_dismissed boolean not null default false;
+
+comment on column public.profiles.setup_banner_dismissed is
+  'Set to true when the user dismisses the onboarding setup banner via the X button. Persists dismissal across devices/browsers.';


### PR DESCRIPTION
## Summary

The "we noticed you work at multiple schools" banner kept reappearing for existing users. Three root causes:

- Dismissal lived only in `localStorage`, so it returned on a new browser, in incognito, or after clearing site data.
- The banner never checked whether the user had already done the thing it was nagging about (saving per-site work schedules), so it kept showing after the task was complete.
- It triggered off a `provider_schools` row count instead of the `profile.works_at_multiple_schools` flag the rest of the app uses, so the signal could disagree with reality.

Fixes:

- Add `profiles.multi_school_banner_dismissed` (boolean, default false). Dismiss button writes to the column instead of `localStorage`, so the X click sticks across devices.
- Auto-hide the multi-school banner once the user has any rows in `user_site_schedules` — the call to action is done.
- Gate the multi-school banner on `profile.works_at_multiple_schools` so it lines up with the rest of the app.

Applied the same durable-dismissal treatment to the setup banner ("add Students, Bell Schedule, Special Activities") for consistency:

- Add `profiles.setup_banner_dismissed` (boolean, default false).
- Setup banner still auto-hides on its own once at least one student, one bell schedule, and one special activity exist; the X click now persists per-user instead of per-browser.

Both new columns are covered by the existing `profiles_update` RLS policy (users can write their own non-protected profile fields).

## Test plan

- [ ] As a multi-school user with no `user_site_schedules` rows and `multi_school_banner_dismissed = false`, the banner appears on the dashboard.
- [ ] Clicking the X dismisses the banner; it does not return after logging out, switching browsers, or opening incognito.
- [ ] Adding any `user_site_schedules` row (via Settings → Work Schedule) hides the banner without needing an explicit dismiss.
- [ ] A single-school user (`works_at_multiple_schools = false`) never sees the banner, even with stray `provider_schools` rows.
- [ ] As a brand-new user, the setup banner appears; clicking X persists across browsers.
- [ ] Adding at least one student, one bell schedule, and one special activity hides the setup banner without needing an explicit dismiss.

https://claude.ai/code/session_01K47gArcvCsuRVgUdhrq9XB

---
_Generated by [Claude Code](https://claude.ai/code/session_01K47gArcvCsuRVgUdhrq9XB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding banner dismissal preferences now persist across all devices and browsers, rather than being stored locally on each device.
  
* **Bug Fixes**
  * Fixed issue where dismissing setup and multi-school onboarding banners did not sync preferences across different devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->