### PR TITLE
SPE-9: disable pg_graphql (unused GraphQL introspection surface)

### DIFF
--- a/supabase/migrations/20260529_disable_pg_graphql.sql
+++ b/supabase/migrations/20260529_disable_pg_graphql.sql
@@ -1,0 +1,14 @@
+-- SPE-9: Disable pg_graphql.
+--
+-- The app uses PostgREST (REST) + RPC exclusively — there is no `graphql`
+-- dependency in package.json and no GraphQL call/import anywhere in the codebase.
+-- Meanwhile pg_graphql exposes every anon/authenticated-SELECTable table's name,
+-- columns, relationships and generated mutations through /graphql/v1 introspection
+-- (advisors pg_graphql_anon_table_exposed / pg_graphql_authenticated_table_exposed,
+-- 70 each). RLS protects rows, not schema visibility, so this is an unnecessary
+-- discovery surface.
+--
+-- Dropping the extension removes the GraphQL surface entirely and clears both
+-- lints (per Supabase's own remediation for lint 0026/0027). REST, RPC and RLS are
+-- unaffected. Reversible: CREATE EXTENSION pg_graphql;
+DROP EXTENSION IF EXISTS pg_graphql;


### PR DESCRIPTION
## What & why

SPE-9 — `pg_graphql_anon_table_exposed` / `pg_graphql_authenticated_table_exposed` (70 tables each). `pg_graphql` reflects every `anon`/`authenticated`-SELECTable table's name, columns, relationships and generated mutations through `/graphql/v1` introspection. RLS protects rows, not schema visibility, so this is an unnecessary discovery surface.

**The app does not use GraphQL** — no `graphql` dependency in `package.json`, and no GraphQL call/import anywhere in `app/`, `lib/`, or `components/` (REST/PostgREST + RPC only). Per [Supabase's own remediation for lints 0026/0027](https://supabase.com/docs/guides/database/database-advisors?lint=0026_pg_graphql_anon_table_exposed) ("If you are not using `pg_graphql`, disable it"), the fix is to drop the extension.

## Change
```sql
DROP EXTENSION IF EXISTS pg_graphql;
```
REST, RPC, and RLS are unaffected. Reversible via `CREATE EXTENSION pg_graphql;`.

## Applied + verified (via Supabase MCP)
- `pg_extension` no longer lists `pg_graphql`.
- `get_advisors(security)`: `pg_graphql_anon_table_exposed` **70 → 0** and `pg_graphql_authenticated_table_exposed` **70 → 0** (140 lints cleared). Total security advisors 180 → 40.

## Assumption
This removes the `/graphql/v1` endpoint entirely. Verified no in-repo consumer; if there's an external/out-of-repo client hitting GraphQL (none known), it would be affected — easily reverted.

https://claude.ai/code/session_01YBNd82veHsRu58jCxahrru

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBNd82veHsRu58jCxahrru)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled unused GraphQL endpoint to reduce API surface complexity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bstewart2255/speddy/pull/641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->