### PR TITLE
Migrate manual-progress and lessons/v2/generate to withRoute

### DIFF
--- a/app/api/lessons/v2/generate/route.ts
+++ b/app/api/lessons/v2/generate/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { generateV2Worksheet } from '@/lib/lessons/v2-generator';
 import type { V2GenerationRequest } from '@/lib/lessons/v2-generator';
 import { generateLessonPlan } from '@/lib/lessons/lesson-plan-generator';
@@ -6,13 +6,14 @@ import type { LessonPlanRequest } from '@/lib/lessons/lesson-plan-generator';
 import { createClient } from '@/lib/supabase/server';
 import type { Student } from '@/lib/lessons/ability-detector';
 import { determineContentLevel, hasMatchingGoals } from '@/lib/lessons/ability-detector';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function POST(request: NextRequest) {
-  return withAuth(async (req: NextRequest, userId: string) => {
+export const POST = withRoute(
+  { rateLimit: { requests: 30, windowSeconds: 3600, name: 'lessons/v2/generate' } },
+  async ({ req, userId }) => {
   try {
     // Parse request body
     const body = await req.json();
@@ -408,5 +409,5 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-  })(request);
-}
+  }
+);

--- a/app/api/manual-progress/route.ts
+++ b/app/api/manual-progress/route.ts
@@ -1,344 +1,220 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
-import { withAuth } from '@/lib/api/with-auth';
+import { withRoute } from '@/lib/api/with-route';
 
-interface ManualProgressBody {
-  student_id: string;
-  iep_goal_index: number;
-  score: number;
-  observation_date: string;
-  source?: string;
-  notes?: string;
-  school_id?: string;
-  district_id?: string;
-  state_id?: string;
+const studentIdQuerySchema = z.object({
+  student_id: z.string().min(1),
+});
+
+const idQuerySchema = z.object({
+  id: z.string().min(1),
+});
+
+const createSchema = z
+  .object({
+    student_id: z.string().min(1),
+    iep_goal_index: z.number().min(0),
+    score: z.number().min(0).max(100),
+    observation_date: z.string().min(1),
+    source: z.string().nullish(),
+    notes: z.string().nullish(),
+    school_id: z.string().nullish(),
+    district_id: z.string().nullish(),
+    state_id: z.string().nullish(),
+  })
+  .passthrough();
+
+const updateSchema = z
+  .object({
+    id: z.string().min(1),
+    iep_goal_index: z.number().min(0).optional(),
+    score: z.number().min(0).max(100).optional(),
+    observation_date: z.string().optional(),
+    source: z.string().nullish(),
+    notes: z.string().nullish(),
+  })
+  .passthrough();
+
+function isFutureDate(observationDate: string): boolean {
+  const [year, month, day] = observationDate.split('-').map(Number);
+  const date = new Date(year, month - 1, day);
+  const today = new Date();
+  today.setHours(23, 59, 59, 999);
+  return date > today;
 }
 
 // GET: Fetch manual progress for a student
-export async function GET(request: NextRequest) {
-  return withAuth(async (req: NextRequest, userId: string) => {
-    try {
-      const supabase = await createClient();
-      const { searchParams } = new URL(req.url);
-      const studentId = searchParams.get('student_id');
+export const GET = withRoute({ query: studentIdQuerySchema }, async ({ query }) => {
+  try {
+    const supabase = await createClient();
+    const studentId = query.student_id;
 
-      if (!studentId) {
-        return NextResponse.json(
-          { error: 'student_id is required' },
-          { status: 400 }
-        );
-      }
+    // Verify user has access to this student (RLS enforces ownership)
+    const { data: student, error: studentError } = await supabase
+      .from('students')
+      .select('id')
+      .eq('id', studentId)
+      .single();
 
-      // Verify user has access to this student
-      const { data: student, error: studentError } = await supabase
-        .from('students')
-        .select('id')
-        .eq('id', studentId)
-        .single();
-
-      if (studentError || !student) {
-        return NextResponse.json(
-          { error: 'Student not found or access denied' },
-          { status: 403 }
-        );
-      }
-
-      const { data, error } = await supabase
-        .from('manual_goal_progress')
-        .select('*')
-        .eq('student_id', studentId)
-        .order('observation_date', { ascending: false });
-
-      if (error) {
-        console.error('Error fetching manual progress:', error);
-        return NextResponse.json(
-          { error: 'Failed to fetch manual progress', details: error.message },
-          { status: 500 }
-        );
-      }
-
-      return NextResponse.json({
-        success: true,
-        data: data || [],
-      });
-    } catch (error: any) {
-      console.error('Error in manual progress GET:', error);
-      return NextResponse.json(
-        { error: error.message || 'Failed to fetch manual progress' },
-        { status: 500 }
-      );
+    if (studentError || !student) {
+      return NextResponse.json({ error: 'Student not found or access denied' }, { status: 403 });
     }
-  })(request);
-}
+
+    const { data, error } = await supabase
+      .from('manual_goal_progress')
+      .select('*')
+      .eq('student_id', studentId)
+      .order('observation_date', { ascending: false });
+
+    if (error) {
+      console.error('Error fetching manual progress:', error);
+      return NextResponse.json({ error: 'Failed to fetch manual progress', details: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, data: data || [] });
+  } catch (error: any) {
+    console.error('Error in manual progress GET:', error);
+    return NextResponse.json({ error: error.message || 'Failed to fetch manual progress' }, { status: 500 });
+  }
+});
 
 // POST: Create new manual progress entry
-export async function POST(request: NextRequest) {
-  return withAuth(async (req: NextRequest, userId: string) => {
-    try {
-      const supabase = await createClient();
-      const body: ManualProgressBody = await req.json();
+export const POST = withRoute({ body: createSchema }, async ({ userId, body }) => {
+  try {
+    const supabase = await createClient();
 
-      // Validate required fields
-      if (!body.student_id) {
-        return NextResponse.json(
-          { error: 'student_id is required' },
-          { status: 400 }
-        );
-      }
-
-      if (typeof body.iep_goal_index !== 'number' || body.iep_goal_index < 0) {
-        return NextResponse.json(
-          { error: 'iep_goal_index must be a non-negative number' },
-          { status: 400 }
-        );
-      }
-
-      if (typeof body.score !== 'number' || body.score < 0 || body.score > 100) {
-        return NextResponse.json(
-          { error: 'score must be a number between 0 and 100' },
-          { status: 400 }
-        );
-      }
-
-      if (!body.observation_date) {
-        return NextResponse.json(
-          { error: 'observation_date is required' },
-          { status: 400 }
-        );
-      }
-
-      // Validate date is not in the future (parse as local date)
-      const [year, month, day] = body.observation_date.split('-').map(Number);
-      const observationDate = new Date(year, month - 1, day);
-      const today = new Date();
-      today.setHours(23, 59, 59, 999);
-      if (observationDate > today) {
-        return NextResponse.json(
-          { error: 'observation_date cannot be in the future' },
-          { status: 400 }
-        );
-      }
-
-      // Verify user has access to this student
-      const { data: student, error: studentError } = await supabase
-        .from('students')
-        .select('id')
-        .eq('id', body.student_id)
-        .single();
-
-      if (studentError || !student) {
-        return NextResponse.json(
-          { error: 'Student not found or access denied' },
-          { status: 403 }
-        );
-      }
-
-      const { data, error } = await supabase
-        .from('manual_goal_progress')
-        .insert({
-          student_id: body.student_id,
-          provider_id: userId,
-          iep_goal_index: body.iep_goal_index,
-          score: body.score,
-          observation_date: body.observation_date,
-          source: body.source || null,
-          notes: body.notes || null,
-          school_id: body.school_id || null,
-          district_id: body.district_id || null,
-          state_id: body.state_id || null,
-        })
-        .select()
-        .single();
-
-      if (error) {
-        console.error('Error creating manual progress:', error);
-        return NextResponse.json(
-          { error: 'Failed to create manual progress', details: error.message },
-          { status: 500 }
-        );
-      }
-
-      return NextResponse.json({
-        success: true,
-        data,
-        message: 'Manual progress created successfully',
-      });
-    } catch (error: any) {
-      console.error('Error in manual progress POST:', error);
-      return NextResponse.json(
-        { error: error.message || 'Failed to create manual progress' },
-        { status: 500 }
-      );
+    // Validate date is not in the future (parse as local date)
+    if (isFutureDate(body.observation_date)) {
+      return NextResponse.json({ error: 'observation_date cannot be in the future' }, { status: 400 });
     }
-  })(request);
-}
+
+    // Verify user has access to this student
+    const { data: student, error: studentError } = await supabase
+      .from('students')
+      .select('id')
+      .eq('id', body.student_id)
+      .single();
+
+    if (studentError || !student) {
+      return NextResponse.json({ error: 'Student not found or access denied' }, { status: 403 });
+    }
+
+    const { data, error } = await supabase
+      .from('manual_goal_progress')
+      .insert({
+        student_id: body.student_id,
+        provider_id: userId,
+        iep_goal_index: body.iep_goal_index,
+        score: body.score,
+        observation_date: body.observation_date,
+        source: body.source || null,
+        notes: body.notes || null,
+        school_id: body.school_id || null,
+        district_id: body.district_id || null,
+        state_id: body.state_id || null,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error creating manual progress:', error);
+      return NextResponse.json({ error: 'Failed to create manual progress', details: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, data, message: 'Manual progress created successfully' });
+  } catch (error: any) {
+    console.error('Error in manual progress POST:', error);
+    return NextResponse.json({ error: error.message || 'Failed to create manual progress' }, { status: 500 });
+  }
+});
 
 // PUT: Update existing manual progress entry
-export async function PUT(request: NextRequest) {
-  return withAuth(async (req: NextRequest, userId: string) => {
-    try {
-      const supabase = await createClient();
-      const body = await req.json();
-      const { id, ...updateData } = body as ManualProgressBody & { id: string };
+export const PUT = withRoute({ body: updateSchema }, async ({ userId, body }) => {
+  try {
+    const supabase = await createClient();
+    const { id, ...updateData } = body;
 
-      if (!id) {
-        return NextResponse.json(
-          { error: 'id is required for update' },
-          { status: 400 }
-        );
-      }
-
-      // Validate score if provided
-      if (updateData.score !== undefined) {
-        if (typeof updateData.score !== 'number' || updateData.score < 0 || updateData.score > 100) {
-          return NextResponse.json(
-            { error: 'score must be a number between 0 and 100' },
-            { status: 400 }
-          );
-        }
-      }
-
-      // Validate iep_goal_index if provided
-      if (updateData.iep_goal_index !== undefined) {
-        if (typeof updateData.iep_goal_index !== 'number' || updateData.iep_goal_index < 0) {
-          return NextResponse.json(
-            { error: 'iep_goal_index must be a non-negative number' },
-            { status: 400 }
-          );
-        }
-      }
-
-      // Validate date if provided (parse as local date)
-      if (updateData.observation_date) {
-        const [year, month, day] = updateData.observation_date.split('-').map(Number);
-        const observationDate = new Date(year, month - 1, day);
-        const today = new Date();
-        today.setHours(23, 59, 59, 999);
-        if (observationDate > today) {
-          return NextResponse.json(
-            { error: 'observation_date cannot be in the future' },
-            { status: 400 }
-          );
-        }
-      }
-
-      // Verify ownership before update (RLS will also enforce this)
-      const { data: existing, error: fetchError } = await supabase
-        .from('manual_goal_progress')
-        .select('provider_id')
-        .eq('id', id)
-        .single();
-
-      if (fetchError || !existing) {
-        return NextResponse.json(
-          { error: 'Manual progress entry not found' },
-          { status: 404 }
-        );
-      }
-
-      if (existing.provider_id !== userId) {
-        return NextResponse.json(
-          { error: 'You can only edit your own entries' },
-          { status: 403 }
-        );
-      }
-
-      const { data, error } = await supabase
-        .from('manual_goal_progress')
-        .update({
-          ...(updateData.iep_goal_index !== undefined && { iep_goal_index: updateData.iep_goal_index }),
-          ...(updateData.score !== undefined && { score: updateData.score }),
-          ...(updateData.observation_date && { observation_date: updateData.observation_date }),
-          ...(updateData.source !== undefined && { source: updateData.source || null }),
-          ...(updateData.notes !== undefined && { notes: updateData.notes || null }),
-          updated_at: new Date().toISOString(),
-        })
-        .eq('id', id)
-        .select()
-        .single();
-
-      if (error) {
-        console.error('Error updating manual progress:', error);
-        return NextResponse.json(
-          { error: 'Failed to update manual progress', details: error.message },
-          { status: 500 }
-        );
-      }
-
-      return NextResponse.json({
-        success: true,
-        data,
-        message: 'Manual progress updated successfully',
-      });
-    } catch (error: any) {
-      console.error('Error in manual progress PUT:', error);
-      return NextResponse.json(
-        { error: error.message || 'Failed to update manual progress' },
-        { status: 500 }
-      );
+    // Validate date if provided (parse as local date)
+    if (updateData.observation_date && isFutureDate(updateData.observation_date)) {
+      return NextResponse.json({ error: 'observation_date cannot be in the future' }, { status: 400 });
     }
-  })(request);
-}
+
+    // Verify ownership before update (RLS will also enforce this)
+    const { data: existing, error: fetchError } = await supabase
+      .from('manual_goal_progress')
+      .select('provider_id')
+      .eq('id', id)
+      .single();
+
+    if (fetchError || !existing) {
+      return NextResponse.json({ error: 'Manual progress entry not found' }, { status: 404 });
+    }
+
+    if (existing.provider_id !== userId) {
+      return NextResponse.json({ error: 'You can only edit your own entries' }, { status: 403 });
+    }
+
+    const { data, error } = await supabase
+      .from('manual_goal_progress')
+      .update({
+        ...(updateData.iep_goal_index !== undefined && { iep_goal_index: updateData.iep_goal_index }),
+        ...(updateData.score !== undefined && { score: updateData.score }),
+        ...(updateData.observation_date && { observation_date: updateData.observation_date }),
+        ...(updateData.source !== undefined && { source: updateData.source || null }),
+        ...(updateData.notes !== undefined && { notes: updateData.notes || null }),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error updating manual progress:', error);
+      return NextResponse.json({ error: 'Failed to update manual progress', details: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, data, message: 'Manual progress updated successfully' });
+  } catch (error: any) {
+    console.error('Error in manual progress PUT:', error);
+    return NextResponse.json({ error: error.message || 'Failed to update manual progress' }, { status: 500 });
+  }
+});
 
 // DELETE: Remove manual progress entry
-export async function DELETE(request: NextRequest) {
-  return withAuth(async (req: NextRequest, userId: string) => {
-    try {
-      const supabase = await createClient();
-      const { searchParams } = new URL(req.url);
-      const id = searchParams.get('id');
+export const DELETE = withRoute({ query: idQuerySchema }, async ({ userId, query }) => {
+  try {
+    const supabase = await createClient();
+    const id = query.id;
 
-      if (!id) {
-        return NextResponse.json(
-          { error: 'id is required' },
-          { status: 400 }
-        );
-      }
+    // Verify ownership before delete (RLS will also enforce this)
+    const { data: existing, error: fetchError } = await supabase
+      .from('manual_goal_progress')
+      .select('provider_id')
+      .eq('id', id)
+      .single();
 
-      // Verify ownership before delete (RLS will also enforce this)
-      const { data: existing, error: fetchError } = await supabase
-        .from('manual_goal_progress')
-        .select('provider_id')
-        .eq('id', id)
-        .single();
-
-      if (fetchError || !existing) {
-        return NextResponse.json(
-          { error: 'Manual progress entry not found' },
-          { status: 404 }
-        );
-      }
-
-      if (existing.provider_id !== userId) {
-        return NextResponse.json(
-          { error: 'You can only delete your own entries' },
-          { status: 403 }
-        );
-      }
-
-      const { error } = await supabase
-        .from('manual_goal_progress')
-        .delete()
-        .eq('id', id);
-
-      if (error) {
-        console.error('Error deleting manual progress:', error);
-        return NextResponse.json(
-          { error: 'Failed to delete manual progress', details: error.message },
-          { status: 500 }
-        );
-      }
-
-      return NextResponse.json({
-        success: true,
-        message: 'Manual progress deleted successfully',
-      });
-    } catch (error: any) {
-      console.error('Error in manual progress DELETE:', error);
-      return NextResponse.json(
-        { error: error.message || 'Failed to delete manual progress' },
-        { status: 500 }
-      );
+    if (fetchError || !existing) {
+      return NextResponse.json({ error: 'Manual progress entry not found' }, { status: 404 });
     }
-  })(request);
-}
+
+    if (existing.provider_id !== userId) {
+      return NextResponse.json({ error: 'You can only delete your own entries' }, { status: 403 });
+    }
+
+    const { error } = await supabase
+      .from('manual_goal_progress')
+      .delete()
+      .eq('id', id);
+
+    if (error) {
+      console.error('Error deleting manual progress:', error);
+      return NextResponse.json({ error: 'Failed to delete manual progress', details: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, message: 'Manual progress deleted successfully' });
+  } catch (error: any) {
+    console.error('Error in manual progress DELETE:', error);
+    return NextResponse.json({ error: error.message || 'Failed to delete manual progress' }, { status: 500 });
+  }
+});


### PR DESCRIPTION
Part of **SPE-75** (continuing #3) — completes the standalone-routes batch.

## Changes
- **`manual-progress` GET/POST/PUT/DELETE** — `withRoute` auth + Zod. Query schemas for `student_id` (GET) and `id` (DELETE); body schemas for POST (`student_id`, `iep_goal_index >= 0`, `score` 0-100, `observation_date` + optional nullish `source`/`notes`/`school_id`/`district_id`/`state_id`) and PUT (`id` + the same fields optional). The future-date guard and the ownership checks (`existing.provider_id !== userId`) stay in-handler. (`iep_goal_index` kept as `>= 0` without `.int()` to match prior behavior; field types verified against `student-progress-tab`.)
- **`lessons/v2/generate` POST** — auth + a **per-user rate limit (30/hr)**, consistent with the other AI-generate endpoints. Its interdependent domain validation (`subjectType`↔`topic`, grade-or-`studentIds`, `duration` enum, grade enum) is left in-handler — too coupled to express cleanly in Zod without changing the specific error messages.

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check: add/edit/delete a manual progress entry (incl. score-range + future-date rejections and the own-entries-only guard), list a student's progress, and generate a v2 worksheet (by grade and by selected students).

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved API route handling with standardized validation and error handling.
  * Enhanced lesson generation endpoint with explicit rate limiting.
  * Strengthened manual progress tracking endpoints with schema-based input validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->