### PR TITLE
Fix session group deconstruction and cross-view consistency

### DIFF
--- a/app/(dashboard)/dashboard/plan/page.tsx
+++ b/app/(dashboard)/dashboard/plan/page.tsx
@@ -497,8 +497,8 @@ export default function CalendarPage() {
 
             {currentView === 'day' && (
               <ToastProvider>
-                <CalendarDayView 
-                  sessions={sessions} 
+                <CalendarDayView
+                  sessions={sessions}
                   students={students}
                   onSessionClick={handleSessionClick}
                   currentDate={currentDate}
@@ -506,6 +506,7 @@ export default function CalendarPage() {
                   calendarEvents={calendarEvents}
                   onAddEvent={handleAddEvent}
                   onEventClick={handleEventClick}
+                  onUpdate={fetchData}
                 />
               </ToastProvider>
             )}

--- a/app/api/sessions/group/route.ts
+++ b/app/api/sessions/group/route.ts
@@ -164,7 +164,9 @@ export const POST = withAuth(async (request: NextRequest, userId: string) => {
     // This ensures existing date-specific instances get the group info too
     if (updatedSessions && updatedSessions.length > 0) {
       for (const template of updatedSessions) {
-        // Update all instances that match this template
+        // Update all instances that match this template. provider_id is part
+        // of the match so we never touch instances owned by a different
+        // provider that happen to share student/day/time.
         const { error: instanceError } = await supabase
           .from('schedule_sessions')
           .update({
@@ -173,6 +175,7 @@ export const POST = withAuth(async (request: NextRequest, userId: string) => {
             group_color: validatedGroupColor,
             updated_at: new Date().toISOString()
           })
+          .eq('provider_id', template.provider_id)
           .eq('student_id', template.student_id)
           .eq('day_of_week', template.day_of_week)
           .eq('start_time', template.start_time)

--- a/app/api/sessions/ungroup/route.ts
+++ b/app/api/sessions/ungroup/route.ts
@@ -217,7 +217,23 @@ export const POST = withAuth(async (request: NextRequest, userId: string) => {
     if (updatedSessions && updatedSessions.length > 0) {
       const templates = updatedSessions.filter(s => s.session_date == null);
 
+      // Need provider_id for instance scoping; the SELECT above on
+      // `updatedSessions` only includes id/student_id/day_of_week/start_time/
+      // session_date. Look it up from the original existingSessions fetch.
+      const providerIdByTemplateId = new Map(
+        existingSessions?.map(s => [s.id, s.provider_id]) || []
+      );
+
       for (const template of templates) {
+        const templateProviderId = providerIdByTemplateId.get(template.id);
+        if (!templateProviderId) {
+          log.warn('Missing provider_id for template during instance cleanup', {
+            userId,
+            templateId: template.id
+          });
+          continue;
+        }
+
         const { error: instanceError } = await supabase
           .from('schedule_sessions')
           .update({
@@ -226,6 +242,7 @@ export const POST = withAuth(async (request: NextRequest, userId: string) => {
             group_color: null,
             updated_at: new Date().toISOString()
           })
+          .eq('provider_id', templateProviderId)
           .eq('student_id', template.student_id)
           .eq('day_of_week', template.day_of_week)
           .eq('start_time', template.start_time)

--- a/app/components/calendar/calendar-day-view.tsx
+++ b/app/components/calendar/calendar-day-view.tsx
@@ -26,6 +26,7 @@ interface CalendarDayViewProps {
   calendarEvents?: CalendarEvent[];
   onAddEvent?: (date: Date) => void;
   onEventClick?: (event: CalendarEvent) => void;
+  onUpdate?: () => void;
 }
 
 export function CalendarDayView({
@@ -36,7 +37,8 @@ export function CalendarDayView({
   holidays = [],
   calendarEvents = [],
   onAddEvent,
-  onEventClick
+  onEventClick,
+  onUpdate
 }: CalendarDayViewProps) {
   const { showToast } = useToast();
   const { currentSchool } = useSchool();
@@ -635,6 +637,7 @@ export function CalendarDayView({
       setSelectedSessionIds(new Set());
       setGroupNameInput('');
       setSelectedGroupColor(0);
+      onUpdate?.();
     } catch (error) {
       log.error('Error creating group', {
         message: error instanceof Error ? error.message : 'Unknown error',
@@ -739,7 +742,17 @@ export function CalendarDayView({
 
       setSessionsState(filteredSessions);
 
+      // Clear any selection that referenced the ungrouped session so a stale
+      // checkbox state can't poison the next group-creation attempt.
+      setSelectedSessionIds(prev => {
+        if (!prev.has(sessionId)) return prev;
+        const next = new Set(prev);
+        next.delete(sessionId);
+        return next;
+      });
+
       showToast('Session removed from group', 'success');
+      onUpdate?.();
     } catch (error) {
       log.error('Error ungrouping session', error);
       showToast(error instanceof Error ? error.message : 'Failed to ungroup session', 'error');

--- a/app/components/calendar/calendar-week-view.tsx
+++ b/app/components/calendar/calendar-week-view.tsx
@@ -150,72 +150,13 @@ export function CalendarWeekView({
   type ViewMode = 'my-sessions' | 'all-sessions' | 'specialist' | 'sea' | 'assigned-to-me';
   const [viewMode, setViewMode] = useState<ViewMode>('my-sessions');
 
-  // Sync sessionsState with sessions prop when parent refreshes
-  // Apply week date, view mode, and school filtering to match the internal fetch behavior
-  useEffect(() => {
-    const syncSessions = async () => {
-      // Skip if we don't have user context yet
-      if (!currentUser) return;
-
-      // Get current week's date range
-      const weekStartStr = weekDates.length > 0 ? toLocalDateKey(weekDates[0]) : null;
-      const weekEndStr = weekDates.length > 0 ? toLocalDateKey(weekDates[weekDates.length - 1]) : null;
-
-      let filteredSessions = sessions;
-
-      // Filter by current week's date range first
-      if (weekStartStr && weekEndStr) {
-        filteredSessions = filteredSessions.filter(s =>
-          s.session_date &&
-          s.session_date >= weekStartStr &&
-          s.session_date <= weekEndStr
-        );
-      }
-
-      // Apply view mode filter (same logic as internal fetch)
-      const userId = currentUser.id;
-      if (viewMode === 'my-sessions') {
-        filteredSessions = filteredSessions.filter(s =>
-          (s.provider_id === userId && !s.assigned_to_specialist_id && !s.assigned_to_sea_id) ||
-          s.assigned_to_specialist_id === userId ||
-          s.assigned_to_sea_id === userId
-        );
-      } else if (viewMode === 'all-sessions') {
-        filteredSessions = filteredSessions.filter(s =>
-          s.provider_id === userId ||
-          s.assigned_to_specialist_id === userId ||
-          s.assigned_to_sea_id === userId
-        );
-      } else if (viewMode === 'specialist') {
-        filteredSessions = filteredSessions.filter(s =>
-          s.provider_id === userId &&
-          s.assigned_to_specialist_id !== null &&
-          s.assigned_to_specialist_id !== userId
-        );
-      } else if (viewMode === 'sea') {
-        filteredSessions = filteredSessions.filter(s =>
-          s.provider_id === userId &&
-          s.assigned_to_sea_id !== null &&
-          s.assigned_to_sea_id !== userId
-        );
-      } else if (viewMode === 'assigned-to-me') {
-        filteredSessions = filteredSessions.filter(s =>
-          s.assigned_to_specialist_id === userId &&
-          s.provider_id !== userId
-        );
-      }
-
-      // Then apply school filtering if user works at multiple schools and has a current school selected
-      if (currentSchool && worksAtMultipleSchools && currentSchool.school_id) {
-        const supabase = createClient<Database>();
-        filteredSessions = await filterSessionsBySchool(supabase, filteredSessions, currentSchool) as SessionWithCurriculum[];
-      }
-
-      setSessionsState(filteredSessions);
-    };
-
-    syncSessions();
-  }, [sessions, currentSchool, worksAtMultipleSchools, weekDates, viewMode, currentUser]);
+  // The internal loadSessions effect below is the single source of truth for
+  // sessionsState. It pulls fresh data from SessionGenerator on every relevant
+  // change. We previously had a second effect that synced from the `sessions`
+  // prop in parallel, which raced with the internal fetch and could revert to
+  // stale parent data right after a local mutation. Now we only listen to the
+  // prop as a signal that the parent refetched, and re-run the internal fetch
+  // (see the deps array on the loadSessions useEffect below).
 
   // Keep selectedGroupSessions in sync when sessions refresh
   useEffect(() => {
@@ -444,8 +385,12 @@ export function CalendarWeekView({
     };
 
     loadSessions();
+    // `sessions` is included so a parent refetch (e.g. after a Day-tab group
+    // change calls Plan page's fetchData) causes the week view to pull fresh
+    // data from the DB. The prop itself is not consumed, only used as a
+    // refresh signal.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [weekOffset, viewMode, currentSchool]);
+  }, [weekOffset, viewMode, currentSchool, sessions]);
 
   // Fetch student data for assigned sessions (students that aren't in the prop)
   React.useEffect(() => {

--- a/app/components/weekly-view.tsx
+++ b/app/components/weekly-view.tsx
@@ -648,10 +648,6 @@ export function WeeklyView({ viewMode }: WeeklyViewProps) {
     return today;
   }, []); // Empty dependency array since we only calculate this once
 
-  // Morning and afternoon time slots
-  const MORNING_SLOTS = ["8:00 AM", "8:30 AM", "9:00 AM", "9:30 AM", "10:00 AM", "10:30 AM", "11:00 AM", "11:30 AM"];
-  const AFTERNOON_SLOTS = ["12:00 PM", "12:30 PM", "1:00 PM", "1:30 PM", "2:00 PM", "2:30 PM", "3:00 PM"];
-
   React.useEffect(() => {
     let displayedCount = 0;
 
@@ -734,6 +730,163 @@ return (
           // Skip weekends
           if (dayIndex < 0 || dayIndex > 4) return null;
 
+          const holidayCheck = isHoliday(currentDate);
+          const dateStr = format(currentDate, 'yyyy-MM-dd');
+
+          // Aggregate the entire day's sessions into blocks once, then split by
+          // earliest start time so a group whose sessions straddle noon
+          // renders as a single block (not duplicated into both halves with
+          // partial metadata).
+          const daySessions: SessionWithCurriculum[] = [];
+          TIME_SLOTS.forEach((_, timeIndex) => {
+            const sessionsInSlot = sessionsByDayTime[`${dayIndex}-${timeIndex}`] || [];
+            daySessions.push(...sessionsInSlot);
+          });
+          const scheduledDaySessions = daySessions.filter(isScheduledSession);
+          const { groups, ungroupedSessions } = aggregateSessionsForDisplay(scheduledDaySessions);
+
+          const dayBlocks: SessionBlock[] = [];
+          groups.forEach((groupSessions, groupId) => {
+            const firstSession = groupSessions[0];
+            if (firstSession && firstSession.start_time && firstSession.end_time) {
+              const { earliestStart, latestEnd } = getGroupTimeRange(groupSessions);
+              dayBlocks.push({
+                type: 'group',
+                data: {
+                  groupId,
+                  groupName: firstSession.group_name || 'Unnamed Group',
+                  sessions: groupSessions,
+                  earliestStart,
+                  latestEnd
+                }
+              });
+            }
+          });
+          ungroupedSessions.forEach(session => {
+            dayBlocks.push({ type: 'session', data: { session } });
+          });
+          dayBlocks.sort((a, b) => {
+            const aTime = a.type === 'group' ? a.data.earliestStart : a.data.session.start_time;
+            const bTime = b.type === 'group' ? b.data.earliestStart : b.data.session.start_time;
+            return (aTime || '').localeCompare(bTime || '');
+          });
+
+          const NOON = '12:00:00';
+          const blockStart = (b: SessionBlock) =>
+            b.type === 'group' ? b.data.earliestStart : (b.data.session.start_time || '');
+          const morningBlocks = dayBlocks.filter(b => blockStart(b) < NOON);
+          const afternoonBlocks = dayBlocks.filter(b => blockStart(b) >= NOON);
+
+          const renderBlock = (block: SessionBlock, idx: number) => {
+            if (block.type === 'group') {
+              const { groupId, groupName, sessions: groupSessions, earliestStart, latestEnd } = block.data;
+              const studentInitials = getUniqueStudentInitials(groupSessions);
+              const groupCurriculumSession = groupSessions.find(s => s.curriculum_tracking && s.curriculum_tracking.length > 0);
+              const groupCurriculum = groupCurriculumSession ? getFirstCurriculum(groupCurriculumSession.curriculum_tracking) : null;
+              const groupIsActive = isGroupActive(groupSessions, currentDate);
+
+              return (
+                <button
+                  key={`group-${groupId}-${idx}`}
+                  type="button"
+                  onClick={() => handleOpenGroupModal(groupId, groupName, groupSessions)}
+                  className={cn(
+                    'w-full text-left border-2 rounded-lg p-2 text-xs transition-colors relative',
+                    groupIsActive
+                      ? 'border-red-500 ring-2 ring-red-200'
+                      : 'border-blue-300 hover:border-blue-400',
+                    getGroupColor(groupSessions)
+                  )}
+                  aria-label={`Open group ${groupName} details`}
+                >
+                  <div className="flex items-center justify-between mb-1">
+                    <div className="font-semibold text-blue-900">📚 {groupName}</div>
+                    <div className="flex items-center gap-1">
+                      {groupIndicators[`${groupId}|${dateStr}`]?.hasNotes && (
+                        <span title="Has notes"><FileText className="w-3 h-3 text-blue-600" /></span>
+                      )}
+                      {groupIndicators[`${groupId}|${dateStr}`]?.hasDocuments && (
+                        <span title="Has documents"><Paperclip className="w-3 h-3 text-blue-600" /></span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="font-medium text-gray-900">
+                    {formatTime(earliestStart)} - {formatTime(latestEnd)}
+                  </div>
+                  <div className="text-gray-700 mt-1">
+                    {studentInitials}
+                  </div>
+                  {groupCurriculum && (
+                    <span className="absolute bottom-0.5 right-0.5 px-1 py-0.5 text-[10px] font-medium rounded bg-indigo-100 text-indigo-700">
+                      {formatCurriculumBadge(groupCurriculum)}
+                    </span>
+                  )}
+                </button>
+              );
+            }
+
+            const session = block.data.session;
+            const studentData = {
+              id: session.student_id || '',
+              initials: session.student_id ? students[session.student_id]?.initials || '?' : '?',
+              grade_level: session.student_id ? students[session.student_id]?.grade_level || '' : '',
+              teacher_name: session.student_id ? students[session.student_id]?.teacher_name : undefined
+            };
+            const sessionCurriculum = getFirstCurriculum(session.curriculum_tracking);
+            const sessionIsActive = isSessionActive(session.start_time, session.end_time, currentDate);
+
+            return (
+              <button
+                key={`session-${session.id}`}
+                type="button"
+                onClick={() => handleOpenSessionModal(session, studentData)}
+                className={cn(
+                  'w-full text-left border-2 rounded-lg p-2 text-xs transition-colors relative',
+                  sessionIsActive
+                    ? 'border-red-500 ring-2 ring-red-200'
+                    : 'border-blue-300 hover:border-blue-400',
+                  getSessionColor(session)
+                )}
+                aria-label={`Open session for ${studentData.initials} at ${formatTime(session.start_time)}`}
+              >
+                <div className="flex items-center justify-between">
+                  <div className="font-medium text-gray-900">
+                    {formatTime(session.start_time)} - {formatTime(session.end_time)}
+                  </div>
+                  <div className="flex items-center gap-1">
+                    {sessionIndicators[`${session.id}|${session.session_date}`]?.hasNotes && (
+                      <span title="Has notes"><FileText className="w-3 h-3 text-blue-600" /></span>
+                    )}
+                    {sessionIndicators[`${session.id}|${session.session_date}`]?.hasDocuments && (
+                      <span title="Has documents"><Paperclip className="w-3 h-3 text-blue-600" /></span>
+                    )}
+                  </div>
+                </div>
+                <div className={session.delivered_by === 'sea' ? 'text-green-600 font-medium' : 'text-gray-700'}>
+                  {studentData.initials}
+                  {session.delivered_by === 'sea' && (
+                    <span className="ml-1 text-xs">(SEA)</span>
+                  )}
+                </div>
+                {sessionCurriculum && (
+                  <span className="absolute bottom-0.5 right-0.5 px-1 py-0.5 text-[10px] font-medium rounded bg-indigo-100 text-indigo-700">
+                    {formatCurriculumBadge(sessionCurriculum)}
+                  </span>
+                )}
+              </button>
+            );
+          };
+
+          const renderColumn = (blocks: SessionBlock[]) => {
+            if (holidayCheck.isHoliday) {
+              return <div className="text-center text-red-600 font-medium text-sm py-4">Holiday - {holidayCheck.name}</div>;
+            }
+            if (blocks.length === 0) {
+              return <div className="text-center text-gray-400 text-sm py-4">No sessions</div>;
+            }
+            return blocks.map(renderBlock);
+          };
+
           return (
             <div key={dayOffset} className={`border rounded-lg ${isToday ? 'border-blue-400' : 'border-gray-200'}`}>
               <div className="px-3 py-2 font-medium text-sm bg-gray-50 rounded-t-lg">
@@ -744,338 +897,13 @@ return (
                 {/* Morning */}
                 <div className="p-2 space-y-2">
                   <div className="text-xs font-medium text-gray-600 mb-2">Morning</div>
-                  {(() => {
-                    const holidayCheck = isHoliday(currentDate);
-                    if (holidayCheck.isHoliday) {
-                      return <div className="text-center text-red-600 font-medium text-sm py-4">Holiday - {holidayCheck.name}</div>;
-                    }
-
-                    // Get all morning sessions for this day
-                    const morningSessions: SessionWithCurriculum[] = [];
-                    MORNING_SLOTS.forEach((time) => {
-                      const timeIndex = TIME_SLOTS.findIndex(slot => slot === time);
-                      const sessionKey = `${dayIndex}-${timeIndex}`;
-                      const sessionsInSlot = sessionsByDayTime[sessionKey] || [];
-                      morningSessions.push(...sessionsInSlot);
-                    });
-
-                    // Filter to only scheduled sessions
-                    const scheduledMorningSessions = morningSessions.filter(isScheduledSession);
-
-                    if (scheduledMorningSessions.length === 0) {
-                      return <div className="text-center text-gray-400 text-sm py-4">No sessions</div>;
-                    }
-
-                    // Aggregate into groups and individual sessions
-                    const { groups, ungroupedSessions } = aggregateSessionsForDisplay(scheduledMorningSessions);
-                    const allBlocks: SessionBlock[] = [];
-
-                    // Add groups
-                    groups.forEach((groupSessions, groupId) => {
-                      const firstSession = groupSessions[0];
-                      if (firstSession && firstSession.start_time && firstSession.end_time) {
-                        const { earliestStart, latestEnd } = getGroupTimeRange(groupSessions);
-                        allBlocks.push({
-                          type: 'group',
-                          data: {
-                            groupId,
-                            groupName: firstSession.group_name || 'Unnamed Group',
-                            sessions: groupSessions,
-                            earliestStart,
-                            latestEnd
-                          }
-                        });
-                      }
-                    });
-
-                    // Add ungrouped sessions
-                    ungroupedSessions.forEach(session => {
-                      allBlocks.push({ type: 'session', data: { session } });
-                    });
-
-                    // Sort by start time
-                    allBlocks.sort((a, b) => {
-                      const aTime = a.type === 'group' ? a.data.earliestStart : a.data.session.start_time;
-                      const bTime = b.type === 'group' ? b.data.earliestStart : b.data.session.start_time;
-                      return (aTime || '').localeCompare(bTime || '');
-                    });
-
-                    return allBlocks.map((block, idx) => {
-                      if (block.type === 'group') {
-                        const { groupId, groupName, sessions: groupSessions, earliestStart, latestEnd } = block.data;
-                        const studentInitials = getUniqueStudentInitials(groupSessions);
-                        // Check if any session in the group has curriculum tracking
-                        const groupCurriculumSession = groupSessions.find(s => s.curriculum_tracking && s.curriculum_tracking.length > 0);
-                        const groupCurriculum = groupCurriculumSession ? getFirstCurriculum(groupCurriculumSession.curriculum_tracking) : null;
-                        // Check if group is currently active
-                        const groupIsActive = isGroupActive(groupSessions, currentDate);
-
-                        return (
-                          <button
-                            key={`group-${groupId}-${idx}`}
-                            type="button"
-                            onClick={() => handleOpenGroupModal(groupId, groupName, groupSessions)}
-                            className={cn(
-                              'w-full text-left border-2 rounded-lg p-2 text-xs transition-colors relative',
-                              groupIsActive
-                                ? 'border-red-500 ring-2 ring-red-200'
-                                : 'border-blue-300 hover:border-blue-400',
-                              getGroupColor(groupSessions)
-                            )}
-                            aria-label={`Open group ${groupName} details`}
-                          >
-                            <div className="flex items-center justify-between mb-1">
-                              <div className="font-semibold text-blue-900">📚 {groupName}</div>
-                              {/* Notes and documents indicators */}
-                              <div className="flex items-center gap-1">
-                                {groupIndicators[`${groupId}|${format(currentDate, 'yyyy-MM-dd')}`]?.hasNotes && (
-                                  <span title="Has notes"><FileText className="w-3 h-3 text-blue-600" /></span>
-                                )}
-                                {groupIndicators[`${groupId}|${format(currentDate, 'yyyy-MM-dd')}`]?.hasDocuments && (
-                                  <span title="Has documents"><Paperclip className="w-3 h-3 text-blue-600" /></span>
-                                )}
-                              </div>
-                            </div>
-                            <div className="font-medium text-gray-900">
-                              {formatTime(earliestStart)} - {formatTime(latestEnd)}
-                            </div>
-                            <div className="text-gray-700 mt-1">
-                              {studentInitials}
-                            </div>
-                            {/* Curriculum badge for group */}
-                            {groupCurriculum && (
-                              <span className="absolute bottom-0.5 right-0.5 px-1 py-0.5 text-[10px] font-medium rounded bg-indigo-100 text-indigo-700">
-                                {formatCurriculumBadge(groupCurriculum)}
-                              </span>
-                            )}
-                          </button>
-                        );
-                      } else {
-                        const session = block.data.session;
-                        const studentData = {
-                          id: session.student_id || '',
-                          initials: session.student_id ? students[session.student_id]?.initials || '?' : '?',
-                          grade_level: session.student_id ? students[session.student_id]?.grade_level || '' : '',
-                          teacher_name: session.student_id ? students[session.student_id]?.teacher_name : undefined
-                        };
-
-                        const sessionCurriculum = getFirstCurriculum(session.curriculum_tracking);
-                        // Check if session is currently active
-                        const sessionIsActive = isSessionActive(session.start_time, session.end_time, currentDate);
-
-                        return (
-                          <button
-                            key={`session-${session.id}`}
-                            type="button"
-                            onClick={() => handleOpenSessionModal(session, studentData)}
-                            className={cn(
-                              'w-full text-left border-2 rounded-lg p-2 text-xs transition-colors relative',
-                              sessionIsActive
-                                ? 'border-red-500 ring-2 ring-red-200'
-                                : 'border-blue-300 hover:border-blue-400',
-                              getSessionColor(session)
-                            )}
-                            aria-label={`Open session for ${studentData.initials} at ${formatTime(session.start_time)}`}
-                          >
-                            <div className="flex items-center justify-between">
-                              <div className="font-medium text-gray-900">
-                                {formatTime(session.start_time)} - {formatTime(session.end_time)}
-                              </div>
-                              {/* Notes and documents indicators */}
-                              <div className="flex items-center gap-1">
-                                {sessionIndicators[`${session.id}|${session.session_date}`]?.hasNotes && (
-                                  <span title="Has notes"><FileText className="w-3 h-3 text-blue-600" /></span>
-                                )}
-                                {sessionIndicators[`${session.id}|${session.session_date}`]?.hasDocuments && (
-                                  <span title="Has documents"><Paperclip className="w-3 h-3 text-blue-600" /></span>
-                                )}
-                              </div>
-                            </div>
-                            <div className={session.delivered_by === 'sea' ? 'text-green-600 font-medium' : 'text-gray-700'}>
-                              {studentData.initials}
-                              {session.delivered_by === 'sea' && (
-                                <span className="ml-1 text-xs">(SEA)</span>
-                              )}
-                            </div>
-                            {/* Curriculum badge */}
-                            {sessionCurriculum && (
-                              <span className="absolute bottom-0.5 right-0.5 px-1 py-0.5 text-[10px] font-medium rounded bg-indigo-100 text-indigo-700">
-                                {formatCurriculumBadge(sessionCurriculum)}
-                              </span>
-                            )}
-                          </button>
-                        );
-                      }
-                    });
-                  })()}
+                  {renderColumn(morningBlocks)}
                 </div>
 
                 {/* Afternoon */}
                 <div className="p-2 space-y-2">
                   <div className="text-xs font-medium text-gray-600 mb-2">Afternoon</div>
-                  {(() => {
-                    const holidayCheck = isHoliday(currentDate);
-                    if (holidayCheck.isHoliday) {
-                      return <div className="text-center text-red-600 font-medium text-sm py-4">Holiday - {holidayCheck.name}</div>;
-                    }
-
-                    // Get all afternoon sessions for this day
-                    const afternoonSessions: SessionWithCurriculum[] = [];
-                    AFTERNOON_SLOTS.forEach((time) => {
-                      const timeIndex = TIME_SLOTS.findIndex(slot => slot === time);
-                      const sessionKey = `${dayIndex}-${timeIndex}`;
-                      const sessionsInSlot = sessionsByDayTime[sessionKey] || [];
-                      afternoonSessions.push(...sessionsInSlot);
-                    });
-
-                    // Filter to only scheduled sessions
-                    const scheduledAfternoonSessions = afternoonSessions.filter(isScheduledSession);
-
-                    if (scheduledAfternoonSessions.length === 0) {
-                      return <div className="text-center text-gray-400 text-sm py-4">No sessions</div>;
-                    }
-
-                    // Aggregate into groups and individual sessions
-                    const { groups, ungroupedSessions } = aggregateSessionsForDisplay(scheduledAfternoonSessions);
-                    const allBlocks: SessionBlock[] = [];
-
-                    // Add groups
-                    groups.forEach((groupSessions, groupId) => {
-                      const firstSession = groupSessions[0];
-                      if (firstSession && firstSession.start_time && firstSession.end_time) {
-                        const { earliestStart, latestEnd } = getGroupTimeRange(groupSessions);
-                        allBlocks.push({
-                          type: 'group',
-                          data: {
-                            groupId,
-                            groupName: firstSession.group_name || 'Unnamed Group',
-                            sessions: groupSessions,
-                            earliestStart,
-                            latestEnd
-                          }
-                        });
-                      }
-                    });
-
-                    // Add ungrouped sessions
-                    ungroupedSessions.forEach(session => {
-                      allBlocks.push({ type: 'session', data: { session } });
-                    });
-
-                    // Sort by start time
-                    allBlocks.sort((a, b) => {
-                      const aTime = a.type === 'group' ? a.data.earliestStart : a.data.session.start_time;
-                      const bTime = b.type === 'group' ? b.data.earliestStart : b.data.session.start_time;
-                      return (aTime || '').localeCompare(bTime || '');
-                    });
-
-                    return allBlocks.map((block, idx) => {
-                      if (block.type === 'group') {
-                        const { groupId, groupName, sessions: groupSessions, earliestStart, latestEnd } = block.data;
-                        const studentInitials = getUniqueStudentInitials(groupSessions);
-                        // Check if any session in the group has curriculum tracking
-                        const groupCurriculumSession = groupSessions.find(s => s.curriculum_tracking && s.curriculum_tracking.length > 0);
-                        const groupCurriculum = groupCurriculumSession ? getFirstCurriculum(groupCurriculumSession.curriculum_tracking) : null;
-                        // Check if group is currently active
-                        const groupIsActive = isGroupActive(groupSessions, currentDate);
-
-                        return (
-                          <button
-                            key={`group-${groupId}-${idx}`}
-                            type="button"
-                            onClick={() => handleOpenGroupModal(groupId, groupName, groupSessions)}
-                            className={cn(
-                              'w-full text-left border-2 rounded-lg p-2 text-xs transition-colors relative',
-                              groupIsActive
-                                ? 'border-red-500 ring-2 ring-red-200'
-                                : 'border-blue-300 hover:border-blue-400',
-                              getGroupColor(groupSessions)
-                            )}
-                            aria-label={`Open group ${groupName} details`}
-                          >
-                            <div className="flex items-center justify-between mb-1">
-                              <div className="font-semibold text-blue-900">📚 {groupName}</div>
-                              {/* Notes and documents indicators */}
-                              <div className="flex items-center gap-1">
-                                {groupIndicators[`${groupId}|${format(currentDate, 'yyyy-MM-dd')}`]?.hasNotes && (
-                                  <span title="Has notes"><FileText className="w-3 h-3 text-blue-600" /></span>
-                                )}
-                                {groupIndicators[`${groupId}|${format(currentDate, 'yyyy-MM-dd')}`]?.hasDocuments && (
-                                  <span title="Has documents"><Paperclip className="w-3 h-3 text-blue-600" /></span>
-                                )}
-                              </div>
-                            </div>
-                            <div className="font-medium text-gray-900">
-                              {formatTime(earliestStart)} - {formatTime(latestEnd)}
-                            </div>
-                            <div className="text-gray-700 mt-1">
-                              {studentInitials}
-                            </div>
-                            {/* Curriculum badge for group */}
-                            {groupCurriculum && (
-                              <span className="absolute bottom-0.5 right-0.5 px-1 py-0.5 text-[10px] font-medium rounded bg-indigo-100 text-indigo-700">
-                                {formatCurriculumBadge(groupCurriculum)}
-                              </span>
-                            )}
-                          </button>
-                        );
-                      } else {
-                        const session = block.data.session;
-                        const studentData = {
-                          id: session.student_id || '',
-                          initials: session.student_id ? students[session.student_id]?.initials || '?' : '?',
-                          grade_level: session.student_id ? students[session.student_id]?.grade_level || '' : '',
-                          teacher_name: session.student_id ? students[session.student_id]?.teacher_name : undefined
-                        };
-                        const sessionCurriculum = getFirstCurriculum(session.curriculum_tracking);
-                        // Check if session is currently active
-                        const sessionIsActive = isSessionActive(session.start_time, session.end_time, currentDate);
-
-                        return (
-                          <button
-                            key={`session-${session.id}`}
-                            type="button"
-                            onClick={() => handleOpenSessionModal(session, studentData)}
-                            className={cn(
-                              'w-full text-left border-2 rounded-lg p-2 text-xs transition-colors relative',
-                              sessionIsActive
-                                ? 'border-red-500 ring-2 ring-red-200'
-                                : 'border-blue-300 hover:border-blue-400',
-                              getSessionColor(session)
-                            )}
-                            aria-label={`Open session for ${studentData.initials} at ${formatTime(session.start_time)}`}
-                          >
-                            <div className="flex items-center justify-between">
-                              <div className="font-medium text-gray-900">
-                                {formatTime(session.start_time)} - {formatTime(session.end_time)}
-                              </div>
-                              {/* Notes and documents indicators */}
-                              <div className="flex items-center gap-1">
-                                {sessionIndicators[`${session.id}|${session.session_date}`]?.hasNotes && (
-                                  <span title="Has notes"><FileText className="w-3 h-3 text-blue-600" /></span>
-                                )}
-                                {sessionIndicators[`${session.id}|${session.session_date}`]?.hasDocuments && (
-                                  <span title="Has documents"><Paperclip className="w-3 h-3 text-blue-600" /></span>
-                                )}
-                              </div>
-                            </div>
-                            <div className={session.delivered_by === 'sea' ? 'text-green-600 font-medium' : 'text-gray-700'}>
-                              {studentData.initials}
-                              {session.delivered_by === 'sea' && (
-                                <span className="ml-1 text-xs">(SEA)</span>
-                              )}
-                            </div>
-                            {/* Curriculum badge */}
-                            {sessionCurriculum && (
-                              <span className="absolute bottom-0.5 right-0.5 px-1 py-0.5 text-[10px] font-medium rounded bg-indigo-100 text-indigo-700">
-                                {formatCurriculumBadge(sessionCurriculum)}
-                              </span>
-                            )}
-                          </button>
-                        );
-                      }
-                    });
-                  })()}
+                  {renderColumn(afternoonBlocks)}
                 </div>
               </div>
             </div>

--- a/lib/services/session-generator.ts
+++ b/lib/services/session-generator.ts
@@ -332,6 +332,7 @@ export class SessionGenerator {
         session_notes: session.session_notes,
         group_id: session.group_id || null,
         group_name: session.group_name || null,
+        group_color: session.group_color ?? null,
         template_id: (session as ScheduleSession & { template_id?: string }).template_id || null,
         is_template: false
       } as ScheduleSessionInsert;

--- a/lib/services/session-instance-generator.ts
+++ b/lib/services/session-instance-generator.ts
@@ -198,6 +198,7 @@ export async function createInstancesFromTemplate(
       manually_placed: templateSession.manually_placed,
       group_id: templateSession.group_id,
       group_name: templateSession.group_name,
+      group_color: templateSession.group_color,
       status: templateSession.status,
       student_absent: false,
       outside_schedule_conflict: false,

--- a/supabase/migrations/20260520_fix_auto_ungroup_propagation.sql
+++ b/supabase/migrations/20260520_fix_auto_ungroup_propagation.sql
@@ -15,9 +15,13 @@
 -- trigger that propagates the ungrouping to matching instances and runs the
 -- same orphan-cleanup check that the ungroup API performs.
 
--- Update the BEFORE trigger to also clear group_color on the template row
+-- Update the BEFORE trigger to also clear group_color on the template row.
+-- search_path is pinned to satisfy the function_search_path_mutable advisor.
 CREATE OR REPLACE FUNCTION auto_ungroup_on_delivered_by_change()
-RETURNS TRIGGER AS $$
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
 BEGIN
   IF NEW.session_date IS NULL
      AND OLD.delivered_by IS DISTINCT FROM NEW.delivered_by
@@ -33,7 +37,7 @@ BEGIN
 
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 -- New AFTER trigger: propagate the ungroup to matching instances and clean up
 -- any single-session groups that result.
@@ -112,6 +116,12 @@ BEGIN
   RETURN NULL;
 END;
 $$;
+
+-- Lock down the SECURITY DEFINER function so it is not exposed via PostgREST.
+-- The trigger machinery does not require an explicit grant.
+REVOKE EXECUTE ON FUNCTION propagate_ungroup_after_delivered_by_change() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION propagate_ungroup_after_delivered_by_change() FROM anon;
+REVOKE EXECUTE ON FUNCTION propagate_ungroup_after_delivered_by_change() FROM authenticated;
 
 DROP TRIGGER IF EXISTS trigger_propagate_ungroup_after_delivered_by_change
   ON schedule_sessions;

--- a/supabase/migrations/20260520_fix_auto_ungroup_propagation.sql
+++ b/supabase/migrations/20260520_fix_auto_ungroup_propagation.sql
@@ -1,0 +1,125 @@
+-- Fix auto-ungroup behavior when a template's delivered_by changes
+--
+-- The original trigger (20251018_auto_ungroup_on_delivered_by_change.sql) only
+-- cleared group_id and group_name on the template row itself. Two problems:
+--
+-- 1. group_color was left set, leaving stale data on rows that no longer belong
+--    to a group.
+-- 2. Date-specific instances of the same template still carried the group, so
+--    Week view and Today's Schedule disagreed depending on the date.
+-- 3. Removing one template from a group could leave a single remaining template
+--    in that group, violating the "groups must have >=2 sessions" rule that the
+--    explicit ungroup API enforces.
+--
+-- Fix: extend the BEFORE trigger to also clear group_color, and add an AFTER
+-- trigger that propagates the ungrouping to matching instances and runs the
+-- same orphan-cleanup check that the ungroup API performs.
+
+-- Update the BEFORE trigger to also clear group_color on the template row
+CREATE OR REPLACE FUNCTION auto_ungroup_on_delivered_by_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.session_date IS NULL
+     AND OLD.delivered_by IS DISTINCT FROM NEW.delivered_by
+     AND OLD.group_id IS NOT NULL THEN
+
+    NEW.group_id := NULL;
+    NEW.group_name := NULL;
+    NEW.group_color := NULL;
+
+    RAISE NOTICE 'Auto-ungrouped template session % due to delivered_by change from % to %',
+      NEW.id, OLD.delivered_by, NEW.delivered_by;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- New AFTER trigger: propagate the ungroup to matching instances and clean up
+-- any single-session groups that result.
+--
+-- SECURITY DEFINER so the propagation works even when the affected instances
+-- or sibling templates were assigned to a different provider. This is a
+-- server-side data-integrity action, not a user-initiated write.
+CREATE OR REPLACE FUNCTION propagate_ungroup_after_delivered_by_change()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  remaining_count INTEGER;
+  last_template_id UUID;
+  last_provider_id UUID;
+  last_student_id UUID;
+  last_day_of_week INTEGER;
+  last_start_time TIME;
+BEGIN
+  -- Only act when the BEFORE trigger just ungrouped this template
+  IF OLD.session_date IS NULL
+     AND OLD.delivered_by IS DISTINCT FROM NEW.delivered_by
+     AND OLD.group_id IS NOT NULL
+     AND NEW.group_id IS NULL THEN
+
+    -- Propagate ungroup to matching date-specific instances
+    UPDATE schedule_sessions
+    SET group_id = NULL,
+        group_name = NULL,
+        group_color = NULL,
+        updated_at = NOW()
+    WHERE provider_id = OLD.provider_id
+      AND student_id = OLD.student_id
+      AND day_of_week = OLD.day_of_week
+      AND start_time = OLD.start_time
+      AND session_date IS NOT NULL;
+
+    -- If the old group now has only one remaining template, ungroup it too
+    -- (groups must have >=2 sessions, matching the ungroup API's behavior)
+    SELECT COUNT(*) INTO remaining_count
+    FROM schedule_sessions
+    WHERE group_id = OLD.group_id
+      AND session_date IS NULL;
+
+    IF remaining_count = 1 THEN
+      SELECT id, provider_id, student_id, day_of_week, start_time
+      INTO last_template_id, last_provider_id, last_student_id,
+           last_day_of_week, last_start_time
+      FROM schedule_sessions
+      WHERE group_id = OLD.group_id
+        AND session_date IS NULL
+      LIMIT 1;
+
+      UPDATE schedule_sessions
+      SET group_id = NULL,
+          group_name = NULL,
+          group_color = NULL,
+          updated_at = NOW()
+      WHERE id = last_template_id;
+
+      UPDATE schedule_sessions
+      SET group_id = NULL,
+          group_name = NULL,
+          group_color = NULL,
+          updated_at = NOW()
+      WHERE provider_id = last_provider_id
+        AND student_id = last_student_id
+        AND day_of_week = last_day_of_week
+        AND start_time = last_start_time
+        AND session_date IS NOT NULL;
+    END IF;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trigger_propagate_ungroup_after_delivered_by_change
+  ON schedule_sessions;
+
+CREATE TRIGGER trigger_propagate_ungroup_after_delivered_by_change
+  AFTER UPDATE OF delivered_by ON schedule_sessions
+  FOR EACH ROW
+  EXECUTE FUNCTION propagate_ungroup_after_delivered_by_change();
+
+COMMENT ON FUNCTION propagate_ungroup_after_delivered_by_change() IS
+  'Propagates template ungrouping (triggered by delivered_by change) to date-specific instances, and ungroups any single-session group orphans that result.';


### PR DESCRIPTION
## Summary

Fixes a cluster of bugs around session groups on the Plan page's Day tab and how those groups render in the Week view and the Dashboard's Today's Schedule.

### Database
- **`04cd5a7` — Propagate auto-ungroup to instances and orphan single-session groups.** When a template's `delivered_by` changed, the existing BEFORE trigger ungrouped the template row but left date-specific instances of that template still carrying the group, so Week view and Today's Schedule disagreed depending on the date. It also could leave a single remaining template in the old group, violating the >=2 rule the ungroup API enforces. New AFTER trigger propagates the ungroup to matching instances and runs the same orphan-cleanup check. BEFORE trigger now also clears `group_color`.
- **`50965aa` — Harden trigger functions per Supabase advisor.** Pins `search_path` on the BEFORE function and revokes EXECUTE on the new SECURITY DEFINER function from PUBLIC/anon/authenticated so it is not callable via `/rest/v1/rpc/`.

Both migrations have been applied to the remote Supabase project already.

### Application
- **`a46cead` — Preserve `group_color` when copying templates to instances.** Two paths (`saveSessionInstance` in session-generator, `createInstancesFromTemplate` in session-instance-generator) were copying `group_id` and `group_name` while dropping `group_color`, so persisted/generated instances lost the color the user picked on the Day tab.
- **`f501fcd` — Refresh propagation + Week-view dual-fetch race.** `CalendarDayView` now takes an `onUpdate` callback; Plan page wires it to `fetchData` so group/ungroup changes trigger a parent refetch. Stale selection IDs are cleared when the matching session is removed via the ✕ button. `CalendarWeekView`'s prop-sync effect (which raced its own SessionGenerator fetcher) is removed in favor of a single internal source of truth that re-runs when the prop changes signal a parent refresh.
- **`4c2dff5` — Aggregate dashboard Today's Schedule across morning/afternoon.** A group whose sessions straddled noon was being duplicated into both columns, each card showing only that half's time range and initials, and the modal handoff only carried the half clicked. Now compute the day's blocks once and place each in morning or afternoon by earliest start time. Also extracts the duplicated render JSX into one local `renderBlock` helper.
- **`7d22c1d` — Scope group/ungroup API instance lookups by `provider_id`.** The template→instance update queries matched on student/day/time only while the Day view's template lookup already filters by `provider_id`. Aligning them prevents touching instances owned by a different provider.

## Test plan

- [ ] On the Plan page Day tab, create a group of two sessions, then verify:
  - [ ] The chosen color appears on the Day tab for today and for future weeks.
  - [ ] The group renders as a single block (not duplicated) in Today's Schedule on the Dashboard, even if its sessions straddle noon.
  - [ ] Clicking the group block in Today's Schedule opens the modal with every session in the group.
- [ ] Ungroup one session of a 2-session group via the ✕ button:
  - [ ] The remaining session is auto-ungrouped (no orphan single-session group).
  - [ ] Switching to the Week tab on the Plan page reflects the ungrouped state immediately, not after a manual refresh.
  - [ ] The previously selected checkbox state is cleared.
- [ ] Change `delivered_by` on a grouped template (assign to a SEA/specialist) and verify:
  - [ ] The template ungroups.
  - [ ] Existing date-specific instances of that template also ungroup (Week view and Today's Schedule agree).
  - [ ] If only one template remains in the old group, it also ungroups.
- [ ] Verify cross-provider safety: a specialist with assigned sessions can still create/remove groups they're authorized for without touching another provider's data.

https://claude.ai/code/session_01JDyncJouXH8T4GTssTpPQC

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDyncJouXH8T4GTssTpPQC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed session grouping and ungrouping to prevent unintended conflicts between sessions from different providers
  * Improved auto-ungroup behavior when provider information changes

* **Improvements**
  * Calendar views now refresh automatically after grouping and ungrouping sessions
  * Group colors are properly preserved throughout session management operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->