### PR TITLE
Migrate groups/[groupId] lesson and modal-data routes to withRoute

### DIFF
--- a/app/api/groups/[groupId]/lesson/route.ts
+++ b/app/api/groups/[groupId]/lesson/route.ts
@@ -149,12 +149,18 @@ export const POST = withRoute<{ groupId: string }, z.infer<typeof saveLessonSche
       }
 
       // Check if a lesson already exists for this group AND date
-      const { data: existingLesson } = await supabase
+      const { data: existingLesson, error: existingLessonError } = await supabase
         .from('lessons')
         .select('id, lesson_date')
         .eq('group_id', groupId)
         .eq('lesson_date', lessonDate)
         .maybeSingle();
+
+      if (existingLessonError) {
+        log.error('Error checking for existing group lesson', existingLessonError, { userId, groupId, lessonDate });
+        perf.end({ success: false });
+        return NextResponse.json({ error: 'Failed to save lesson' }, { status: 500 });
+      }
 
       let data;
       let error;

--- a/app/api/groups/[groupId]/lesson/route.ts
+++ b/app/api/groups/[groupId]/lesson/route.ts
@@ -1,391 +1,307 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
 import { track } from '@/lib/monitoring/analytics';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
+import { withRoute } from '@/lib/api/with-route';
+
+const lessonDateQuerySchema = z.object({
+  lesson_date: z.string().optional(),
+});
+
+const saveLessonSchema = z
+  .object({
+    title: z.any().optional(),
+    content: z.any().optional(),
+    lesson_source: z.any().optional(),
+    subject: z.any().optional(),
+    grade_levels: z.any().optional(),
+    duration_minutes: z.any().optional(),
+    ai_prompt: z.any().optional(),
+    notes: z.any().optional(),
+    school_id: z.any().optional(),
+    district_id: z.any().optional(),
+    state_id: z.any().optional(),
+    lesson_date: z.string().nullish(),
+  })
+  .passthrough();
 
 // GET - Fetch the lesson plan for a group
