### PR TITLE
SPE-10: revoke anon EXECUTE on SECURITY DEFINER functions (Tier 1+2)

### DIFF
--- a/supabase/migrations/20260529_revoke_anon_execute_security_definer_functions.sql
+++ b/supabase/migrations/20260529_revoke_anon_execute_security_definer_functions.sql
@@ -6,71 +6,89 @@
 -- (plus explicit anon/authenticated grants). SECURITY DEFINER bypasses RLS, so a
 -- function callable by anon effectively grants RLS-bypassed access.
 --
--- This migration covers two low-risk tiers (see SPE-10 for the full audit):
+-- Two low-risk tiers (see SPE-10 for the full audit):
 --   Tier 1 — trigger functions: invoked by triggers, where EXECUTE is not checked.
 --            Safe to revoke from PUBLIC/anon/authenticated entirely.
---   Tier 2 — revoke anon (and PUBLIC) on the remaining functions while KEEPING
---            authenticated, which still needs them (RLS policy helpers and
---            client-invoked RPCs). The signup/admin flows that use
---            create_profile_for_new_user / mark_password_reset run via the
---            service_role client, so dropping anon does not affect them.
+--   Tier 2 — revoke anon (and PUBLIC) while KEEPING authenticated, which still
+--            needs them (RLS policy helpers and client-invoked RPCs). The
+--            signup/admin flows that use create_profile_for_new_user /
+--            mark_password_reset run via the service_role client, so dropping
+--            anon does not affect them.
 --
--- service_role and the table owner (postgres) retain EXECUTE throughout.
--- Reversible: re-GRANT EXECUTE ... TO <role> if anything is found to need it.
+-- Each revoke is guarded with to_regprocedure(): some of these functions exist in
+-- production via historical drift but have no CREATE in the committed migrations,
+-- and REVOKE has no IF EXISTS. Guarding keeps this migration replayable on a
+-- fresh database (missing functions are skipped) and idempotent. service_role and
+-- the owner (postgres) retain EXECUTE throughout. Reversible via GRANT EXECUTE.
 
--- ── Tier 1: trigger functions ────────────────────────────────────────────────
-REVOKE EXECUTE ON FUNCTION
-  public.capture_sign_in_log(),
-  public.check_progress_milestones(),
-  public.handle_new_user(),
-  public.handle_new_user_schools(),
-  public.set_holidays_created_by(),
-  public.update_updated_at(),
-  public.update_updated_at_column(),
-  public.update_holidays_updated_at(),
-  public.update_calendar_events_updated_at(),
-  public.update_group_documents_updated_at(),
-  public.update_ai_generated_lessons_updated_at(),
-  public.validate_session_assignment_permissions()
-FROM PUBLIC, anon, authenticated;
+do $$
+declare
+  sig text;
+  -- Tier 1: trigger functions -> revoke from PUBLIC, anon, authenticated
+  tier1_revoke_all text[] := array[
+    'public.capture_sign_in_log()',
+    'public.check_progress_milestones()',
+    'public.handle_new_user()',
+    'public.handle_new_user_schools()',
+    'public.set_holidays_created_by()',
+    'public.update_updated_at()',
+    'public.update_updated_at_column()',
+    'public.update_holidays_updated_at()',
+    'public.update_calendar_events_updated_at()',
+    'public.update_group_documents_updated_at()',
+    'public.update_ai_generated_lessons_updated_at()',
+    'public.validate_session_assignment_permissions()'
+  ];
+  -- Tier 2: revoke PUBLIC + anon; authenticated retained
+  tier2_revoke_anon text[] := array[
+    'public.can_assign_sea_to_session(uuid, uuid)',
+    'public.can_assign_sea_to_session(uuid, uuid, uuid)',
+    'public.can_assign_specialist_to_session(uuid, uuid)',
+    'public.can_assign_specialist_to_session(uuid, uuid, uuid)',
+    'public.can_view_team_member(uuid)',
+    'public.copy_schedule_to_year(text, text, text)',
+    'public.create_profile_for_new_user(uuid, text, jsonb)',
+    'public.find_all_team_members_multi_school(uuid, character varying)',
+    'public.find_all_team_members_v2(uuid)',
+    'public.find_matching_provider_roles(uuid)',
+    'public.find_matching_provider_sessions(uuid)',
+    'public.find_school_ids_by_names(text, text, text)',
+    'public.get_available_specialists(uuid)',
+    'public.get_available_specialists(uuid, character varying)',
+    'public.get_available_specialists(uuid, uuid)',
+    'public.get_care_assignable_users(character varying)',
+    'public.get_my_school_ids()',
+    'public.get_providers_at_my_schools()',
+    'public.get_scheduling_data_batch(uuid, text)',
+    'public.get_school_migration_stats()',
+    'public.get_school_seas(character varying, character varying, character varying)',
+    'public.get_school_site_admins(text)',
+    'public.get_sea_assigned_sessions(uuid)',
+    'public.get_sea_students(character varying, text, text)',
+    'public.get_sign_in_logs(integer, integer)',
+    'public.get_special_activity_teacher_name(uuid, text)',
+    'public.get_student_district_id(uuid)',
+    'public.get_student_school_id(uuid)',
+    'public.get_teacher_student_ids(uuid)',
+    'public.get_user_schools(uuid)',
+    'public.import_student_atomic(uuid, text, text, text, text, text, text, text, text, text[], integer, integer, uuid)',
+    'public.increment_referral_uses(uuid)',
+    'public.is_teacher_for_student(uuid, uuid)',
+    'public.is_teacher_of_student(uuid)',
+    'public.mark_password_reset(uuid)',
+    'public.upsert_students_atomic(uuid, jsonb)',
+    'public.user_accessible_school_ids()'
+  ];
+begin
+  foreach sig in array tier1_revoke_all loop
+    if to_regprocedure(sig) is not null then
+      execute format('revoke execute on function %s from public, anon, authenticated', sig);
+    end if;
+  end loop;
 
