### PR TITLE
Add Hayward test accounts script; allow .us email domains

### DIFF
--- a/app/(auth)/signup/signup-form.tsx
+++ b/app/(auth)/signup/signup-form.tsx
@@ -416,7 +416,7 @@ const handleSubmit = async (e: React.FormEvent) => {
           placeholder="you@school.edu"
         />
         <p className="mt-1 text-xs text-gray-500">
-          Use your school or organization email (.edu, .org, etc.)
+          Use your school or district email (.edu, .org, .k12., .gov, or .us)
         </p>
       </div>
 

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -36,13 +36,14 @@ export const POST = asyncHandler(async (request: NextRequest) => {
 
     // Validate email domain
     const emailDomain = email.split('@')[1];
-    if (!emailDomain || 
-        (!emailDomain.endsWith('.edu') && 
-         !emailDomain.endsWith('.org') && 
-         !emailDomain.includes('.k12.') && 
-         !emailDomain.endsWith('.gov'))) {
+    if (!emailDomain ||
+        (!emailDomain.endsWith('.edu') &&
+         !emailDomain.endsWith('.org') &&
+         !emailDomain.includes('.k12.') &&
+         !emailDomain.endsWith('.gov') &&
+         !emailDomain.endsWith('.us'))) {
       return NextResponse.json(
-        { error: 'Email must be from an educational institution (.edu, .org, .k12., or .gov)' },
+        { error: 'Email must be from an educational institution (.edu, .org, .k12., .gov, or .us)' },
         { status: 400 }
       );
     }

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -34,8 +34,8 @@ export const POST = asyncHandler(async (request: NextRequest) => {
     );
   }
 
-    // Validate email domain
-    const emailDomain = email.split('@')[1];
+    // Validate email domain (case-insensitive)
+    const emailDomain = email.split('@')[1]?.toLowerCase();
     if (!emailDomain ||
         (!emailDomain.endsWith('.edu') &&
          !emailDomain.endsWith('.org') &&

--- a/app/components/providers/auth-provider.tsx
+++ b/app/components/providers/auth-provider.tsx
@@ -138,10 +138,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const emailDomain = email.split("@")[1];
       if (
         !emailDomain ||
-        (!emailDomain.includes(".edu") &&
-          !emailDomain.includes(".org") &&
+        (!emailDomain.endsWith(".edu") &&
+          !emailDomain.endsWith(".org") &&
           !emailDomain.includes(".k12.") &&
-          !emailDomain.includes(".gov") &&
+          !emailDomain.endsWith(".gov") &&
           !emailDomain.endsWith(".us"))
       ) {
         throw new Error("Please use your district email address");

--- a/app/components/providers/auth-provider.tsx
+++ b/app/components/providers/auth-provider.tsx
@@ -141,7 +141,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         (!emailDomain.includes(".edu") &&
           !emailDomain.includes(".org") &&
           !emailDomain.includes(".k12.") &&
-          !emailDomain.includes(".gov"))
+          !emailDomain.includes(".gov") &&
+          !emailDomain.endsWith(".us"))
       ) {
         throw new Error("Please use your district email address");
       }

--- a/app/components/providers/auth-provider.tsx
+++ b/app/components/providers/auth-provider.tsx
@@ -134,8 +134,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       const dbRole = roleMap[metadata.role] || metadata.role;
 
-      // Validate district email domain
-      const emailDomain = email.split("@")[1];
+      // Validate district email domain (case-insensitive)
+      const emailDomain = email.split("@")[1]?.toLowerCase();
       if (
         !emailDomain ||
         (!emailDomain.endsWith(".edu") &&

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -24,7 +24,7 @@ export default function TermsPage() {
             <h2 className="text-xl font-semibold text-gray-900 mt-8 mb-4">3. Account Registration</h2>
             <p className="text-gray-700 mb-4">To use Speddy, you must:</p>
             <ul className="list-disc pl-6 mb-4 text-gray-700">
-              <li>Register using your official school district email address (.edu, .org, .k12, .gov, or .us domains)</li>
+              <li>Register using your official school district email address (.edu, .org, .k12., .gov, or .us domains)</li>
               <li>Provide accurate, complete, and current information about your professional role and credentials</li>
               <li>Maintain the security of your password and login credentials</li>
               <li>Accept responsibility for all activities under your account</li>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -24,7 +24,7 @@ export default function TermsPage() {
             <h2 className="text-xl font-semibold text-gray-900 mt-8 mb-4">3. Account Registration</h2>
             <p className="text-gray-700 mb-4">To use Speddy, you must:</p>
             <ul className="list-disc pl-6 mb-4 text-gray-700">
-              <li>Register using your official school district email address (.edu, .org, .k12, or .gov domains)</li>
+              <li>Register using your official school district email address (.edu, .org, .k12, .gov, or .us domains)</li>
               <li>Provide accurate, complete, and current information about your professional role and credentials</li>
               <li>Maintain the security of your password and login credentials</li>
               <li>Accept responsibility for all activities under your account</li>

--- a/scripts/create-test-accounts.ts
+++ b/scripts/create-test-accounts.ts
@@ -1,0 +1,201 @@
+/**
+ * Creates the canonical Hayward Unified test accounts:
+ *   - district-test@husd.us  → district_admin (scope: Hayward Unified)
+ *   - admin-test@husd.us     → site_admin    (scope: Schafer Park Elementary)
+ *   - provider-test@husd.us  → resource      (school: Schafer Park Elementary)
+ *
+ * Also ensures the parent district and school rows exist. Safe to re-run -
+ * any existing test users with these emails are wiped and recreated so the
+ * script doubles as a "reset test accounts" tool.
+ *
+ * Usage: npx tsx scripts/create-test-accounts.ts
+ *
+ * Requires NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in .env.local.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { config } from 'dotenv';
+
+config({ path: '.env.local' });
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  console.error('Missing required environment variables:');
+  console.error('  NEXT_PUBLIC_SUPABASE_URL:', SUPABASE_URL ? 'set' : 'MISSING');
+  console.error('  SUPABASE_SERVICE_ROLE_KEY:', SUPABASE_SERVICE_ROLE_KEY ? 'set' : 'MISSING');
+  process.exit(1);
+}
+
+const DISTRICT = {
+  id: '0161192',
+  name: 'Hayward Unified',
+  state_id: 'CA',
+  district_type: 'Unified',
+  city: 'Hayward',
+  county: 'Alameda',
+  zip: '94544',
+  phone: '(510) 784-2600',
+  website: 'https://www.husd.us',
+};
+
+const SCHOOL = {
+  id: '061674002130',
+  name: 'Schafer Park Elementary',
+  district_id: DISTRICT.id,
+  school_type: 'Elementary',
+  grade_span_low: 'K',
+  grade_span_high: '6',
+  city: 'Hayward',
+  county: 'Alameda',
+  zip: '94544',
+  phone: '(510) 723-3895',
+  website: 'https://schafer.husd.us',
+  mailing_address: '26268 Flamingo Avenue',
+};
+
+const TEST_PASSWORD = 'SpeddyTest2025!';
+const DISTRICT_DOMAIN = 'husd.us';
+
+type TestAccount = {
+  email: string;
+  fullName: string;
+  role: 'district_admin' | 'site_admin' | 'resource';
+  schoolSite: string;
+  schoolId: string | null;
+};
+
+const ACCOUNTS: TestAccount[] = [
+  {
+    email: 'district-test@husd.us',
+    fullName: 'Test District Admin',
+    role: 'district_admin',
+    schoolSite: '',
+    schoolId: null,
+  },
+  {
+    email: 'admin-test@husd.us',
+    fullName: 'Test Site Admin',
+    role: 'site_admin',
+    schoolSite: SCHOOL.name,
+    schoolId: SCHOOL.id,
+  },
+  {
+    email: 'provider-test@husd.us',
+    fullName: 'Test Resource Provider',
+    role: 'resource',
+    schoolSite: SCHOOL.name,
+    schoolId: SCHOOL.id,
+  },
+];
+
+const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+async function upsertDistrictAndSchool() {
+  console.log('Ensuring district & school exist...');
+
+  const { error: districtErr } = await admin
+    .from('districts')
+    .upsert(DISTRICT, { onConflict: 'id' });
+  if (districtErr) throw new Error(`District upsert failed: ${districtErr.message}`);
+
+  const { error: schoolErr } = await admin
+    .from('schools')
+    .upsert(SCHOOL, { onConflict: 'id' });
+  if (schoolErr) throw new Error(`School upsert failed: ${schoolErr.message}`);
+
+  console.log(`  district: ${DISTRICT.id} (${DISTRICT.name})`);
+  console.log(`  school:   ${SCHOOL.id} (${SCHOOL.name})`);
+}
+
+async function deleteExisting(email: string) {
+  const { data, error } = await admin.auth.admin.listUsers();
+  if (error) throw new Error(`listUsers failed: ${error.message}`);
+
+  const existing = data.users.find((u) => u.email?.toLowerCase() === email.toLowerCase());
+  if (!existing) return;
+
+  console.log(`  removing existing ${email} (${existing.id})`);
+  await admin.from('admin_permissions').delete().eq('admin_id', existing.id);
+  await admin.from('profiles').delete().eq('id', existing.id);
+  const { error: delErr } = await admin.auth.admin.deleteUser(existing.id);
+  if (delErr) throw new Error(`deleteUser failed for ${email}: ${delErr.message}`);
+}
+
+async function createAccount(account: TestAccount) {
+  console.log(`\nCreating ${account.email} (${account.role})...`);
+  await deleteExisting(account.email);
+
+  // auth.admin.createUser fires handle_new_user, which seeds public.profiles
+  // from raw_user_meta_data. We then patch the profile with the FK IDs that
+  // the trigger doesn't populate (district_id, school_id, state_id).
+  const { data: created, error: createErr } = await admin.auth.admin.createUser({
+    email: account.email,
+    password: TEST_PASSWORD,
+    email_confirm: true,
+    user_metadata: {
+      full_name: account.fullName,
+      role: account.role,
+      state: DISTRICT.state_id,
+      school_district: DISTRICT.name,
+      school_site: account.schoolSite,
+      works_at_multiple_schools: false,
+    },
+  });
+
+  if (createErr || !created.user) {
+    throw new Error(`createUser failed for ${account.email}: ${createErr?.message}`);
+  }
+  const userId = created.user.id;
+  console.log(`  auth user: ${userId}`);
+
+  const { error: profileErr } = await admin
+    .from('profiles')
+    .update({
+      full_name: account.fullName,
+      role: account.role,
+      school_district: DISTRICT.name,
+      school_site: account.schoolSite,
+      district_id: DISTRICT.id,
+      school_id: account.schoolId,
+      state_id: DISTRICT.state_id,
+      state: DISTRICT.state_id,
+      district_domain: DISTRICT_DOMAIN,
+    })
+    .eq('id', userId);
+  if (profileErr) throw new Error(`profile update failed for ${account.email}: ${profileErr.message}`);
+
+  if (account.role === 'district_admin' || account.role === 'site_admin') {
+    const { error: permErr } = await admin.from('admin_permissions').insert({
+      admin_id: userId,
+      role: account.role,
+      district_id: DISTRICT.id,
+      school_id: account.role === 'site_admin' ? account.schoolId : null,
+      state_id: DISTRICT.state_id,
+    });
+    if (permErr) throw new Error(`admin_permissions insert failed for ${account.email}: ${permErr.message}`);
+    console.log(`  admin_permissions: ${account.role}`);
+  }
+}
+
+async function main() {
+  await upsertDistrictAndSchool();
+  for (const account of ACCOUNTS) {
+    await createAccount(account);
+  }
+
+  console.log('\n========================================');
+  console.log('Test accounts ready (password: ' + TEST_PASSWORD + ')');
+  console.log('========================================');
+  for (const a of ACCOUNTS) {
+    console.log(`  ${a.role.padEnd(15)} ${a.email}`);
+  }
+}
+
+main().catch((err) => {
+  console.error('\nFailed:', err.message ?? err);
+  process.exit(1);
+});

--- a/scripts/create-test-accounts.ts
+++ b/scripts/create-test-accounts.ts
@@ -111,17 +111,26 @@ async function upsertDistrictAndSchool() {
   console.log(`  school:   ${SCHOOL.id} (${SCHOOL.name})`);
 }
 
+async function findUserIdByEmail(email: string): Promise<string | null> {
+  const target = email.toLowerCase();
+  const perPage = 1000;
+  for (let page = 1; ; page++) {
+    const { data, error } = await admin.auth.admin.listUsers({ page, perPage });
+    if (error) throw new Error(`listUsers failed: ${error.message}`);
+    const match = data.users.find((u) => u.email?.toLowerCase() === target);
+    if (match) return match.id;
+    if (data.users.length < perPage) return null;
+  }
+}
+
 async function deleteExisting(email: string) {
-  const { data, error } = await admin.auth.admin.listUsers();
-  if (error) throw new Error(`listUsers failed: ${error.message}`);
+  const existingId = await findUserIdByEmail(email);
+  if (!existingId) return;
 
-  const existing = data.users.find((u) => u.email?.toLowerCase() === email.toLowerCase());
-  if (!existing) return;
-
-  console.log(`  removing existing ${email} (${existing.id})`);
-  await admin.from('admin_permissions').delete().eq('admin_id', existing.id);
-  await admin.from('profiles').delete().eq('id', existing.id);
-  const { error: delErr } = await admin.auth.admin.deleteUser(existing.id);
+  console.log(`  removing existing ${email} (${existingId})`);
+  await admin.from('admin_permissions').delete().eq('admin_id', existingId);
+  await admin.from('profiles').delete().eq('id', existingId);
+  const { error: delErr } = await admin.auth.admin.deleteUser(existingId);
   if (delErr) throw new Error(`deleteUser failed for ${email}: ${delErr.message}`);
 }
 

--- a/scripts/create-test-accounts.ts
+++ b/scripts/create-test-accounts.ts
@@ -128,8 +128,15 @@ async function deleteExisting(email: string) {
   if (!existingId) return;
 
   console.log(`  removing existing ${email} (${existingId})`);
-  await admin.from('admin_permissions').delete().eq('admin_id', existingId);
-  await admin.from('profiles').delete().eq('id', existingId);
+  const { error: permsErr } = await admin
+    .from('admin_permissions')
+    .delete()
+    .eq('admin_id', existingId);
+  if (permsErr) throw new Error(`admin_permissions delete failed for ${email}: ${permsErr.message}`);
+
+  const { error: profileErr } = await admin.from('profiles').delete().eq('id', existingId);
+  if (profileErr) throw new Error(`profiles delete failed for ${email}: ${profileErr.message}`);
+
   const { error: delErr } = await admin.auth.admin.deleteUser(existingId);
   if (delErr) throw new Error(`deleteUser failed for ${email}: ${delErr.message}`);
 }


### PR DESCRIPTION
## Summary
- Adds `scripts/create-test-accounts.ts` to reproducibly create three test accounts (`district_admin`, `site_admin`, `resource`) under Hayward Unified + Schafer Park Elementary. Script also upserts the parent `districts` and `schools` rows and is idempotent (re-runs cleanly).
- Extends the signup email-domain validator to accept `.us`, so legitimate district domains like `husd.us` are no longer rejected. Updated in both the server route and the client `auth-provider`, plus the user-facing help text under the email field and the terms-of-service copy.

The `.us` change is safe now that admins provision provider accounts rather than providers self-signing up (per @bstewart2255).

Test accounts created in the live DB (password `SpeddyTest2025!`):
- `district-test@husd.us` → district admin (scope: Hayward Unified)
- `admin-test@husd.us` → site admin (scope: Schafer Park Elementary)
- `provider-test@husd.us` → resource specialist at Schafer Park Elementary

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] Log in as each of the three accounts and verify the role-appropriate dashboard loads
- [ ] Verify signup form accepts a `.us` district email and rejects unrelated TLDs
- [ ] (Optional) Re-run `npx tsx scripts/create-test-accounts.ts` and confirm it cleanly resets the accounts

https://claude.ai/code/session_01EZor3dryXdstmwNZ15SLsR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZor3dryXdstmwNZ15SLsR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signup now accepts .us email domains.

* **Documentation**
  * Clarified acceptable district email domains in the signup form and Terms page.

* **Bug Fixes**
  * Email-domain validation made case-insensitive and updated messaging to list allowed domains.

* **Chores**
  * Added a script to provision canonical test accounts and related test data for development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->