-export async function GET(
-  request: NextRequest,
-  props: { params: Promise<{ groupId: string }> }
-) {
-  const perf = measurePerformanceWithAlerts('get_group_lesson', 'api');
-  const params = await props.params;
-  const { groupId } = params;
-  let userId: string | undefined;
+export const GET = withRoute<{ groupId: string }, undefined, z.infer<typeof lessonDateQuerySchema>>(
+  { query: lessonDateQuerySchema },
+  async ({ userId, query, params }) => {
+    const perf = measurePerformanceWithAlerts('get_group_lesson', 'api');
+    const { groupId } = params;
+    const lessonDate = query.lesson_date;
 
-  // Get lesson_date from query params (optional - if provided, fetch lesson for specific date)
-  const searchParams = request.nextUrl.searchParams;
-  const lessonDate = searchParams.get('lesson_date');
+    try {
+      const supabase = await createClient();
 
-  try {
-    const supabase = await createClient();
+      log.info('Fetching group lesson', { userId, groupId, lessonDate: lessonDate || 'not specified' });
 
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
+      // Verify user has access to this group
+      const { data: groupSessions, error: accessError } = await supabase
+        .from('schedule_sessions')
+        .select('id')
+        .eq('group_id', groupId)
+        .or(`provider_id.eq.${userId},assigned_to_specialist_id.eq.${userId},assigned_to_sea_id.eq.${userId}`)
+        .limit(1);
+
+      if (accessError || !groupSessions || groupSessions.length === 0) {
+        log.warn('User does not have access to group', { userId, groupId });
+        perf.end({ success: false });
+        return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+      }
+
+      // Fetch lesson for the group (optionally filtered by date)
+      const fetchPerf = measurePerformanceWithAlerts('fetch_group_lesson_db', 'database');
+      let lessonQuery = supabase
+        .from('lessons')
+        .select('*')
+        .eq('group_id', groupId);
+
+      // If lesson_date provided, filter by exact date; otherwise get most recent
+      if (lessonDate) {
+        lessonQuery = lessonQuery.eq('lesson_date', lessonDate);
+      }
+
+      const { data: lesson, error } = await lessonQuery
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      fetchPerf.end({ success: !error });
+
+      if (error) {
+        log.error('Error fetching group lesson', error, { userId, groupId });
+        perf.end({ success: false });
+        return NextResponse.json({ error: 'Failed to fetch lesson' }, { status: 500 });
+      }
+
+      log.info('Group lesson fetched successfully', { userId, groupId, hasLesson: !!lesson });
+
+      track.event('group_lesson_fetched', { userId, groupId, hasLesson: !!lesson });
+
+      perf.end({ success: true, hasLesson: !!lesson });
+      return NextResponse.json({ lesson: lesson || null });
+    } catch (error) {
+      log.error('Error in get-group-lesson route', error, { userId, groupId });
       perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
     }
-    userId = user.id;
-
-    log.info('Fetching group lesson', {
-      userId,
-      groupId,
-      lessonDate: lessonDate || 'not specified'
-    });
-
-    // Verify user has access to this group
-    const { data: groupSessions, error: accessError } = await supabase
-      .from('schedule_sessions')
-      .select('id')
-      .eq('group_id', groupId)
-      .or(`provider_id.eq.${userId},assigned_to_specialist_id.eq.${userId},assigned_to_sea_id.eq.${userId}`)
-      .limit(1);
-
-    if (accessError || !groupSessions || groupSessions.length === 0) {
-      log.warn('User does not have access to group', {
-        userId,
-        groupId
-      });
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'Access denied' },
-        { status: 403 }
-      );
-    }
-
-    // Fetch lesson for the group (optionally filtered by date)
-    const fetchPerf = measurePerformanceWithAlerts('fetch_group_lesson_db', 'database');
-    let query = supabase
-      .from('lessons')
-      .select('*')
-      .eq('group_id', groupId);
-
-    // If lesson_date provided, filter by exact date; otherwise get most recent
-    if (lessonDate) {
-      query = query.eq('lesson_date', lessonDate);
-    }
-
-    const { data: lesson, error } = await query
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .maybeSingle();
-    fetchPerf.end({ success: !error });
-
-    if (error) {
-      log.error('Error fetching group lesson', error, {
-        userId,
-        groupId
-      });
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'Failed to fetch lesson' },
-        { status: 500 }
-      );
-    }
-
-    log.info('Group lesson fetched successfully', {
-      userId,
-      groupId,
-      hasLesson: !!lesson
-    });
-
-    track.event('group_lesson_fetched', {
-      userId,
-      groupId,
-      hasLesson: !!lesson
-    });
-
-    perf.end({ success: true, hasLesson: !!lesson });
-    return NextResponse.json({ lesson: lesson || null });
-  } catch (error) {
-    log.error('Error in get-group-lesson route', error, { userId, groupId });
-    perf.end({ success: false });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
   }
-}
+);
 
 // POST - Create or update lesson plan for a group
