### PR TITLE
Add withRoute API wrapper + pilot on 3 routes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -92,7 +92,8 @@
       "mcp__52287d5e-942b-4bb1-a760-a897e4851102__save_issue",
       "Bash(mkdir -p .claude/hooks)",
       "mcp__playwright__browser_resize",
-      "mcp__playwright__browser_navigate"
+      "mcp__playwright__browser_navigate",
+      "mcp__context7__query-docs"
     ],
     "deny": []
   },

--- a/app/api/lessons/[id]/route.ts
+++ b/app/api/lessons/[id]/route.ts
@@ -1,72 +1,38 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
+import { withRoute } from '@/lib/api/with-route';
 
 // DELETE: Remove saved lesson
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  let userId: string | undefined;
-  
-  try {
-    const supabase = await createClient();
-    
-    // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
-    }
-    
-    userId = user.id;
-    const { id: lessonId } = await params;
-    
-    // First verify the lesson belongs to the user
-    const { data: lesson, error: fetchError } = await supabase
-      .from('lessons')
-      .select('provider_id')
-      .eq('id', lessonId)
-      .single();
+export const DELETE = withRoute<{ id: string }>({}, async ({ userId, params }) => {
+  const supabase = await createClient();
+  const lessonId = params.id;
 
-    if (fetchError || !lesson) {
-      return NextResponse.json(
-        { error: 'Lesson not found' },
-        { status: 404 }
-      );
-    }
+  // Verify the lesson belongs to the user before deleting.
+  const { data: lesson, error: fetchError } = await supabase
+    .from('lessons')
+    .select('provider_id')
+    .eq('id', lessonId)
+    .single();
 
-    if (lesson.provider_id !== userId) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 403 }
-      );
-    }
-
-    // Delete the lesson
-    const { error: deleteError } = await supabase
-      .from('lessons')
-      .delete()
-      .eq('id', lessonId);
-
-    if (deleteError) {
-      log.error('Failed to delete lesson', deleteError, { userId, lessonId });
-      return NextResponse.json(
-        { error: 'Failed to delete lesson' },
-        { status: 500 }
-      );
-    }
-
-    log.info('Lesson deleted successfully', { userId, lessonId });
-
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    log.error('Error in DELETE /api/lessons/[id]', error, { userId });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+  if (fetchError || !lesson) {
+    return NextResponse.json({ error: 'Lesson not found' }, { status: 404 });
   }
-}
+
+  if (lesson.provider_id !== userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+  }
+
+  const { error: deleteError } = await supabase
+    .from('lessons')
+    .delete()
+    .eq('id', lessonId);
+
+  if (deleteError) {
+    log.error('Failed to delete lesson', deleteError, { userId, lessonId });
+    return NextResponse.json({ error: 'Failed to delete lesson' }, { status: 500 });
+  }
+
+  log.info('Lesson deleted successfully', { userId, lessonId });
+  return NextResponse.json({ success: true });
+});

--- a/app/api/lessons/generate/route.ts
+++ b/app/api/lessons/generate/route.ts
@@ -1,12 +1,12 @@
 // Unified API endpoint for JSON-first lesson generation
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { lessonGenerator } from '@/lib/lessons/generator';
 import {
   LessonRequest,
   StudentProfile,
   isValidTeacherRole
 } from '@/lib/lessons/schema';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 import { parseGradeLevel } from '@/lib/utils/grade-parser';
 import { createClient } from '@/lib/supabase/server';
 
@@ -30,8 +30,9 @@ const CAPTURE_FULL_PROMPTS = process.env.CAPTURE_FULL_PROMPTS === 'true';
 const CAPTURE_AI_RAW = process.env.CAPTURE_AI_RAW === 'true';
 const SHOULD_CAPTURE_METADATA = CAPTURE_FULL_PROMPTS || CAPTURE_AI_RAW;
 
