### PR TITLE
Migrate internal/* admin routes to withRoute

### DIFF
--- a/app/api/internal/create-admin-account/route.ts
+++ b/app/api/internal/create-admin-account/route.ts
@@ -1,38 +1,30 @@
 import { createClient } from '@supabase/supabase-js';
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { Database } from '@/src/types/database';
 import { generateTemporaryPassword } from '@/lib/utils/password-generator';
 import { logger } from '@/lib/logger';
+import { withRoute } from '@/lib/api/with-route';
 
 const log = logger.child({ module: 'internal-create-admin' });
 
-export async function POST(request: NextRequest) {
+export const POST = withRoute({}, async ({ req: request, userId }) => {
   try {
-    // Get current user to verify they're a speddy admin
-    const cookieStore = cookies();
-    const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore });
-
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
-    }
+    // Admin (service-role) client; also used to verify the caller is a speddy admin.
+    const adminClient = createClient<Database>(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!
+    );
 
     // Verify the user is a speddy admin
     // Note: is_speddy_admin column added via migration, cast to bypass type check until types regenerated
-    const { data: profile, error: profileError } = await supabase
+    const { data: profile, error: profileError } = await adminClient
       .from('profiles')
       .select('is_speddy_admin')
-      .eq('id', user.id)
+      .eq('id', userId)
       .single() as unknown as { data: { is_speddy_admin: boolean } | null; error: Error | null };
 
     if (profileError || !profile?.is_speddy_admin) {
-      log.warn('Non-speddy-admin tried to create admin account', { userId: user.id });
+      log.warn('Non-speddy-admin tried to create admin account', { userId });
       return NextResponse.json(
         { error: 'Forbidden: Speddy admin access required' },
         { status: 403 }
@@ -85,11 +77,6 @@ export async function POST(request: NextRequest) {
     }
 
     // Check if email already exists
-    const adminClient = createClient<Database>(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!
-    );
-
     const { data: existingProfile } = await adminClient
       .from('profiles')
       .select('id')
@@ -128,7 +115,7 @@ export async function POST(request: NextRequest) {
       adminType,
       districtId,
       schoolId,
-      createdBy: user.id
+      createdBy: userId
     });
 
     // Create auth user using admin API (this skips email confirmation)
@@ -199,7 +186,7 @@ export async function POST(request: NextRequest) {
           state_id: stateId,
           district_id: districtId,
           school_id: adminType === 'site_admin' ? schoolId : null,
-          granted_by: user.id,
+          granted_by: userId,
         });
 
       if (permissionsError) {
@@ -210,7 +197,7 @@ export async function POST(request: NextRequest) {
         newUserId,
         email: normalizedEmail,
         adminType,
-        createdBy: user.id
+        createdBy: userId
       });
 
       return NextResponse.json({
@@ -246,4 +233,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/internal/create-district/route.ts
+++ b/app/api/internal/create-district/route.ts
@@ -1,37 +1,29 @@
 import { createClient } from '@supabase/supabase-js';
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { Database } from '@/src/types/database';
 import { logger } from '@/lib/logger';
 import { v4 as uuidv4 } from 'uuid';
+import { withRoute } from '@/lib/api/with-route';
 
 const log = logger.child({ module: 'internal-create-district' });
 
-export async function POST(request: NextRequest) {
+export const POST = withRoute({}, async ({ req: request, userId }) => {
   try {
-    // Get current user to verify they're a speddy admin
-    const cookieStore = cookies();
-    const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore });
-
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
-    }
+    // Admin (service-role) client; also used to verify the caller is a speddy admin.
+    const adminClient = createClient<Database>(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!
+    );
 
     // Verify the user is a speddy admin
-    const { data: profile, error: profileError } = await supabase
+    const { data: profile, error: profileError } = await adminClient
       .from('profiles')
       .select('is_speddy_admin')
-      .eq('id', user.id)
+      .eq('id', userId)
       .single() as unknown as { data: { is_speddy_admin: boolean } | null; error: Error | null };
 
     if (profileError || !profile?.is_speddy_admin) {
-      log.warn('Non-speddy-admin tried to create district', { userId: user.id });
+      log.warn('Non-speddy-admin tried to create district', { userId });
       return NextResponse.json(
         { error: 'Forbidden: Speddy admin access required' },
         { status: 403 }
@@ -59,12 +51,6 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Use admin client for insert
-    const adminClient = createClient<Database>(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!
-    );
-
     // Verify state exists
     const { data: state, error: stateError } = await adminClient
       .from('states')
@@ -86,7 +72,7 @@ export async function POST(request: NextRequest) {
       districtId,
       name,
       stateId,
-      createdBy: user.id
+      createdBy: userId
     });
 
     // Insert the district
@@ -115,7 +101,7 @@ export async function POST(request: NextRequest) {
     log.info('District created successfully', {
       districtId,
       name,
-      createdBy: user.id
+      createdBy: userId
     });
 
     return NextResponse.json({
@@ -132,4 +118,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/internal/create-school/route.ts
+++ b/app/api/internal/create-school/route.ts
@@ -1,37 +1,29 @@
 import { createClient } from '@supabase/supabase-js';
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { Database } from '@/src/types/database';
 import { logger } from '@/lib/logger';
 import { v4 as uuidv4 } from 'uuid';
+import { withRoute } from '@/lib/api/with-route';
 
 const log = logger.child({ module: 'internal-create-school' });
 
-export async function POST(request: NextRequest) {
+export const POST = withRoute({}, async ({ req: request, userId }) => {
   try {
-    // Get current user to verify they're a speddy admin
-    const cookieStore = cookies();
-    const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore });
-
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    // Admin (service-role) client; also used to verify the caller is a speddy admin.
+    const adminClient = createClient<Database>(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!
+    );
 
     // Verify the user is a speddy admin
-    const { data: profile, error: profileError } = (await supabase
+    const { data: profile, error: profileError } = (await adminClient
       .from('profiles')
       .select('is_speddy_admin')
-      .eq('id', user.id)
+      .eq('id', userId)
       .single()) as unknown as { data: { is_speddy_admin: boolean } | null; error: Error | null };
 
     if (profileError || !profile?.is_speddy_admin) {
-      log.warn('Non-speddy-admin tried to create school', { userId: user.id });
+      log.warn('Non-speddy-admin tried to create school', { userId });
       return NextResponse.json({ error: 'Forbidden: Speddy admin access required' }, { status: 403 });
     }
 
@@ -66,12 +58,6 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Missing required fields: name, districtId' }, { status: 400 });
     }
 
-    // Use admin client for insert
-    const adminClient = createClient<Database>(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!
-    );
-
     // Verify district exists
     const { data: district, error: districtError } = await adminClient
       .from('districts')
@@ -90,7 +76,7 @@ export async function POST(request: NextRequest) {
       schoolId,
       name,
       districtId,
-      createdBy: user.id,
+      createdBy: userId,
     });
 
     // Insert the school
@@ -117,7 +103,7 @@ export async function POST(request: NextRequest) {
       schoolId,
       name,
       districtId,
-      createdBy: user.id,
+      createdBy: userId,
     });
 
     return NextResponse.json({
@@ -130,4 +116,4 @@ export async function POST(request: NextRequest) {
     log.error('Unexpected error in create-school', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});

--- a/app/api/internal/sign-in-logs/route.ts
+++ b/app/api/internal/sign-in-logs/route.ts
@@ -1,32 +1,23 @@
 import { createClient, createServiceClient } from '@/lib/supabase/server';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
+import { withRoute } from '@/lib/api/with-route';
 
 const log = logger.child({ module: 'internal-sign-in-logs' });
 
-export async function GET(request: NextRequest) {
+export const GET = withRoute({}, async ({ req: request, userId }) => {
   try {
-    // Get current user to verify they're a speddy admin
     const supabase = await createClient();
-
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
-    }
 
     // Verify the user is a speddy admin
     const { data: profile, error: profileError } = await supabase
       .from('profiles')
       .select('is_speddy_admin')
-      .eq('id', user.id)
+      .eq('id', userId)
       .single();
 
     if (profileError || !profile?.is_speddy_admin) {
-      log.warn('Non-speddy-admin tried to access sign-in logs', { userId: user.id });
+      log.warn('Non-speddy-admin tried to access sign-in logs', { userId: userId });
       return NextResponse.json(
         { error: 'Forbidden: Speddy admin access required' },
         { status: 403 }
@@ -106,7 +97,7 @@ export async function GET(request: NextRequest) {
       timestamp: event.created_at,
     })) || [];
 
-    log.info('Sign-in logs fetched', { count: signInLogs.length, requestedBy: user.id });
+    log.info('Sign-in logs fetched', { count: signInLogs.length, requestedBy: userId });
 
     return NextResponse.json({
       logs: signInLogs,
@@ -124,4 +115,4 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});


### PR DESCRIPTION
Part of **SPE-75** (continuing #3) — begins the admin/internal cluster with the `internal/*` group.

## Changes
- **`internal/create-admin-account`, `create-district`, `create-school` (POST)** — these used the bespoke `createRouteHandlerClient` (auth-helpers) for auth plus an `is_speddy_admin` super-admin gate and an inline typed service-role client. Swapped auth to `withRoute` (verified `userId`); the **`is_speddy_admin` gate is preserved**, now read via the service-role client filtered by the verified `userId` (equivalent, not spoofable). The typed admin client, email/field/`adminType` validation, the `site_admin` → `schoolId` requirement, and the create-admin rollback + RPC + `admin_permissions` logic are all unchanged. (`granted_by`/`createdBy` now use `userId`; `newUser.user.id` left intact.)
- **`internal/sign-in-logs` (GET)** — standard-helper route; `withRoute` auth, with the `is_speddy_admin` gate and the custom limit/offset clamping (min 1 / max 200 / default 50) kept in-handler.

## Security note
Every permission gate is preserved. The only change is *where* the caller's identity comes from (now `withRoute`'s validated session `userId` instead of a second `getUser()` call), and the `is_speddy_admin` lookup now uses the service client by that verified id.

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check (as a speddy admin): create a district, a school, and a district/site admin account; load sign-in logs. Confirm a **non**-speddy-admin gets 403 on each, and an unauthenticated request gets 401.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authentication mechanisms for internal administrative operations to improve system security and code maintainability across multiple API endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/629?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->