### PR TITLE
Migrate curriculum-tracking API routes to withRoute

### DIFF
--- a/app/api/curriculum-tracking/answer-prompt/route.ts
+++ b/app/api/curriculum-tracking/answer-prompt/route.ts
@@ -1,60 +1,28 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient, createServiceClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
 import { track } from '@/lib/monitoring/analytics';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
+import { withRoute } from '@/lib/api/with-route';
+
+const answerPromptSchema = z
+  .object({
+    sessionId: z.string().min(1),
+    answer: z.enum(['yes', 'no']),
+    previousLesson: z.number().int().min(1),
+    curriculumType: z.string().min(1),
+    curriculumLevel: z.string().min(1),
+  })
+  .passthrough();
 
 // POST - Handle lesson completion prompt answer (Yes/No)
-export async function POST(request: NextRequest) {
+export const POST = withRoute({ body: answerPromptSchema }, async ({ userId, body }) => {
   const perf = measurePerformanceWithAlerts('answer_curriculum_prompt', 'api');
-  let userId: string | undefined;
+  const { sessionId, answer, previousLesson, curriculumType, curriculumLevel } = body;
 
   try {
     const supabase = await createClient();
-
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    userId = user.id;
-
-    const body = await request.json();
-    const {
-      sessionId,
-      answer,
-      previousLesson,
-      curriculumType,
-      curriculumLevel
-    } = body;
-
-    // Validate required fields
-    if (!sessionId || !answer || !curriculumType || !curriculumLevel) {
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'sessionId, answer, curriculumType, and curriculumLevel are required' },
-        { status: 400 }
-      );
-    }
-
-    // Validate previousLesson is a positive integer
-    if (typeof previousLesson !== 'number' || !Number.isInteger(previousLesson) || previousLesson < 1) {
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'previousLesson must be a positive integer' },
-        { status: 400 }
-      );
-    }
-
-    // Validate answer value
-    if (answer !== 'yes' && answer !== 'no') {
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'answer must be "yes" or "no"' },
-        { status: 400 }
-      );
-    }
 
     log.info('Answering curriculum prompt', {
       userId,
@@ -75,15 +43,9 @@ export async function POST(request: NextRequest) {
       .maybeSingle();
 
     if (accessError || !session) {
-      log.warn('User does not have access to session', {
-        userId,
-        sessionId
-      });
+      log.warn('User does not have access to session', { userId, sessionId });
       perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'Access denied' },
-        { status: 403 }
-      );
+      return NextResponse.json({ error: 'Access denied' }, { status: 403 });
     }
 
     // Calculate new lesson number
@@ -137,11 +99,7 @@ export async function POST(request: NextRequest) {
     }
 
     if (error) {
-      log.error('Error saving curriculum prompt answer', error, {
-        userId,
-        sessionId,
-        answer
-      });
+      log.error('Error saving curriculum prompt answer', error, { userId, sessionId, answer });
       perf.end({ success: false });
       return NextResponse.json(
         { error: 'Failed to save curriculum tracking', details: error.message },
@@ -150,15 +108,9 @@ export async function POST(request: NextRequest) {
     }
 
     if (!data) {
-      log.error('No data returned from curriculum tracking save', {
-        userId,
-        sessionId
-      });
+      log.error('No data returned from curriculum tracking save', { userId, sessionId });
       perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'Curriculum tracking save returned no data' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Curriculum tracking save returned no data' }, { status: 500 });
     }
 
     log.info('Curriculum prompt answered successfully', {
@@ -185,9 +137,6 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     log.error('Error in answer-curriculum-prompt route', error, { userId });
     perf.end({ success: false });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});

--- a/app/api/curriculum-tracking/previous/route.ts
+++ b/app/api/curriculum-tracking/previous/route.ts
@@ -1,7 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
+import { withRoute } from '@/lib/api/with-route';
 
 // Type for curriculum tracking with joined session data
 interface CurriculumWithSession {
@@ -24,50 +26,27 @@ interface CurriculumWithSession {
   } | null;
 }
 
+const previousQuerySchema = z.object({
+  sessionId: z.string().optional(),
+  groupId: z.string().optional(),
+  sessionDate: z.string().min(1),
+});
+
 // GET - Fetch curriculum tracking from previous instance of same recurring session
-export async function GET(request: NextRequest) {
+export const GET = withRoute({ query: previousQuerySchema }, async ({ userId, query }) => {
   const perf = measurePerformanceWithAlerts('get_previous_curriculum', 'api');
-  let userId: string | undefined;
+  const { sessionId, groupId, sessionDate } = query;
 
   try {
     const supabase = await createClient();
-    const searchParams = request.nextUrl.searchParams;
-    const sessionId = searchParams.get('sessionId');
-    const groupId = searchParams.get('groupId');
-    const sessionDate = searchParams.get('sessionDate');
 
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    userId = user.id;
-
-    // Validate required parameters
     // sessionId is required for individual sessions, but optional for group sessions (groupId provided)
-    if (!sessionDate) {
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'sessionDate is required' },
-        { status: 400 }
-      );
-    }
-
     if (!sessionId && !groupId) {
       perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'Either sessionId or groupId is required' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Either sessionId or groupId is required' }, { status: 400 });
     }
 
-    log.info('Fetching previous curriculum tracking', {
-      userId,
-      sessionId,
-      groupId,
-      sessionDate
-    });
+    log.info('Fetching previous curriculum tracking', { userId, sessionId, groupId, sessionDate });
 
     let previousCurriculum: CurriculumWithSession | null = null;
 
@@ -105,16 +84,9 @@ export async function GET(request: NextRequest) {
       });
 
       if (error) {
-        log.error('Error fetching previous curriculum for group', error, {
-          userId,
-          groupId,
-          sessionDate
-        });
+        log.error('Error fetching previous curriculum for group', error, { userId, groupId, sessionDate });
         perf.end({ success: false });
-        return NextResponse.json(
-          { error: 'Failed to fetch previous curriculum' },
-          { status: 500 }
-        );
+        return NextResponse.json({ error: 'Failed to fetch previous curriculum' }, { status: 500 });
       }
       previousCurriculum = data;
     } else {
@@ -127,15 +99,9 @@ export async function GET(request: NextRequest) {
         .single();
 
       if (sessionError || !currentSession) {
-        log.error('Error fetching current session', sessionError, {
-          userId,
-          sessionId
-        });
+        log.error('Error fetching current session', sessionError, { userId, sessionId });
         perf.end({ success: false });
-        return NextResponse.json(
-          { error: 'Failed to fetch session details' },
-          { status: 500 }
-        );
+        return NextResponse.json({ error: 'Failed to fetch session details' }, { status: 500 });
       }
 
       // Find previous session with same characteristics
@@ -162,16 +128,9 @@ export async function GET(request: NextRequest) {
         .maybeSingle();
 
       if (error) {
-        log.error('Error fetching previous curriculum for individual', error, {
-          userId,
-          sessionId,
-          sessionDate
-        });
+        log.error('Error fetching previous curriculum for individual', error, { userId, sessionId, sessionDate });
         perf.end({ success: false });
-        return NextResponse.json(
-          { error: 'Failed to fetch previous curriculum' },
-          { status: 500 }
-        );
+        return NextResponse.json({ error: 'Failed to fetch previous curriculum' }, { status: 500 });
       }
       previousCurriculum = data;
     }
@@ -227,9 +186,6 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     log.error('Error in get-previous-curriculum route', error, { userId });
     perf.end({ success: false });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});

--- a/app/api/curriculum-tracking/route.ts
+++ b/app/api/curriculum-tracking/route.ts
@@ -1,40 +1,34 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient, createServiceClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
 import { track } from '@/lib/monitoring/analytics';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
+import { withRoute } from '@/lib/api/with-route';
+
+const sessionIdQuerySchema = z.object({
+  sessionId: z.string().min(1),
+});
+
+const saveCurriculumSchema = z
+  .object({
+    sessionId: z.string().min(1),
+    curriculumType: z.string().min(1),
+    curriculumLevel: z.string().min(1),
+    currentLesson: z.number(),
+    promptAnswered: z.boolean().optional(),
+  })
+  .passthrough();
 
 // GET - Fetch curriculum tracking by session_id
-export async function GET(request: NextRequest) {
+export const GET = withRoute({ query: sessionIdQuerySchema }, async ({ userId, query }) => {
   const perf = measurePerformanceWithAlerts('get_curriculum_tracking', 'api');
-  let userId: string | undefined;
+  const { sessionId } = query;
 
   try {
     const supabase = await createClient();
-    const searchParams = request.nextUrl.searchParams;
-    const sessionId = searchParams.get('sessionId');
 
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    userId = user.id;
-
-    // Validate that sessionId is provided
-    if (!sessionId) {
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'sessionId is required' },
-        { status: 400 }
-      );
-    }
-
-    log.info('Fetching curriculum tracking', {
-      userId,
-      sessionId
-    });
+    log.info('Fetching curriculum tracking', { userId, sessionId });
 
     const { data, error } = await supabase
       .from('curriculum_tracking')
@@ -43,77 +37,29 @@ export async function GET(request: NextRequest) {
       .maybeSingle();
 
     if (error) {
-      log.error('Error fetching curriculum tracking', error, {
-        userId,
-        sessionId
-      });
+      log.error('Error fetching curriculum tracking', error, { userId, sessionId });
       perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'Failed to fetch curriculum tracking' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Failed to fetch curriculum tracking' }, { status: 500 });
     }
 
-    log.info('Curriculum tracking fetched successfully', {
-      userId,
-      sessionId,
-      hasData: !!data
-    });
+    log.info('Curriculum tracking fetched successfully', { userId, sessionId, hasData: !!data });
 
     perf.end({ success: true, hasData: !!data });
     return NextResponse.json({ data: data || null });
   } catch (error) {
     log.error('Error in get-curriculum-tracking route', error, { userId });
     perf.end({ success: false });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});
 
 // POST - Create or update curriculum tracking
-export async function POST(request: NextRequest) {
+export const POST = withRoute({ body: saveCurriculumSchema }, async ({ userId, body }) => {
   const perf = measurePerformanceWithAlerts('save_curriculum_tracking', 'api');
-  let userId: string | undefined;
+  const { sessionId, curriculumType, curriculumLevel, currentLesson, promptAnswered } = body;
 
   try {
     const supabase = await createClient();
-
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    userId = user.id;
-
-    const body = await request.json();
-    const {
-      sessionId,
-      curriculumType,
-      curriculumLevel,
-      currentLesson,
-      promptAnswered
-    } = body;
-
-    // Validate required fields
-    if (!curriculumType || !curriculumLevel || !currentLesson) {
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'curriculumType, curriculumLevel, and currentLesson are required' },
-        { status: 400 }
-      );
-    }
-
-    // Validate that sessionId is provided
-    if (!sessionId) {
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'sessionId is required' },
-        { status: 400 }
-      );
-    }
 
     log.info('Creating/updating curriculum tracking', {
       userId,
@@ -133,15 +79,9 @@ export async function POST(request: NextRequest) {
       .maybeSingle();
 
     if (accessError || !session) {
-      log.warn('User does not have access to session', {
-        userId,
-        sessionId
-      });
+      log.warn('User does not have access to session', { userId, sessionId });
       perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'Access denied' },
-        { status: 403 }
-      );
+      return NextResponse.json({ error: 'Access denied' }, { status: 403 });
     }
 
     // Use service client for database operations (bypasses RLS since we've verified access above)
@@ -247,10 +187,7 @@ export async function POST(request: NextRequest) {
         isUpdate: !!existing
       });
       perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'Curriculum tracking save returned no data' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Curriculum tracking save returned no data' }, { status: 500 });
     }
 
     log.info('Curriculum tracking saved successfully', {
@@ -273,44 +210,19 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     log.error('Error in save-curriculum-tracking route', error, { userId });
     perf.end({ success: false });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});
 
 // DELETE - Delete curriculum tracking
-export async function DELETE(request: NextRequest) {
+export const DELETE = withRoute({ query: sessionIdQuerySchema }, async ({ userId, query }) => {
   const perf = measurePerformanceWithAlerts('delete_curriculum_tracking', 'api');
-  let userId: string | undefined;
+  const { sessionId } = query;
 
   try {
     const supabase = await createClient();
-    const searchParams = request.nextUrl.searchParams;
-    const sessionId = searchParams.get('sessionId');
 
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    userId = user.id;
-
-    // Validate that sessionId is provided
-    if (!sessionId) {
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'sessionId is required' },
-        { status: 400 }
-      );
-    }
-
-    log.info('Deleting curriculum tracking', {
-      userId,
-      sessionId
-    });
+    log.info('Deleting curriculum tracking', { userId, sessionId });
 
     const deletePerf = measurePerformanceWithAlerts('delete_curriculum_tracking_db', 'database');
     const { error } = await supabase
@@ -320,35 +232,20 @@ export async function DELETE(request: NextRequest) {
     deletePerf.end({ success: !error });
 
     if (error) {
-      log.error('Error deleting curriculum tracking', error, {
-        userId,
-        sessionId
-      });
+      log.error('Error deleting curriculum tracking', error, { userId, sessionId });
       perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'Failed to delete curriculum tracking' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Failed to delete curriculum tracking' }, { status: 500 });
     }
 
-    log.info('Curriculum tracking deleted successfully', {
-      userId,
-      sessionId
-    });
+    log.info('Curriculum tracking deleted successfully', { userId, sessionId });
 
-    track.event('curriculum_tracking_deleted', {
-      userId,
-      sessionId
-    });
+    track.event('curriculum_tracking_deleted', { userId, sessionId });
 
     perf.end({ success: true });
     return NextResponse.json({ success: true });
   } catch (error) {
     log.error('Error in delete-curriculum-tracking route', error, { userId });
     perf.end({ success: false });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});

--- a/app/api/curriculum-tracking/route.ts
+++ b/app/api/curriculum-tracking/route.ts
@@ -15,7 +15,7 @@ const saveCurriculumSchema = z
     sessionId: z.string().min(1),
     curriculumType: z.string().min(1),
     curriculumLevel: z.string().min(1),
-    currentLesson: z.number(),
+    currentLesson: z.number().int().min(1),
     promptAnswered: z.boolean().optional(),
   })
   .passthrough();


### PR DESCRIPTION
Part of **SPE-75** (continuing #3) — the curriculum-tracking trio.

## Changes
- **`curriculum-tracking` GET/POST/DELETE** — auth consolidation + Zod. GET/DELETE validate the `sessionId` query; POST validates the body (`sessionId`, `curriculumType`, `curriculumLevel` as non-empty strings, `currentLesson` as number, `promptAnswered?`). The session access check (`provider/specialist/sea` `.or()`) and the deliberate `createServiceClient()` writes (after access is verified) are preserved exactly, as is all the perf/log/track telemetry.
- **`curriculum-tracking/answer-prompt` POST** — auth + Zod body: `answer` (`'yes'|'no'` enum), `previousLesson` (positive int), plus `sessionId`/`curriculumType`/`curriculumLevel`. Same access-check + service-client pattern.
- **`curriculum-tracking/previous` GET** — auth + Zod query: `sessionDate` required, `sessionId`/`groupId` optional; kept the in-handler "either sessionId or groupId is required" cross-field guard.

## Notes
- Field types verified against the callers (`lesson-control.tsx`, `session-details-modal.tsx`): `curriculumType`/`curriculumLevel` are always non-empty strings, `currentLesson`/`previousLesson` numbers, `answer` is `'yes'|'no'` — none sent as null, so tightening is safe.
- Net −198 lines (mostly removed hand-rolled auth + validation boilerplate).

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check: open a recurring session (curriculum prompt → answer yes/no advances the lesson), manually set/save a lesson number, and confirm the "previous instance" lookup works for both individual and group sessions.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized request handling and authentication for curriculum-tracking endpoints.
  * Added structured request validation for incoming data to reduce invalid requests.
  * Standardized and simplified error responses and logging for clearer failures.
  * Streamlined GET, POST and DELETE flows for more consistent behavior and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->