### PR TITLE
Migrate admin/district/schools routes to withRoute

### DIFF
--- a/app/api/admin/district/schools/[schoolId]/route.ts
+++ b/app/api/admin/district/schools/[schoolId]/route.ts
@@ -228,7 +228,7 @@ export const DELETE = withRoute<{ schoolId: string }>({}, async ({ userId, param
 });
 
 /**
- * GET /api/admin/district/schools/[schoolId]/deletable
+ * GET /api/admin/district/schools/[schoolId]
  * Check if a school can be deleted (used by frontend before showing delete modal)
  */
 export const GET = withRoute<{ schoolId: string }>({}, async ({ userId, params }) => {

--- a/app/api/admin/district/schools/[schoolId]/route.ts
+++ b/app/api/admin/district/schools/[schoolId]/route.ts
@@ -1,14 +1,11 @@
 import { createClient, createServiceClient } from '@/lib/supabase/server';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { Database } from '@/src/types/database';
 import { logger } from '@/lib/logger';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { withRoute } from '@/lib/api/with-route';
 
 const log = logger.child({ module: 'district-admin-school' });
-
-interface RouteParams {
-  params: { schoolId: string };
-}
 
 /**
  * Helper to verify district admin has access to the school
@@ -54,26 +51,16 @@ async function verifyDistrictAdminAccess(
  * PATCH /api/admin/district/schools/[schoolId]
  * Update a school in the district admin's district
  */
-export async function PATCH(request: NextRequest, { params }: RouteParams) {
+export const PATCH = withRoute<{ schoolId: string }>({}, async ({ req: request, userId, params }) => {
   try {
     const { schoolId } = params;
     const supabase = await createClient();
 
-    // Get current user
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     // Verify access
-    const accessCheck = await verifyDistrictAdminAccess(supabase, user.id, schoolId);
+    const accessCheck = await verifyDistrictAdminAccess(supabase, userId, schoolId);
     if (!accessCheck.allowed) {
       log.warn('District admin access denied for school update', {
-        userId: user.id,
+        userId,
         schoolId,
         reason: accessCheck.error,
       });
@@ -112,7 +99,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     log.info('District admin updating school', {
       schoolId,
       updates: Object.keys(updates),
-      updatedBy: user.id,
+      updatedBy: userId,
     });
 
     const { data: updatedSchool, error: updateError } = await adminClient
@@ -132,7 +119,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     log.info('School updated successfully', {
       schoolId,
-      updatedBy: user.id,
+      updatedBy: userId,
     });
 
     return NextResponse.json({
@@ -143,32 +130,22 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     log.error('Unexpected error in school update', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});
 
 /**
  * DELETE /api/admin/district/schools/[schoolId]
  * Delete a school (only if no active dependencies)
  */
-export async function DELETE(request: NextRequest, { params }: RouteParams) {
+export const DELETE = withRoute<{ schoolId: string }>({}, async ({ userId, params }) => {
   try {
     const { schoolId } = params;
     const supabase = await createClient();
 
-    // Get current user
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     // Verify access
-    const accessCheck = await verifyDistrictAdminAccess(supabase, user.id, schoolId);
+    const accessCheck = await verifyDistrictAdminAccess(supabase, userId, schoolId);
     if (!accessCheck.allowed) {
       log.warn('District admin access denied for school delete', {
-        userId: user.id,
+        userId,
         schoolId,
         reason: accessCheck.error,
       });
@@ -218,7 +195,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
 
     log.info('District admin deleting school', {
       schoolId,
-      deletedBy: user.id,
+      deletedBy: userId,
     });
 
     // Delete the school
@@ -237,7 +214,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
 
     log.info('School deleted successfully', {
       schoolId,
-      deletedBy: user.id,
+      deletedBy: userId,
     });
 
     return NextResponse.json({
@@ -248,29 +225,19 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     log.error('Unexpected error in school delete', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});
 
 /**
  * GET /api/admin/district/schools/[schoolId]/deletable
  * Check if a school can be deleted (used by frontend before showing delete modal)
  */
-export async function GET(request: NextRequest, { params }: RouteParams) {
+export const GET = withRoute<{ schoolId: string }>({}, async ({ userId, params }) => {
   try {
     const { schoolId } = params;
     const supabase = await createClient();
 
-    // Get current user
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     // Verify access
-    const accessCheck = await verifyDistrictAdminAccess(supabase, user.id, schoolId);
+    const accessCheck = await verifyDistrictAdminAccess(supabase, userId, schoolId);
     if (!accessCheck.allowed) {
       return NextResponse.json({ error: accessCheck.error }, { status: 403 });
     }
@@ -317,4 +284,4 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     log.error('Unexpected error checking school deletability', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});

--- a/app/api/admin/district/schools/route.ts
+++ b/app/api/admin/district/schools/route.ts
@@ -1,8 +1,9 @@
 import { createClient, createServiceClient } from '@/lib/supabase/server';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { Database } from '@/src/types/database';
 import { logger } from '@/lib/logger';
 import { v4 as uuidv4 } from 'uuid';
+import { withRoute } from '@/lib/api/with-route';
 
 const log = logger.child({ module: 'district-admin-schools' });
 
@@ -10,30 +11,20 @@ const log = logger.child({ module: 'district-admin-schools' });
  * POST /api/admin/district/schools
  * Create a new school in the district admin's district
  */
-export async function POST(request: NextRequest) {
+export const POST = withRoute({}, async ({ req: request, userId }) => {
   try {
     const supabase = await createClient();
-
-    // Get current user
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     // Verify user is a district admin and get their district
     const { data: adminPermission, error: permError } = await supabase
       .from('admin_permissions')
       .select('district_id, state_id')
-      .eq('admin_id', user.id)
+      .eq('admin_id', userId)
       .eq('role', 'district_admin')
       .single();
 
     if (permError || !adminPermission?.district_id) {
-      log.warn('Non-district-admin tried to create school', { userId: user.id });
+      log.warn('Non-district-admin tried to create school', { userId });
       return NextResponse.json(
         { error: 'Forbidden: District admin access required' },
         { status: 403 }
@@ -70,7 +61,7 @@ export async function POST(request: NextRequest) {
       schoolId,
       name,
       districtId,
-      createdBy: user.id,
+      createdBy: userId,
     });
 
     // Insert the school
@@ -103,7 +94,7 @@ export async function POST(request: NextRequest) {
       schoolId,
       name,
       districtId,
-      createdBy: user.id,
+      createdBy: userId,
     });
 
     return NextResponse.json({
@@ -114,4 +105,4 @@ export async function POST(request: NextRequest) {
     log.error('Unexpected error in district admin create-school', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});


### PR DESCRIPTION
Part of **SPE-75** (continuing #3) — the `admin/district/schools` pair (first of the district-admin group).

## Changes
- **`schools` POST** — `withRoute` auth; the **district-admin gate** (`admin_permissions` where `admin_id = userId`, `role = 'district_admin'`) is preserved, now keyed on the verified `userId`. Service-client insert, district/state scoping, and the name-required validation are unchanged.
- **`schools/[schoolId]` PATCH/DELETE/GET** — `withRoute` auth + dynamic params (dropped the old sync `RouteParams` interface). The `verifyDistrictAdminAccess(supabase, userId, schoolId)` helper (district-admin + school-belongs-to-district) is **unchanged** and called with the verified `userId`. The dependency-count checks, the 409 delete guard, and the "deletable" GET are all preserved.

## Security note
Both permission layers are intact — the `district_admin` role check and the school-in-your-district check. Only the identity source changed (verified `withRoute` `userId` instead of a second `getUser()`).

## Verification
- `tsc --noEmit --skipLibCheck` — 0 errors
- `next lint` — exit 0, no new errors; confirmed no leftover `user.id`.

## Test plan
- [x] typecheck clean
- [x] lint clean
- [ ] CI green
- [ ] Smoke-check (as a district admin): create a school in your district, edit it, check deletability, delete an empty one, and confirm the 409 when it has dependencies. Confirm a non-district-admin / cross-district school returns 403.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified authentication plumbing for district admin API endpoints, standardizing how requests are processed.
  * Consistent audit metadata and logging for create/update/delete actions.
  * No functional changes to behavior, responses, or authorization checks; improvements are internal and aim at maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->