-export async function POST(
-  request: NextRequest,
-  props: { params: Promise<{ groupId: string }> }
-) {
-  const perf = measurePerformanceWithAlerts('save_group_lesson', 'api');
-  const params = await props.params;
-  const { groupId } = params;
-  let userId: string | undefined;
+export const POST = withRoute<{ groupId: string }, z.infer<typeof saveLessonSchema>>(
+  { body: saveLessonSchema },
+  async ({ userId, body, params }) => {
+    const perf = measurePerformanceWithAlerts('save_group_lesson', 'api');
+    const { groupId } = params;
 
-  try {
-    const supabase = await createClient();
+    try {
+      const supabase = await createClient();
 
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    userId = user.id;
+      const {
+        title,
+        content,
+        lesson_source,
+        subject,
+        grade_levels,
+        duration_minutes,
+        ai_prompt,
+        notes,
+        school_id,
+        district_id,
+        state_id,
+        lesson_date: requestLessonDate
+      } = body;
 
-    const body = await request.json();
-    const {
-      title,
-      content,
-      lesson_source,
-      subject,
-      grade_levels,
-      duration_minutes,
-      ai_prompt,
-      notes,
-      school_id,
-      district_id,
-      state_id,
-      lesson_date: requestLessonDate  // Accept lesson_date from request body
-    } = body;
+      // Validate - at least content OR notes must be provided
+      if (!content && !notes) {
+        perf.end({ success: false });
+        return NextResponse.json({ error: 'Content or notes is required' }, { status: 400 });
+      }
 
-    // Validate - at least content OR notes must be provided
-    if (!content && !notes) {
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'Content or notes is required' },
-        { status: 400 }
-      );
-    }
+      // Normalize lesson date - use provided date or default to today
+      const lessonDate = requestLessonDate || new Date().toISOString().split('T')[0];
 
-    // Normalize lesson date - use provided date or default to today
-    const lessonDate = requestLessonDate || new Date().toISOString().split('T')[0];
-
-    log.info('Creating/updating group lesson', {
-      userId,
-      groupId,
-      lesson_source: lesson_source || 'manual',
-      title,
-      lessonDate
-    });
-
-    // Verify user has access to this group
-    const { data: groupSessions, error: accessError } = await supabase
-      .from('schedule_sessions')
-      .select('id')
-      .eq('group_id', groupId)
-      .or(`provider_id.eq.${userId},assigned_to_specialist_id.eq.${userId},assigned_to_sea_id.eq.${userId}`)
-      .limit(1);
-
-    if (accessError || !groupSessions || groupSessions.length === 0) {
-      log.warn('User does not have access to group', {
+      log.info('Creating/updating group lesson', {
         userId,
-        groupId
+        groupId,
+        lesson_source: lesson_source || 'manual',
+        title,
+        lessonDate
       });
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'Access denied' },
-        { status: 403 }
-      );
-    }
 
-    // Check if a lesson already exists for this group AND date
-    const { data: existingLesson } = await supabase
-      .from('lessons')
-      .select('id, lesson_date')
-      .eq('group_id', groupId)
-      .eq('lesson_date', lessonDate)
-      .maybeSingle();
+      // Verify user has access to this group
+      const { data: groupSessions, error: accessError } = await supabase
+        .from('schedule_sessions')
+        .select('id')
+        .eq('group_id', groupId)
+        .or(`provider_id.eq.${userId},assigned_to_specialist_id.eq.${userId},assigned_to_sea_id.eq.${userId}`)
+        .limit(1);
 
-    let data;
-    let error;
+      if (accessError || !groupSessions || groupSessions.length === 0) {
+        log.warn('User does not have access to group', { userId, groupId });
+        perf.end({ success: false });
+        return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+      }
 
-    if (existingLesson) {
-      // Update existing lesson
-      const updatePerf = measurePerformanceWithAlerts('update_group_lesson_db', 'database');
-      const result = await supabase
+      // Check if a lesson already exists for this group AND date
+      const { data: existingLesson } = await supabase
         .from('lessons')
-        .update({
-          lesson_date: lessonDate,
-          title: title || null,
-          content: content || {},
-          lesson_source: lesson_source || 'manual',
-          subject: subject || null,
-          grade_levels: grade_levels || null,
-          duration_minutes: duration_minutes || null,
-          ai_prompt: ai_prompt || null,
-          notes: notes || null,
-          school_id: school_id || null,
-          district_id: district_id || null,
-          state_id: state_id || null,
-          updated_at: new Date().toISOString()
-        })
-        .eq('id', existingLesson.id)
-        .select('*')
-        .single();
-      updatePerf.end({ success: !result.error });
-      data = result.data;
-      error = result.error;
-    } else {
-      // Create new lesson
-      const createPerf = measurePerformanceWithAlerts('create_group_lesson_db', 'database');
-      const result = await supabase
-        .from('lessons')
-        .insert({
-          provider_id: userId,
-          group_id: groupId,
-          lesson_date: lessonDate,
-          title: title || null,
-          content: content || {},
-          lesson_source: lesson_source || 'manual',
-          subject: subject || null,
-          grade_levels: grade_levels || null,
-          duration_minutes: duration_minutes || null,
-          ai_prompt: ai_prompt || null,
-          notes: notes || null,
-          school_id: school_id || null,
-          district_id: district_id || null,
-          state_id: state_id || null
-        })
-        .select('*')
-        .single();
-      createPerf.end({ success: !result.error });
-      data = result.data;
-      error = result.error;
-    }
+        .select('id, lesson_date')
+        .eq('group_id', groupId)
+        .eq('lesson_date', lessonDate)
+        .maybeSingle();
 
-    if (error) {
-      log.error('Error saving group lesson', error, {
+      let data;
+      let error;
+
+      if (existingLesson) {
+        // Update existing lesson
+        const updatePerf = measurePerformanceWithAlerts('update_group_lesson_db', 'database');
+        const result = await supabase
+          .from('lessons')
+          .update({
+            lesson_date: lessonDate,
+            title: title || null,
+            content: content || {},
+            lesson_source: lesson_source || 'manual',
+            subject: subject || null,
+            grade_levels: grade_levels || null,
+            duration_minutes: duration_minutes || null,
+            ai_prompt: ai_prompt || null,
+            notes: notes || null,
+            school_id: school_id || null,
+            district_id: district_id || null,
+            state_id: state_id || null,
+            updated_at: new Date().toISOString()
+          })
+          .eq('id', existingLesson.id)
+          .select('*')
+          .single();
+        updatePerf.end({ success: !result.error });
+        data = result.data;
+        error = result.error;
+      } else {
+        // Create new lesson
+        const createPerf = measurePerformanceWithAlerts('create_group_lesson_db', 'database');
+        const result = await supabase
+          .from('lessons')
+          .insert({
+            provider_id: userId,
+            group_id: groupId,
+            lesson_date: lessonDate,
+            title: title || null,
+            content: content || {},
+            lesson_source: lesson_source || 'manual',
+            subject: subject || null,
+            grade_levels: grade_levels || null,
+            duration_minutes: duration_minutes || null,
+            ai_prompt: ai_prompt || null,
+            notes: notes || null,
+            school_id: school_id || null,
+            district_id: district_id || null,
+            state_id: state_id || null
+          })
+          .select('*')
+          .single();
+        createPerf.end({ success: !result.error });
+        data = result.data;
+        error = result.error;
+      }
+
+      if (error) {
+        log.error('Error saving group lesson', error, { userId, groupId });
+        perf.end({ success: false });
+        return NextResponse.json({ error: 'Failed to save lesson' }, { status: 500 });
+      }
+
+      log.info('Group lesson saved successfully', {
         userId,
-        groupId
+        groupId,
+        lessonId: data.id,
+        isUpdate: !!existingLesson
       });
+
+      track.event(existingLesson ? 'group_lesson_updated' : 'group_lesson_created', {
+        userId,
+        groupId,
+        lessonId: data.id,
+        lesson_source: lesson_source || 'manual'
+      });
+
+      perf.end({ success: true, lessonId: data.id });
+      return NextResponse.json({ lesson: data }, { status: existingLesson ? 200 : 201 });
+    } catch (error) {
+      log.error('Error in save-group-lesson route', error, { userId, groupId });
       perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'Failed to save lesson' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
     }
-
-    log.info('Group lesson saved successfully', {
-      userId,
-      groupId,
-      lessonId: data.id,
-      isUpdate: !!existingLesson
-    });
-
-    track.event(existingLesson ? 'group_lesson_updated' : 'group_lesson_created', {
-      userId,
-      groupId,
-      lessonId: data.id,
-      lesson_source: lesson_source || 'manual'
-    });
-
-    perf.end({ success: true, lessonId: data.id });
-    return NextResponse.json({ lesson: data }, { status: existingLesson ? 200 : 201 });
-  } catch (error) {
-    log.error('Error in save-group-lesson route', error, { userId, groupId });
-    perf.end({ success: false });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
   }
-}
+);
 
 // DELETE - Delete the lesson plan for a group
-export async function DELETE(
-  request: NextRequest,
-  props: { params: Promise<{ groupId: string }> }
-) {
-  const perf = measurePerformanceWithAlerts('delete_group_lesson', 'api');
-  const params = await props.params;
-  const { groupId } = params;
-  let userId: string | undefined;
+export const DELETE = withRoute<{ groupId: string }, undefined, z.infer<typeof lessonDateQuerySchema>>(
+  { query: lessonDateQuerySchema },
+  async ({ userId, query, params }) => {
+    const perf = measurePerformanceWithAlerts('delete_group_lesson', 'api');
+    const { groupId } = params;
+    const lessonDate = query.lesson_date;
 
-  // Get lesson_date from query params (optional - if provided, delete lesson for specific date)
-  const searchParams = request.nextUrl.searchParams;
-  const lessonDate = searchParams.get('lesson_date');
+    try {
+      const supabase = await createClient();
 
-  try {
-    const supabase = await createClient();
+      log.info('Deleting group lesson', { userId, groupId, lessonDate: lessonDate || 'all dates' });
 
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
+      // Verify user has access to this group
+      const { data: groupSessions, error: accessError } = await supabase
+        .from('schedule_sessions')
+        .select('id')
+        .eq('group_id', groupId)
+        .or(`provider_id.eq.${userId},assigned_to_specialist_id.eq.${userId},assigned_to_sea_id.eq.${userId}`)
+        .limit(1);
+
+      if (accessError || !groupSessions || groupSessions.length === 0) {
+        log.warn('User does not have access to group', { userId, groupId });
+        perf.end({ success: false });
+        return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+      }
+
+      // Delete the lesson (optionally filtered by date)
+      const deletePerf = measurePerformanceWithAlerts('delete_group_lesson_db', 'database');
+      let deleteQuery = supabase
+        .from('lessons')
+        .delete()
+        .eq('group_id', groupId)
+        .eq('provider_id', userId); // Ensure user owns the lesson
+
+      // If lesson_date provided, only delete that specific lesson
+      if (lessonDate) {
+        deleteQuery = deleteQuery.eq('lesson_date', lessonDate);
+      }
+
+      const { error } = await deleteQuery;
+      deletePerf.end({ success: !error });
+
+      if (error) {
+        log.error('Error deleting group lesson', error, { userId, groupId });
+        perf.end({ success: false });
+        return NextResponse.json({ error: 'Failed to delete lesson' }, { status: 500 });
+      }
+
+      log.info('Group lesson deleted successfully', { userId, groupId });
+
+      track.event('group_lesson_deleted', { userId, groupId });
+
+      perf.end({ success: true });
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      log.error('Error in delete-group-lesson route', error, { userId, groupId });
       perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
     }
-    userId = user.id;
-
-    log.info('Deleting group lesson', {
-      userId,
-      groupId,
-      lessonDate: lessonDate || 'all dates'
-    });
-
-    // Verify user has access to this group
-    const { data: groupSessions, error: accessError } = await supabase
-      .from('schedule_sessions')
-      .select('id')
-      .eq('group_id', groupId)
-      .or(`provider_id.eq.${userId},assigned_to_specialist_id.eq.${userId},assigned_to_sea_id.eq.${userId}`)
-      .limit(1);
-
-    if (accessError || !groupSessions || groupSessions.length === 0) {
-      log.warn('User does not have access to group', {
-        userId,
-        groupId
-      });
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'Access denied' },
-        { status: 403 }
-      );
-    }
-
-    // Delete the lesson (optionally filtered by date)
-    const deletePerf = measurePerformanceWithAlerts('delete_group_lesson_db', 'database');
-    let deleteQuery = supabase
-      .from('lessons')
-      .delete()
-      .eq('group_id', groupId)
-      .eq('provider_id', userId); // Ensure user owns the lesson
-
-    // If lesson_date provided, only delete that specific lesson
-    if (lessonDate) {
-      deleteQuery = deleteQuery.eq('lesson_date', lessonDate);
-    }
-
-    const { error } = await deleteQuery;
-    deletePerf.end({ success: !error });
-
-    if (error) {
-      log.error('Error deleting group lesson', error, {
-        userId,
-        groupId
-      });
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'Failed to delete lesson' },
-        { status: 500 }
-      );
-    }
-
-    log.info('Group lesson deleted successfully', {
-      userId,
-      groupId
-    });
-
-    track.event('group_lesson_deleted', {
-      userId,
-      groupId
-    });
-
-    perf.end({ success: true });
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    log.error('Error in delete-group-lesson route', error, { userId, groupId });
-    perf.end({ success: false });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
   }
-}
+);