-export async function POST(request: NextRequest) {
-  return withAuth(async (req: NextRequest, userId: string) => {
+export const POST = withRoute(
+  { rateLimit: { requests: 30, windowSeconds: 3600, name: 'lessons/generate' } },
+  async ({ req, userId }) => {
     try {
       // Create supabase client for database operations
       const supabase = await createClient();
@@ -361,8 +362,8 @@ export async function POST(request: NextRequest) {
         { status: 500 }
       );
     }
-  })(request);
-}
+  }
+);
 
 /**
  * Validates the incoming request

--- a/app/api/save-lesson/by-session/route.ts
+++ b/app/api/save-lesson/by-session/route.ts
@@ -1,69 +1,38 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
+
+const querySchema = z.object({
+  lesson_date: z.string().min(1),
+  time_slot: z.string().min(1),
+});
 
 // GET - Fetch a lesson by session parameters (provider_id, lesson_date, time_slot)
-export const GET = withAuth(async (request: NextRequest, userId: string) => {
-  try {
-    const supabase = await createClient();
+export const GET = withRoute({ query: querySchema }, async ({ userId, query }) => {
+  const supabase = await createClient();
+  const { lesson_date: lessonDate, time_slot: timeSlot } = query;
 
-    // Get query parameters
-    const searchParams = request.nextUrl.searchParams;
-    const lessonDate = searchParams.get('lesson_date');
-    const timeSlot = searchParams.get('time_slot');
+  log.info('Fetching lesson by session', { userId, lessonDate, timeSlot });
 
-    if (!lessonDate || !timeSlot) {
-      return NextResponse.json(
-        { error: 'lesson_date and time_slot are required' },
-        { status: 400 }
-      );
-    }
+  const { data: lesson, error } = await supabase
+    .from('lessons')
+    .select('*')
+    .eq('provider_id', userId)
+    .eq('lesson_date', lessonDate)
+    .eq('time_slot', timeSlot)
+    .maybeSingle();
 
-    log.info('Fetching lesson by session', {
-      userId,
-      lessonDate,
-      timeSlot
-    });
-
-    // Fetch lesson by provider_id, lesson_date, and time_slot
-    const { data: lesson, error } = await supabase
-      .from('lessons')
-      .select('*')
-      .eq('provider_id', userId)
-      .eq('lesson_date', lessonDate)
-      .eq('time_slot', timeSlot)
-      .maybeSingle();
-
-    if (error) {
-      log.error('Error fetching lesson by session', error, {
-        userId,
-        lessonDate,
-        timeSlot
-      });
-      return NextResponse.json(
-        { error: 'Failed to fetch lesson' },
-        { status: 500 }
-      );
-    }
-
-    if (!lesson) {
-      return NextResponse.json({ lesson: null }, { status: 200 });
-    }
-
-    log.info('Lesson fetched successfully', {
-      userId,
-      lessonId: lesson.id,
-      lessonDate,
-      timeSlot
-    });
-
-    return NextResponse.json({ lesson });
-  } catch (error) {
-    log.error('Error in get-lesson-by-session route', error, { userId });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+  if (error) {
+    log.error('Error fetching lesson by session', error, { userId, lessonDate, timeSlot });
+    return NextResponse.json({ error: 'Failed to fetch lesson' }, { status: 500 });
   }
+
+  if (!lesson) {
+    return NextResponse.json({ lesson: null }, { status: 200 });
+  }
+
+  log.info('Lesson fetched successfully', { userId, lessonId: lesson.id, lessonDate, timeSlot });
+  return NextResponse.json({ lesson });
 });

--- a/lib/api/rate-limit-user.ts
+++ b/lib/api/rate-limit-user.ts
@@ -37,7 +37,8 @@ export async function checkUserRateLimit(
     const supabase = createServiceClient();
     const windowStart = new Date(Date.now() - rule.windowSeconds * 1000).toISOString();
 
-    // Drop this key's expired rows so the table stays bounded.
+    // Prune this key's expired rows (keeps active keys bounded; abandoned keys
+    // are purged by a separate scheduled job).
     await supabase
       .from('api_rate_limits')
       .delete()
@@ -62,7 +63,13 @@ export async function checkUserRateLimit(
       return { allowed: false, remaining: 0, resetSeconds: rule.windowSeconds };
     }
 
-    await supabase.from('api_rate_limits').insert({ user_id: userId, endpoint });
+    const { error: insertError } = await supabase
+      .from('api_rate_limits')
+      .insert({ user_id: userId, endpoint });
+    if (insertError) {
+      log.error('Rate limit insert failed; allowing request', insertError, { userId, endpoint });
+      return allow();
+    }
     return allow(rule.requests - used - 1);
   } catch (err) {
     log.error('Rate limit check threw; allowing request', err, { userId, endpoint });

--- a/lib/api/rate-limit-user.ts
+++ b/lib/api/rate-limit-user.ts
@@ -1,0 +1,71 @@
+import { createServiceClient } from '@/lib/supabase/server';
+import { log } from '@/lib/monitoring/logger';
+
+export interface RateLimitRule {
+  /** Max requests allowed within the window. */
+  requests: number;
+  /** Window length in seconds. */
+  windowSeconds: number;
+}
+
+export interface RateLimitOutcome {
+  allowed: boolean;
+  remaining: number;
+  /** Seconds until the window resets (used for the Retry-After header). */
+  resetSeconds: number;
+}
+
+/**
+ * Per-user, DB-backed rate limiter for authenticated endpoints.
+ *
+ * Uses the service-role client so the counter table is invisible to the user's
+ * own client and cannot be tampered with. Fails open: if the check errors, the
+ * request is allowed rather than blocking legitimate traffic.
+ */
+export async function checkUserRateLimit(
+  userId: string,
+  endpoint: string,
+  rule: RateLimitRule
+): Promise<RateLimitOutcome> {
+  const allow = (remaining = rule.requests): RateLimitOutcome => ({
+    allowed: true,
+    remaining,
+    resetSeconds: rule.windowSeconds,
+  });
+
+  try {
+    const supabase = createServiceClient();
+    const windowStart = new Date(Date.now() - rule.windowSeconds * 1000).toISOString();
+
+    // Drop this key's expired rows so the table stays bounded.
+    await supabase
+      .from('api_rate_limits')
+      .delete()
+      .eq('user_id', userId)
+      .eq('endpoint', endpoint)
+      .lt('created_at', windowStart);
+
+    const { count, error } = await supabase
+      .from('api_rate_limits')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .eq('endpoint', endpoint)
+      .gte('created_at', windowStart);
+
+    if (error) {
+      log.error('Rate limit check failed; allowing request', error, { userId, endpoint });
+      return allow();
+    }
+
+    const used = count ?? 0;
+    if (used >= rule.requests) {
+      return { allowed: false, remaining: 0, resetSeconds: rule.windowSeconds };
+    }
+
+    await supabase.from('api_rate_limits').insert({ user_id: userId, endpoint });
+    return allow(rule.requests - used - 1);
+  } catch (err) {
+    log.error('Rate limit check threw; allowing request', err, { userId, endpoint });
+    return allow();
+  }
+}

