### PR TITLE
Migrate progress-check API routes to withRoute

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -93,7 +93,8 @@
       "Bash(mkdir -p .claude/hooks)",
       "mcp__playwright__browser_resize",
       "mcp__playwright__browser_navigate",
-      "mcp__context7__query-docs"
+      "mcp__context7__query-docs",
+      "mcp__52287d5e-942b-4bb1-a760-a897e4851102__list_issue_statuses"
     ],
     "deny": []
   },

--- a/app/api/progress-check/[id]/discard/route.ts
+++ b/app/api/progress-check/[id]/discard/route.ts
@@ -1,71 +1,44 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  return withAuth(async (req: NextRequest, userId: string) => {
-    try {
-      const supabase = await createClient();
-      const checkId = params.id;
+export const PATCH = withRoute<{ id: string }>({}, async ({ params }) => {
+  const supabase = await createClient();
+  const checkId = params.id;
 
-      if (!checkId) {
-        return NextResponse.json(
-          { error: 'Progress check ID is required' },
-          { status: 400 }
-        );
-      }
+  // Fetch the current progress check to confirm it exists and read discarded_at
+  const { data: existingCheck, error: fetchError } = await supabase
+    .from('progress_checks')
+    .select('id, discarded_at, provider_id')
+    .eq('id', checkId)
+    .single();
 
-      // Fetch the current progress check to check if it exists and get current discarded_at value
-      const { data: existingCheck, error: fetchError } = await supabase
-        .from('progress_checks')
-        .select('id, discarded_at, provider_id')
-        .eq('id', checkId)
-        .single();
+  if (fetchError || !existingCheck) {
+    console.error('Error fetching progress check:', fetchError);
+    return NextResponse.json({ error: 'Progress check not found' }, { status: 404 });
+  }
 
-      if (fetchError || !existingCheck) {
-        console.error('Error fetching progress check:', fetchError);
-        return NextResponse.json(
-          { error: 'Progress check not found' },
-          { status: 404 }
-        );
-      }
+  // Toggle discard status (ownership is enforced by RLS).
+  const newDiscardedAt = existingCheck.discarded_at ? null : new Date().toISOString();
 
-      // Verify user has permission to discard this check
-      // (either they created it, or RLS policies will handle it)
+  const { data: updatedCheck, error: updateError } = await supabase
+    .from('progress_checks')
+    .update({ discarded_at: newDiscardedAt })
+    .eq('id', checkId)
+    .select('id, discarded_at')
+    .single();
 
-      // Toggle discard status
-      const newDiscardedAt = existingCheck.discarded_at ? null : new Date().toISOString();
+  if (updateError) {
+    console.error('Error updating progress check:', updateError);
+    return NextResponse.json(
+      { error: 'Failed to update progress check', details: updateError.message },
+      { status: 500 }
+    );
+  }
 
-      const { data: updatedCheck, error: updateError } = await supabase
-        .from('progress_checks')
-        .update({ discarded_at: newDiscardedAt })
-        .eq('id', checkId)
-        .select('id, discarded_at')
-        .single();
-
-      if (updateError) {
-        console.error('Error updating progress check:', updateError);
-        return NextResponse.json(
-          { error: 'Failed to update progress check', details: updateError.message },
-          { status: 500 }
-        );
-      }
-
-      return NextResponse.json({
-        success: true,
-        check: updatedCheck,
-        message: newDiscardedAt ? 'Progress check discarded' : 'Progress check restored',
-      });
-
-    } catch (error: any) {
-      console.error('Error toggling progress check discard status:', error);
-      return NextResponse.json(
-        { error: error.message || 'Failed to update progress check' },
-        { status: 500 }
-      );
-    }
-  })(request);
-}
+  return NextResponse.json({
+    success: true,
+    check: updatedCheck,
+    message: newDiscardedAt ? 'Progress check discarded' : 'Progress check restored',
+  });
+});

--- a/app/api/progress-check/generate/route.ts
+++ b/app/api/progress-check/generate/route.ts
@@ -1,10 +1,17 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { withAuth } from '@/lib/api/with-auth';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withRoute } from '@/lib/api/with-route';
 import { createClient } from '@/lib/supabase/server';
 import { generateProgressCheck, type AssessmentItem, type IEPGoalAssessment } from '@/lib/progress-checks/generator';
 
 // Extended timeout for AI generation
 export const maxDuration = 300; // 5 minutes