--- a/app/api/groups/[groupId]/modal-data/route.ts
+++ b/app/api/groups/[groupId]/modal-data/route.ts
@@ -1,124 +1,111 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
+import { withRoute } from '@/lib/api/with-route';
 
-export async function GET(
-  request: NextRequest,
-  props: { params: Promise<{ groupId: string }> }
-) {
-  const perf = measurePerformanceWithAlerts('get_group_modal_data', 'api');
-  const params = await props.params;
-  const { groupId } = params;
-  let userId: string | undefined;
+const querySchema = z.object({
+  session_date: z.string().optional(),
+  session_id: z.string().optional(),
+});
 
-  const searchParams = request.nextUrl.searchParams;
-  const sessionDate = searchParams.get('session_date');
-  const sessionId = searchParams.get('session_id');
+export const GET = withRoute<{ groupId: string }, undefined, z.infer<typeof querySchema>>(
+  { query: querySchema },
+  async ({ userId, query, params }) => {
+    const perf = measurePerformanceWithAlerts('get_group_modal_data', 'api');
+    const { groupId } = params;
+    const { session_date: sessionDate, session_id: sessionId } = query;
 
-  try {
-    const supabase = await createClient();
+    try {
+      const supabase = await createClient();
 
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
+      log.info('Fetching consolidated group modal data', { userId, groupId, sessionDate, sessionId });
+
+      const { data: accessCheck, error: accessError } = await supabase
+        .from('schedule_sessions')
+        .select('id')
+        .eq('group_id', groupId)
+        .or(`provider_id.eq.${userId},assigned_to_specialist_id.eq.${userId},assigned_to_sea_id.eq.${userId}`)
+        .limit(1);
+
+      if (accessError || !accessCheck || accessCheck.length === 0) {
+        perf.end({ success: false });
+        return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+      }
+
+      const results = await Promise.all([
+        sessionDate
+          ? supabase
+              .from('lessons')
+              .select('*')
+              .eq('group_id', groupId)
+              .eq('lesson_date', sessionDate)
+              .order('created_at', { ascending: false })
+              .limit(1)
+              .maybeSingle()
+          : supabase
+              .from('lessons')
+              .select('*')
+              .eq('group_id', groupId)
+              .order('created_at', { ascending: false })
+              .limit(1)
+              .maybeSingle(),
+
+        sessionDate
+          ? supabase
+              .from('documents')
+              .select('*')
+              .eq('documentable_type', 'group')
+              .eq('documentable_id', groupId)
+              .eq('session_date', sessionDate)
+              .order('created_at', { ascending: false })
+          : supabase
+              .from('documents')
+              .select('*')
+              .eq('documentable_type', 'group')
+              .eq('documentable_id', groupId)
+              .order('created_at', { ascending: false }),
+
+        sessionId
+          ? supabase
+              .from('curriculum_tracking')
+              .select('*')
+              .eq('session_id', sessionId)
+              .maybeSingle()
+          : Promise.resolve({ data: null, error: null }),
+
+        sessionDate && sessionId
+          ? fetchPreviousCurriculum(supabase, groupId, sessionDate, sessionId, userId)
+          : Promise.resolve(null)
+      ]);
+
+      const [lessonResult, documentsResult, curriculumResult, previousCurriculumData] = results;
+
+      if (lessonResult.error) {
+        log.warn('Error fetching lesson in group modal data', { error: lessonResult.error, userId, groupId });
+      }
+      if (documentsResult.error) {
+        log.warn('Error fetching documents in group modal data', { error: documentsResult.error, userId, groupId });
+      }
+      if (curriculumResult.error) {
+        log.warn('Error fetching curriculum in group modal data', { error: curriculumResult.error, userId, groupId });
+      }
+
+      perf.end({ success: true });
+      return NextResponse.json({
+        lesson: lessonResult.data || null,
+        documents: documentsResult.data || [],
+        curriculum: curriculumResult.data || null,
+        previousCurriculum: previousCurriculumData
+      });
+    } catch (error) {
+      log.error('Error in get-group-modal-data route', error, { userId, groupId });
       perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
     }
-    userId = user.id;
-
-    log.info('Fetching consolidated group modal data', {
-      userId,
-      groupId,
-      sessionDate,
-      sessionId
-    });
-
-    const { data: accessCheck, error: accessError } = await supabase
-      .from('schedule_sessions')
-      .select('id')
-      .eq('group_id', groupId)
-      .or(`provider_id.eq.${userId},assigned_to_specialist_id.eq.${userId},assigned_to_sea_id.eq.${userId}`)
-      .limit(1);
-
-    if (accessError || !accessCheck || accessCheck.length === 0) {
-      perf.end({ success: false });
-      return NextResponse.json({ error: 'Access denied' }, { status: 403 });
-    }
-
-    const results = await Promise.all([
-      sessionDate
-        ? supabase
-            .from('lessons')
-            .select('*')
-            .eq('group_id', groupId)
-            .eq('lesson_date', sessionDate)
-            .order('created_at', { ascending: false })
-            .limit(1)
-            .maybeSingle()
-        : supabase
-            .from('lessons')
-            .select('*')
-            .eq('group_id', groupId)
-            .order('created_at', { ascending: false })
-            .limit(1)
-            .maybeSingle(),
-
-      sessionDate
-        ? supabase
-            .from('documents')
-            .select('*')
-            .eq('documentable_type', 'group')
-            .eq('documentable_id', groupId)
-            .eq('session_date', sessionDate)
-            .order('created_at', { ascending: false })
-        : supabase
-            .from('documents')
-            .select('*')
-            .eq('documentable_type', 'group')
-            .eq('documentable_id', groupId)
-            .order('created_at', { ascending: false }),
-
-      sessionId
-        ? supabase
-            .from('curriculum_tracking')
-            .select('*')
-            .eq('session_id', sessionId)
-            .maybeSingle()
-        : Promise.resolve({ data: null, error: null }),
-
-      sessionDate && sessionId
-        ? fetchPreviousCurriculum(supabase, groupId, sessionDate, sessionId, userId)
-        : Promise.resolve(null)
-    ]);
-
-    const [lessonResult, documentsResult, curriculumResult, previousCurriculumData] = results;
-
-    if (lessonResult.error) {
-      log.warn('Error fetching lesson in group modal data', { error: lessonResult.error, userId, groupId });
-    }
-    if (documentsResult.error) {
-      log.warn('Error fetching documents in group modal data', { error: documentsResult.error, userId, groupId });
-    }
-    if (curriculumResult.error) {
-      log.warn('Error fetching curriculum in group modal data', { error: curriculumResult.error, userId, groupId });
-    }
-
-    perf.end({ success: true });
-    return NextResponse.json({
-      lesson: lessonResult.data || null,
-      documents: documentsResult.data || [],
-      curriculum: curriculumResult.data || null,
-      previousCurriculum: previousCurriculumData
-    });
-  } catch (error) {
-    log.error('Error in get-group-modal-data route', error, { userId, groupId });
-    perf.end({ success: false });
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
   }
-}
+);
 
 async function fetchPreviousCurriculum(
   supabase: Awaited<ReturnType<typeof createClient>>,


### PR DESCRIPTION
Part of **SPE-75** (continuing #3) — the groups/[groupId] lesson + modal-data routes.

## Changes
- **`groups/[groupId]/modal-data` GET** — `withRoute` auth + dynamic params + Zod query (`session_date`/`session_id`, both optional). The group access check (`provider/specialist/sea` `.or()`) and the `fetchPreviousCurriculum` helper are preserved.
- **`groups/[groupId]/lesson` GET/POST/DELETE** — auth + params + Zod query (`lesson_date`) / body. POST keeps a permissive body schema (free-form lesson fields: `title`/`content`/`subject`/`grade_levels`/etc. as `z.any()`, `lesson_date` nullish) and retains the in-handler "content or notes is required" cross-field check + the group access check.

All perf/log/track telemetry and the access-control logic are unchanged (`user.id` → wrapper `userId`).

## Notes
- `groups/[groupId]/documents` (~561 lines, multipart) is **deferred** alongside `sessions/[sessionId]/documents` under SPE-75.

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check: open a group session modal (lesson/documents/curriculum + previous-curriculum prompt), save/update a group lesson (incl. the content-or-notes guard), and delete a group lesson.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved backend request validation and routing for lesson and modal-data endpoints.
  * More consistent input handling and preserved response behavior (create/update/delete/fetch), with unchanged user-visible outcomes.
  * Increased reliability, clearer error responses, and modest performance improvements for lesson and modal-data operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->