### PR TITLE
Migrate admin/district/site-admin routes to withRoute

### DIFF
--- a/app/api/admin/district/site-admin/[adminId]/route.ts
+++ b/app/api/admin/district/site-admin/[adminId]/route.ts
@@ -1,14 +1,11 @@
 import { createClient, createServiceClient } from '@/lib/supabase/server';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { Database } from '@/src/types/database';
 import { logger } from '@/lib/logger';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { withRoute } from '@/lib/api/with-route';
 
 const log = logger.child({ module: 'district-admin-site-admin' });
-
-interface RouteParams {
-  params: { adminId: string };
-}
 
 /**
  * Helper to verify district admin has access to manage site admin
@@ -55,26 +52,16 @@ async function verifyDistrictAdminAccess(
  * DELETE /api/admin/district/site-admin/[adminId]
  * Remove site admin permission (keeps the account)
  */
-export async function DELETE(request: NextRequest, { params }: RouteParams) {
+export const DELETE = withRoute<{ adminId: string }>({}, async ({ userId, params }) => {
   try {
     const { adminId } = params;
     const supabase = await createClient();
 
-    // Get current user
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     // Verify access
-    const accessCheck = await verifyDistrictAdminAccess(supabase, user.id, adminId);
+    const accessCheck = await verifyDistrictAdminAccess(supabase, userId, adminId);
     if (!accessCheck.allowed) {
       log.warn('District admin access denied for site admin removal', {
-        userId: user.id,
+        userId,
         adminId,
         reason: accessCheck.error,
       });
@@ -95,7 +82,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     log.info('District admin removing site admin permission', {
       siteAdminId: adminId,
       schoolId: siteAdminInfo?.school_id,
-      removedBy: user.id,
+      removedBy: userId,
     });
 
     // Delete the admin_permissions record (NOT the auth user)
@@ -115,7 +102,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
 
     log.info('Site admin permission removed successfully', {
       siteAdminId: adminId,
-      removedBy: user.id,
+      removedBy: userId,
     });
 
     return NextResponse.json({
@@ -126,29 +113,19 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     log.error('Unexpected error in site admin removal', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});
 
 /**
  * GET /api/admin/district/site-admin/[adminId]
  * Get site admin details
  */
-export async function GET(request: NextRequest, { params }: RouteParams) {
+export const GET = withRoute<{ adminId: string }>({}, async ({ userId, params }) => {
   try {
     const { adminId } = params;
     const supabase = await createClient();
 
-    // Get current user
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     // Verify access
-    const accessCheck = await verifyDistrictAdminAccess(supabase, user.id, adminId);
+    const accessCheck = await verifyDistrictAdminAccess(supabase, userId, adminId);
     if (!accessCheck.allowed) {
       return NextResponse.json({ error: accessCheck.error }, { status: 403 });
     }
@@ -195,4 +172,4 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     log.error('Unexpected error fetching site admin', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});

--- a/app/api/admin/district/site-admin/route.ts
+++ b/app/api/admin/district/site-admin/route.ts
@@ -1,8 +1,9 @@
 import { createClient, createServiceClient } from '@/lib/supabase/server';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { Database } from '@/src/types/database';
 import { logger } from '@/lib/logger';
 import { generateTemporaryPassword } from '@/lib/utils/password-generator';
+import { withRoute } from '@/lib/api/with-route';
 
 const log = logger.child({ module: 'district-admin-site-admin' });
 
@@ -10,30 +11,20 @@ const log = logger.child({ module: 'district-admin-site-admin' });
  * POST /api/admin/district/site-admin
  * Create a new site admin account for a school in the district admin's district
  */
-export async function POST(request: NextRequest) {
+export const POST = withRoute({}, async ({ req: request, userId }) => {
   try {
     const supabase = await createClient();
-
-    // Get current user
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     // Verify user is a district admin and get their district
     const { data: adminPermission, error: permError } = await supabase
       .from('admin_permissions')
       .select('district_id, state_id')
-      .eq('admin_id', user.id)
+      .eq('admin_id', userId)
       .eq('role', 'district_admin')
       .single();
 
     if (permError || !adminPermission?.district_id) {
-      log.warn('Non-district-admin tried to create site admin', { userId: user.id });
+      log.warn('Non-district-admin tried to create site admin', { userId });
       return NextResponse.json(
         { error: 'Forbidden: District admin access required' },
         { status: 403 }
@@ -93,7 +84,7 @@ export async function POST(request: NextRequest) {
 
     if (school.district_id !== districtId) {
       log.warn('District admin tried to create site admin for school outside district', {
-        userId: user.id,
+        userId,
         schoolId: school_id,
         adminDistrict: districtId,
         schoolDistrict: school.district_id,
@@ -139,7 +130,7 @@ export async function POST(request: NextRequest) {
       schoolId: school_id,
       schoolName: school.name,
       email: trimmedEmail,
-      createdBy: user.id,
+      createdBy: userId,
     });
 
     // Create auth user via Admin API
@@ -210,7 +201,7 @@ export async function POST(request: NextRequest) {
       log.info('Site admin created successfully', {
         siteAdminId: authUser.user.id,
         schoolId: school_id,
-        createdBy: user.id,
+        createdBy: userId,
       });
 
       return NextResponse.json({
@@ -241,4 +232,4 @@ export async function POST(request: NextRequest) {
     log.error('Unexpected error in create site admin', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});


### PR DESCRIPTION
Swap bespoke getUser/401 auth for the shared withRoute wrapper on the site-admin POST and the [adminId] GET/DELETE handlers. Keeps the district-admin permission gate, the verifyDistrictAdminAccess helper, and all in-handler validation unchanged; caller user.id becomes userId while the newly created site admin's authUser.user.id is left intact.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

## Summary
- Migrates the admin/district/site-admin route pair onto the shared withRoute wrapper, continuing the API-standardization effort.
- site-admin/route.ts (POST) and site-admin/[adminId]/route.ts (GET/DELETE) drop their bespoke getUser()/401 blocks in favor of withRoute.
- Preserves the district-admin permission gate and the verifyDistrictAdminAccess helper unchanged; all in-handler validation (email format, school-in-district, duplicate-admin checks) kept as-is.
- Caller <user.id> → userId; the newly created site admin's <authUser.user.id> is left intact.

## Test plan
- [x] tsc --noEmit — 0 errors
- [x] next lint on both files — clean
- [ ] CI green (CodeQL, Analyze, dependency-review)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal authentication handling in admin API routes for better code maintainability and consistency.

---

**Note:** This release contains no user-facing changes; updates are internal infrastructure improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/632?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->