### PR TITLE
Migrate groups/[groupId]/documents to withRoute

### DIFF
--- a/app/api/groups/[groupId]/documents/route.ts
+++ b/app/api/groups/[groupId]/documents/route.ts
@@ -1,34 +1,38 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
 import { track } from '@/lib/monitoring/analytics';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
 import { validateDocumentFile, generateSafeFilename } from '@/lib/document-utils';
+import { withRoute } from '@/lib/api/with-route';
+
+const sessionDateQuerySchema = z.object({
+  session_date: z.string().optional(),
+});
+
+const documentIdQuerySchema = z.object({
+  documentId: z.string().min(1),
+});
+
+const updateDocSchema = z
+  .object({
+    documentId: z.string().min(1),
+    title: z.any().optional(),
+    content: z.any().optional(),
+    url: z.any().optional(),
+    file_path: z.any().optional(),
+  })
+  .passthrough();
 
 // GET - Fetch all documents for a group
-export async function GET(
-  request: NextRequest,
-  props: { params: Promise<{ groupId: string }> }
-) {
+export const GET = withRoute<{ groupId: string }, undefined, z.infer<typeof sessionDateQuerySchema>>({ query: sessionDateQuerySchema }, async ({ userId, query, params }) => {
   const perf = measurePerformanceWithAlerts('get_group_documents', 'api');
-  const params = await props.params;
   const { groupId } = params;
-  let userId: string | undefined;
-
-  // Get session_date from query params (optional - if provided, filter documents for specific date)
-  const searchParams = request.nextUrl.searchParams;
-  const sessionDate = searchParams.get('session_date');
+  const sessionDate = query.session_date;
 
   try {
     const supabase = await createClient();
-
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    userId = user.id;
 
     log.info('Fetching group documents', {
       userId,
@@ -107,28 +111,15 @@ export async function GET(
       { status: 500 }
     );
   }
-}
+});
 
 // POST - Create a new document for a group
-export async function POST(
-  request: NextRequest,
-  props: { params: Promise<{ groupId: string }> }
-) {
+export const POST = withRoute<{ groupId: string }>({}, async ({ req: request, userId, params }) => {
   const perf = measurePerformanceWithAlerts('create_group_document', 'api');
-  const params = await props.params;
   const { groupId } = params;
-  let userId: string | undefined;
 
   try {
     const supabase = await createClient();
-
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    userId = user.id;
 
     // Verify user has access to this group BEFORE processing any file uploads
     const { data: groupSessions, error: accessError } = await supabase
@@ -356,39 +347,17 @@ export async function POST(
       { status: 500 }
     );
   }
-}
+});
 
 // PUT - Update an existing document
-export async function PUT(
-  request: NextRequest,
-  props: { params: Promise<{ groupId: string }> }
-) {
+export const PUT = withRoute<{ groupId: string }, z.infer<typeof updateDocSchema>>({ body: updateDocSchema }, async ({ userId, body, params }) => {
   const perf = measurePerformanceWithAlerts('update_group_document', 'api');
-  const params = await props.params;
   const { groupId } = params;
-  let userId: string | undefined;
 
   try {
     const supabase = await createClient();
 
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    userId = user.id;
-
-    const body = await request.json();
     const { documentId, title, content, url, file_path } = body;
-
-    if (!documentId) {
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'documentId is required' },
-        { status: 400 }
-      );
-    }
 
     log.info('Updating group document', {
       userId,
@@ -472,39 +441,16 @@ export async function PUT(
       { status: 500 }
     );
   }
-}
+});
 
 // DELETE - Delete a document
-export async function DELETE(
-  request: NextRequest,
-  props: { params: Promise<{ groupId: string }> }
-) {
+export const DELETE = withRoute<{ groupId: string }, undefined, z.infer<typeof documentIdQuerySchema>>({ query: documentIdQuerySchema }, async ({ userId, query, params }) => {
   const perf = measurePerformanceWithAlerts('delete_group_document', 'api');
-  const params = await props.params;
   const { groupId } = params;
-  let userId: string | undefined;
+  const documentId = query.documentId;
 
   try {
     const supabase = await createClient();
-
-    // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      perf.end({ success: false });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    userId = user.id;
-
-    const searchParams = request.nextUrl.searchParams;
-    const documentId = searchParams.get('documentId');
-
-    if (!documentId) {
-      perf.end({ success: false });
-      return NextResponse.json(
-        { error: 'documentId query parameter is required' },
-        { status: 400 }
-      );
-    }
 
     log.info('Deleting group document', {
       userId,
@@ -558,4 +504,4 @@ export async function DELETE(
       { status: 500 }
     );
   }
-}
+});


### PR DESCRIPTION
Part of **SPE-75** (continuing #3) — the group documents route (sibling of #626).

## Changes
- **`groups/[groupId]/documents` GET** — `withRoute` auth + dynamic params + Zod query (`session_date` optional). Group `.or()` access check preserved.
- **POST** — wrapper-only swap; content-type-variable body (multipart upload OR JSON link/note) stays parsed in-handler with `req` aliased to `request`.
- **PUT** — auth + params + Zod body (`documentId` required; `title`/`content`/`url`/`file_path` permissive). The `http(s)` URL validation stays in-handler.
- **DELETE** — auth + params + Zod query (`documentId` required). (Unlike the sessions route, there's no `temp-` short-circuit here, so requiring `documentId` via Zod matches the prior 400 behavior.)

Access checks already keyed on the resolved user id, so no `user.id` rewrites; all perf/log/track telemetry preserved.

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check: list group documents (with/without date), upload a file, add a link/note, edit a document (incl. URL validation), and delete one.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of document management API endpoints for improved code maintainability and consistency.

**Note:** This release contains no user-facing changes or new features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->