### PR TITLE
Migrate students-area API routes to withRoute

### DIFF
--- a/app/api/import-students/confirm/route.ts
+++ b/app/api/import-students/confirm/route.ts
@@ -3,9 +3,9 @@
  * Creates student records from bulk import after user review
  */
 
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 import { log } from '@/lib/monitoring/logger';
 import { track } from '@/lib/monitoring/analytics';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
@@ -41,7 +41,7 @@ interface ImportResult {
   error?: string;
 }
 
-export const POST = withAuth(async (request: NextRequest, userId: string) => {
+export const POST = withRoute({}, async ({ req: request, userId }) => {
   const perf = measurePerformanceWithAlerts('import_students_confirm', 'api');
 
   try {

--- a/app/api/import-students/route.ts
+++ b/app/api/import-students/route.ts
@@ -7,9 +7,9 @@
  * Returns preview data for user review before creating/updating students
  */
 
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 import { parseSEISReport, ParseResult as SEISParseResult } from '@/lib/parsers/seis-parser';
 import { parseCSVReport, ParseResult as CSVParseResult } from '@/lib/parsers/csv-parser';
 import { parseDeliveriesCSV, DeliveryRecord } from '@/lib/parsers/deliveries-parser';
@@ -475,7 +475,7 @@ async function handleDeliveriesOrClassListOnly(
   });
 }
 
-export const POST = withAuth(async (request: NextRequest, userId: string) => {
+export const POST = withRoute({}, async ({ req: request, userId }) => {
   const perf = measurePerformanceWithAlerts('import_students_preview', 'api');
 
   try {

--- a/app/api/students/[studentId]/attendance/route.ts
+++ b/app/api/students/[studentId]/attendance/route.ts
@@ -1,5 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
+import { withRoute } from '@/lib/api/with-route';
 
 function formatTime12hr(time: string | null): string {
   if (!time) return '';
@@ -10,26 +12,19 @@ function formatTime12hr(time: string | null): string {
   return `${hour12}:${minutes} ${ampm}`;
 }
 
-export async function GET(
-  request: NextRequest,
-  props: { params: Promise<{ studentId: string }> }
-) {
-  const params = await props.params;
-  const { studentId } = params;
+const querySchema = z.object({
+  // Invalid/missing/out-of-range values fall back to 50 (matches prior behavior).
+  limit: z.coerce.number().int().positive().max(500).catch(50),
+});
 
-  const supabase = await createClient();
+export const GET = withRoute<{ studentId: string }, undefined, z.infer<typeof querySchema>>(
+  { query: querySchema },
+  async ({ query, params }) => {
+    const { studentId } = params;
+    const { limit } = query;
 
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+    const supabase = await createClient();
 
-  const { searchParams } = new URL(request.url);
-  const limitParam = searchParams.get('limit');
-  const parsedLimit = limitParam ? parseInt(limitParam, 10) : NaN;
-  const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : 50;
-
-  try {
     // First, get summary counts from ALL records (not limited)
     const { data: allRecords, error: countError } = await supabase
       .from('attendance')
@@ -120,8 +115,5 @@ export async function GET(
       },
       records
     });
-  } catch (error) {
-    console.error('Error fetching student attendance:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+);


### PR DESCRIPTION
Continues the API standardization (#3), migrating the students area onto `withRoute`.

## Changes
- **`students/[studentId]/attendance` GET** — full migration: `withRoute` auth + dynamic `params` + a Zod `query` schema for `limit`. The schema uses `.catch(50)` so invalid/missing/out-of-range values fall back to 50, preserving the route's prior lenient behavior; added a `max(500)` guardrail.
- **`import-students` POST** and **`import-students/confirm` POST** — wrapper-only swap to `withRoute` for auth consolidation. These are large (1,112 / 597 lines), complex import endpoints; one takes multipart `formData`, the other a manually-cast JSON payload. I intentionally **did not** add Zod body schemas here — their bodies stay parsed in-handler — to avoid regressions on payloads I can't runtime-test. Body validation for imports is a candidate for a dedicated, tested follow-up.

## Notes
- Removed now-unused `NextRequest` imports from both import routes.
- Applied the lesson from #613: this batch avoids tightening any optional write-path fields, so there's no `|| null` caller-mismatch risk. (attendance is GET-only.)

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check: student attendance panel loads (with and without `?limit=`), and the student import preview + confirm flow still works end-to-end

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated backend API infrastructure for student import and attendance endpoints to improve system reliability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->