### PR TITLE
Migrate ai-upload group API routes to withRoute

### DIFF
--- a/app/api/ai-upload/confirm/route.ts
+++ b/app/api/ai-upload/confirm/route.ts
@@ -1,6 +1,8 @@
 // app/api/ai-upload/confirm/route.ts
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
+import { withRoute } from '@/lib/api/with-route';
 import { 
   dedupeSpecialActivities, 
   dedupeBellSchedules,
@@ -11,27 +13,24 @@ import {
   type ImportSummary
 } from '@/lib/utils/dedupe-helpers';
 
-export async function POST(request: NextRequest) {
+const confirmSchema = z
+  .object({
+    uploadType: z.string().min(1),
+    confirmedData: z.array(z.any()),
+  })
+  .passthrough();
+
+export const POST = withRoute({ body: confirmSchema }, async ({ userId, body }) => {
   try {
     const supabase = await createClient();
 
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const { uploadType, confirmedData } = await request.json();
-
-    if (!uploadType || !confirmedData || !Array.isArray(confirmedData)) {
-      return NextResponse.json({ error: 'Invalid request data' }, { status: 400 });
-    }
+    const { uploadType, confirmedData } = body;
 
     // Get user's school information including school_id
     const { data: profile } = await supabase
       .from('profiles')
       .select('school_site, school_district, school_id')
-      .eq('id', user.id)
+      .eq('id', userId)
       .single();
 
     const summary = createImportSummary();
@@ -44,7 +43,7 @@ export async function POST(request: NextRequest) {
           const { error } = await supabase
             .from('students')
             .insert({
-              provider_id: user.id,
+              provider_id: userId,
               initials: student.initials.toUpperCase(),
               grade_level: student.grade_level.toUpperCase(),
               teacher_id: student.teacher_id || null,
@@ -94,7 +93,7 @@ export async function POST(request: NextRequest) {
       const { data: existingSchedules } = await supabase
         .from('bell_schedules')
         .select('*')
-        .eq('provider_id', user.id)
+        .eq('provider_id', userId)
         .eq('school_id', profile?.school_id);
       
       // Create a map of existing schedules by normalized key
@@ -110,7 +109,7 @@ export async function POST(request: NextRequest) {
       for (const schedule of dedupedSchedules) {
         try {
           const scheduleData = {
-            provider_id: user.id,
+            provider_id: userId,
             grade_level: schedule.grade_level,
             period_name: schedule.period_name,
             day_of_week: schedule.day_of_week,
@@ -167,7 +166,7 @@ export async function POST(request: NextRequest) {
       const { data: existingActivities } = await supabase
         .from('special_activities')
         .select('*')
-        .eq('provider_id', user.id)
+        .eq('provider_id', userId)
         .eq('school_id', profile?.school_id);
       
       // Create a map of existing activities by normalized key
@@ -183,7 +182,7 @@ export async function POST(request: NextRequest) {
       for (const activity of dedupedActivities) {
         try {
           const activityData = {
-            provider_id: user.id,
+            provider_id: userId,
             teacher_id: activity.teacher_id || null,
             teacher_name: activity.teacher_name || null,
             activity_name: activity.activity_name,
@@ -246,4 +245,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/ai-upload/route.ts
+++ b/app/api/ai-upload/route.ts
@@ -1,12 +1,12 @@
 // app/api/ai-upload/route.ts
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { createClient } from '@/lib/supabase/server';
 import Anthropic from "@anthropic-ai/sdk";
 import mammoth from "mammoth";
 import { log } from '@/lib/monitoring/logger';
 import { track } from '@/lib/monitoring/analytics';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 
 // Force Node.js runtime for file processing
 export const runtime = "nodejs";
@@ -24,7 +24,7 @@ const SUPPORTED_TYPES = [
   "text/rtf",
 ];
 
-export const POST = withAuth(async (request: NextRequest, userId: string) => {
+export const POST = withRoute({}, async ({ req: request, userId }) => {
   const perf = measurePerformanceWithAlerts('ai_upload', 'api');
   
   try {

--- a/app/api/import-iep-goals/route.ts
+++ b/app/api/import-iep-goals/route.ts
@@ -3,9 +3,9 @@
  * Handles Excel file upload, parsing, student matching, and PII scrubbing
  */
 
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 import { parseSEISReport, ParseResult as SEISParseResult } from '@/lib/parsers/seis-parser';
 import { parseCSVReport, ParseResult as CSVParseResult } from '@/lib/parsers/csv-parser';
 import { matchStudents, DatabaseStudent } from '@/lib/utils/student-matcher';
@@ -31,7 +31,7 @@ interface ProcessedMatch {
   }>;
 }
 
-export const POST = withAuth(async (request: NextRequest, userId: string) => {
+export const POST = withRoute({}, async ({ req: request, userId }) => {
   const perf = measurePerformanceWithAlerts('import_iep_goals', 'api');
 
   try {


### PR DESCRIPTION
Part of **SPE-75** (continuing #3) — the ai-upload group.

## Changes
- **`ai-upload` POST** and **`import-iep-goals` POST** — wrapper-only swaps to `withRoute` (auth consolidation). Both are multipart `formData` uploads, so no Zod body; the file parsing/AI/validation logic stays in-handler, with `req` aliased to `request`. Removed now-unused `NextRequest` imports.
- **`ai-upload/confirm` POST** — auth + Zod body (`uploadType` non-empty string, `confirmedData` array). `uploadType` is intentionally not an enum so an unknown type still no-ops (matching prior behavior). The dedupe/upsert logic per upload type and the per-item error summary are preserved (`user.id` → `userId`).

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors
- Caller (`ai-upload-modal.tsx`) sends a valid `uploadType` + a non-empty array, no `|| null`.

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check: upload a students / bell-schedule / special-activities file through the AI upload flow, then confirm the import (insert + dedupe/update + error-summary paths), and run an IEP-goals import.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal request validation and handler consistency across API endpoints for improved code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->