### PR TITLE
Migrate admin/district/providers routes to withRoute

### DIFF
--- a/app/api/admin/district/providers/[providerId]/route.ts
+++ b/app/api/admin/district/providers/[providerId]/route.ts
@@ -1,14 +1,11 @@
 import { createClient, createServiceClient } from '@/lib/supabase/server';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { Database } from '@/src/types/database';
 import { logger } from '@/lib/logger';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { withRoute } from '@/lib/api/with-route';
 
 const log = logger.child({ module: 'district-admin-provider' });
-
-interface RouteParams {
-  params: { providerId: string };
-}
 
 /**
  * Helper to verify district admin has access to the provider
@@ -87,23 +84,13 @@ async function verifyAdminAccess(
  * GET /api/admin/district/providers/[providerId]
  * Get provider details including deletability check
  */
-export async function GET(request: NextRequest, { params }: RouteParams) {
+export const GET = withRoute<{ providerId: string }>({}, async ({ userId, params }) => {
   try {
     const { providerId } = params;
     const supabase = await createClient();
 
-    // Get current user
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     // Verify access
-    const accessCheck = await verifyAdminAccess(supabase, user.id, providerId);
+    const accessCheck = await verifyAdminAccess(supabase, userId, providerId);
     if (!accessCheck.allowed) {
       return NextResponse.json({ error: accessCheck.error }, { status: 403 });
     }
@@ -171,32 +158,22 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     log.error('Unexpected error fetching provider', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});
 
 /**
  * PATCH /api/admin/district/providers/[providerId]
  * Update provider profile and school assignments
  */
-export async function PATCH(request: NextRequest, { params }: RouteParams) {
+export const PATCH = withRoute<{ providerId: string }>({}, async ({ req: request, userId, params }) => {
   try {
     const { providerId } = params;
     const supabase = await createClient();
 
-    // Get current user
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     // Verify access
-    const accessCheck = await verifyAdminAccess(supabase, user.id, providerId);
+    const accessCheck = await verifyAdminAccess(supabase, userId, providerId);
     if (!accessCheck.allowed) {
       log.warn('District admin access denied for provider update', {
-        userId: user.id,
+        userId,
         providerId,
         reason: accessCheck.error,
       });
@@ -385,7 +362,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     log.info('Provider updated successfully', {
       providerId,
-      updatedBy: user.id,
+      updatedBy: userId,
     });
 
     return NextResponse.json({
@@ -396,32 +373,22 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     log.error('Unexpected error in provider update', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});
 
 /**
  * DELETE /api/admin/district/providers/[providerId]
  * Remove provider (soft delete - removes permissions and deactivates)
  */
-export async function DELETE(request: NextRequest, { params }: RouteParams) {
+export const DELETE = withRoute<{ providerId: string }>({}, async ({ userId, params }) => {
   try {
     const { providerId } = params;
     const supabase = await createClient();
 
-    // Get current user
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     // Verify access
-    const accessCheck = await verifyAdminAccess(supabase, user.id, providerId);
+    const accessCheck = await verifyAdminAccess(supabase, userId, providerId);
     if (!accessCheck.allowed) {
       log.warn('District admin access denied for provider removal', {
-        userId: user.id,
+        userId,
         providerId,
         reason: accessCheck.error,
       });
@@ -467,7 +434,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
 
     log.info('District admin removing provider', {
       providerId,
-      removedBy: user.id,
+      removedBy: userId,
     });
 
     // Delete provider_schools entries
@@ -487,7 +454,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
 
     log.info('Provider removed successfully', {
       providerId,
-      removedBy: user.id,
+      removedBy: userId,
     });
 
     return NextResponse.json({
@@ -498,4 +465,4 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     log.error('Unexpected error in provider removal', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});

--- a/app/api/admin/district/providers/route.ts
+++ b/app/api/admin/district/providers/route.ts
@@ -1,8 +1,9 @@
 import { createClient, createServiceClient } from '@/lib/supabase/server';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { Database } from '@/src/types/database';
 import { logger } from '@/lib/logger';
 import { generateTemporaryPassword } from '@/lib/utils/password-generator';
+import { withRoute } from '@/lib/api/with-route';
 
 const log = logger.child({ module: 'district-admin-providers' });
 
@@ -21,28 +22,18 @@ interface CreateProviderRequest {
  * POST /api/admin/district/providers
  * Create a new provider account for schools in the district admin's district
  */
-export async function POST(request: NextRequest) {
+export const POST = withRoute({}, async ({ req: request, userId }) => {
   try {
     const supabase = await createClient();
-
-    // Get current user
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     // Verify user is a district admin or site admin
     const { data: adminPermissions, error: permError } = await supabase
       .from('admin_permissions')
       .select('role, district_id, school_id, state_id')
-      .eq('admin_id', user.id);
+      .eq('admin_id', userId);
 
     if (permError || !adminPermissions || adminPermissions.length === 0) {
-      log.warn('Non-admin tried to create provider', { userId: user.id });
+      log.warn('Non-admin tried to create provider', { userId });
       return NextResponse.json(
         { error: 'Forbidden: Admin access required' },
         { status: 403 }
@@ -53,7 +44,7 @@ export async function POST(request: NextRequest) {
     const sitePerm = adminPermissions.find(p => p.role === 'site_admin' && p.school_id);
 
     if (!districtPerm && !sitePerm) {
-      log.warn('Admin without district or site role tried to create provider', { userId: user.id });
+      log.warn('Admin without district or site role tried to create provider', { userId });
       return NextResponse.json(
         { error: 'Forbidden: District or site admin access required' },
         { status: 403 }
@@ -131,7 +122,7 @@ export async function POST(request: NextRequest) {
       const invalidSchools = schools.filter(s => s.district_id !== districtId);
       if (invalidSchools.length > 0) {
         log.warn('District admin tried to assign provider to school outside district', {
-          userId: user.id,
+          userId,
           invalidSchools: invalidSchools.map(s => s.id),
         });
         return NextResponse.json(
@@ -144,7 +135,7 @@ export async function POST(request: NextRequest) {
       const invalidSchools = schools.filter(s => s.id !== sitePerm.school_id);
       if (invalidSchools.length > 0) {
         log.warn('Site admin tried to assign provider to another school', {
-          userId: user.id,
+          userId,
           invalidSchools: invalidSchools.map(s => s.id),
         });
         return NextResponse.json(
@@ -185,7 +176,7 @@ export async function POST(request: NextRequest) {
       role,
       schoolIds: school_ids,
       primarySchoolId: primary_school_id,
-      createdBy: user.id,
+      createdBy: userId,
     });
 
     // Create auth user
@@ -269,7 +260,7 @@ export async function POST(request: NextRequest) {
         email: trimmedEmail,
         role,
         schoolCount: school_ids.length,
-        createdBy: user.id,
+        createdBy: userId,
       });
 
       return NextResponse.json({
@@ -302,4 +293,4 @@ export async function POST(request: NextRequest) {
     log.error('Unexpected error in create provider', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});


### PR DESCRIPTION
## Summary
- Migrates the `admin/district/providers` route pair onto the shared `withRoute` wrapper (auth + consistent `{ error }` shape), continuing the API-standardization effort.
- `providers/route.ts` (POST) and `providers/[providerId]/route.ts` (GET/PATCH/DELETE) now drop their bespoke `getUser()`/401 blocks in favor of `withRoute`.
- Permission gates are preserved unchanged: the district-vs-site-admin role check in POST and the `verifyAdminAccess` helper for the `[providerId]` handlers. All in-handler validation (role enum, email format, school-membership checks, primary-school checks) is kept as-is.
- Caller `user.id` → `userId`; the newly created provider's `authUser.user.id` is deliberately left intact.

## Test plan
- [x] `tsc --noEmit` — 0 errors
- [x] `next lint` on both files — clean
- [ ] CI green (CodeQL, Analyze, dependency-review)
- [ ] Spot-check provider create/edit/delete via district-admin and site-admin flows in preview

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal refactoring of admin API endpoints to improve code consistency and maintainability. No changes to user-facing functionality or API behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/631?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->