### PR TITLE
Migrate attendance-summary, document-download, migrations routes to withRoute

### DIFF
--- a/app/api/attendance/summary/route.ts
+++ b/app/api/attendance/summary/route.ts
@@ -1,5 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
+import { withRoute } from '@/lib/api/with-route';
 
 interface AttendanceRecord {
   id: string;
@@ -19,24 +21,16 @@ function formatTime12hr(time: string | null): string {
   return `${hour12}:${minutes} ${ampm}`;
 }
 
-export async function GET(request: NextRequest) {
+const querySchema = z.object({
+  start_date: z.string().min(1),
+  end_date: z.string().min(1),
+  school_id: z.string().optional(),
+  limit: z.coerce.number().int().min(1).optional(),
+});
+
+export const GET = withRoute({ query: querySchema }, async ({ userId, query }) => {
   const supabase = await createClient();
-
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  const { searchParams } = new URL(request.url);
-  const startDate = searchParams.get('start_date');
-  const endDate = searchParams.get('end_date');
-  const schoolId = searchParams.get('school_id');
-  const limitParam = searchParams.get('limit');
-  const limit = limitParam ? parseInt(limitParam, 10) : null;
-
-  if (!startDate || !endDate) {
-    return NextResponse.json({ error: 'start_date and end_date are required' }, { status: 400 });
-  }
+  const { start_date: startDate, end_date: endDate, school_id: schoolId, limit } = query;
 
   // Get today's date for filtering unmarked sessions (don't show future sessions as unmarked)
   // Use local date format to match session_date storage format
@@ -52,7 +46,7 @@ export async function GET(request: NextRequest) {
         end_time,
         student_id
       `)
-      .or(`provider_id.eq.${user.id},assigned_to_specialist_id.eq.${user.id},assigned_to_sea_id.eq.${user.id}`)
+      .or(`provider_id.eq.${userId},assigned_to_specialist_id.eq.${userId},assigned_to_sea_id.eq.${userId}`)
       .eq('is_template', false)
       .gte('session_date', startDate)
       .lte('session_date', endDate);
@@ -246,4 +240,4 @@ export async function GET(request: NextRequest) {
     console.error('Error fetching attendance summary:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});

--- a/app/api/documents/[documentId]/download/route.ts
+++ b/app/api/documents/[documentId]/download/route.ts
@@ -1,29 +1,17 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
 import { track } from '@/lib/monitoring/analytics';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
+import { withRoute } from '@/lib/api/with-route';
 
 // GET - Generate download URL for a document
-export async function GET(
-  request: NextRequest,
-  props: { params: Promise<{ documentId: string }> }
-) {
+export const GET = withRoute<{ documentId: string }>({}, async ({ userId, params }) => {
   const perf = measurePerformanceWithAlerts('download_document', 'api');
-  const params = await props.params;
   const { documentId } = params;
-  let userId: string | undefined;
 
   try {
     const supabase = await createClient();
-
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    userId = user.id;
 
     log.info('Fetching document for download', {
       userId,
@@ -198,4 +186,4 @@ export async function GET(
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/migrations/generate-instances/route.ts
+++ b/app/api/migrations/generate-instances/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { withRoute } from '@/lib/api/with-route';
 import { generateInstancesForAllTemplates, getSchoolYearEndDate, InstanceGenerationOptions } from '@/lib/services/session-instance-generator';
 import { log } from '@/lib/monitoring/logger';
 import { formatDateLocal } from '@/lib/utils/date-helpers';
@@ -15,25 +16,19 @@ import { formatDateLocal } from '@/lib/utils/date-helpers';
  *   untilDate?: string             // Optional: specific end date (YYYY-MM-DD)
  * }
  */
-export async function POST(request: NextRequest) {
+export const POST = withRoute({}, async ({ req: request, userId }) => {
   try {
     const supabase = await createClient();
-
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     // Check if user is an admin (optional security check)
     const { data: profile } = await supabase
       .from('profiles')
       .select('role')
-      .eq('id', user.id)
+      .eq('id', userId)
       .single();
 
     if (!profile || profile.role !== 'admin') {
-      log.warn('[Migration] Non-admin user attempted to run migration', { userId: user.id });
+      log.warn('[Migration] Non-admin user attempted to run migration', { userId: userId });
       return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
     }
 
@@ -64,7 +59,7 @@ export async function POST(request: NextRequest) {
     const endDateStr = formatDateLocal(endDate);
 
     log.info('[Migration] Starting instance generation for all templates', {
-      userId: user.id,
+      userId: userId,
       endDate: endDateStr,
       options
     });
@@ -73,7 +68,7 @@ export async function POST(request: NextRequest) {
     const result = await generateInstancesForAllTemplates(options);
 
     log.info('[Migration] Instance generation completed', {
-      userId: user.id,
+      userId: userId,
       total: result.total,
       created: result.created,
       endDate: result.endDate,
@@ -98,21 +93,15 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});
 
 /**
  * GET endpoint to check migration status
  * Returns count of templates and instances, plus school year end info
  */
-export async function GET() {
+export const GET = withRoute({}, async () => {
   try {
     const supabase = await createClient();
-
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     // Count templates (session_date = NULL)
     const { count: templateCount, error: templateError } = await supabase
@@ -177,4 +166,4 @@ export async function GET() {
       { status: 500 }
     );
   }
-}
+});


### PR DESCRIPTION
Part of **SPE-75** (continuing #3) — three standalone read/query routes.

## Changes
- **`attendance/summary` GET** — `withRoute` auth + Zod query (`start_date`/`end_date` required, `school_id`/`limit` optional; `limit` coerced). The summary aggregation, holiday filtering, and the provider/specialist/sea `.or()` access scope are unchanged.
- **`documents/[documentId]/download` GET** — auth + dynamic params (sync→async). The `documentable_type`-based access check (session vs group) and the signed-URL generation incl. legacy-bucket fallback are preserved.
- **`migrations/generate-instances` POST/GET** — auth consolidation. POST keeps its **optional** body parse in-handler (`req.json().catch(() => ({}))` — no Zod body, since a bodyless call is valid) plus the admin-role 403 check; GET is auth-only.

## Notes
- The remaining two standalone routes — `manual-progress` (4 methods + bodies) and `lessons/v2/generate` (AI) — are the next batch (kept separate for reviewability).

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check: attendance summary widget (with date range + school filter + limit), download a session/group document (link + file types), and the admin migration status (GET) / generate (POST).

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal API route architecture and request handling patterns across attendance, document, and migration endpoints for improved code consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->