### PR TITLE
Add autonomous-execution policy for high-confidence non-UX work

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,3 +4,40 @@
 - Use the Github CLI tool to manage actions in the repo.
 - When encountering a complex issue, or a bug that is proving difficult to resolve, use Web Search to investigate the problem and receive support in finding a solution.
 - Don't over-engineer anything. It's better to add more later, than to have to go back and fix what's been done. At any juncture point, ask yourself, "Is this over-engineering?"
+
+## Autonomous execution for high-confidence, non-UX work
+
+For work that is purely technical and internal, proceed end-to-end without
+asking for approval at each step — implement, verify, commit, push, open a PR,
+watch CI and review bots, address valid feedback, merge when green, log
+follow-ups in Linear, and continue to the next batch. Treat me as a teammate
+with merge rights operating inside an agreed objective, not a gate to ask at
+every turn.
+
+**Proceed autonomously (and merge) only when ALL of these hold:**
+- The change is purely technical/internal: refactors, standardizations,
+  type-safety, tests, internal tooling, dead-code removal.
+- It does NOT change user-facing behavior or UX in any way, even subtly.
+- It is verifiable by automated gates: typecheck, lint, tests, and CI all
+  green, with zero unresolved review threads.
+- It is reversible / low blast radius (a follow-up commit could undo it).
+- It is within an objective we already agreed on.
+- Confidence is genuinely high — the pattern is established, not a guess.
+  When leaning on confidence, weight the objective gates above more than gut
+  feel, and bias toward escalating when anything is fuzzy.
+
+**Stop and discuss with me first if ANY of these are true:**
+- Any user-facing or UX change, or any change in behavior.
+- Database schema/data migrations, or anything destructive or hard to reverse.
+- Security, auth, or permissions changes where I am not fully certain.
+- Adding, removing, or upgrading dependencies.
+- Anything touching money, secrets, external services, or shared infra.
+- Ambiguous requirements, multiple reasonable interpretations, or scope creep
+  beyond what we agreed.
+- A real bug or regression surfaces that was not part of the plan.
+
+**Always, regardless of confidence:** never force-push, never merge over branch
+protection, never bypass hooks or commit signing, stay on the designated
+branch, and keep capturing deferred items in Linear. Report a brief summary
+when a batch merges or when escalating — keep me informed without making me a
+bottleneck.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -94,7 +94,8 @@
       "mcp__playwright__browser_resize",
       "mcp__playwright__browser_navigate",
       "mcp__context7__query-docs",
-      "mcp__52287d5e-942b-4bb1-a760-a897e4851102__list_issue_statuses"
+      "mcp__52287d5e-942b-4bb1-a760-a897e4851102__list_issue_statuses",
+      "mcp__52287d5e-942b-4bb1-a760-a897e4851102__get_issue"
     ],
     "deny": []
   },


### PR DESCRIPTION
## Summary
- Adds an "Autonomous execution for high-confidence, non-UX work" section to `.claude/CLAUDE.md`.
- Codifies when Claude should proceed end-to-end without per-step approval (implement → verify → PR → merge → track follow-ups in Linear) versus when to stop and discuss.
- Deliberately leans on objective gates (typecheck/lint/tests/CI green, established in-repo pattern, no UX change, reversibility) rather than self-assessed confidence, and biases toward escalating on any ambiguity.
- No code or behavior change — documentation/process only.

## Notes
- This policy becomes active for future sessions once merged to `main` (sessions clone from the default branch).
- A companion change to pre-authorize routine tools in `settings.json` was intentionally deferred to a separate change.

https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U71pQGfRZkuh2TT556sTgR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development process guidelines and configuration settings. These are infrastructure and documentation updates with no impact on user-facing features or functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->