### PR TITLE
Security: signup role allow-list, AI cost caps, private worksheet bucket (SPE-124/125/126/127)

### DIFF
--- a/app/api/ai-upload/route.ts
+++ b/app/api/ai-upload/route.ts
@@ -24,7 +24,11 @@ const SUPPORTED_TYPES = [
   "text/rtf",
 ];
 
-export const POST = withRoute({}, async ({ req: request, userId }) => {
+// Each request runs a paid external conversion (PDF.co) plus an Anthropic
+// completion, so cap how often a single user can invoke it.
+export const POST = withRoute(
+  { rateLimit: { requests: 20, windowSeconds: 3600, name: 'ai-upload' } },
+  async ({ req: request, userId }) => {
   const perf = measurePerformanceWithAlerts('ai_upload', 'api');
   
   try {

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -6,6 +6,18 @@ import { Database } from '@/src/types/database';
 import { asyncHandler, ErrorFactory } from '@/lib/error-handler';
 import { logger } from '@/lib/logger';
 
+// Roles a user is allowed to assign themselves through public self-signup.
+// These are the provider roles offered by the signup form. Elevated roles
+// (site_admin, district_admin), teacher, and sea accounts are provisioned only
+// by an administrator via the admin flow, so they must never be self-assigned.
+const SELF_REGISTERABLE_ROLES = new Set([
+  'resource',
+  'speech',
+  'ot',
+  'counseling',
+  'specialist',
+]);
+
 export const POST = asyncHandler(async (request: NextRequest) => {
   const requestLogger = logger.child({ 
     endpoint: '/api/auth/signup',
@@ -34,15 +46,22 @@ export const POST = asyncHandler(async (request: NextRequest) => {
     );
   }
 
-  // SEA (Special Education Assistant) accounts are provisioned only by
-  // district/site admins, never through public self-signup. Enforce this on
-  // the server so a direct POST can't bypass the (client-side) role list.
-  if (String(metadata.role).trim().toLowerCase() === 'sea') {
+  // Enforce a server-side allow-list of self-registerable roles. The role from
+  // the request body flows into both the `handle_new_user` trigger and the
+  // `create_profile_for_new_user` RPC, so an unvalidated value would let a
+  // direct POST self-assign an elevated role (e.g. site_admin/district_admin).
+  // Validate here, before the auth user is created, so neither path can be
+  // reached with a disallowed role. Admin-provisioned roles (sea, teacher,
+  // site_admin, district_admin, etc.) are created through the admin flow only.
+  const requestedRole = String(metadata.role).trim().toLowerCase();
+  if (!SELF_REGISTERABLE_ROLES.has(requestedRole)) {
     return NextResponse.json(
       { error: 'This role cannot be self-registered. Please ask your district or site administrator to create your account.' },
       { status: 403 }
     );
   }
+  // Use the normalized role from here on so the stored value is canonical.
+  metadata.role = requestedRole;
 
     // Validate email domain (case-insensitive)
     const emailDomain = email.split('@')[1]?.toLowerCase();

--- a/app/api/email-webhook/route.ts
+++ b/app/api/email-webhook/route.ts
@@ -176,10 +176,10 @@ async function processWorksheetSubmission(
     throw uploadError;
   }
 
-  // Get public URL
-  const { data: { publicUrl } } = supabase.storage
-    .from('worksheet-submissions')
-    .getPublicUrl(fileName);
+  // The worksheet-submissions bucket is private (holds student work / PII).
+  // Store the object path, not a permanent public URL — readers generate a
+  // short-lived signed URL on demand.
+  const storagePath = uploadData?.path ?? fileName;
 
   // TODO: Add AI vision analysis here if you have Claude/GPT-4 Vision API
   // For now, we'll simulate with random accuracy
@@ -191,7 +191,7 @@ async function processWorksheetSubmission(
     .insert({
       worksheet_id: worksheet.id,
       submitted_by: worksheet.students.provider_id,
-      image_url: publicUrl,
+      image_url: storagePath,
       accuracy_percentage: mockAccuracy,
       skills_assessed: [{
         skill: worksheet.worksheet_type,

--- a/app/api/lessons/generate/route.ts
+++ b/app/api/lessons/generate/route.ts
@@ -22,6 +22,12 @@ interface ErrorWithDetails {
 // self-hosted (unlimited). Falls back to platform limits on free/hobby tiers (e.g., 10s on Vercel Hobby)
 export const maxDuration = 300; // 5 minutes
 
+// Upper bound on lesson groups per batch request. A batch is built from a
+// single day's time slots (see calendar-week-view), so legitimate batches are
+// well under this; the cap stops a crafted request from fanning out into
+// thousands of parallel AI calls and defeating the per-request rate limit.
+const MAX_LESSON_BATCH_SIZE = 50;
+
 // Debug logging only in development
 const DEBUG = process.env.NODE_ENV === 'development' || process.env.DEBUG === 'true';
 
@@ -50,6 +56,14 @@ export const POST = withRoute(
       
       // Check if this is a batch request
       if (body.batch && Array.isArray(body.batch)) {
+        // Reject oversized batches before doing any work or AI calls.
+        if (body.batch.length > MAX_LESSON_BATCH_SIZE) {
+          return NextResponse.json(
+            { error: `Too many lesson groups in one request (max ${MAX_LESSON_BATCH_SIZE}).` },
+            { status: 400 }
+          );
+        }
+
         // Handle batch lesson generation
         if (DEBUG) {
           console.log(`[DEBUG] Processing batch request with ${body.batch.length} lesson groups`);

--- a/app/api/submit-worksheet/route.ts
+++ b/app/api/submit-worksheet/route.ts
@@ -261,10 +261,10 @@ export const POST = withRoute({ auth: false }, async ({ req: request }) => {
       );
     }
 
-    // Get public URL for the uploaded image
-    const { data: { publicUrl } } = supabase.storage
-      .from('worksheet-submissions')
-      .getPublicUrl(fileName);
+    // The worksheet-submissions bucket is private (holds student work / PII).
+    // Store the object path, not a permanent public URL — readers generate a
+    // short-lived signed URL on demand (see documents/saved-worksheets).
+    const storagePath = uploadData?.path ?? fileName;
 
     // Use Claude Vision API to analyze the worksheet (if API key exists)
     let analysisResult: AnalysisResult | null = null;
@@ -356,7 +356,7 @@ export const POST = withRoute({ auth: false }, async ({ req: request }) => {
         submitted_by: Array.isArray(finalWorksheet.students)
           ? finalWorksheet.students[0]?.provider_id
           : finalWorksheet.students?.provider_id,
-        image_url: publicUrl,
+        image_url: storagePath,
         student_responses: analysisResult?.responses || null,
         accuracy_percentage: analysisResult?.accuracy ? analysisResult.accuracy * 100 : null,
         skills_assessed: extractSkillsAssessed(finalWorksheet, analysisResult),

--- a/supabase/migrations/20260610_make_worksheet_submissions_bucket_private.sql
+++ b/supabase/migrations/20260610_make_worksheet_submissions_bucket_private.sql
@@ -1,0 +1,29 @@
+-- SPE-125: Make the worksheet-submissions storage bucket private.
+--
+-- The bucket holds photos of completed student worksheets (handwriting, and
+-- sometimes names students write on the page) — FERPA-relevant educational
+-- records. It was `public = true`, so every object was readable by anyone with
+-- the URL, indefinitely, with no auth. SPE-12 (20260529) closed object LISTING
+-- but objects stayed reachable via the public CDN URL
+-- (/storage/v1/object/public/...). This makes the objects themselves private.
+--
+-- After this change, getPublicUrl() links stop resolving. That is intended:
+--   * App code no longer stores or serves public URLs — the submit-worksheet
+--     and email-webhook routes now persist the storage object PATH in
+--     worksheet_submissions.image_url, and any future reader signs it on demand
+--     with createSignedUrl() (the pattern already used by documents and
+--     saved-worksheets).
+--   * Nothing in the app currently renders image_url, so there is no in-app
+--     read path to regress.
+--
+-- Upload/update/delete RLS policies on storage.objects are governed by RLS, not
+-- the public flag, so they are unaffected.
+--
+-- Also add guardrails that were missing (file_size_limit was null, allowed_mime
+-- _types was null): cap object size and restrict to image content types.
+UPDATE storage.buckets
+SET
+  public = false,
+  file_size_limit = 10485760, -- 10 MB, matches the app-level image validation
+  allowed_mime_types = ARRAY['image/jpeg', 'image/png', 'image/webp']
+WHERE id = 'worksheet-submissions';


### PR DESCRIPTION
Implements the four Urgent findings from the June 2026 security & functionality review. All net-new issues; each fix is small and reversible.

## SPE-124 — Self-signup role injection
`app/api/auth/signup/route.ts` passed the request body's `role` straight into the `handle_new_user` trigger and `create_profile_for_new_user` RPC with no allow-list (only `sea` was blocked), so a direct POST could self-register as `site_admin`/`district_admin`.

- Replaced the SEA-only rejection with a positive allow-list of the provider roles the signup form actually offers (`resource`, `speech`, `ot`, `counseling`, `specialist`).
- The check runs **before** `auth.signUp`, so neither the trigger nor the RPC can be reached with a disallowed role. The stored value is normalized to canonical lowercase.

## SPE-126 — Uncapped AI/PDF spend
`app/api/ai-upload/route.ts` ran a paid PDF.co conversion + an 8k-token Anthropic completion with **no rate limit** (`withRoute({})`).

- Added `rateLimit: { requests: 20, windowSeconds: 3600 }`, matching the other AI routes.

## SPE-127 — Unbounded lesson batch
`app/api/lessons/generate/route.ts` accepted an unbounded `batch[]` and fired one AI generation per group in parallel, so a single request could fan out into thousands of calls despite the 30/hour limit.

- Cap the batch at **50 groups**, rejected with 400 before any work. A batch is built from one day's time slots, so legitimate batches are well under this; worst case drops from ~30,000 to ~1,500 calls/hour/user.

## SPE-125 — Public bucket of student work (FERPA)
The `worksheet-submissions` storage bucket was `public=true` with no size/MIME limits and held photos of completed student worksheets, readable by URL with no auth. SPE-12 closed *listing* but objects stayed reachable via the public CDN URL.

- **Migration** (`supabase/migrations/20260610_make_worksheet_submissions_bucket_private.sql`): set `public=false`, add a 10MB `file_size_limit` and image-only `allowed_mime_types` (both were null). **Already applied to the production project** and verified (`public=false`).
- `submit-worksheet` and `email-webhook` now store the storage object **path** in `worksheet_submissions.image_url` instead of a permanent public URL; a future reader signs it on demand (the `documents`/`saved-worksheets` pattern).
- Nothing currently renders `image_url`, so there's no read-path regression. Upload RLS is governed by policy independent of the public flag, so uploads are unaffected.

## Verification
- `npm run typecheck:fast` — pass
- `npx next lint` on changed files — clean
- `npm test` — 7 suites, 46 passed / 12 skipped
- Production bucket state confirmed `public=false`, 10MB limit, image MIME allow-list.

## Notes
- Existing `worksheet_submissions` rows still hold old public-URL strings in `image_url`; since nothing reads them, no backfill is required for functionality (optional cleanup later).
- Related existing issues: SPE-12 (listing), SPE-80 (rate-limiter hardening), SPE-111/SPE-102 (removing self-signup entirely).

https://claude.ai/code/session_01BzFfG6AUZyj9TXkqwXYr5F

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzFfG6AUZyj9TXkqwXYr5F)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to AI upload endpoint (20 requests per hour)
  * Implemented role validation during user signup to restrict elevated role assignments
  * Added batch size validation for lesson generation requests

* **Security**
  * Worksheet submission images now stored privately with signed URL access
  * Applied file type restrictions (JPEG, PNG, WebP) and 10MB size limit to image uploads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->