### PR TITLE
Migrate admin/district/teachers routes to withRoute

### DIFF
--- a/app/api/admin/district/teachers/[teacherId]/route.ts
+++ b/app/api/admin/district/teachers/[teacherId]/route.ts
@@ -1,14 +1,11 @@
 import { createClient, createServiceClient } from '@/lib/supabase/server';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { Database } from '@/src/types/database';
 import { logger } from '@/lib/logger';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { withRoute } from '@/lib/api/with-route';
 
 const log = logger.child({ module: 'district-admin-teacher' });
-
-interface RouteParams {
-  params: { teacherId: string };
-}
 
 /**
  * Helper to verify district admin has access to the teacher
@@ -56,23 +53,13 @@ async function verifyDistrictAdminAccess(
  * GET /api/admin/district/teachers/[teacherId]
  * Get teacher details including deletability check
  */
-export async function GET(request: NextRequest, { params }: RouteParams) {
+export const GET = withRoute<{ teacherId: string }>({}, async ({ userId, params }) => {
   try {
     const { teacherId } = params;
     const supabase = await createClient();
 
-    // Get current user
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     // Verify access
-    const accessCheck = await verifyDistrictAdminAccess(supabase, user.id, teacherId);
+    const accessCheck = await verifyDistrictAdminAccess(supabase, userId, teacherId);
     if (!accessCheck.allowed) {
       return NextResponse.json({ error: accessCheck.error }, { status: 403 });
     }
@@ -126,32 +113,22 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     log.error('Unexpected error fetching teacher', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});
 
 /**
  * PATCH /api/admin/district/teachers/[teacherId]
  * Update teacher information
  */
-export async function PATCH(request: NextRequest, { params }: RouteParams) {
+export const PATCH = withRoute<{ teacherId: string }>({}, async ({ req: request, userId, params }) => {
   try {
     const { teacherId } = params;
     const supabase = await createClient();
 
-    // Get current user
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     // Verify access
-    const accessCheck = await verifyDistrictAdminAccess(supabase, user.id, teacherId);
+    const accessCheck = await verifyDistrictAdminAccess(supabase, userId, teacherId);
     if (!accessCheck.allowed) {
       log.warn('District admin access denied for teacher update', {
-        userId: user.id,
+        userId,
         teacherId,
         reason: accessCheck.error,
       });
@@ -203,7 +180,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     log.info('District admin updating teacher', {
       teacherId,
       updates: Object.keys(updates),
-      updatedBy: user.id,
+      updatedBy: userId,
     });
 
     const { data: updatedTeacher, error: updateError } = await adminClient
@@ -232,7 +209,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     log.info('Teacher updated successfully', {
       teacherId,
-      updatedBy: user.id,
+      updatedBy: userId,
     });
 
     return NextResponse.json({
@@ -243,32 +220,22 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     log.error('Unexpected error in teacher update', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});
 
 /**
  * DELETE /api/admin/district/teachers/[teacherId]
  * Delete a teacher (only if no dependencies)
  */
-export async function DELETE(request: NextRequest, { params }: RouteParams) {
+export const DELETE = withRoute<{ teacherId: string }>({}, async ({ userId, params }) => {
   try {
     const { teacherId } = params;
     const supabase = await createClient();
 
-    // Get current user
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     // Verify access
-    const accessCheck = await verifyDistrictAdminAccess(supabase, user.id, teacherId);
+    const accessCheck = await verifyDistrictAdminAccess(supabase, userId, teacherId);
     if (!accessCheck.allowed) {
       log.warn('District admin access denied for teacher delete', {
-        userId: user.id,
+        userId,
         teacherId,
         reason: accessCheck.error,
       });
@@ -316,7 +283,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
 
     log.info('District admin deleting teacher', {
       teacherId,
-      deletedBy: user.id,
+      deletedBy: userId,
     });
 
     // Delete the teacher record
@@ -335,7 +302,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
 
     log.info('Teacher deleted successfully', {
       teacherId,
-      deletedBy: user.id,
+      deletedBy: userId,
     });
 
     return NextResponse.json({
@@ -346,4 +313,4 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     log.error('Unexpected error in teacher delete', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});

--- a/app/api/admin/district/teachers/route.ts
+++ b/app/api/admin/district/teachers/route.ts
@@ -1,8 +1,9 @@
 import { createClient, createServiceClient } from '@/lib/supabase/server';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { Database } from '@/src/types/database';
 import { logger } from '@/lib/logger';
 import { generateTemporaryPassword } from '@/lib/utils/password-generator';
+import { withRoute } from '@/lib/api/with-route';
 
 const log = logger.child({ module: 'district-admin-teachers' });
 
@@ -10,30 +11,20 @@ const log = logger.child({ module: 'district-admin-teachers' });
  * POST /api/admin/district/teachers
  * Create a new teacher account for a school in the district admin's district
  */
-export async function POST(request: NextRequest) {
+export const POST = withRoute({}, async ({ req: request, userId }) => {
   try {
     const supabase = await createClient();
-
-    // Get current user
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     // Verify user is a district admin and get their district
     const { data: adminPermission, error: permError } = await supabase
       .from('admin_permissions')
       .select('district_id, state_id')
-      .eq('admin_id', user.id)
+      .eq('admin_id', userId)
       .eq('role', 'district_admin')
       .single();
 
     if (permError || !adminPermission?.district_id) {
-      log.warn('Non-district-admin tried to create teacher', { userId: user.id });
+      log.warn('Non-district-admin tried to create teacher', { userId });
       return NextResponse.json(
         { error: 'Forbidden: District admin access required' },
         { status: 403 }
@@ -95,7 +86,7 @@ export async function POST(request: NextRequest) {
 
     if (school.district_id !== districtId) {
       log.warn('District admin tried to create teacher for school outside district', {
-        userId: user.id,
+        userId,
         schoolId: school_id,
         adminDistrict: districtId,
         schoolDistrict: school.district_id,
@@ -141,7 +132,7 @@ export async function POST(request: NextRequest) {
     log.info('District admin creating teacher', {
       email: trimmedEmail,
       schoolId: school_id,
-      createdBy: user.id,
+      createdBy: userId,
     });
 
     // Create auth user
@@ -220,7 +211,7 @@ export async function POST(request: NextRequest) {
         accountId: authUser.user.id,
         email: trimmedEmail,
         schoolId: school_id,
-        createdBy: user.id,
+        createdBy: userId,
       });
 
       return NextResponse.json({
@@ -246,4 +237,4 @@ export async function POST(request: NextRequest) {
     log.error('Unexpected error in create teacher', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});


### PR DESCRIPTION
Swap bespoke getUser/401 auth for the shared withRoute wrapper on the teachers POST and the [teacherId] GET/PATCH/DELETE handlers. Keeps the district-admin permission gate, the verifyDistrictAdminAccess helper, and all in-handler validation unchanged; caller user.id becomes userId while the newly created teacher's authUser.user.id is left intact.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

## Summary
- Migrates the admin/district/teachers route pair onto the shared withRoute wrapper, continuing the API-standardization effort.
- teachers/route.ts (POST) and teachers/[teacherId]/route.ts (GET/PATCH/DELETE) drop their bespoke getUser()/401 blocks in favor of withRoute.
- Preserves the district-admin permission gate and the verifyDistrictAdminAccess helper unchanged; all in-handler validation (email format, school-in-district, duplicate-teacher, dependency/account checks) kept as-is.
- Caller <user.id> → userId; the newly created teacher's <authUser.user.id> is left intact.

## Test plan
- [x] tsc --noEmit — 0 errors
- [x] next lint on both files — clean
- [ ] CI green (CodeQL, Analyze, dependency-review)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized district admin teacher management endpoints to reduce processing overhead and improve system efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/633?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->