### PR TITLE
Migrate saved-worksheets API routes to withRoute

### DIFF
--- a/app/api/saved-worksheets/[id]/route.ts
+++ b/app/api/saved-worksheets/[id]/route.ts
@@ -1,168 +1,97 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
+import { withRoute } from '@/lib/api/with-route';
 
 // GET: Download worksheet file
-export async function GET(
-  request: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  let userId: string | undefined;
+export const GET = withRoute<{ id: string }>({}, async ({ userId, params }) => {
+  const supabase = await createClient();
+  const { id: worksheetId } = params;
 
-  try {
-    const supabase = await createClient();
+  log.info('Fetching worksheet for download', { userId, worksheetId });
 
-    // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
-    }
+  // Get worksheet metadata and verify ownership
+  const { data: worksheet, error: dbError } = await supabase
+    .from('saved_worksheets')
+    .select('*')
+    .eq('id', worksheetId)
+    .eq('provider_id', userId)
+    .single();
 
-    userId = user.id;
-    const { id: worksheetId } = params;
-
-    log.info('Fetching worksheet for download', { userId, worksheetId });
-
-    // Get worksheet metadata and verify ownership
-    const { data: worksheet, error: dbError } = await supabase
-      .from('saved_worksheets')
-      .select('*')
-      .eq('id', worksheetId)
-      .eq('provider_id', userId)
-      .single();
-
-    if (dbError || !worksheet) {
-      log.error('Worksheet not found or access denied', dbError, {
-        userId,
-        worksheetId
-      });
-      return NextResponse.json(
-        { error: 'Worksheet not found' },
-        { status: 404 }
-      );
-    }
-
-    // Generate signed URL for file download (valid for 1 hour)
-    const { data: signedUrlData, error: urlError } = await supabase.storage
-      .from('saved-worksheets')
-      .createSignedUrl(worksheet.file_path, 3600);
-
-    if (urlError || !signedUrlData) {
-      log.error('Failed to generate signed URL', urlError, {
-        userId,
-        worksheetId,
-        filePath: worksheet.file_path
-      });
-      return NextResponse.json(
-        { error: 'Failed to generate download URL' },
-        { status: 500 }
-      );
-    }
-
-    log.info('Generated signed URL for worksheet download', {
-      userId,
-      worksheetId
-    });
-
-    return NextResponse.json({
-      signedUrl: signedUrlData.signedUrl,
-      worksheet
-    });
-  } catch (error) {
-    log.error('Error in GET /api/saved-worksheets/[id]', error, { userId });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+  if (dbError || !worksheet) {
+    log.error('Worksheet not found or access denied', dbError, { userId, worksheetId });
+    return NextResponse.json({ error: 'Worksheet not found' }, { status: 404 });
   }
-}
+
+  // Generate signed URL for file download (valid for 1 hour)
+  const { data: signedUrlData, error: urlError } = await supabase.storage
+    .from('saved-worksheets')
+    .createSignedUrl(worksheet.file_path, 3600);
+
+  if (urlError || !signedUrlData) {
+    log.error('Failed to generate signed URL', urlError, {
+      userId,
+      worksheetId,
+      filePath: worksheet.file_path
+    });
+    return NextResponse.json({ error: 'Failed to generate download URL' }, { status: 500 });
+  }
+
+  log.info('Generated signed URL for worksheet download', { userId, worksheetId });
+
+  return NextResponse.json({
+    signedUrl: signedUrlData.signedUrl,
+    worksheet
+  });
+});
 
 // DELETE: Delete worksheet and file
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  let userId: string | undefined;
+export const DELETE = withRoute<{ id: string }>({}, async ({ userId, params }) => {
+  const supabase = await createClient();
+  const { id: worksheetId } = params;
 
-  try {
-    const supabase = await createClient();
+  log.info('Deleting worksheet', { userId, worksheetId });
 
-    // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
-    }
+  // Get worksheet metadata and verify ownership
+  const { data: worksheet, error: fetchError } = await supabase
+    .from('saved_worksheets')
+    .select('*')
+    .eq('id', worksheetId)
+    .eq('provider_id', userId)
+    .single();
 
-    userId = user.id;
-    const { id: worksheetId } = params;
-
-    log.info('Deleting worksheet', { userId, worksheetId });
-
-    // Get worksheet metadata and verify ownership
-    const { data: worksheet, error: fetchError } = await supabase
-      .from('saved_worksheets')
-      .select('*')
-      .eq('id', worksheetId)
-      .eq('provider_id', userId)
-      .single();
-
-    if (fetchError || !worksheet) {
-      log.error('Worksheet not found or access denied', fetchError, {
-        userId,
-        worksheetId
-      });
-      return NextResponse.json(
-        { error: 'Worksheet not found' },
-        { status: 404 }
-      );
-    }
-
-    // Delete worksheet metadata from database first
-    const { error: dbError } = await supabase
-      .from('saved_worksheets')
-      .delete()
-      .eq('id', worksheetId)
-      .eq('provider_id', userId);
-
-    if (dbError) {
-      log.error('Failed to delete worksheet from database', dbError, {
-        userId,
-        worksheetId
-      });
-      return NextResponse.json(
-        { error: 'Failed to delete worksheet' },
-        { status: 500 }
-      );
-    }
-
-    // Delete file from storage
-    const { error: storageError } = await supabase.storage
-      .from('saved-worksheets')
-      .remove([worksheet.file_path]);
-
-    if (storageError) {
-      log.error('Failed to delete file from storage', storageError, {
-        userId,
-        worksheetId,
-        filePath: worksheet.file_path
-      });
-      // Log but don't fail - orphaned files can be cleaned up by a background job
-    }
-
-    log.info('Worksheet deleted successfully', { userId, worksheetId });
-
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    log.error('Error in DELETE /api/saved-worksheets/[id]', error, { userId });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+  if (fetchError || !worksheet) {
+    log.error('Worksheet not found or access denied', fetchError, { userId, worksheetId });
+    return NextResponse.json({ error: 'Worksheet not found' }, { status: 404 });
   }
-}
+
+  // Delete worksheet metadata from database first
+  const { error: dbError } = await supabase
+    .from('saved_worksheets')
+    .delete()
+    .eq('id', worksheetId)
+    .eq('provider_id', userId);
+
+  if (dbError) {
+    log.error('Failed to delete worksheet from database', dbError, { userId, worksheetId });
+    return NextResponse.json({ error: 'Failed to delete worksheet' }, { status: 500 });
+  }
+
+  // Delete file from storage
+  const { error: storageError } = await supabase.storage
+    .from('saved-worksheets')
+    .remove([worksheet.file_path]);
+
+  if (storageError) {
+    log.error('Failed to delete file from storage', storageError, {
+      userId,
+      worksheetId,
+      filePath: worksheet.file_path
+    });
+    // Log but don't fail - orphaned files can be cleaned up by a background job
+  }
+
+  log.info('Worksheet deleted successfully', { userId, worksheetId });
+
+  return NextResponse.json({ success: true });
+});