--- ── Tier 2: revoke anon (+ PUBLIC); authenticated retained ───────────────────
-REVOKE EXECUTE ON FUNCTION
-  public.can_assign_sea_to_session(provider_id uuid, sea_id uuid),
-  public.can_assign_sea_to_session(provider_id uuid, sea_id uuid, session_id uuid),
-  public.can_assign_specialist_to_session(provider_id uuid, specialist_id uuid),
-  public.can_assign_specialist_to_session(provider_id uuid, specialist_id uuid, current_school_id uuid),
-  public.can_view_team_member(target_user_id uuid),
-  public.copy_schedule_to_year(p_school_id text, p_from_year text, p_to_year text),
-  public.create_profile_for_new_user(user_id uuid, user_email text, user_metadata jsonb),
-  public.find_all_team_members_multi_school(current_user_id uuid, target_school_id character varying),
-  public.find_all_team_members_v2(current_user_id uuid),
-  public.find_matching_provider_roles(p_student_id uuid),
-  public.find_matching_provider_sessions(p_student_id uuid),
-  public.find_school_ids_by_names(p_school_site_name text, p_school_district_name text, p_state_name text),
-  public.get_available_specialists(current_user_id uuid),
-  public.get_available_specialists(current_user_id uuid, filter_school_id character varying),
-  public.get_available_specialists(current_user_id uuid, current_school_id uuid),
-  public.get_care_assignable_users(p_school_id character varying),
-  public.get_my_school_ids(),
-  public.get_providers_at_my_schools(),
-  public.get_scheduling_data_batch(p_provider_id uuid, p_school_site text),
-  public.get_school_migration_stats(),
-  public.get_school_seas(p_school_id character varying, p_school_site character varying, p_school_district character varying),
-  public.get_school_site_admins(p_school_id text),
-  public.get_sea_assigned_sessions(sea_user_id uuid),
-  public.get_sea_students(p_school_id character varying, p_school_site text, p_school_district text),
-  public.get_sign_in_logs(p_limit integer, p_offset integer),
-  public.get_special_activity_teacher_name(activity_teacher_id uuid, activity_teacher_name text),
-  public.get_student_district_id(p_student_id uuid),
-  public.get_student_school_id(p_student_id uuid),
-  public.get_teacher_student_ids(user_id uuid),
-  public.get_user_schools(user_id uuid),
-  public.import_student_atomic(p_provider_id uuid, p_initials text, p_grade_level text, p_school_site text, p_school_id text, p_district_id text, p_state_id text, p_first_name text, p_last_name text, p_iep_goals text[], p_sessions_per_week integer, p_minutes_per_session integer, p_teacher_id uuid),
-  public.increment_referral_uses(referrer_user_id uuid),
-  public.is_teacher_for_student(p_student_id uuid, p_account_id uuid),
-  public.is_teacher_of_student(student_uuid uuid),
-  public.mark_password_reset(target_user_id uuid),
-  public.upsert_students_atomic(p_provider_id uuid, p_students jsonb),
-  public.user_accessible_school_ids()
-FROM PUBLIC, anon;
+  foreach sig in array tier2_revoke_anon loop
+    if to_regprocedure(sig) is not null then
+      execute format('revoke execute on function %s from public, anon', sig);
+    end if;
+  end loop;
+end $$;

