### PR TITLE
Migrate session detail/instance API routes to withRoute

### DIFF
--- a/app/api/sessions/[sessionId]/attendance/route.ts
+++ b/app/api/sessions/[sessionId]/attendance/route.ts
@@ -1,34 +1,41 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createServiceClient } from '@/lib/supabase/server';
+import { withRoute } from '@/lib/api/with-route';
 
-interface AttendanceRecord {
-  student_id: string;
-  present: boolean;
-  absence_reason?: string | null;
-}
+const getQuerySchema = z.object({
+  session_date: z.string().optional(),
+});
 
-interface AttendancePayload {
-  session_date: string;
-  attendance: AttendanceRecord[];
-}
+const attendanceRecordSchema = z
+  .object({
+    student_id: z.string(),
+    present: z.boolean(),
+    absence_reason: z.string().nullish(),
+  })
+  .passthrough();
 
-export async function GET(
-  request: NextRequest,
-  props: { params: Promise<{ sessionId: string }> }
-) {
-  const params = await props.params;
-  const { sessionId } = params;
+const postSchema = z
+  .object({
+    session_date: z.string().min(1),
+    attendance: z.array(attendanceRecordSchema),
+  })
+  .passthrough();
 
-  const searchParams = request.nextUrl.searchParams;
-  const sessionDate = searchParams.get('session_date');
+const putSchema = z
+  .object({
+    student_id: z.string().min(1),
+    session_date: z.string().min(1),
+    present: z.boolean(),
+    absence_reason: z.string().nullish(),
+  })
+  .passthrough();
 
-  try {
-    const supabase = await createClient();
-
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+export const GET = withRoute<{ sessionId: string }, undefined, z.infer<typeof getQuerySchema>>(
+  { query: getQuerySchema },
+  async ({ userId, query, params }) => {
+    const { sessionId } = params;
+    const sessionDate = query.session_date;
 
     if (sessionId.startsWith('temp-')) {
       return NextResponse.json({ attendance: [] });
@@ -50,9 +57,9 @@ export async function GET(
       return NextResponse.json({ error: 'Session not found' }, { status: 404 });
     }
 
-    const hasAccess = session.provider_id === user.id ||
-      session.assigned_to_specialist_id === user.id ||
-      session.assigned_to_sea_id === user.id;
+    const hasAccess = session.provider_id === userId ||
+      session.assigned_to_specialist_id === userId ||
+      session.assigned_to_sea_id === userId;
 
     if (!hasAccess) {
       return NextResponse.json({ error: 'Access denied' }, { status: 403 });
@@ -70,42 +77,19 @@ export async function GET(
     }
 
     return NextResponse.json({ attendance: attendance || [] });
-  } catch (error) {
-    console.error('Error in attendance GET:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+);
 
-export async function POST(
-  request: NextRequest,
-  props: { params: Promise<{ sessionId: string }> }
-) {
-  const params = await props.params;
-  const { sessionId } = params;
-
-  try {
-    const supabase = await createClient();
-
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+export const POST = withRoute<{ sessionId: string }, z.infer<typeof postSchema>>(
+  { body: postSchema },
+  async ({ userId, body, params }) => {
+    const { sessionId } = params;
 
     if (sessionId.startsWith('temp-')) {
       return NextResponse.json({ error: 'Cannot save attendance for temporary sessions' }, { status: 400 });
     }
 
-    const body: AttendancePayload = await request.json();
     const { session_date, attendance } = body;
-
-    if (!session_date) {
-      return NextResponse.json({ error: 'session_date is required' }, { status: 400 });
-    }
-
-    if (!attendance || !Array.isArray(attendance)) {
-      return NextResponse.json({ error: 'attendance array is required' }, { status: 400 });
-    }
-
     const serviceClient = createServiceClient();
 
     const { data: session, error: sessionError } = await serviceClient
@@ -118,9 +102,9 @@ export async function POST(
       return NextResponse.json({ error: 'Session not found' }, { status: 404 });
     }
 
-    const hasAccess = session.provider_id === user.id ||
-      session.assigned_to_specialist_id === user.id ||
-      session.assigned_to_sea_id === user.id;
+    const hasAccess = session.provider_id === userId ||
+      session.assigned_to_specialist_id === userId ||
+      session.assigned_to_sea_id === userId;
 
     if (!hasAccess) {
       return NextResponse.json({ error: 'Access denied' }, { status: 403 });
@@ -132,7 +116,7 @@ export async function POST(
       session_date: session_date,
       present: record.present,
       absence_reason: record.present ? null : (record.absence_reason || null),
-      marked_by: user.id
+      marked_by: userId
     }));
 
     const { data: savedAttendance, error: upsertError } = await serviceClient
@@ -152,39 +136,20 @@ export async function POST(
       attendance: savedAttendance,
       message: 'Attendance saved successfully'
     });
-  } catch (error) {
-    console.error('Error in attendance POST:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+);
 
 // PUT handler for quick-marking a single student's attendance
-export async function PUT(
-  request: NextRequest,
-  props: { params: Promise<{ sessionId: string }> }
-) {
-  const params = await props.params;
-  const { sessionId } = params;
-
-  try {
-    const supabase = await createClient();
-
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+export const PUT = withRoute<{ sessionId: string }, z.infer<typeof putSchema>>(
+  { body: putSchema },
+  async ({ userId, body, params }) => {
+    const { sessionId } = params;
 
     if (sessionId.startsWith('temp-')) {
       return NextResponse.json({ error: 'Cannot save attendance for temporary sessions' }, { status: 400 });
     }
 
-    const body = await request.json();
     const { student_id, session_date, present, absence_reason } = body;
-
-    if (!student_id || !session_date || typeof present !== 'boolean') {
-      return NextResponse.json({ error: 'student_id, session_date, and present (boolean) are required' }, { status: 400 });
-    }
-
     const serviceClient = createServiceClient();
 
     const { data: session, error: sessionError } = await serviceClient
@@ -197,9 +162,9 @@ export async function PUT(
       return NextResponse.json({ error: 'Session not found' }, { status: 404 });
     }
 
-    const hasAccess = session.provider_id === user.id ||
-      session.assigned_to_specialist_id === user.id ||
-      session.assigned_to_sea_id === user.id;
+    const hasAccess = session.provider_id === userId ||
+      session.assigned_to_specialist_id === userId ||
+      session.assigned_to_sea_id === userId;
 
     if (!hasAccess) {
       return NextResponse.json({ error: 'Access denied' }, { status: 403 });
@@ -213,7 +178,7 @@ export async function PUT(
         session_date,
         present,
         absence_reason: present ? null : (absence_reason?.trim() || null),
-        marked_by: user.id
+        marked_by: userId
       }, {
         onConflict: 'session_id,student_id,session_date'
       })
@@ -230,8 +195,5 @@ export async function PUT(
       attendance: savedAttendance,
       message: `Marked as ${present ? 'present' : 'absent'}`
     });
-  } catch (error) {
-    console.error('Error in attendance PUT:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+);

--- a/app/api/sessions/[sessionId]/modal-data/route.ts
+++ b/app/api/sessions/[sessionId]/modal-data/route.ts
@@ -1,99 +1,91 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
+import { withRoute } from '@/lib/api/with-route';
 
-export async function GET(
-  request: NextRequest,
-  props: { params: Promise<{ sessionId: string }> }
-) {
-  const perf = measurePerformanceWithAlerts('get_session_modal_data', 'api');
-  const params = await props.params;
-  const { sessionId } = params;
-  let userId: string | undefined;
+const querySchema = z.object({
+  session_date: z.string().optional(),
+  start_time: z.string().optional(),
+  end_time: z.string().optional(),
+  group_id: z.string().optional(),
+});
 
-  const searchParams = request.nextUrl.searchParams;
-  const sessionDate = searchParams.get('session_date');
-  const startTime = searchParams.get('start_time');
-  const endTime = searchParams.get('end_time');
-  const groupId = searchParams.get('group_id');
+export const GET = withRoute<{ sessionId: string }, undefined, z.infer<typeof querySchema>>(
+  { query: querySchema },
+  async ({ userId, query, params }) => {
+    const perf = measurePerformanceWithAlerts('get_session_modal_data', 'api');
+    const { sessionId } = params;
+    const { session_date: sessionDate, start_time: startTime, end_time: endTime, group_id: groupId } = query;
 
-  try {
-    const supabase = await createClient();
+    try {
+      const supabase = await createClient();
 
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
+      log.info('Fetching consolidated session modal data', {
+        userId,
+        sessionId,
+        sessionDate,
+        groupId
+      });
+
+      const timeSlot = startTime && endTime ? `${startTime}-${endTime}` : null;
+
+      const results = await Promise.all([
+        sessionDate && timeSlot
+          ? supabase
+              .from('lessons')
+              .select('*')
+              .eq('provider_id', userId)
+              .eq('lesson_date', sessionDate)
+              .eq('time_slot', timeSlot)
+              .maybeSingle()
+          : Promise.resolve({ data: null, error: null }),
+
+        sessionDate
+          ? supabase
+              .from('documents')
+              .select('*')
+              .eq('documentable_type', 'session')
+              .eq('documentable_id', sessionId)
+              .eq('session_date', sessionDate)
+              .order('created_at', { ascending: false })
+          : supabase
+              .from('documents')
+              .select('*')
+              .eq('documentable_type', 'session')
+              .eq('documentable_id', sessionId)
+              .order('created_at', { ascending: false }),
+
+        supabase
+          .from('curriculum_tracking')
+          .select('*')
+          .eq('session_id', sessionId)
+          .maybeSingle()
+      ]);
+
+      const [lessonResult, documentsResult, curriculumResult] = results;
+
+      if (lessonResult.error) {
+        log.warn('Error fetching lesson in modal data', { error: lessonResult.error, userId, sessionId });
+      }
+      if (documentsResult.error) {
+        log.warn('Error fetching documents in modal data', { error: documentsResult.error, userId, sessionId });
+      }
+      if (curriculumResult.error) {
+        log.warn('Error fetching curriculum in modal data', { error: curriculumResult.error, userId, sessionId });
+      }
+
+      perf.end({ success: true });
+      return NextResponse.json({
+        lesson: lessonResult.data || null,
+        documents: documentsResult.data || [],
+        curriculum: curriculumResult.data || null
+      });
+    } catch (error) {
+      log.error('Error in get-session-modal-data route', error, { userId, sessionId });
       perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
     }
-    userId = user.id;
-
-    log.info('Fetching consolidated session modal data', {
-      userId,
-      sessionId,
-      sessionDate,
-      groupId
-    });
-
-    const timeSlot = startTime && endTime ? `${startTime}-${endTime}` : null;
-
-    const results = await Promise.all([
-      sessionDate && timeSlot
-        ? supabase
-            .from('lessons')
-            .select('*')
-            .eq('provider_id', userId)
-            .eq('lesson_date', sessionDate)
-            .eq('time_slot', timeSlot)
-            .maybeSingle()
-        : Promise.resolve({ data: null, error: null }),
-
-      sessionDate
-        ? supabase
-            .from('documents')
-            .select('*')
-            .eq('documentable_type', 'session')
-            .eq('documentable_id', sessionId)
-            .eq('session_date', sessionDate)
-            .order('created_at', { ascending: false })
-        : supabase
-            .from('documents')
-            .select('*')
-            .eq('documentable_type', 'session')
-            .eq('documentable_id', sessionId)
-            .order('created_at', { ascending: false }),
-
-      supabase
-        .from('curriculum_tracking')
-        .select('*')
-        .eq('session_id', sessionId)
-        .maybeSingle()
-    ]);
-
-    const [lessonResult, documentsResult, curriculumResult] = results;
-
-    if (lessonResult.error) {
-      log.warn('Error fetching lesson in modal data', { error: lessonResult.error, userId, sessionId });
-    }
-    if (documentsResult.error) {
-      log.warn('Error fetching documents in modal data', { error: documentsResult.error, userId, sessionId });
-    }
-    if (curriculumResult.error) {
-      log.warn('Error fetching curriculum in modal data', { error: curriculumResult.error, userId, sessionId });
-    }
-
-    perf.end({ success: true });
-    return NextResponse.json({
-      lesson: lessonResult.data || null,
-      documents: documentsResult.data || [],
-      curriculum: curriculumResult.data || null
-    });
-  } catch (error) {
-    log.error('Error in get-session-modal-data route', error, { userId, sessionId });
-    perf.end({ success: false });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
   }
-}
+);

--- a/app/api/sessions/generate-instances/route.ts
+++ b/app/api/sessions/generate-instances/route.ts
@@ -1,9 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { createInstancesFromTemplate, getSchoolYearEndDate, InstanceGenerationOptions } from '@/lib/services/session-instance-generator';
 import { log } from '@/lib/monitoring/logger';
 import { formatDateLocal } from '@/lib/utils/date-helpers';
 import type { Database } from '@/src/types/database';
+import { withRoute } from '@/lib/api/with-route';
 
 type ScheduleSession = Database['public']['Tables']['schedule_sessions']['Row'];
 
@@ -17,28 +19,26 @@ type ScheduleSession = Database['public']['Tables']['schedule_sessions']['Row'];
  *   untilDate?: string             // Optional: specific end date (YYYY-MM-DD)
  * }
  */
-export async function POST(request: NextRequest) {
+const bodySchema = z
+  .object({
+    sessionId: z.string().min(1),
+    weeksAhead: z.number().nullish(),
+    useSchoolYearEnd: z.boolean().default(true),
+    untilDate: z.string().nullish(),
+  })
+  .passthrough();
+
+export const POST = withRoute({ body: bodySchema }, async ({ userId, body }) => {
   try {
     const supabase = await createClient();
 
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const body = await request.json();
-    const { sessionId, weeksAhead, useSchoolYearEnd = true, untilDate } = body;
-
-    if (!sessionId) {
-      return NextResponse.json({ error: 'sessionId is required' }, { status: 400 });
-    }
+    const { sessionId, weeksAhead, useSchoolYearEnd, untilDate } = body;
 
     // Build options from request body
     const options: InstanceGenerationOptions = {};
     if (untilDate) {
       options.untilDate = new Date(untilDate);
-    } else if (weeksAhead !== undefined) {
+    } else if (weeksAhead != null) {
       options.weeksAhead = weeksAhead;
     } else {
       options.useSchoolYearEnd = useSchoolYearEnd;
@@ -57,7 +57,7 @@ export async function POST(request: NextRequest) {
     const endDateStr = formatDateLocal(endDate);
 
     log.info('[GenerateInstances] Generating instances for session', {
-      userId: user.id,
+      userId,
       sessionId,
       endDate: endDateStr,
       options
@@ -87,7 +87,7 @@ export async function POST(request: NextRequest) {
     }
 
     log.info('[GenerateInstances] Instances generated successfully', {
-      userId: user.id,
+      userId,
       sessionId,
       instancesCreated: result.instancesCreated,
       endDate: endDateStr
@@ -109,4 +109,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});


### PR DESCRIPTION
Continues the API standardization (#3) for the sessions area.

## Changes
- **`sessions/[sessionId]/modal-data` GET** — `withRoute` auth + dynamic params + Zod query (`session_date`, `start_time`, `end_time`, `group_id`, all optional).
- **`sessions/[sessionId]/attendance` GET/POST/PUT** — auth + params + Zod query/body. Notable: kept the `temp-` session short-circuit in-handler (so it isn't pre-empted by query validation), and `absence_reason` is `.nullish()` because the caller (`session-details-modal.tsx`) sends `absence_reason || null` — verified before tightening, per the lesson from #613.
- **`sessions/generate-instances` POST** — auth + Zod body: `sessionId` required, `weeksAhead`/`untilDate` nullish, `useSchoolYearEnd` defaults to `true`.

Access-control behavior is unchanged (the attendance routes still use `createServiceClient` + the provider/specialist/SEA `hasAccess` check, now keyed on the wrapper-provided `userId`).

## Deferred to a follow-up
- `sessions/[sessionId]/documents` (581 lines, multipart + nested body) and the `sessions/group` / `indicators` / `ungroup` action trio — to keep this PR focused and reviewable.

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors
- Grepped callers for `|| null` payloads before tightening optional fields.

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check: open a session modal (loads lesson/documents/curriculum), mark attendance (bulk save + single quick-toggle), and generate instances from a template.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized API route handlers to use a consistent wrapper pattern for improved maintainability.
  * Enhanced input validation across session and attendance management endpoints.
  * Streamlined authorization and user identification processes in API routes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->