### PR TITLE
Migrate lessons-area API routes to withRoute (+ Zod validation)

### DIFF
--- a/app/api/lessons/[id]/render/route.ts
+++ b/app/api/lessons/[id]/render/route.ts
@@ -1,35 +1,38 @@
 // API endpoint to render lesson worksheets
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { worksheetRenderer } from '@/lib/lessons/renderer';
 import { LessonResponse, isValidLessonResponse } from '@/lib/lessons/schema';
+import { withRoute } from '@/lib/api/with-route';
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  const searchParams = request.nextUrl.searchParams;
-  const renderType = searchParams.get('type') || 'plan'; // plan, worksheet, answer
-  
-  try {
-    const supabase = await createClient();
+const querySchema = z.object({
+  type: z.string().optional(),
+  studentId: z.string().optional(),
+});
+
+// Public (no auth) by design — access is gated by RLS on the lessons table.
+// TODO: revisit whether this should require auth + an explicit ownership check.
+export const GET = withRoute<{ id: string }, undefined, z.infer<typeof querySchema>>(
+  { auth: false, query: querySchema },
+  async ({ query, params }) => {
     const lessonId = params.id;
-    const studentId = searchParams.get('studentId');
-    
+    const renderType = query.type || 'plan'; // plan, worksheet, answer
+    const studentId = query.studentId ?? null;
+
+    const supabase = await createClient();
+
     // Fetch lesson from database
     const { data: lessonData, error } = await supabase
       .from('lessons')
       .select('*')
       .eq('id', lessonId)
       .single();
-    
+
     if (error || !lessonData) {
-      return NextResponse.json(
-        { error: 'Lesson not found' },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: 'Lesson not found' }, { status: 404 });
     }
-    
+
     // Validate and extract lesson content
     let lesson: LessonResponse | null = null;
     if (lessonData?.content) {
@@ -42,17 +45,14 @@ export async function GET(
         // ignore parse failure
       }
     }
-    
+
     if (!lesson || !isValidLessonResponse(lesson)) {
-      return NextResponse.json(
-        { error: 'Invalid or missing lesson content' },
-        { status: 422 }
-      );
+      return NextResponse.json({ error: 'Invalid or missing lesson content' }, { status: 422 });
     }
-    
+
     // Render based on type
     let html: string;
-    
+
     switch (renderType) {
       case 'worksheet': {
         if (!studentId) {
@@ -61,31 +61,31 @@ export async function GET(
             { status: 400 }
           );
         }
-        
+
         // Find the student's material
         const studentMaterial = lesson.studentMaterials.find(
           m => m.studentId === studentId
         );
-        
+
         if (!studentMaterial) {
           return NextResponse.json(
             { error: 'No worksheet found for this student' },
             { status: 404 }
           );
         }
-        
+
         // Get student name and grade from database
         const { data: student } = await supabase
           .from('students')
           .select('first_name, last_name, initials, grade_level')
           .eq('id', studentId)
           .single();
-        
+
         const studentName =
           student?.first_name || student?.last_name
             ? `${student.first_name ?? ''} ${student.last_name ?? ''}`.trim()
             : (student?.initials ?? 'Student');
-        
+
         // Add grade level to the student material for proper display
         if (student?.grade_level && studentMaterial) {
           // Parse grade level (handle "K" for kindergarten as 0)
@@ -102,7 +102,7 @@ export async function GET(
             studentMaterial.worksheet.grade = gradeNum;
           }
         }
-        
+
         // Generate QR code for worksheet (using existing system)
         let qrCodeUrl: string | undefined;
         try {
@@ -113,14 +113,14 @@ export async function GET(
             .eq('lesson_id', lessonId)
             .eq('student_id', studentId)
             .single();
-          
+
           if (worksheetRecord?.qr_code) {
             qrCodeUrl = worksheetRecord.qr_code;
           }
         } catch (qrError) {
           console.log('QR code not available for this worksheet');
         }
-        
+
         html = worksheetRenderer.renderStudentWorksheet(
           studentMaterial,
           studentName,
@@ -128,19 +128,19 @@ export async function GET(
         );
         break;
       }
-      
+
       case 'answer': {
         html = worksheetRenderer.renderAnswerKey(lesson);
         break;
       }
-      
+
       case 'plan':
       default: {
         html = worksheetRenderer.renderLessonPlan(lesson);
         break;
       }
     }
-    
+
     // Return HTML response with security headers to prevent caching of PII
     return new NextResponse(html, {
       headers: {
@@ -151,27 +151,5 @@ export async function GET(
         'Referrer-Policy': 'no-referrer',
       },
     });
-    
-  } catch (error) {
-    // Log error with context but don't expose details to client
-    console.error('[Render API] Error rendering lesson:', {
-      lessonId: params.id,
-      renderType: renderType,
-      error: error instanceof Error ? error.message : 'Unknown error'
-    });
-    
-    // Return generic error message to client
-    return NextResponse.json(
-      { 
-        error: 'Failed to render lesson', 
-        message: 'An error occurred while rendering the lesson. Please try again.'
-      },
-      { 
-        status: 500,
-        headers: {
-          'Cache-Control': 'no-store'
-        }
-      }
-    );
   }
-}
+);

--- a/app/api/lessons/route.ts
+++ b/app/api/lessons/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 import { log } from '@/lib/monitoring/logger';
 
 // GET: Fetch user's saved lessons
-export const GET = withAuth(async (request: NextRequest, userId: string) => {
+export const GET = withRoute({}, async ({ userId }) => {
   try {
     const supabase = await createClient();
     
@@ -54,21 +55,21 @@ export const GET = withAuth(async (request: NextRequest, userId: string) => {
   }
 });
 
+const saveLessonSchema = z
+  .object({
+    title: z.string().min(1),
+    subject: z.string().min(1),
+    grade: z.string().min(1),
+    content: z.any().refine(v => v !== undefined && v !== null && v !== '', 'content is required'),
+    time_duration: z.string().optional(),
+  })
+  .passthrough();
+
 // POST: Save new lesson (for manual lesson creation)
-export const POST = withAuth(async (request: NextRequest, userId: string) => {
+export const POST = withRoute({ body: saveLessonSchema }, async ({ userId, body }) => {
   try {
     const supabase = await createClient();
-    const body = await request.json();
-    
     const { title, subject, grade, time_duration, content } = body;
-    
-    // Validate required fields
-    if (!title || !subject || !grade || !content) {
-      return NextResponse.json(
-        { error: 'Missing required fields' },
-        { status: 400 }
-      );
-    }
 
     // Parse duration from string format (e.g., "15 minutes" -> 15)
     const durationMatch = time_duration?.match(/(\d+)/);

--- a/app/api/lessons/route.ts
+++ b/app/api/lessons/route.ts
@@ -76,8 +76,15 @@ export const POST = withRoute({ body: saveLessonSchema }, async ({ userId, body 
     const duration = durationMatch ? parseInt(durationMatch[1]) : null;
 
     // Create content structure
-    const lessonContent = typeof content === 'string' ? JSON.parse(content) : content;
-    
+    let lessonContent = content;
+    if (typeof content === 'string') {
+      try {
+        lessonContent = JSON.parse(content);
+      } catch {
+        return NextResponse.json({ error: 'content must be valid JSON' }, { status: 400 });
+      }
+    }
+
     const { data: lesson, error } = await supabase
       .from('lessons')
       .insert({

--- a/app/api/manual-lessons/[id]/route.ts
+++ b/app/api/manual-lessons/[id]/route.ts
@@ -1,18 +1,13 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
 import { track } from '@/lib/monitoring/analytics';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 
 // PUT - Update existing lesson
-export async function PUT(
-  request: NextRequest,
-  context: { params: Promise<{ id: string }> }
-) {
-  return withAuth(async (req: NextRequest, userId: string) => {
+export const PUT = withRoute<{ id: string }>({}, async ({ req, userId, params }) => {
     const perf = measurePerformanceWithAlerts('update_manual_lesson', 'api');
-    const params = await context.params;
     const lessonId = params.id;
   
     
@@ -187,17 +182,11 @@ export async function PUT(
       { status: 500 }
     );
   }
-  })(request);
-}
+  });
 
 // DELETE - Delete lesson
-export async function DELETE(
-  request: NextRequest,
-  context: { params: Promise<{ id: string }> }
-) {
-  return withAuth(async (req: NextRequest, userId: string) => {
+export const DELETE = withRoute<{ id: string }>({}, async ({ userId, params }) => {
     const perf = measurePerformanceWithAlerts('delete_manual_lesson', 'api');
-    const params = await context.params;
     const lessonId = params.id;
   
     try {
@@ -317,5 +306,4 @@ export async function DELETE(
       { status: 500 }
     );
   }
-  })(request);
-}
+  });

--- a/app/api/manual-lessons/route.ts
+++ b/app/api/manual-lessons/route.ts
@@ -1,36 +1,36 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
 import { track } from '@/lib/monitoring/analytics';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
+
+const createManualLessonSchema = z
+  .object({
+    title: z.string().refine(s => s.trim().length > 0, 'Title is required'),
+    lesson_date: z.string().min(1),
+    subject: z.any().optional(),
+    grade_levels: z.any().optional(),
+    duration_minutes: z.any().optional(),
+    objectives: z.any().optional(),
+    materials: z.any().optional(),
+    activities: z.any().optional(),
+    assessment: z.any().optional(),
+    notes: z.any().optional(),
+    school_id: z.any().optional(),
+    district_id: z.any().optional(),
+    state_id: z.any().optional(),
+  })
+  .passthrough();
 
 // POST - Create new manual lesson
-export const POST = withAuth(async (request: NextRequest, userId: string) => {
+export const POST = withRoute({ body: createManualLessonSchema }, async ({ userId, body: lessonData }) => {
   const perf = measurePerformanceWithAlerts('create_manual_lesson', 'api');
-  
+
   try {
     const supabase = await createClient();
 
-    const lessonData = await request.json();
-    
-    // Validate required fields
-    if (!lessonData.title?.trim()) {
-      perf.end({ success: false, error: 'validation' });
-      return NextResponse.json(
-        { error: 'Title is required' },
-        { status: 400 }
-      );
-    }
-
-    if (!lessonData.lesson_date) {
-      perf.end({ success: false, error: 'validation' });
-      return NextResponse.json(
-        { error: 'Lesson date is required' },
-        { status: 400 }
-      );
-    }
-    
     log.info('Creating manual lesson', {
       userId,
       title: lessonData.title,
@@ -141,26 +141,19 @@ export const POST = withAuth(async (request: NextRequest, userId: string) => {
   }
 });
 
+const fetchManualLessonsQuerySchema = z.object({
+  start_date: z.string().min(1),
+  end_date: z.string().min(1),
+});
+
 // GET - Fetch lessons for date range
-export const GET = withAuth(async (request: NextRequest, userId: string) => {
+export const GET = withRoute({ query: fetchManualLessonsQuerySchema }, async ({ userId, query }) => {
   const perf = measurePerformanceWithAlerts('fetch_manual_lessons', 'api');
-  
+
   try {
     const supabase = await createClient();
-    const { searchParams } = new URL(request.url);
-    
-    const startDate = searchParams.get('start_date');
-    const endDate = searchParams.get('end_date');
-    
-    // Validate date parameters
-    if (!startDate || !endDate) {
-      perf.end({ success: false, error: 'validation' });
-      return NextResponse.json(
-        { error: 'start_date and end_date are required' },
-        { status: 400 }
-      );
-    }
-    
+    const { start_date: startDate, end_date: endDate } = query;
+
     log.info('Fetching manual lessons', {
       userId,
       startDate,

--- a/app/api/manual-lessons/route.ts
+++ b/app/api/manual-lessons/route.ts
@@ -11,7 +11,7 @@ const createManualLessonSchema = z
     title: z.string().refine(s => s.trim().length > 0, 'Title is required'),
     lesson_date: z.string().min(1),
     subject: z.any().optional(),
-    grade_levels: z.any().optional(),
+    grade_levels: z.union([z.string(), z.array(z.any())]).nullish(),
     duration_minutes: z.any().optional(),
     objectives: z.any().optional(),
     materials: z.any().optional(),

--- a/app/api/save-lesson/[id]/route.ts
+++ b/app/api/save-lesson/[id]/route.ts
@@ -1,38 +1,21 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { withRoute } from '@/lib/api/with-route';
 
-export async function DELETE(
-  request: NextRequest,
-  props: { params: Promise<{ id: string }> }
-) {
-  const params = await props.params;
-  try {
-    const supabase = await createClient();
+export const DELETE = withRoute<{ id: string }>({}, async ({ userId, params }) => {
+  const supabase = await createClient();
 
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+  // RLS plus the provider_id filter ensure a user can only delete their own lesson.
+  const { error } = await supabase
+    .from('lessons')
+    .delete()
+    .eq('id', params.id)
+    .eq('provider_id', userId);
 
-    // Delete the lesson - RLS will ensure user can only delete their own lessons
-    const { error } = await supabase
-      .from('lessons')
-      .delete()
-      .eq('id', params.id)
-      .eq('provider_id', user.id); // Extra safety check
-
-    if (error) {
-      console.error('Error deleting lesson:', error);
-      return NextResponse.json({ error: 'Failed to delete lesson' }, { status: 500 });
-    }
-
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    console.error('Error in delete-lesson route:', error);
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+  if (error) {
+    console.error('Error deleting lesson:', error);
+    return NextResponse.json({ error: 'Failed to delete lesson' }, { status: 500 });
   }
-}
+
+  return NextResponse.json({ success: true });
+});

--- a/app/api/save-lesson/route.ts
+++ b/app/api/save-lesson/route.ts
@@ -20,9 +20,9 @@ const saveLessonSchema = z
     timeSlot: z.string(),
     students: z.array(studentSchema),
     content: z.any().optional(),
-    lessonDate: z.string().optional(),
-    schoolSite: z.string().optional(),
-    notes: z.string().optional(),
+    lessonDate: z.string().nullish(),
+    schoolSite: z.string().nullish(),
+    notes: z.string().nullish(),
   })
   .passthrough();
 
@@ -225,7 +225,7 @@ export const POST = withRoute({ body: saveLessonSchema }, async ({ userId, body 
 });
 
 const getLessonsQuerySchema = z.object({
-  limit: z.coerce.number().int().min(1).default(10),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
   offset: z.coerce.number().int().min(0).default(0),
 });
 

--- a/app/api/save-lesson/route.ts
+++ b/app/api/save-lesson/route.ts
@@ -1,24 +1,38 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
 import { track } from '@/lib/monitoring/analytics';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 
-export const POST = withAuth(async (request: NextRequest, userId: string) => {
+const studentSchema = z
+  .object({
+    id: z.string(),
+    initials: z.string().optional(),
+    grade_level: z.string().optional(),
+    teacher_name: z.string().optional(),
+  })
+  .passthrough();
+
+const saveLessonSchema = z
+  .object({
+    timeSlot: z.string(),
+    students: z.array(studentSchema),
+    content: z.any().optional(),
+    lessonDate: z.string().optional(),
+    schoolSite: z.string().optional(),
+    notes: z.string().optional(),
+  })
+  .passthrough();
+
+export const POST = withRoute({ body: saveLessonSchema }, async ({ userId, body }) => {
   const perf = measurePerformanceWithAlerts('save_lesson', 'api');
-  
+
   try {
     const supabase = await createClient();
 
-    const { 
-      timeSlot, 
-      students, 
-      content, 
-      lessonDate,
-      schoolSite,
-      notes 
-    } = await request.json();
+    const { timeSlot, students, content, lessonDate, schoolSite, notes } = body;
     
     log.info('Saving lesson', {
       userId,
@@ -210,16 +224,18 @@ export const POST = withAuth(async (request: NextRequest, userId: string) => {
   }
 });
 
-export const GET = withAuth(async (request: NextRequest, userId: string) => {
+const getLessonsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).default(10),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export const GET = withRoute({ query: getLessonsQuerySchema }, async ({ userId, query }) => {
   const perf = measurePerformanceWithAlerts('get_lessons', 'api');
-  
+
   try {
     const supabase = await createClient();
 
-    // Get query parameters
-    const searchParams = request.nextUrl.searchParams;
-    const limit = parseInt(searchParams.get('limit') || '10');
-    const offset = parseInt(searchParams.get('offset') || '0');
+    const { limit, offset } = query;
     
     log.info('Fetching lessons', {
       userId,

--- a/lib/api/with-route.ts
+++ b/lib/api/with-route.ts
@@ -8,9 +8,9 @@ interface WithRouteConfig<TBody, TQuery> {
   /** Require an authenticated user (default true). When false, `userId` is ''. */
   auth?: boolean;
   /** Zod schema for the JSON request body. */
-  body?: ZodType<TBody>;
+  body?: ZodType<TBody, any, any>;
   /** Zod schema for the URL search params (validated as a flat string record). */
-  query?: ZodType<TQuery>;
+  query?: ZodType<TQuery, any, any>;
   /** Per-user rate limit. Applied only on authenticated routes. */
   rateLimit?: RateLimitRule & { name?: string };
 }


### PR DESCRIPTION
## Summary
Second `#3` batch (after the #612 pilot): migrates the **lessons area** off per-route auth boilerplate onto the `withRoute` wrapper, adding Zod validation for bodies and query params. 6 files, ~10 handlers.

| Route | Handlers migrated | Validation added |
|---|---|---|
| `lessons/route.ts` | GET, POST | POST body schema |
| `lessons/[id]/render` | GET | query schema (`type`, `studentId`) |
| `save-lesson/route.ts` | POST, GET | POST body schema; GET query (`limit`, `offset`) |
| `save-lesson/[id]` | DELETE | — |
| `manual-lessons/route.ts` | POST, GET | POST body schema; GET query (`start_date`, `end_date`) |
| `manual-lessons/[id]` | PUT, DELETE | wrapper only (partial-update body kept in-handler) |

## Safety choices
- **Conservative body schemas** — `.passthrough()` (never strips extra fields), `z.any()` for free-form fields (content, objectives, etc.), and `refine` instead of value-mutating `.trim()`. They enforce only what the routes already required, so existing payloads keep working. This matters because I can't runtime-test these authenticated endpoints from here.
- **`lessons/[id]/render` kept `auth: false`** to preserve its current public/RLS-gated behavior rather than change security posture in a mechanical migration. ⚠️ Flagged with a TODO — it fetches a lesson by id with no explicit ownership check; worth a dedicated auth/IDOR review.
- **`manual-lessons/[id]` PUT/DELETE**: migrated the wrapper only; the partial-update logic with its own `!== undefined` field checks stays in-handler (a strict Zod schema there would add risk for little gain).
- Wrapper tweak: pinned the `withRoute` schema generics' input/def params to `any` so query/body **output** types infer correctly when Zod defaults are present (otherwise `z.coerce.number().default()` was inferred as `number | undefined`).

## Verification
- [x] `tsc --noEmit` — 0 errors (incl. post-merge with main)
- [x] `next lint` — clean
- [x] full `next build` — exit 0 (route types validated)
- [ ] CI green
- [ ] Note: endpoint behavior not runtime-tested from here; body schemas deliberately permissive to avoid regressions

## Follow-ups (not in this PR)
- Remaining route batches (students, schedule, admin, etc.) + the 22 other `withAuth` routes.
- The `render` auth/IDOR review.
- Deferred from #612: cron purge for `api_rate_limits`; atomic rate-limit RPC if limits become a hard quota.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified API request handling and validation across lesson endpoints for more consistent behavior.

* **Bug Fixes**
  * Improved validation with clearer error responses and specific status codes for invalid submissions.

* **New Features**
  * Rendering improvements for lesson/worksheet views: student name resolution, normalized grade handling (including kindergarten), optional QR code support, and type-specific HTML rendering with updated security and caching headers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->