--- a/supabase/migrations/20260529_revoke_anon_execute_security_definer_functions.sql
+++ b/supabase/migrations/20260529_revoke_anon_execute_security_definer_functions.sql
@@ -1,0 +1,76 @@
+-- SPE-10: Restrict EXECUTE on SECURITY DEFINER functions exposed to anon/authenticated.
+--
+-- Advisors anon_security_definer_function_executable (49) and
+-- authenticated_security_definer_function_executable (49). These functions were
+-- executable by anon/authenticated because they carried the default PUBLIC grant
+-- (plus explicit anon/authenticated grants). SECURITY DEFINER bypasses RLS, so a
+-- function callable by anon effectively grants RLS-bypassed access.
+--
+-- This migration covers two low-risk tiers (see SPE-10 for the full audit):
+--   Tier 1 — trigger functions: invoked by triggers, where EXECUTE is not checked.
+--            Safe to revoke from PUBLIC/anon/authenticated entirely.
+--   Tier 2 — revoke anon (and PUBLIC) on the remaining functions while KEEPING
+--            authenticated, which still needs them (RLS policy helpers and
+--            client-invoked RPCs). The signup/admin flows that use
+--            create_profile_for_new_user / mark_password_reset run via the
+--            service_role client, so dropping anon does not affect them.
+--
+-- service_role and the table owner (postgres) retain EXECUTE throughout.
+-- Reversible: re-GRANT EXECUTE ... TO <role> if anything is found to need it.
+
+-- ── Tier 1: trigger functions ────────────────────────────────────────────────
+REVOKE EXECUTE ON FUNCTION
+  public.capture_sign_in_log(),
+  public.check_progress_milestones(),
+  public.handle_new_user(),
+  public.handle_new_user_schools(),
+  public.set_holidays_created_by(),
+  public.update_updated_at(),
+  public.update_updated_at_column(),
+  public.update_holidays_updated_at(),
+  public.update_calendar_events_updated_at(),
+  public.update_group_documents_updated_at(),
+  public.update_ai_generated_lessons_updated_at(),
+  public.validate_session_assignment_permissions()
+FROM PUBLIC, anon, authenticated;
+
+-- ── Tier 2: revoke anon (+ PUBLIC); authenticated retained ───────────────────
+REVOKE EXECUTE ON FUNCTION
+  public.can_assign_sea_to_session(provider_id uuid, sea_id uuid),
+  public.can_assign_sea_to_session(provider_id uuid, sea_id uuid, session_id uuid),
+  public.can_assign_specialist_to_session(provider_id uuid, specialist_id uuid),
+  public.can_assign_specialist_to_session(provider_id uuid, specialist_id uuid, current_school_id uuid),
+  public.can_view_team_member(target_user_id uuid),
+  public.copy_schedule_to_year(p_school_id text, p_from_year text, p_to_year text),
+  public.create_profile_for_new_user(user_id uuid, user_email text, user_metadata jsonb),
+  public.find_all_team_members_multi_school(current_user_id uuid, target_school_id character varying),
+  public.find_all_team_members_v2(current_user_id uuid),
+  public.find_matching_provider_roles(p_student_id uuid),
+  public.find_matching_provider_sessions(p_student_id uuid),
+  public.find_school_ids_by_names(p_school_site_name text, p_school_district_name text, p_state_name text),
+  public.get_available_specialists(current_user_id uuid),
+  public.get_available_specialists(current_user_id uuid, filter_school_id character varying),
+  public.get_available_specialists(current_user_id uuid, current_school_id uuid),
+  public.get_care_assignable_users(p_school_id character varying),
+  public.get_my_school_ids(),
+  public.get_providers_at_my_schools(),
+  public.get_scheduling_data_batch(p_provider_id uuid, p_school_site text),
+  public.get_school_migration_stats(),
+  public.get_school_seas(p_school_id character varying, p_school_site character varying, p_school_district character varying),
+  public.get_school_site_admins(p_school_id text),
+  public.get_sea_assigned_sessions(sea_user_id uuid),
+  public.get_sea_students(p_school_id character varying, p_school_site text, p_school_district text),
+  public.get_sign_in_logs(p_limit integer, p_offset integer),
+  public.get_special_activity_teacher_name(activity_teacher_id uuid, activity_teacher_name text),
+  public.get_student_district_id(p_student_id uuid),
+  public.get_student_school_id(p_student_id uuid),
+  public.get_teacher_student_ids(user_id uuid),
+  public.get_user_schools(user_id uuid),
+  public.import_student_atomic(p_provider_id uuid, p_initials text, p_grade_level text, p_school_site text, p_school_id text, p_district_id text, p_state_id text, p_first_name text, p_last_name text, p_iep_goals text[], p_sessions_per_week integer, p_minutes_per_session integer, p_teacher_id uuid),
+  public.increment_referral_uses(referrer_user_id uuid),
+  public.is_teacher_for_student(p_student_id uuid, p_account_id uuid),
+  public.is_teacher_of_student(student_uuid uuid),
+  public.mark_password_reset(target_user_id uuid),
+  public.upsert_students_atomic(p_provider_id uuid, p_students jsonb),
+  public.user_accessible_school_ids()
+FROM PUBLIC, anon;


