### PR TITLE
SPE-114: revoke authenticated EXECUTE on internal/service-only SECURITY DEFINER functions

### DIFF
--- a/supabase/migrations/20260531_revoke_authenticated_security_definer_functions.sql
+++ b/supabase/migrations/20260531_revoke_authenticated_security_definer_functions.sql
@@ -1,0 +1,54 @@
+-- SPE-114 (SPE-10 Tier 3): revoke `authenticated` EXECUTE on SECURITY DEFINER
+-- functions that signed-in users do not need to call directly.
+--
+-- Follows SPE-10 Tier 1+2 (which removed anon + trigger-function access). Of the
+-- 37 functions still executable by `authenticated`, these 15 don't need it (full
+-- per-function audit in SPE-114):
+--   * Service-role-only callers (2): create_profile_for_new_user and
+--     get_sign_in_logs are only ever invoked via the service_role client in
+--     server routes; service_role bypasses these grants.
+--   * Internal-only via definer chain (5): can_assign_(sea|specialist)_to_session
+--     are called only by the validate_session_assignment_permissions trigger, and
+--     find_school_ids_by_names only inside create_profile_for_new_user. The definer
+--     caller runs as the owner, so `authenticated` never needs direct EXECUTE.
+--   * Unused (8): zero references anywhere in the app (no RPC, no RLS policy, not
+--     called by any other function) — can_view_team_member,
+--     find_all_team_members_multi_school, get_sea_assigned_sessions,
+--     get_special_activity_teacher_name, get_user_schools, increment_referral_uses,
+--     is_teacher_for_student, is_teacher_of_student.
+--
+-- The 22 functions authenticated genuinely uses (RLS-policy helpers + client RPCs)
+-- are intentionally left untouched. service_role and the owner (postgres) retain
+-- EXECUTE. Guarded with to_regprocedure() for fresh-DB replayability + idempotency.
+-- Reversible: GRANT EXECUTE ON FUNCTION <sig> TO authenticated;
+
+do $$
+declare
+  sig text;
+  revoke_authenticated text[] := array[
+    -- service-role-only callers
+    'public.create_profile_for_new_user(uuid, text, jsonb)',
+    'public.get_sign_in_logs(integer, integer)',
+    -- internal-only via definer chain
+    'public.can_assign_sea_to_session(uuid, uuid)',
+    'public.can_assign_sea_to_session(uuid, uuid, uuid)',
+    'public.can_assign_specialist_to_session(uuid, uuid)',
+    'public.can_assign_specialist_to_session(uuid, uuid, uuid)',
+    'public.find_school_ids_by_names(text, text, text)',
+    -- unused (zero references in the app)
+    'public.can_view_team_member(uuid)',
+    'public.find_all_team_members_multi_school(uuid, character varying)',
+    'public.get_sea_assigned_sessions(uuid)',
+    'public.get_special_activity_teacher_name(uuid, text)',
+    'public.get_user_schools(uuid)',
+    'public.increment_referral_uses(uuid)',
+    'public.is_teacher_for_student(uuid, uuid)',
+    'public.is_teacher_of_student(uuid)'
+  ];
+begin
+  foreach sig in array revoke_authenticated loop
+    if to_regprocedure(sig) is not null then
+      execute format('revoke execute on function %s from public, anon, authenticated', sig);
+    end if;
+  end loop;
+end $$;


### PR DESCRIPTION
## What & why

SPE-114 (SPE-10 Tier 3). After SPE-10 Tier 1+2 removed `anon` + trigger-function access, **37** SECURITY DEFINER functions were still executable by `authenticated`. A full per-function audit (RPC call sites incl. `(supabase.rpc as any)(...)` casts, RLS-policy references, and inter-function call graph) found **15** that `authenticated` doesn't need. Revoking them takes the advisor `authenticated_security_definer_function_executable` from **37 → 22**, leaving only functions `authenticated` legitimately calls.

### Revoked (15)
- **Service-role-only callers (2):** `create_profile_for_new_user` (all 6 callers use `createServiceClient`/admin), `get_sign_in_logs` (service client). `service_role` bypasses the grant, so no impact.
- **Internal-only via definer chain (5):** `can_assign_sea_to_session` (×2), `can_assign_specialist_to_session` (×2) — called only by the `validate_session_assignment_permissions` trigger; `find_school_ids_by_names` — called only inside `create_profile_for_new_user`. The definer caller runs as the owner, so `authenticated` never needs direct EXECUTE.
- **Unused — zero references anywhere (8):** `can_view_team_member`, `find_all_team_members_multi_school`, `get_sea_assigned_sessions`, `get_special_activity_teacher_name`, `get_user_schools`, `increment_referral_uses`, `is_teacher_for_student`, `is_teacher_of_student` (no RPC, no RLS, not called by any function — likely dead code).

### Kept (22) — intentionally
The 5 RLS-policy helpers (`get_my_school_ids`, `get_providers_at_my_schools`, `get_student_school_id`, `get_student_district_id`, `get_teacher_student_ids`) + 17 client-invoked RPCs (incl. `find_matching_provider_roles`/`sessions` and `mark_password_reset`, which use the authenticated client).

## Implementation
Guarded `DO` block (`to_regprocedure(<sig>) IS NOT NULL` per signature) → replayable on a fresh DB + idempotent. `REVOKE EXECUTE ... FROM public, anon, authenticated`; `service_role` + owner retained.

## Applied + verified (Supabase MCP)
ACL: SECURITY DEFINER functions with `authenticated` EXECUTE **22**, `anon` **0**. Advisor `authenticated_security_definer_function_executable` **37 → 22**. Reversible via `GRANT EXECUTE … TO authenticated`.

https://claude.ai/code/session_01YBNd82veHsRu58jCxahrru

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBNd82veHsRu58jCxahrru)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database security by restricting execution permissions on sensitive functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->