+
+const generateProgressCheckSchema = z
+  .object({
+    studentIds: z.array(z.string()).min(1).max(10),
+  })
+  .passthrough();
 
 interface Worksheet {
   studentId: string;
@@ -13,30 +20,15 @@ interface Worksheet {
   iepGoals: IEPGoalAssessment[];
 }
 
-export async function POST(request: NextRequest) {
-  return withAuth(async (req: NextRequest, userId: string) => {
+export const POST = withRoute(
+  {
+    body: generateProgressCheckSchema,
+    rateLimit: { requests: 30, windowSeconds: 3600, name: 'progress-check/generate' },
+  },
+  async ({ userId, body }) => {
     try {
       const supabase = await createClient();
-      const body = await req.json();
-
-      // Validate request
-      const validation = validateRequest(body);
-      if (!validation.isValid) {
-        return NextResponse.json(
-          { error: 'Invalid request', details: validation.errors },
-          { status: 400 }
-        );
-      }
-
       const { studentIds } = body;
-
-      // Enforce max 10 students limit
-      if (studentIds.length > 10) {
-        return NextResponse.json(
-          { error: 'Too many students', details: 'Maximum 10 students allowed per batch' },
-          { status: 400 }
-        );
-      }
 
       // Get user's role to determine filtering
       const { data: profile, error: profileError } = await supabase
@@ -256,22 +248,6 @@ export async function POST(request: NextRequest) {
         { status: 500 }
       );
     }
-  })(request);
-}
-
-function validateRequest(body: any): { isValid: boolean; errors: string[] } {
-  const errors: string[] = [];
-
-  if (!body.studentIds || !Array.isArray(body.studentIds) || body.studentIds.length === 0) {
-    errors.push('studentIds array is required and must not be empty');
   }
+);
 
-  if (body.studentIds && body.studentIds.length > 10) {
-    errors.push('Maximum 10 students allowed per batch');
-  }
-
-  return {
-    isValid: errors.length === 0,
-    errors
-  };
-}

--- a/app/api/progress-check/results/route.ts
+++ b/app/api/progress-check/results/route.ts
@@ -28,7 +28,7 @@ const getResultsQuerySchema = z.object({
 export const POST = withRoute({ body: submitResultsSchema }, async ({ userId, body }) => {
     try {
       const supabase = await createClient();
-      const { progress_check_id, results } = body as {
+      const { progress_check_id, results } = body as unknown as {
         progress_check_id: string;
         results: QuestionResult[];
       };

--- a/app/api/progress-check/results/route.ts
+++ b/app/api/progress-check/results/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 
 interface QuestionResult {
   iep_goal_index: number;
@@ -9,30 +10,28 @@ interface QuestionResult {
   notes?: string;
 }
 
-export async function POST(request: NextRequest) {
-  return withAuth(async (req: NextRequest, userId: string) => {
+const submitResultsSchema = z
+  .object({
+    progress_check_id: z.string().min(1),
+    results: z.array(z.any()).min(1),
+  })
+  .passthrough();
+
+const getResultsQuerySchema = z.object({
+  student_id: z.string().optional(),
+  school_id: z.string().optional(),
+  status: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export const POST = withRoute({ body: submitResultsSchema }, async ({ userId, body }) => {
     try {
       const supabase = await createClient();
-      const body = await req.json();
       const { progress_check_id, results } = body as {
         progress_check_id: string;
         results: QuestionResult[];
       };
-
-      // Validate required fields
-      if (!progress_check_id) {
-        return NextResponse.json(
-          { error: 'Progress check ID is required' },
-          { status: 400 }
-        );
-      }
-
-      if (!results || !Array.isArray(results) || results.length === 0) {
-        return NextResponse.json(
-          { error: 'Results array is required' },
-          { status: 400 }
-        );
-      }
 
       // Validate each result
       for (const result of results) {
@@ -149,19 +148,12 @@ export async function POST(request: NextRequest) {
         { status: 500 }
       );
     }
-  })(request);
-}
+  });
 
-export async function GET(request: NextRequest) {
-  return withAuth(async (req: NextRequest, userId: string) => {
+export const GET = withRoute({ query: getResultsQuerySchema }, async ({ query: queryParams }) => {
     try {
       const supabase = await createClient();
-      const { searchParams } = new URL(req.url);
-      const studentId = searchParams.get('student_id');
-      const schoolId = searchParams.get('school_id');
-      const status = searchParams.get('status'); // 'graded', 'needs_grading', 'discarded', or 'all'
-      const limit = parseInt(searchParams.get('limit') || '50', 10);
-      const offset = parseInt(searchParams.get('offset') || '0', 10);
+      const { student_id: studentId, school_id: schoolId, status, limit, offset } = queryParams;
 
       // If filtering by school, get the student IDs for that school first
       let schoolStudentIds: string[] | null = null;
@@ -270,5 +262,4 @@ export async function GET(request: NextRequest) {
         { status: 500 }
       );
     }
-  })(request);
-}
+  });

--- a/app/api/progress-check/results/route.ts
+++ b/app/api/progress-check/results/route.ts
@@ -13,7 +13,7 @@ interface QuestionResult {
 const submitResultsSchema = z
   .object({
     progress_check_id: z.string().min(1),
-    results: z.array(z.any()).min(1),
+    results: z.array(z.object({}).passthrough()).min(1),
   })
   .passthrough();
 


### PR DESCRIPTION
Continues #3, migrating the progress-check routes — the structural mirror of #617 (exit-tickets).

## Changes
- **`progress-check/[id]/discard` PATCH** — `withRoute` auth + dynamic params (also upgrades the old sync `{ params }` to Next 15 async params).
- **`progress-check/generate` POST** — auth + Zod body (`studentIds`, 1-10, replacing the `validateRequest` helper, which is now removed) + a **per-user rate limit (30/hr)** on this AI-generation endpoint.
- **`progress-check/results` POST/GET** — Zod body for the top-level shape (`progress_check_id`, non-empty `results`); per-result validity, the "notes required for incorrect" rule, and the all-questions-graded completeness check stay in-handler to preserve their specific messages. GET gets a Zod query schema (`limit` capped at 100). Aliased the validated query arg to `queryParams` to avoid colliding with the local `let query` Supabase builder (same as #617).

## Notes
- Verified caller payloads (`progress-check.tsx`, `progress-check-results-tab.tsx`) before tightening — `studentIds`/`progress_check_id`/`results` are always sent, no `|| null`.

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check: generate progress checks (incl. the 10-student cap), grade results, discard/restore, and the results list status filters.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated progress‑check endpoints to a unified handler pattern for consistent routing and wiring.
  * Standardized request validation and query/body parsing for generate and results endpoints.
  * Simplified discard/restore flow and harmonized success/error responses for progress‑check operations.

* **Chores**
  * Added a permission entry to local settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->