### PR TITLE
Close modals on backdrop click

### DIFF
--- a/app/(dashboard)/dashboard/admin/master-schedule/components/availability-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/availability-modal.tsx
@@ -158,11 +158,13 @@ export function AvailabilityModal({
       role="dialog"
       aria-modal="true"
       aria-labelledby={headingId}
+      onClick={loading ? undefined : onClose}
     >
       <div
         ref={modalRef}
         className="bg-white rounded-lg shadow-xl max-w-sm w-full mx-4"
         tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="border-b border-gray-200 px-6 py-4">

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/create-item-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/create-item-modal.tsx
@@ -586,11 +586,13 @@ export function CreateItemModal({
       role="dialog"
       aria-modal="true"
       aria-labelledby={headingId}
+      onClick={loading ? undefined : onClose}
     >
       <div
         ref={modalRef}
         className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4"
         tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="border-b border-gray-200 px-6 py-4">

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/edit-item-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/edit-item-modal.tsx
@@ -502,11 +502,13 @@ export function EditItemModal({
       role="dialog"
       aria-modal="true"
       aria-labelledby={headingId}
+      onClick={loading ? undefined : onClose}
     >
       <div
         ref={modalRef}
         className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4"
         tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="border-b border-gray-200 px-6 py-4">

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/rotation-group-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/rotation-group-modal.tsx
@@ -472,11 +472,13 @@ export function RotationGroupModal({
       role="dialog"
       aria-modal="true"
       aria-labelledby={headingId}
+      onClick={loading ? undefined : onClose}
     >
       <div
         ref={modalRef}
         className="bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] flex flex-col"
         tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="border-b border-gray-200 px-6 py-4 flex-shrink-0">

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/rotation-quick-edit-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/rotation-quick-edit-modal.tsx
@@ -130,11 +130,13 @@ export function RotationQuickEditModal({
       role="dialog"
       aria-modal="true"
       aria-labelledby={headingId}
+      onClick={loading ? undefined : onClose}
     >
       <div
         ref={modalRef}
         className="bg-white rounded-lg shadow-xl max-w-sm w-full mx-4"
         tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="border-b border-gray-200 px-6 py-4">

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/yard-duty-zones-modal.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/yard-duty-zones-modal.tsx
@@ -105,11 +105,13 @@ export function YardDutyZonesModal({
       role="dialog"
       aria-modal="true"
       aria-labelledby="zones-modal-heading"
+      onClick={onClose}
     >
       <div
         ref={modalRef}
         className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4"
         tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="border-b border-gray-200 px-6 py-4">

--- a/app/components/admin/provider-edit-modal.tsx
+++ b/app/components/admin/provider-edit-modal.tsx
@@ -96,8 +96,14 @@ export function ProviderEditModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-lg w-full p-6 m-4 max-h-[90vh] overflow-y-auto">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={loading ? undefined : onClose}
+    >
+      <div
+        className="bg-white rounded-lg shadow-xl max-w-lg w-full p-6 m-4 max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="mb-6">
           <h2 className="text-xl font-semibold text-gray-900">Edit Provider</h2>
           <p className="text-sm text-gray-500 mt-1">

--- a/app/components/admin/provider-schedule-modal.tsx
+++ b/app/components/admin/provider-schedule-modal.tsx
@@ -102,8 +102,14 @@ export function ProviderScheduleModal({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full m-4 max-h-[80vh] flex flex-col">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-lg shadow-xl max-w-2xl w-full m-4 max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
         {/* Header */}
         <div className="px-6 py-4 border-b border-gray-200 flex justify-between items-center flex-shrink-0">
           <h2 className="text-xl font-semibold text-gray-900">

--- a/app/components/admin/staff-modal.tsx
+++ b/app/components/admin/staff-modal.tsx
@@ -219,13 +219,17 @@ export function StaffModal({ isOpen, onClose, onSuccess, staff, schoolId, teache
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={saving ? undefined : onClose}
+    >
       <div
         ref={modalRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="staff-modal-title"
         className="bg-white rounded-lg shadow-xl max-w-2xl w-full p-6 m-4 max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
       >
         <h2 id="staff-modal-title" className="text-lg font-semibold text-gray-900 mb-4">
           {isEdit ? 'Edit Staff Member' : 'Add Staff Member'}

--- a/app/components/admin/student-schedule-modal.tsx
+++ b/app/components/admin/student-schedule-modal.tsx
@@ -95,8 +95,14 @@ export function StudentScheduleModal({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-lg w-full m-4 max-h-[80vh] flex flex-col">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-lg shadow-xl max-w-lg w-full m-4 max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
         {/* Header */}
         <div className="px-6 py-4 border-b border-gray-200 flex justify-between items-center flex-shrink-0">
           <h2 className="text-xl font-semibold text-gray-900">

--- a/app/components/admin/teacher-edit-modal.tsx
+++ b/app/components/admin/teacher-edit-modal.tsx
@@ -154,7 +154,7 @@ export function TeacherEditModal({
   return (
     <div
       className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
-      onClick={loading ? undefined : onClose}
+      onClick={loading || deleting ? undefined : onClose}
     >
       <div
         className="bg-white rounded-lg shadow-xl max-w-lg w-full p-6 m-4 max-h-[90vh] overflow-y-auto"

--- a/app/components/admin/teacher-edit-modal.tsx
+++ b/app/components/admin/teacher-edit-modal.tsx
@@ -152,8 +152,14 @@ export function TeacherEditModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-lg w-full p-6 m-4 max-h-[90vh] overflow-y-auto">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={loading ? undefined : onClose}
+    >
+      <div
+        className="bg-white rounded-lg shadow-xl max-w-lg w-full p-6 m-4 max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="mb-6">
           <h2 className="text-xl font-semibold text-gray-900">Edit Teacher</h2>
           <p className="text-sm text-gray-500 mt-1">

--- a/app/components/ai-content-modal-enhanced.tsx
+++ b/app/components/ai-content-modal-enhanced.tsx
@@ -335,8 +335,14 @@ export function AIContentModalEnhanced({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg w-full max-w-5xl h-[90vh] flex flex-col">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-lg w-full max-w-5xl h-[90vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
         {/* Header with navigation */}
         <div className="px-6 py-4 border-b flex justify-between items-center bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-t-lg">
           <div className="flex items-center gap-4">

--- a/app/components/ai-content-modal.tsx
+++ b/app/components/ai-content-modal.tsx
@@ -395,8 +395,14 @@ export function AIContentModal({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] flex flex-col">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
         {/* Header */}
         <div className="border-b border-gray-200 px-6 py-4 flex items-center justify-between">
           <div>

--- a/app/components/ai-upload/ai-upload-modal.tsx
+++ b/app/components/ai-upload/ai-upload-modal.tsx
@@ -449,7 +449,7 @@ export default function AIUploadModal({
   return (
     <div
       className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50"
-      onClick={handleClose}
+      onClick={showExamples ? undefined : handleClose}
     >
       <div
         className="relative top-20 mx-auto p-5 border w-full max-w-4xl shadow-lg rounded-md bg-white"

--- a/app/components/ai-upload/ai-upload-modal.tsx
+++ b/app/components/ai-upload/ai-upload-modal.tsx
@@ -447,8 +447,14 @@ export default function AIUploadModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
-      <div className="relative top-20 mx-auto p-5 border w-full max-w-4xl shadow-lg rounded-md bg-white">
+    <div
+      className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50"
+      onClick={handleClose}
+    >
+      <div
+        className="relative top-20 mx-auto p-5 border w-full max-w-4xl shadow-lg rounded-md bg-white"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="flex justify-between items-center mb-4">
           <h3 className="text-lg font-medium">
             AI Upload - {uploadTypeLabels[uploadType]}

--- a/app/components/calendar/calendar-event-modal.tsx
+++ b/app/components/calendar/calendar-event-modal.tsx
@@ -179,8 +179,14 @@ export function CalendarEventModal({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={loading ? undefined : handleClose}
+    >
+      <div
+        className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
         <h3 className="text-lg font-semibold mb-4">
           {event ? 'Edit Event' : 'Add New Event'}
         </h3>

--- a/app/components/modals/session-details-modal.tsx
+++ b/app/components/modals/session-details-modal.tsx
@@ -1270,8 +1270,14 @@ export function SessionDetailsModal(props: SessionDetailsModalProps) {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg w-full max-w-4xl max-h-[90vh] flex flex-col shadow-xl">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-lg w-full max-w-4xl max-h-[90vh] flex flex-col shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
         {/* Header */}
         <div className="p-4 border-b border-gray-200">
           <div className="flex items-center justify-between mb-3">

--- a/app/components/students/add-manual-progress-modal.tsx
+++ b/app/components/students/add-manual-progress-modal.tsx
@@ -170,8 +170,14 @@ export function AddManualProgressModal({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={loading ? undefined : handleClose}
+    >
+      <div
+        className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
         <h3 className="text-lg font-semibold mb-4">
           {isEditMode ? 'Edit Progress Entry' : 'Add Manual Progress'}
         </h3>


### PR DESCRIPTION
## Summary

Adds click-outside-to-close behavior to 17 inline modals that previously could only be dismissed via the X / Cancel button. Pattern is consistent: outer overlay calls the close handler, inner content panel stops event propagation. Where a modal already gates Escape on a `loading`/`saving` state, the backdrop click is gated the same way so behavior matches.

### Modals updated (17)

- `admin/provider-edit-modal`, `provider-schedule-modal`, `staff-modal`, `student-schedule-modal`, `teacher-edit-modal`
- `ai-content-modal`, `ai-content-modal-enhanced`, `ai-upload/ai-upload-modal`
- `calendar/calendar-event-modal`
- `modals/session-details-modal`
- `students/add-manual-progress-modal`
- `master-schedule/availability-modal`, `create-item-modal`, `edit-item-modal`, `rotation-group-modal`, `rotation-quick-edit-modal`, `yard-duty-zones-modal`

### Already had backdrop-click — unchanged

Shared `Modal` / `Dialog`, `migration-review-dialog`, `master-schedule-settings-modal`, `student-details-modal`, `teacher-details-modal`, `lesson-type-modal`, `manual-lesson-form-modal`, `manual-lesson-view-modal`, `iep-goals-preview-modal`, `student-import-preview-modal`, `seis-upload-wizard-modal`, `move-to-initials-modal`, `close-case-modal`, `session-details-popup`.

### Intentionally excluded

- **Confirmation dialogs** (`confirmation-modal`, `delete-confirmation-modal`) — destructive; a stray backdrop click shouldn't dismiss a "Delete?" prompt.
- **One-time credential displays** (`credentials-modal`, `teacher-credentials-modal`, `internal/admin-credentials-modal`) — already gated by `window.confirm("Have you saved these?")` because the password isn't shown again.
- **Session timeout warning** (`auth/timeout-warning-modal`) — deliberately treats Escape as "stay signed in"; backdrop dismiss shouldn't silently override a session decision.

## Test plan

- [ ] Open an updated modal (e.g. Edit Teacher), click anywhere on the dimmed backdrop — modal closes.
- [ ] Click inside the modal panel (inputs, buttons, headings) — modal stays open.
- [ ] Begin a save/upload in a loading-aware modal (Provider Edit, Teacher Edit, Add Progress, Calendar Event, Master Schedule modals) — backdrop click is ignored while loading.
- [ ] Verify excluded modals still require explicit button click (Delete confirm, Credentials display, Session Timeout).
- [ ] `npm run typecheck` passes.

https://claude.ai/code/session_01G18bv1h5saoW79ugfxujxX

---
_Generated by [Claude Code](https://claude.ai/code/session_01G18bv1h5saoW79ugfxujxX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal behavior across the app: clicking the backdrop now closes modals, clicks inside dialogs no longer cause accidental closes, and backdrop-dismiss is temporarily disabled during in-progress operations (e.g., loading/saving or special modal states) to prevent unintended dismissal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->