### PR TITLE
Fix 400 on school-context query: drop nonexistent nces_id column

### DIFF
--- a/app/components/providers/school-context.tsx
+++ b/app/components/providers/school-context.tsx
@@ -59,7 +59,6 @@ export interface SchoolInfo {
     name?: string;
     district_name?: string;
     state_name?: string;
-    nces_id?: string;
   };
 }
 
@@ -113,7 +112,6 @@ export function SchoolProvider({ children }: { children: ReactNode }) {
           .from('schools')
           .select(`
             name,
-            nces_id,
             districts!inner(
               name,
               states!inner(
@@ -135,7 +133,6 @@ export function SchoolProvider({ children }: { children: ReactNode }) {
               name: schoolDetails.name,
               district_name: district.name,
               state_name: state.name,
-              nces_id: schoolDetails.nces_id,
             };
 
             // Update display name with richer data (use short state name)


### PR DESCRIPTION
## Summary
- Removes the `nces_id` reference from the `schools` query in `school-context.tsx`. The column doesn't exist in the live `schools` table (the migration that would have added it — `20250806_create_school_structure_tables.sql` — was never applied), so PostgREST was returning a 400 on every dashboard load for any user with a `school_id` set. The `try/catch` on the call was swallowing it as a `console.warn`, but the resulting `school_details` object was incomplete.
- `nces_id` was set on `enrichedSchool.school_details.nces_id` but **never read** anywhere in the app, so the fix is to drop it from the type, the SELECT clause, and the assignment.

## Test plan
- [ ] `npm run typecheck` passes
- [ ] Sign in as a site_admin or provider with a `school_id` and confirm: no 400 in the network tab for `/rest/v1/schools?select=...`, and `[SchoolContext] School data loaded` still logs the enriched object
- [ ] District admin (no `school_id`) keeps loading the dashboard without entering the enrichment branch
- [ ] No regression in any UI that displays `school_details` (district name, state name still render where applicable)

https://claude.ai/code/session_01EZor3dryXdstmwNZ15SLsR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZor3dryXdstmwNZ15SLsR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated school information data structure to streamline school identification fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->