### PR TITLE
Migrate account/settings API routes to withRoute

### DIFF
--- a/app/api/auth/change-password/route.ts
+++ b/app/api/auth/change-password/route.ts
@@ -1,7 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { validatePassword } from '@/lib/utils/password-validation';
 import { log } from '@/lib/monitoring/logger';
+import { withRoute } from '@/lib/api/with-route';
+
+const bodySchema = z.object({ password: z.string().min(1) }).passthrough();
 
 /**
  * API endpoint for users to change their password after admin reset.
@@ -11,102 +15,60 @@ import { log } from '@/lib/monitoring/logger';
  * 3. Updates the password via Supabase Auth
  * 4. Clears the must_change_password flag
  */
-export async function POST(request: NextRequest) {
+export const POST = withRoute({ body: bodySchema }, async ({ userId, body }) => {
   try {
     const supabase = await createClient();
-
-    // Verify authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
-    }
-
-    // Parse request body
-    const body = await request.json();
     const { password } = body;
-
-    if (!password || typeof password !== 'string') {
-      return NextResponse.json(
-        { error: 'Password is required' },
-        { status: 400 }
-      );
-    }
 
     // Validate password meets requirements
     const validation = validatePassword(password);
     if (!validation.isValid) {
-      return NextResponse.json(
-        { error: validation.errors.join('. ') },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: validation.errors.join('. ') }, { status: 400 });
     }
 
     // Verify user has must_change_password flag set
     const { data: profile, error: profileError } = await supabase
       .from('profiles')
       .select('must_change_password')
-      .eq('id', user.id)
+      .eq('id', userId)
       .single();
 
     if (profileError) {
-      log.error('Failed to fetch profile for password change', profileError, {
-        userId: user.id,
-      });
-      return NextResponse.json(
-        { error: 'Failed to verify user status' },
-        { status: 500 }
-      );
+      log.error('Failed to fetch profile for password change', profileError, { userId });
+      return NextResponse.json({ error: 'Failed to verify user status' }, { status: 500 });
     }
 
     if (!profile?.must_change_password) {
-      return NextResponse.json(
-        { error: 'Password change not required' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Password change not required' }, { status: 400 });
     }
 
     // Update the password via Supabase Auth
-    const { error: updateError } = await supabase.auth.updateUser({
-      password,
-    });
+    const { error: updateError } = await supabase.auth.updateUser({ password });
 
     if (updateError) {
-      log.error('Failed to update password', updateError, {
-        userId: user.id,
-      });
-      return NextResponse.json(
-        { error: 'Failed to update password' },
-        { status: 500 }
-      );
+      log.error('Failed to update password', updateError, { userId });
+      return NextResponse.json({ error: 'Failed to update password' }, { status: 500 });
     }
 
     // Clear the must_change_password flag
     const { error: clearFlagError } = await supabase
       .from('profiles')
       .update({ must_change_password: false })
-      .eq('id', user.id);
+      .eq('id', userId);
 
     if (clearFlagError) {
       // Log but don't fail - password was already changed successfully
       log.warn('Failed to clear must_change_password flag', {
-        userId: user.id,
+        userId,
         error: clearFlagError.message,
       });
     }
 
-    log.info('User changed password successfully', {
-      userId: user.id,
-    });
+    log.info('User changed password successfully', { userId });
 
     return NextResponse.json({ success: true });
   } catch (error) {
     log.error('Unexpected error in change-password:', error);
-    return NextResponse.json(
-      { error: 'An unexpected error occurred' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 });
   }
-}
+});

--- a/app/api/provider/request-password-reset/route.ts
+++ b/app/api/provider/request-password-reset/route.ts
@@ -1,21 +1,16 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { withRoute } from '@/lib/api/with-route';
 