### PR DESCRIPTION
## What & why

SPE-10 — `anon`/`authenticated_security_definer_function_executable` (49 functions each). These `SECURITY DEFINER` functions were executable by `anon`/`authenticated` via the **default `PUBLIC` grant**. Because `SECURITY DEFINER` bypasses RLS, `anon` execution was effectively **unauthenticated, RLS-bypassed** access — the higher-severity half.

Audited every function (trigger vs callable, RLS-policy references, app `.rpc` call sites, signup/admin client type) and applied the two low-risk tiers:

### Tier 1 — 12 trigger functions
Revoke `EXECUTE` from `PUBLIC, anon, authenticated`. Triggers don't check `EXECUTE`, so this is behavior-neutral.

### Tier 2 — 37 functions
Revoke `EXECUTE` from `PUBLIC, anon`, **keeping `authenticated`** (needed by RLS-policy helpers — `get_my_school_ids`, `get_student_school_id`, etc. — and client-invoked RPCs). Verified the signup/admin flows calling `create_profile_for_new_user` / `mark_password_reset` use the **service-role** client, so dropping `anon` doesn't affect them. `service_role` + owner retained throughout.

## Applied + verified (via Supabase MCP)
- ACL check: `anon` EXECUTE on SECURITY DEFINER functions **0**, `authenticated` 37, no PUBLIC defaults remaining.
- `get_advisors(security)`: `anon_security_definer_function_executable` **49 → 0**; `authenticated_security_definer_function_executable` **49 → 37** (the remainder are functions `authenticated` legitimately calls — acceptable per the issue's acceptance criteria).

## Follow-up (not in this PR)
**Tier 3:** drop `authenticated` too on functions only reached via service-role server routes or only called inside other `SECURITY DEFINER` functions. Needs a per-function call-graph review (grep has false negatives), so it's deliberately deferred rather than risk breaking an authenticated RPC.

Reversible: re-`GRANT EXECUTE ... TO <role>` on any function later found to need it.

https://claude.ai/code/session_01YBNd82veHsRu58jCxahrru

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBNd82veHsRu58jCxahrru)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted execute privileges on a curated set of internal database functions; trigger-invoked functions had broader privilege removals while a subset remains callable by authenticated sessions. The migration is idempotent and reversible, and service/owner roles retain execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->