### PR TITLE
Migrate submit-worksheet to withRoute (auth: false)

### DIFF
--- a/app/api/submit-worksheet/route.ts
+++ b/app/api/submit-worksheet/route.ts
@@ -1,6 +1,7 @@
 // app/api/submit-worksheet/route.ts
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { withRoute } from '@/lib/api/with-route';
 import Anthropic from '@anthropic-ai/sdk';
 import { checkRateLimit, recordUpload } from '@/lib/rate-limit';
 import { extractQRCodeForSubmission, verifyQRCodeMatch } from '@/lib/qr-verification';
@@ -20,7 +21,9 @@ interface AnalysisResult {
   confidenceLevel?: string;
 }
 
-export async function POST(request: NextRequest) {
+// Public endpoint: QR-scan uploads are unauthenticated (auth is enforced
+// in-handler only for non-QR direct uploads), and it has its own IP rate limit.
+export const POST = withRoute({ auth: false }, async ({ req: request }) => {
   const startTime = Date.now();
   let imageSize = 0;
   let source: string | undefined;
@@ -461,7 +464,7 @@ export async function POST(request: NextRequest) {
     });
     
     return NextResponse.json(
-      { 
+      {
         error: 'Failed to process worksheet',
         details: 'An unexpected error occurred while processing your worksheet. Please try again.',
         retryable: true
@@ -469,7 +472,7 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});
 
 
 function extractSkillsAssessed(worksheet: any, analysis: any): any {


### PR DESCRIPTION
Part of **SPE-75** (continuing #3) — the public worksheet-submission endpoint.

## Change
- **`submit-worksheet` POST** — wrapper-only swap to `withRoute({ auth: false })` for a consistent error envelope.

This route has a **conditional auth model**: JSON direct-uploads require auth, but QR-scan uploads (`source === 'qr_scan_upload'`) are intentionally **unauthenticated** (a student/parent scanning a printed worksheet QR). That doesn't fit `withRoute`'s binary auth, so `auth: false` is correct — the route keeps doing its own in-handler conditional auth check. Everything else is untouched and stays in-handler:
- IP extraction + the existing **IP-based rate limit** (`checkRateLimit`/`recordUpload`) — the right model for an anonymous endpoint (`withRoute`'s per-user limit doesn't apply).
- QR extraction/verification, image-buffer validation, content-type branching (JSON vs multipart), the Anthropic analysis, and IEP-progress update.

`req` is aliased to `request` so the body/header handling is byte-for-byte the same.

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check: QR-scan upload (unauthenticated) succeeds and is IP-rate-limited; an authenticated direct upload works; an unauthenticated non-QR direct upload still returns 401.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_