### PR TITLE
Fix anon-read regression from SPE-10 (scope public SELECT policies to authenticated)

### DIFF
--- a/supabase/migrations/20260531_scope_public_select_policies_to_authenticated.sql
+++ b/supabase/migrations/20260531_scope_public_select_policies_to_authenticated.sql
@@ -1,0 +1,42 @@
+-- Fix anon-read regression introduced by SPE-10 (PR #640).
+--
+-- SPE-10 revoked `anon` EXECUTE on SECURITY DEFINER helper functions. Five of
+-- them are referenced inside `TO public` SELECT policies on `profiles` and
+-- `schedule_sessions`. Because those policies also apply to `anon`, an
+-- unauthenticated SELECT on either table now evaluates the policy, calls the
+-- helper, and fails with "permission denied for function" instead of returning
+-- zero rows (the prior behavior). Verified by querying as the `anon` role.
+--
+-- We do NOT re-grant `anon` EXECUTE: three of the helpers
+-- (get_student_school_id, get_student_district_id, get_teacher_student_ids) take
+-- an arbitrary id and do not authorize the caller, so granting `anon` would
+-- re-open the exact RLS-bypass SPE-10 closed. Instead, scope these SELECT
+-- policies to `authenticated`. Anon then matches no SELECT policy on these tables
+-- and gets zero rows (same as pre-SPE-10) without calling the helpers; the
+-- functions stay anon-revoked; authenticated behavior is unchanged (USING clause
+-- preserved). These tables are not read by logged-out users.
+--
+-- Guarded with existence checks so the migration is replayable on a fresh DB.
+
+do $$
+begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='profiles'
+             and policyname='profiles_select') then
+    execute 'alter policy "profiles_select" on public.profiles to authenticated';
+  end if;
+
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='schedule_sessions'
+             and policyname='District admins can view schedule sessions in their district') then
+    execute 'alter policy "District admins can view schedule sessions in their district" on public.schedule_sessions to authenticated';
+  end if;
+
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='schedule_sessions'
+             and policyname='Site admins can view schedule sessions at their school') then
+    execute 'alter policy "Site admins can view schedule sessions at their school" on public.schedule_sessions to authenticated';
+  end if;
+
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='schedule_sessions'
+             and policyname='schedule_sessions_select') then
+    execute 'alter policy "schedule_sessions_select" on public.schedule_sessions to authenticated';
+  end if;
+end $$;


### PR DESCRIPTION
## The regression

SPE-10 (#640) revoked `anon` EXECUTE on SECURITY DEFINER helper functions. Five of them are referenced inside **`TO public`** SELECT policies on `profiles` and `schedule_sessions`. Because `TO public` includes `anon`, an **unauthenticated SELECT on either table** now evaluates the policy → calls the helper → fails with **`permission denied for function`** instead of returning zero rows.

Reproduced as the `anon` role:
```
profiles            → ERROR: permission denied for function get_my_school_ids
schedule_sessions   → ERROR: permission denied for function get_teacher_student_ids
```

## Why not just re-grant `anon`

Re-granting `anon` EXECUTE would fix the error but **re-open the exact RLS-bypass SPE-10 closed**: `get_student_school_id`, `get_student_district_id`, and `get_teacher_student_ids` take an arbitrary id and **do not authorize the caller** (`SELECT … WHERE id = $1`), so an anonymous caller could enumerate student→school / student→district / teacher→students via `/rest/v1/rpc/…`. (The other two — `get_my_school_ids`, `get_providers_at_my_schools` — are `auth.uid()`-scoped and safe, but a uniform fix is cleaner.)

## The fix

Scope the 4 affected SELECT policies to **`authenticated`** (`profiles_select` + the 3 `schedule_sessions` SELECT policies). Anon then matches no SELECT policy on these tables → gets **0 rows** (identical to pre-SPE-10) **without** calling the helpers. The functions stay `anon`-revoked (no re-exposure), and `authenticated` behavior is unchanged (the `USING` clauses are preserved — only the role binding narrows from `public`→`authenticated`). These tables are not read by logged-out users. Guarded with `pg_policies` existence checks for fresh-DB replay.

## Verified (as the `anon` role, post-change)
- `profiles` SELECT → **OK, 0 rows** (no error)
- `schedule_sessions` SELECT → **OK, 0 rows** (no error)
- `get_student_school_id(...)` → **still blocked for anon** (permission denied) — hardening intact

Grants are untouched, so the security advisor counts are unaffected (anon definer = 0, authenticated = 22).

## Note
This was found during a post-merge review. It's a real defect introduced by my SPE-10 change — root cause: I checked *which* functions were used in RLS but not the policies' `roles` (they're `TO public`), and I verified at the grant/advisor level rather than by querying as `anon`. Going forward, role-level behavioral testing is the right check for permission changes.

https://claude.ai/code/session_01YBNd82veHsRu58jCxahrru

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBNd82veHsRu58jCxahrru)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database access controls to restrict table access to authenticated users only, preventing permission errors from unauthorized access attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->