--- a/app/api/saved-worksheets/route.ts
+++ b/app/api/saved-worksheets/route.ts
@@ -1,10 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 import { log } from '@/lib/monitoring/logger';
 
 // GET: Fetch user's saved worksheets
-export const GET = withAuth(async (request: NextRequest, userId: string) => {
+export const GET = withRoute({}, async ({ userId }) => {
   try {
     const supabase = await createClient();
 
@@ -43,7 +43,7 @@ export const GET = withAuth(async (request: NextRequest, userId: string) => {
 });
 
 // POST: Upload and save new worksheet
-export const POST = withAuth(async (request: NextRequest, userId: string) => {
+export const POST = withRoute({}, async ({ req: request, userId }) => {
   try {
     const supabase = await createClient();
     const formData = await request.formData();


### PR DESCRIPTION
Part of **SPE-75** (continuing #3).

## Changes
- **`saved-worksheets` GET** — `withRoute` auth consolidation (no body/query).
- **`saved-worksheets` POST** — wrapper-only swap. It's a multipart `formData` file upload, so no Zod body; the in-handler validation (required title/file, allowed MIME types, 10 MB cap, filename sanitization + extension allowlist) is preserved. `req` is aliased to `request` so the body is untouched.
- **`saved-worksheets/[id]` GET + DELETE** — auth + dynamic params (upgrades the old sync `{ params }` to async). The ownership filter (`.eq('provider_id', userId)`) and the storage signed-URL/delete + orphan-cleanup-on-failure behavior are preserved.

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors
- No tightened JSON fields here (GET/DELETE have no body; POST is formData), so no `|| null` caller risk.

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check: list saved worksheets, upload a PDF/DOC (and confirm bad type/oversize are rejected), download via signed URL, delete.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal request handling and authentication flow in API endpoints for better code consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->