### PR TITLE
Migrate session group/ungroup/indicators routes to withRoute

### DIFF
--- a/app/api/sessions/group/route.ts
+++ b/app/api/sessions/group/route.ts
@@ -1,36 +1,27 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
 import { track } from '@/lib/monitoring/analytics';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 
 // POST - Group sessions together
-export const POST = withAuth(async (request: NextRequest, userId: string) => {
+const groupSessionsSchema = z
+  .object({
+    sessionIds: z.array(z.string()).min(2),
+    groupName: z.string().refine(s => s.trim().length > 0, 'Group name is required'),
+    groupId: z.string().nullish(),
+    groupColor: z.any().optional(),
+  })
+  .passthrough();
+
+export const POST = withRoute({ body: groupSessionsSchema }, async ({ userId, body }) => {
   const perf = measurePerformanceWithAlerts('group_sessions', 'api');
 
   try {
     const supabase = await createClient();
-    const body = await request.json();
-
     const { sessionIds, groupName, groupId, groupColor } = body;
-
-    // Validate required fields
-    if (!Array.isArray(sessionIds) || sessionIds.length < 2) {
-      perf.end({ success: false, error: 'validation' });
-      return NextResponse.json(
-        { error: 'At least 2 session IDs are required to create a group' },
-        { status: 400 }
-      );
-    }
-
-    if (!groupName || typeof groupName !== 'string' || !groupName.trim()) {
-      perf.end({ success: false, error: 'validation' });
-      return NextResponse.json(
-        { error: 'Group name is required' },
-        { status: 400 }
-      );
-    }
 
     // Validate group color if provided (must be integer 0-4)
     const validatedGroupColor = typeof groupColor === 'number' && Number.isInteger(groupColor) && groupColor >= 0 && groupColor <= 4

--- a/app/api/sessions/group/route.ts
+++ b/app/api/sessions/group/route.ts
@@ -9,7 +9,10 @@ import { withRoute } from '@/lib/api/with-route';
 // POST - Group sessions together
 const groupSessionsSchema = z
   .object({
-    sessionIds: z.array(z.string()).min(2),
+    sessionIds: z
+      .array(z.string())
+      .min(2)
+      .refine(ids => new Set(ids).size >= 2, 'At least 2 distinct sessions are required'),
     groupName: z.string().refine(s => s.trim().length > 0, 'Group name is required'),
     groupId: z.string().nullish(),
     groupColor: z.any().optional(),

--- a/app/api/sessions/indicators/route.ts
+++ b/app/api/sessions/indicators/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 
 interface IndicatorResult {
   hasNotes: boolean;
@@ -21,90 +22,27 @@ const MAX_SESSIONS = 500;
 const MAX_GROUPS = 100;
 const MAX_DATES = 7;
 
-function isValidSessionInfo(value: unknown): value is SessionInfo {
-  if (!value || typeof value !== 'object') return false;
-  const session = value as Partial<SessionInfo>;
-  return (
-    typeof session.id === 'string' &&
-    typeof session.timeSlot === 'string' &&
-    typeof session.sessionDate === 'string'
-  );
-}
+const sessionInfoSchema = z
+  .object({
+    id: z.string(),
+    timeSlot: z.string(),
+    sessionDate: z.string(),
+  })
+  .passthrough();
+
+const indicatorsSchema = z
+  .object({
+    sessions: z.array(sessionInfoSchema).max(MAX_SESSIONS).default([]),
+    groupIds: z.array(z.string()).max(MAX_GROUPS).default([]),
+    weekDates: z.array(z.string()).max(MAX_DATES).default([]),
+  })
+  .passthrough();
 
 // POST - Get indicators for sessions and groups (has notes, has documents)
-export const POST = withAuth(async (request: NextRequest, userId: string) => {
+export const POST = withRoute({ body: indicatorsSchema }, async ({ userId, body }) => {
   try {
     const supabase = await createClient();
-    const body = await request.json();
-
-    const rawSessions = (body as Record<string, unknown>).sessions;
-    const rawGroupIds = (body as Record<string, unknown>).groupIds;
-    const rawWeekDates = (body as Record<string, unknown>).weekDates;
-
-    // Validate sessions array
-    if (rawSessions !== undefined && !Array.isArray(rawSessions)) {
-      return NextResponse.json(
-        { error: 'Invalid request: sessions must be an array' },
-        { status: 400 }
-      );
-    }
-    if (Array.isArray(rawSessions) && rawSessions.length > MAX_SESSIONS) {
-      return NextResponse.json(
-        { error: `Too many sessions (max ${MAX_SESSIONS})` },
-        { status: 400 }
-      );
-    }
-    if (Array.isArray(rawSessions) && !rawSessions.every(isValidSessionInfo)) {
-      return NextResponse.json(
-        { error: 'Invalid request: each session must have id, timeSlot, and sessionDate as strings' },
-        { status: 400 }
-      );
-    }
-
-    // Validate groupIds array
-    if (rawGroupIds !== undefined && !Array.isArray(rawGroupIds)) {
-      return NextResponse.json(
-        { error: 'Invalid request: groupIds must be an array' },
-        { status: 400 }
-      );
-    }
-    if (Array.isArray(rawGroupIds) && rawGroupIds.length > MAX_GROUPS) {
-      return NextResponse.json(
-        { error: `Too many groups (max ${MAX_GROUPS})` },
-        { status: 400 }
-      );
-    }
-    if (Array.isArray(rawGroupIds) && !rawGroupIds.every(id => typeof id === 'string')) {
-      return NextResponse.json(
-        { error: 'Invalid request: each groupId must be a string' },
-        { status: 400 }
-      );
-    }
-
-    // Validate weekDates array
-    if (rawWeekDates !== undefined && !Array.isArray(rawWeekDates)) {
-      return NextResponse.json(
-        { error: 'Invalid request: weekDates must be an array' },
-        { status: 400 }
-      );
-    }
-    if (Array.isArray(rawWeekDates) && rawWeekDates.length > MAX_DATES) {
-      return NextResponse.json(
-        { error: `Too many dates (max ${MAX_DATES})` },
-        { status: 400 }
-      );
-    }
-    if (Array.isArray(rawWeekDates) && !rawWeekDates.every(d => typeof d === 'string')) {
-      return NextResponse.json(
-        { error: 'Invalid request: each weekDate must be a string' },
-        { status: 400 }
-      );
-    }
-
-    // Cast validated inputs
-    const sessions: SessionInfo[] = Array.isArray(rawSessions) ? rawSessions : [];
-    const groupIds: string[] = Array.isArray(rawGroupIds) ? rawGroupIds : [];
-    const weekDates: string[] = Array.isArray(rawWeekDates) ? rawWeekDates : [];
+    const { sessions, groupIds, weekDates } = body;
 
     log.info('Fetching session indicators', {
       userId,

--- a/app/api/sessions/ungroup/route.ts
+++ b/app/api/sessions/ungroup/route.ts
@@ -1,28 +1,24 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
 import { track } from '@/lib/monitoring/analytics';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 
 // POST - Remove sessions from their group
-export const POST = withAuth(async (request: NextRequest, userId: string) => {
+const ungroupSessionsSchema = z
+  .object({
+    sessionIds: z.array(z.string()).min(1),
+  })
+  .passthrough();
+
+export const POST = withRoute({ body: ungroupSessionsSchema }, async ({ userId, body }) => {
   const perf = measurePerformanceWithAlerts('ungroup_sessions', 'api');
 
   try {
     const supabase = await createClient();
-    const body = await request.json();
-
     const { sessionIds } = body;
-
-    // Validate required fields
-    if (!Array.isArray(sessionIds) || sessionIds.length === 0) {
-      perf.end({ success: false, error: 'validation' });
-      return NextResponse.json(
-        { error: 'At least one session ID is required' },
-        { status: 400 }
-      );
-    }
 
     // Validate that all session IDs are valid UUIDs (not temp IDs)
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;


### PR DESCRIPTION
Continues #3, migrating the session group/ungroup/indicators action routes onto `withRoute`.

## Changes
- **`sessions/group` POST** — Zod body: `sessionIds` (≥2), `groupName` (required, non-empty). `groupId` is `.nullish()`; `groupColor` stays permissive (`z.any()`) so the existing lenient "valid int 0-4 else null" coercion is preserved rather than newly rejecting out-of-range values.
- **`sessions/ungroup` POST** — Zod body: `sessionIds` (≥1). Kept the in-handler UUID-regex check so the user-facing "Please wait for sessions to save before ungrouping" message is preserved (didn't fold it into Zod, which would genericize the message).
- **`sessions/indicators` POST** — replaced ~60 lines of hand-rolled array validation with a Zod schema for `sessions`/`groupIds`/`weekDates` (each optional, same `MAX_SESSIONS`/`MAX_GROUPS`/`MAX_DATES` caps and element typing). Net −75 lines.

## Notes
- Verified caller payloads (`calendar-day-view`, `weekly-view`, `calendar-week-view`) before tightening — all send arrays/strings, `groupColor` is a number, no `|| null` on these fields.
- Auth/ownership behavior unchanged (the group/ungroup ownership + `delivered_by` checks against `userId` are preserved).

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check: group 2+ sessions (with a color), ungroup, and confirm calendar note/document/attendance indicators still render.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized session APIs (group, ungroup, indicators) to use centralized request validation and simplified handlers.
  * Replaced manual parsing/duplicate validation with schema-driven checks, reducing repetitive error handling and improving consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->