-export async function POST() {
+export const POST = withRoute({}, async ({ userId }) => {
   try {
     const supabase = await createClient();
-
-    // Verify authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     // Get user profile to check role
     const { data: profile, error: profileError } = await supabase
       .from('profiles')
       .select('role, password_reset_requested_at')
-      .eq('id', user.id)
+      .eq('id', userId)
       .single();
 
     if (profileError || !profile) {
@@ -43,7 +38,7 @@ export async function POST() {
     const { error: updateError } = await supabase
       .from('profiles')
       .update({ password_reset_requested_at: new Date().toISOString() })
-      .eq('id', user.id);
+      .eq('id', userId);
 
     if (updateError) {
       console.error('Error updating profile:', updateError);
@@ -55,4 +50,4 @@ export async function POST() {
     console.error('Password reset request error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});

--- a/app/api/settings/api-keys/route.ts
+++ b/app/api/settings/api-keys/route.ts
@@ -1,7 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { randomBytes } from 'crypto';
 import bcrypt from 'bcryptjs';
+import { withRoute } from '@/lib/api/with-route';
 
 // Cost factor for bcrypt (10 is standard, provides ~100ms hash time)
 const BCRYPT_ROUNDS = 10;
@@ -23,19 +25,14 @@ export async function verifyApiKey(key: string, hash: string): Promise<boolean> 
 }
 
 // GET - List user's API keys (prefix only, not full key)
-export async function GET() {
+export const GET = withRoute({}, async ({ userId }) => {
   try {
     const supabase = await createClient();
-
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     const { data: keys, error } = await supabase
       .from('api_keys')
       .select('id, key_prefix, name, created_at, last_used_at, revoked_at')
-      .eq('user_id', user.id)
+      .eq('user_id', userId)
       .is('revoked_at', null)
       .order('created_at', { ascending: false });
 
@@ -49,17 +46,12 @@ export async function GET() {
     console.error('API keys GET error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});
 
 // POST - Generate a new API key
-export async function POST(request: NextRequest) {
+export const POST = withRoute({}, async ({ req: request, userId }) => {
   try {
     const supabase = await createClient();
-
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     // Parse optional name from request body
     let name = 'Chrome Extension';
@@ -81,7 +73,7 @@ export async function POST(request: NextRequest) {
     const { data: newKey, error } = await supabase
       .from('api_keys')
       .insert({
-        user_id: user.id,
+        user_id: userId,
         key_hash: keyHash,
         key_prefix: keyPrefix,
         name,
@@ -106,31 +98,24 @@ export async function POST(request: NextRequest) {
     console.error('API keys POST error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});
+
+const deleteQuerySchema = z.object({
+  id: z.string().min(1),
+});
 
 // DELETE - Revoke an API key
-export async function DELETE(request: NextRequest) {
+export const DELETE = withRoute({ query: deleteQuerySchema }, async ({ userId, query }) => {
   try {
     const supabase = await createClient();
-
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const { searchParams } = new URL(request.url);
-    const keyId = searchParams.get('id');
-
-    if (!keyId) {
-      return NextResponse.json({ error: 'Key ID required' }, { status: 400 });
-    }
+    const keyId = query.id;
 
     // Revoke the key (soft delete)
     const { error } = await supabase
       .from('api_keys')
       .update({ revoked_at: new Date().toISOString() })
       .eq('id', keyId)
-      .eq('user_id', user.id); // Ensure user owns this key
+      .eq('user_id', userId); // Ensure user owns this key
 
     if (error) {
       console.error('Error revoking API key:', error);
@@ -142,4 +127,4 @@ export async function DELETE(request: NextRequest) {
     console.error('API keys DELETE error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});


### PR DESCRIPTION
Part of **SPE-75** (continuing #3) — the account/settings routes.

## Changes
- **`settings/api-keys` GET/POST/DELETE** — auth consolidation. GET is body-less. POST keeps its *optional* body parsing in-handler (a bodyless POST still defaults the key name, so no Zod body — that would 400 on no body). DELETE gets a Zod query schema for `id`. The bcrypt helpers and the exported `verifyApiKey` are preserved untouched (confirmed nothing imports `verifyApiKey` from this route — the extension routes define their own).
- **`auth/change-password` POST** — auth + Zod body `{ password }`. The password-strength validation (`validatePassword`) and the `must_change_password` flag gate stay in-handler to preserve their specific error messages.
- **`provider/request-password-reset` POST** — auth-only (the provider-role allowlist check is preserved).

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors
- Only tightened field is `change-password`'s `password` (required string) and api-keys DELETE `id` (required query) — both always sent by callers; no `|| null` risk.

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check: list/create/revoke an API key; change password (post-reset flow); request a provider password reset (incl. the already-pending and non-provider 403 cases).

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to API routing infrastructure for authentication, password reset, and API key management endpoints. No changes to user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/620?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->