--- a/lib/api/with-route.ts
+++ b/lib/api/with-route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type { ZodType } from 'zod';
+import { createClient } from '@/lib/supabase/server';
+import { log } from '@/lib/monitoring/logger';
+import { checkUserRateLimit, type RateLimitRule } from './rate-limit-user';
+
+interface WithRouteConfig<TBody, TQuery> {
+  /** Require an authenticated user (default true). When false, `userId` is ''. */
+  auth?: boolean;
+  /** Zod schema for the JSON request body. */
+  body?: ZodType<TBody>;
+  /** Zod schema for the URL search params (validated as a flat string record). */
+  query?: ZodType<TQuery>;
+  /** Per-user rate limit. Applied only on authenticated routes. */
+  rateLimit?: RateLimitRule & { name?: string };
+}
+
+interface RouteHandlerArgs<TBody, TQuery, TParams> {
+  req: NextRequest;
+  /** Authenticated user id, or '' on `auth: false` routes. */
+  userId: string;
+  body: TBody;
+  query: TQuery;
+  params: TParams;
+}
+
+type Handler<TBody, TQuery, TParams> = (
+  args: RouteHandlerArgs<TBody, TQuery, TParams>
+) => Promise<NextResponse>;
+
+// Next.js 15 passes dynamic segment params as a Promise in the second argument.
+type NextContext<TParams> = { params: Promise<TParams> };
+
+const validationError = (details: unknown) =>
+  NextResponse.json({ error: 'Validation failed', details }, { status: 400 });
+
+/**
+ * Composable route wrapper: auth, Zod body/query validation, per-user rate
+ * limiting, dynamic params, and a consistent `{ error }` response on failure.
+ * All concerns are opt-in via the config; the handler receives validated,
+ * typed inputs.
+ */
+export function withRoute<
+  TParams extends Record<string, string> = Record<string, string>,
+  TBody = undefined,
+  TQuery = undefined,
+>(
+  config: WithRouteConfig<TBody, TQuery>,
+  handler: Handler<TBody, TQuery, TParams>
+) {
+  return async (req: NextRequest, context?: NextContext<TParams>): Promise<NextResponse> => {
+    try {
+      let userId = '';
+      if (config.auth !== false) {
+        const supabase = await createClient();
+        const { data: { user }, error } = await supabase.auth.getUser();
+        if (error || !user) {
+          return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+        }
+        userId = user.id;
+      }
+
+      const params = (context ? await context.params : {}) as TParams;
+
+      let body = undefined as TBody;
+      if (config.body) {
+        let raw: unknown;
+        try {
+          raw = await req.json();
+        } catch {
+          return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+        }
+        const parsed = config.body.safeParse(raw);
+        if (!parsed.success) return validationError(parsed.error.flatten());
+        body = parsed.data;
+      }
+
+      let query = undefined as TQuery;
+      if (config.query) {
+        const raw = Object.fromEntries(req.nextUrl.searchParams.entries());
+        const parsed = config.query.safeParse(raw);
+        if (!parsed.success) return validationError(parsed.error.flatten());
+        query = parsed.data;
+      }
+
+      if (config.rateLimit && userId) {
+        const endpoint = config.rateLimit.name ?? req.nextUrl.pathname;
+        const outcome = await checkUserRateLimit(userId, endpoint, config.rateLimit);
+        if (!outcome.allowed) {
+          return NextResponse.json(
+            { error: 'Too many requests. Please try again later.' },
+            { status: 429, headers: { 'Retry-After': String(outcome.resetSeconds) } }
+          );
+        }
+      }
+
+      return await handler({ req, userId, body, query, params });
+    } catch (error) {
+      log.error('API route error', error, { url: req.url, method: req.method });
+      const message =
+        process.env.NODE_ENV === 'development' ? (error as Error).message : 'Internal server error';
+      return NextResponse.json({ error: message }, { status: 500 });
+    }
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "react-dom": "^19.0.0",
         "recharts": "^3.1.0",
         "resend": "^4.6.0",
-        "tailwind-merge": "^3.3.1"
+        "tailwind-merge": "^3.3.1",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "react-dom": "^19.0.0",
     "recharts": "^3.1.0",
     "resend": "^4.6.0",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/supabase/migrations/20260521_create_api_rate_limits.sql
+++ b/supabase/migrations/20260521_create_api_rate_limits.sql
@@ -1,0 +1,16 @@
+-- Generic per-user API rate limiting (e.g. AI generation endpoints).
+-- Written/read only by the service-role client (createServiceClient), so users
+-- cannot read or tamper with their own counters via the anon key.
+CREATE TABLE public.api_rate_limits (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL,
+  endpoint text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX api_rate_limits_lookup_idx
+  ON public.api_rate_limits (user_id, endpoint, created_at DESC);
+
+-- RLS on with no policies: the anon/user client gets zero access; only the
+-- service-role key (which bypasses RLS) can read/write.
+ALTER TABLE public.api_rate_limits ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
First step of the API request-handling standardization (#3 from the refactor review). Introduces a composable route wrapper and pilots it on three representative routes; the remaining ~70 routes migrate in follow-up batches.

**Why:** of 74 API routes, ~36 hand-roll `auth.getUser`, **zero** validate input, the two error helpers are each used by 1 route, and only 2 routes are rate-limited (and that limiter is worksheet-upload-specific).

## What's here
- **`lib/api/with-route.ts`** — opt-in `auth` (default on), Zod `body`/`query` validation, per-user `rateLimit`, dynamic `[id]` params, and a consistent **flat `{ error }`** response (kept flat deliberately — the frontend reads `data.error` as a string, so the nested envelope would have been a breaking change).
- **`lib/api/rate-limit-user.ts`** — per-user, DB-backed limiter using the **service-role** client (counters are invisible/untamperable to the user's own client) and **fails open** so a limiter hiccup never blocks legitimate traffic.
- **`api_rate_limits` table** — RLS enabled with **no policies**, so only the service role can touch it. Added both as a Supabase migration (already applied to prod) and `supabase/migrations/20260521_create_api_rate_limits.sql`.
- **`zod`** promoted to a direct dependency (was already resolved transitively at 3.25.76).

## Pilot migrations
| Route | What it proves |
|---|---|
| `lessons/[id]` DELETE | auth + dynamic params (drops the hand-rolled auth/try-catch boilerplate) |
| `save-lesson/by-session` GET | auth + Zod **query** validation |
| `lessons/generate` POST | auth + **rate limit** (30/hour/user) — surgical wrapper swap, generation logic unchanged |

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` on changed files — 0 errors
- A local `next build` was started to validate Next's route-type checking; relying on the Vercel CI build here too.

## Test plan
- [ ] CI / Vercel build green (validates route-handler types)
- [ ] `lessons/generate` still generates (auth + rate-limit path); 31st call within an hour returns 429
- [ ] `save-lesson/by-session` returns 400 when `lesson_date`/`time_slot` missing (now via Zod), 200 otherwise
- [ ] `lessons/[id]` DELETE still enforces ownership (404/403/200)

## Follow-up (not in this PR)
Batch-migrate the remaining routes to `withRoute`, add `body` schemas to POST/PUT routes, fold the 22 `withAuth` routes in, and add rate-limiting to the other AI endpoints (`exit-tickets/generate`, `progress-check/generate`).

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user rate limiting added to lesson generation and other API endpoints.

* **Refactor**
  * Unified API route wrapper for consistent auth, validation, rate limiting, and error responses.
  * JSON body and query-string schemas now enforced for relevant endpoints.

* **Database**
  * New database table for recording per-user rate-limit usage (migration added).

* **Dependencies**
  * Validation library added to support schema enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->