### PR TITLE
Migrate sessions/[sessionId]/documents to withRoute

### DIFF
--- a/app/api/sessions/[sessionId]/documents/route.ts
+++ b/app/api/sessions/[sessionId]/documents/route.ts
@@ -1,34 +1,24 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient, createServiceClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
 import { track } from '@/lib/monitoring/analytics';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
 import { validateDocumentFile, generateSafeFilename } from '@/lib/document-utils';
+import { withRoute } from '@/lib/api/with-route';
+
+const sessionDocsQuerySchema = z.object({
+  session_date: z.string().optional(),
+});
 
 // GET - Fetch all documents for a session
-export async function GET(
-  request: NextRequest,
-  props: { params: Promise<{ sessionId: string }> }
-) {
+export const GET = withRoute<{ sessionId: string }, undefined, z.infer<typeof sessionDocsQuerySchema>>({ query: sessionDocsQuerySchema }, async ({ userId, query, params }) => {
   const perf = measurePerformanceWithAlerts('get_session_documents', 'api');
-  const params = await props.params;
   const { sessionId } = params;
-  let userId: string | undefined;
-
-  // Get session_date from query params (optional - if provided, filter documents for specific date)
-  const searchParams = request.nextUrl.searchParams;
-  const sessionDate = searchParams.get('session_date');
+  const sessionDate = query.session_date;
 
   try {
     const supabase = await createClient();
-
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    userId = user.id;
 
     // Handle temporary session IDs (unsaved sessions)
     if (sessionId.startsWith('temp-')) {
@@ -167,28 +157,15 @@ export async function GET(
       { status: 500 }
     );
   }
-}
+});
 
 // POST - Create a new document for a session
-export async function POST(
-  request: NextRequest,
-  props: { params: Promise<{ sessionId: string }> }
-) {
+export const POST = withRoute<{ sessionId: string }>({}, async ({ req: request, userId, params }) => {
   const perf = measurePerformanceWithAlerts('create_session_document', 'api');
-  const params = await props.params;
   const { sessionId } = params;
-  let userId: string | undefined;
 
   try {
     const supabase = await createClient();
-
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    userId = user.id;
 
     // Handle temporary session IDs (unsaved sessions)
     if (sessionId.startsWith('temp-')) {
@@ -479,28 +456,15 @@ export async function POST(
       { status: 500 }
     );
   }
-}
+});
 
 // DELETE - Delete a document
-export async function DELETE(
-  request: NextRequest,
-  props: { params: Promise<{ sessionId: string }> }
-) {
+export const DELETE = withRoute<{ sessionId: string }>({}, async ({ req: request, userId, params }) => {
   const perf = measurePerformanceWithAlerts('delete_session_document', 'api');
-  const params = await props.params;
   const { sessionId } = params;
-  let userId: string | undefined;
 
   try {
     const supabase = await createClient();
-
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    userId = user.id;
 
     // Handle temporary session IDs (unsaved sessions)
     if (sessionId.startsWith('temp-')) {
@@ -578,4 +542,4 @@ export async function DELETE(
       { status: 500 }
     );
   }
-}
+});


### PR DESCRIPTION
Part of **SPE-75** (continuing #3) — the session documents route.

## Changes
- **`sessions/[sessionId]/documents` GET** — `withRoute` auth + dynamic params + Zod query (`session_date` optional). Keeps the `temp-` short-circuit and the `createServiceClient` access check (provider/specialist/sea).
- **POST** — wrapper-only swap (auth + params). The body is **content-type-variable** (multipart file upload OR JSON link/note), so no Zod body; all of it — content-type detection, file validation/upload, link/note validation, `documentable` insert — stays in-handler with `req` aliased to `request`.
- **DELETE** — wrapper + params. `documentId` is still read in-handler (via `request.nextUrl.searchParams`) so the `temp-` session check runs first, exactly as before.

Access-control and all perf/log/track telemetry are unchanged; the access checks already keyed on the resolved user id, so there were no `user.id` references to rewrite.

## Notes
- `groups/[groupId]/documents` (the sibling ~561-line route) is the next PR.

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check: list session documents (with/without a date), upload a file, add a link + a note (incl. the URL/required-field validations), and delete a document; confirm `temp-` sessions still short-circuit.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored API route handler implementation for improved code maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->