### PR TITLE
Reliability/security: cleanup cron, print XSS, client-side session deletion, disable email-webhook (SPE-128/129/130/131)

### DIFF
--- a/app/api/cron/cleanup-uploads/route.ts
+++ b/app/api/cron/cleanup-uploads/route.ts
@@ -5,9 +5,15 @@ export async function GET(request: NextRequest) {
   const startTime = Date.now();
 
   try {
-    // Check for authentication token
-    const token = request.nextUrl.searchParams.get('token') ||
-                  request.headers.get('x-cron-secret');
+    // Read the cron secret from a header only — never the query string, which
+    // leaks into access logs, monitoring dashboards, and copied links. This
+    // endpoint gates service-role deletes, so accept the `x-cron-secret` header
+    // or the standard `Authorization: Bearer <secret>` form (e.g. Vercel Cron).
+    const authHeader = request.headers.get('authorization');
+    const bearerToken = authHeader?.toLowerCase().startsWith('bearer ')
+      ? authHeader.slice(7).trim()
+      : null;
+    const token = request.headers.get('x-cron-secret') || bearerToken;
 
     const expectedToken = process.env.CRON_SECRET;
 

--- a/app/api/cron/cleanup-uploads/route.ts
+++ b/app/api/cron/cleanup-uploads/route.ts
@@ -1,25 +1,27 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createServiceClient } from '@/lib/supabase/server';
 
 export async function GET(request: NextRequest) {
   const startTime = Date.now();
-  
+
   try {
     // Check for authentication token
-    const token = request.nextUrl.searchParams.get('token') || 
+    const token = request.nextUrl.searchParams.get('token') ||
                   request.headers.get('x-cron-secret');
-    
+
     const expectedToken = process.env.CRON_SECRET;
-    
+
     if (!expectedToken) {
       console.error('CRON_SECRET environment variable not set');
+      // Surface misconfiguration as a 5xx so the cron service/monitoring
+      // notices instead of silently succeeding.
       return NextResponse.json({
         success: false,
         error: 'Server configuration error',
         timestamp: new Date().toISOString()
-      }, { status: 200 }); // Return 200 to prevent retries
+      }, { status: 500 });
     }
-    
+
     if (!token || token !== expectedToken) {
       console.warn('Unauthorized cleanup attempt');
       return NextResponse.json({
@@ -28,32 +30,36 @@ export async function GET(request: NextRequest) {
         timestamp: new Date().toISOString()
       }, { status: 401 });
     }
-    
-    // Initialize Supabase client
-    const supabase = await createClient();
-    
+
+    // Use the service-role client: this is an unauthenticated cron request, so
+    // there is no user session for the cookie-based client to read.
+    const supabase = createServiceClient();
+
     // Calculate cutoff date (7 days ago)
     const cutoffDate = new Date();
     cutoffDate.setDate(cutoffDate.getDate() - 7);
-    
-    // Delete old rate limit records
-    const { data: deletedRecords, error: deleteError, count } = await supabase
+
+    // Delete old rate limit records. The column is `uploaded_at` (not
+    // `created_at`); request a count rather than the deleted rows so we don't
+    // pull a large id list back over the wire.
+    const { error: deleteError, count } = await supabase
       .from('upload_rate_limits')
-      .delete()
-      .lt('created_at', cutoffDate.toISOString())
-      .select('id');
-    
+      .delete({ count: 'exact' })
+      .lt('uploaded_at', cutoffDate.toISOString());
+
     if (deleteError) {
       console.error('Error deleting old rate limit records:', deleteError);
+      // Fail loud (5xx) so a broken cleanup is visible instead of letting the
+      // table grow unbounded behind a 200.
       return NextResponse.json({
         success: false,
         error: 'Database error during cleanup',
         details: deleteError.message,
         timestamp: new Date().toISOString()
-      }, { status: 200 }); // Return 200 to prevent retries
+      }, { status: 500 });
     }
-    
-    const deletedCount = deletedRecords?.length || 0;
+
+    const deletedCount = count ?? 0;
     const processingTime = Date.now() - startTime;
     
     // Log the cleanup action
@@ -67,16 +73,15 @@ export async function GET(request: NextRequest) {
       const analyticsCutoffDate = new Date();
       analyticsCutoffDate.setDate(analyticsCutoffDate.getDate() - 90);
       
-      const { data: deletedAnalytics, error: analyticsError } = await supabase
+      const { error: analyticsError, count: analyticsCount } = await supabase
         .from('analytics_events')
-        .delete()
-        .lt('created_at', analyticsCutoffDate.toISOString())
-        .select('id');
-      
+        .delete({ count: 'exact' })
+        .lt('created_at', analyticsCutoffDate.toISOString());
+
       if (analyticsError) {
         console.error('Error deleting old analytics records:', analyticsError);
       } else {
-        analyticsDeleted = deletedAnalytics?.length || 0;
+        analyticsDeleted = analyticsCount ?? 0;
         console.log(`Analytics cleanup: ${analyticsDeleted} records deleted`);
       }
     }
@@ -93,14 +98,15 @@ export async function GET(request: NextRequest) {
     
   } catch (error: any) {
     console.error('Unexpected error in cleanup cron job:', error);
-    
-    // Always return 200 to prevent cron service from retrying
+
+    // Fail loud (5xx) so the cron service retries and monitoring is alerted,
+    // rather than masking failures behind a 200.
     return NextResponse.json({
       success: false,
       error: 'Unexpected error during cleanup',
       details: error.message || 'Unknown error',
       timestamp: new Date().toISOString()
-    }, { status: 200 });
+    }, { status: 500 });
   }
 }
 

--- a/app/api/cron/health/route.ts
+++ b/app/api/cron/health/route.ts
@@ -12,6 +12,12 @@ export async function GET(request: NextRequest) {
       .select('uploaded_at')
       .order('uploaded_at', { ascending: false })
       .limit(1);
+
+    // A health check that swallows query errors and still reports "healthy"
+    // hides the exact regression it exists to catch (e.g. a wrong column).
+    if (rateLimitError) {
+      throw rateLimitError;
+    }
     
     // Get analytics stats if enabled
     let analyticsStats: { lastEvent: string | null } | null = null;
@@ -30,11 +36,15 @@ export async function GET(request: NextRequest) {
     }
     
     // Calculate age of oldest rate limit record
-    const { data: oldestRecord } = await supabase
+    const { data: oldestRecord, error: oldestRecordError } = await supabase
       .from('upload_rate_limits')
       .select('uploaded_at')
       .order('uploaded_at', { ascending: true })
       .limit(1);
+
+    if (oldestRecordError) {
+      throw oldestRecordError;
+    }
 
     const oldestAge = oldestRecord?.[0]?.uploaded_at
       ? Math.floor((Date.now() - new Date(oldestRecord[0].uploaded_at).getTime()) / (1000 * 60 * 60 * 24))
@@ -58,10 +68,12 @@ export async function GET(request: NextRequest) {
   } catch (error: any) {
     console.error('Health check error:', error);
     
+    // Return a non-200 so monitoring actually surfaces a broken health check
+    // instead of treating an error body as success.
     return NextResponse.json({
       status: 'error',
       timestamp: new Date().toISOString(),
       error: error.message || 'Unknown error'
-    }, { status: 200 }); // Return 200 to prevent monitoring alerts
+    }, { status: 503 });
   }
 }

--- a/app/api/cron/health/route.ts
+++ b/app/api/cron/health/route.ts
@@ -5,11 +5,12 @@ export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
     
-    // Get current rate limit stats
+    // Get current rate limit stats. The upload_rate_limits timestamp column is
+    // `uploaded_at` (not `created_at`).
     const { data: rateLimitStats, error: rateLimitError } = await supabase
       .from('upload_rate_limits')
-      .select('created_at')
-      .order('created_at', { ascending: false })
+      .select('uploaded_at')
+      .order('uploaded_at', { ascending: false })
       .limit(1);
     
     // Get analytics stats if enabled
@@ -31,19 +32,19 @@ export async function GET(request: NextRequest) {
     // Calculate age of oldest rate limit record
     const { data: oldestRecord } = await supabase
       .from('upload_rate_limits')
-      .select('created_at')
-      .order('created_at', { ascending: true })
+      .select('uploaded_at')
+      .order('uploaded_at', { ascending: true })
       .limit(1);
-    
-    const oldestAge = oldestRecord?.[0]?.created_at 
-      ? Math.floor((Date.now() - new Date(oldestRecord[0].created_at).getTime()) / (1000 * 60 * 60 * 24))
+
+    const oldestAge = oldestRecord?.[0]?.uploaded_at
+      ? Math.floor((Date.now() - new Date(oldestRecord[0].uploaded_at).getTime()) / (1000 * 60 * 60 * 24))
       : 0;
     
     return NextResponse.json({
       status: 'healthy',
       timestamp: new Date().toISOString(),
       rateLimits: {
-        lastRecord: rateLimitStats?.[0]?.created_at || null,
+        lastRecord: rateLimitStats?.[0]?.uploaded_at || null,
         oldestRecordAgeDays: oldestAge,
         needsCleanup: oldestAge > 7
       },

--- a/app/api/email-webhook/route.ts
+++ b/app/api/email-webhook/route.ts
@@ -5,8 +5,21 @@ import { Resend } from 'resend';
 
 const resend = new Resend(process.env['RESEND_API_KEY']);
 
+// SPE-128: The inbound email -> worksheet flow is not live, and this endpoint
+// had NO sender verification — an unauthenticated POST could trigger outbound
+// emails (open relay via our sending domain) and paid AI vision calls. Keep it
+// disabled by default until the feature is actually wired up.
+//
+// Re-enabling REQUIRES implementing sender verification first (the provider's
+// webhook signature, e.g. Svix for Resend) — do not just flip this flag.
+const EMAIL_WEBHOOK_ENABLED = process.env.EMAIL_WEBHOOK_ENABLED === 'true';
+
 // This endpoint receives forwarded emails from Resend
 export async function POST(request: NextRequest) {
+  if (!EMAIL_WEBHOOK_ENABLED) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
   try {
     const payload = await request.json();
 

--- a/lib/services/session-generator.ts
+++ b/lib/services/session-generator.ts
@@ -111,9 +111,15 @@ export class SessionGenerator {
       return instances || [];
     }
 
-    // AUTO-CLEANUP: Detect and remove orphaned instances
-    // An instance is orphaned if its start_time doesn't match any template for that student+day
-    const orphanedInstanceIds: string[] = [];
+    // Detect orphaned instances (whose start_time no longer matches any template
+    // for that student+day) and exclude them from the rendered set.
+    //
+    // NOTE: we intentionally do NOT delete here. This runs on a read path with a
+    // possibly-partial template set (PostgREST's 1000-row cap, a transient error,
+    // or a role-filter mismatch), so deleting "orphans" from the client risked
+    // permanently destroying valid future sessions. Hiding them is reversible;
+    // any real cleanup must run server-side against the complete template set.
+    // See SPE-130 / SPE-133.
     const validInstances: SessionWithCurriculum[] = [];
     const today = formatDateLocal(new Date());
 
@@ -135,9 +141,8 @@ export class SessionGenerator {
       if (hasMatchingTemplate) {
         validInstances.push(instance);
       } else {
-        // This is an orphaned instance - mark for deletion
-        orphanedInstanceIds.push(instance.id);
-        console.log('[SessionGenerator] Detected orphaned instance:', {
+        // Orphaned for display only — hidden this render, never deleted.
+        console.log('[SessionGenerator] Hiding orphaned instance (not deleting):', {
           id: instance.id,
           student_id: instance.student_id,
           session_date: instance.session_date,
@@ -145,22 +150,6 @@ export class SessionGenerator {
           day_of_week: instance.day_of_week
         });
       }
-    }
-
-    // Delete orphaned instances asynchronously
-    if (orphanedInstanceIds.length > 0) {
-      console.log('[SessionGenerator] Cleaning up', orphanedInstanceIds.length, 'orphaned instances');
-      this.supabase
-        .from('schedule_sessions')
-        .delete()
-        .in('id', orphanedInstanceIds)
-        .then(({ error }) => {
-          if (error) {
-            console.error('[SessionGenerator] Error deleting orphaned instances:', error);
-          } else {
-            console.log('[SessionGenerator] Successfully deleted orphaned instances');
-          }
-        });
     }
 
     // For each day in range, check if we need to create instances

--- a/lib/services/session-generator.ts
+++ b/lib/services/session-generator.ts
@@ -90,7 +90,7 @@ export class SessionGenerator {
     // Only fetch templates for days we actually need (performance optimization)
     let templatesQuery = this.supabase
       .from('schedule_sessions')
-      .select('*')
+      .select('*', { count: 'exact' })
       .is('session_date', null)
       .is('deleted_at', null)
       .in('day_of_week', Array.from(neededDays));
@@ -98,12 +98,19 @@ export class SessionGenerator {
     // Include templates assigned to this user based on their role
     templatesQuery = this.applyRoleFilter(templatesQuery, providerId, normalizedRole);
 
-    const { data: templates, error: templatesError } = await templatesQuery;
+    const { data: templates, error: templatesError, count: templateCount } = await templatesQuery;
 
     if (templatesError) {
       console.error('[SessionGenerator] Failed to fetch templates:', templatesError);
       return instances || [];
     }
+
+    // If the returned template set is shorter than the exact total, the fetch
+    // was truncated (PostgREST's 1000-row cap). We can't reliably tell orphans
+    // from valid instances against a partial set, so suppress nothing in that
+    // case — better to show a stale row than to hide a valid future session.
+    const templatesIncomplete =
+      typeof templateCount === 'number' && (templates?.length ?? 0) < templateCount;
 
     if (!templates || templates.length === 0) {
       // No templates found - return all instances as-is
@@ -124,6 +131,13 @@ export class SessionGenerator {
     const today = formatDateLocal(new Date());
 
     for (const instance of (instances || [])) {
+      // If the template fetch was truncated, we can't trust "no match" to mean
+      // orphaned — keep every instance rather than risk hiding valid sessions.
+      if (templatesIncomplete) {
+        validInstances.push(instance);
+        continue;
+      }
+
       // Skip completed instances and past instances - preserve history
       if (instance.completed_at || (instance.session_date && instance.session_date < today)) {
         validInstances.push(instance);

--- a/lib/utils/export-week-to-pdf.ts
+++ b/lib/utils/export-week-to-pdf.ts
@@ -355,6 +355,16 @@ function formatTime(time: string): string {
   return `${displayHour}:${minutes.toString().padStart(2, '0')} ${ampm}`;
 }
 
+// Escape text interpolated into the printed HTML (written via document.write).
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
 // Helper function to render initials with shapes based on assignment type
 // Only applies shapes in "all-sessions" view
 function renderInitialsWithShape(
@@ -362,18 +372,20 @@ function renderInitialsWithShape(
   session: ScheduleSession,
   viewMode: ViewMode
 ): string {
+  const safeInitials = escapeHtml(initials);
+
   // Only apply shapes in all-sessions view
   if (viewMode !== 'all-sessions') {
-    return initials;
+    return safeInitials;
   }
 
   if (session.assigned_to_sea_id) {
     // Square shape for sessions assigned to SEA
-    return `<span class="shape-square">${initials}</span>`;
+    return `<span class="shape-square">${safeInitials}</span>`;
   } else if (session.assigned_to_specialist_id) {
     // Circle shape for sessions assigned to Specialist
-    return `<span class="shape-circle">${initials}</span>`;
+    return `<span class="shape-circle">${safeInitials}</span>`;
   }
   // Plain text for sessions I own and deliver (no assignment)
-  return initials;
+  return safeInitials;
 }

--- a/lib/worksheets/worksheet-generator.ts
+++ b/lib/worksheets/worksheet-generator.ts
@@ -264,11 +264,21 @@ export function generatePrintableWorksheet(
   student: { initials: string; grade_level: string },
   qrCodeDataUrl: string
 ): string {
+  // Escape all interpolated text fields. title/instructions originate from
+  // AI-generated lesson content and initials/grade from the DB, and the result
+  // is written into a print window via document.write — unescaped values would
+  // allow HTML/script injection. (qrCodeDataUrl is a generated base64 data URI
+  // with no quotes, so it is safe in the src attribute as-is.)
+  const safeTitle = escapeHtml(worksheet.title);
+  const safeInitials = escapeHtml(student.initials);
+  const safeGrade = escapeHtml(student.grade_level);
+  const safeInstructions = escapeHtml(worksheet.instructions);
+
   return `
     <!DOCTYPE html>
     <html>
     <head>
-      <title>${worksheet.title} - ${student.initials}</title>
+      <title>${safeTitle} - ${safeInitials}</title>
       <style>
         @page { margin: 0.75in; }
         body { 
@@ -332,16 +342,16 @@ export function generatePrintableWorksheet(
     <body>
       <div class="header">
         <div class="student-info">
-          <h1>${worksheet.title}</h1>
-          <p><strong>Name:</strong> ${student.initials} &nbsp;&nbsp;&nbsp; 
-             <strong>Grade:</strong> ${student.grade_level} &nbsp;&nbsp;&nbsp;
+          <h1>${safeTitle}</h1>
+          <p><strong>Name:</strong> ${safeInitials} &nbsp;&nbsp;&nbsp;
+             <strong>Grade:</strong> ${safeGrade} &nbsp;&nbsp;&nbsp;
              <strong>Date:</strong> ________________</p>
         </div>
         <img src="${qrCodeDataUrl}" alt="QR Code" class="qr-code" />
       </div>
 
       <div class="instructions">
-        <strong>Instructions:</strong> ${worksheet.instructions}
+        <strong>Instructions:</strong> ${safeInstructions}
       </div>
 
       ${worksheet.questions.map((q, index) => {


### PR DESCRIPTION
Four High-priority findings from the June 2026 review. All reversible; each is internal/behavior-preserving except the intended fix itself.

## SPE-131 — `cleanup-uploads` cron has never worked
`app/api/cron/cleanup-uploads/route.ts` deleted `upload_rate_limits WHERE created_at < cutoff`, but the column is **`uploaded_at`** (verified against the live schema). The query always errored, and the route returned **200 on failure**, so it looked healthy while the table grew unbounded — slowly degrading the unauthenticated `submit-worksheet` rate-limit check.

- Query the correct column (`uploaded_at`) in both the cleanup route and `cron/health` (same bug throughout).
- Use the **service-role client** — a cron request has no user session for the cookie client to read.
- Delete with `{ count: 'exact' }` instead of `.select('id')` so we don't pull a large id list back over the wire.
- Return **5xx** on DB error / unexpected error / missing `CRON_SECRET` so failures are visible and retried, instead of being masked behind a 200.

## SPE-129 — XSS in the printable-worksheet template
`lib/worksheets/worksheet-generator.ts:generatePrintableWorksheet` interpolated `worksheet.title`, `instructions`, and student `initials`/`grade_level` **unescaped** into HTML written via `document.write`, even though an `escapeHtml` helper already existed and was used for questions. `title`/`instructions` come from AI-generated lesson content, so this allowed HTML/script injection in the same-origin print window.

- Escape `title`, `instructions`, `initials`, `grade_level`. (`qrCodeDataUrl` is a generated base64 data URI with no quotes — safe in the `src` attribute as-is.)
- `lib/utils/export-week-to-pdf.ts`: escape student initials in `renderInitialsWithShape` (minor sibling).

## SPE-130 — client-side DELETE of "orphaned" sessions on a read path
`lib/services/session-generator.ts` classified instances whose `start_time` no longer matched a **fetched** template as orphaned and fire-and-forget **DELETEd them from the browser**. When the template fetch was partial (PostgREST's 1000-row cap, a transient error, or a role-filter mismatch), valid future sessions were misclassified and **permanently deleted**; two tabs raced each other.

- Remove the delete entirely. Orphaned instances are still excluded from the rendered set (reversible, display-only); any real cleanup must run server-side against the complete template set. (Related: SPE-133 pagination, SPE-108 display symptom.)

## SPE-128 — disable `email-webhook` until it's secured
`app/api/email-webhook/route.ts` had **no sender verification** — an unauthenticated POST could trigger outbound Resend emails (open relay via our sending domain) and paid AI vision calls. The endpoint's real sender/signing scheme is undetermined (no signing secret configured; payload shape doesn't match Resend's Svix event format) and the inbound email→worksheet flow isn't live.

- Gate the handler behind `EMAIL_WEBHOOK_ENABLED` (default **off**); return 404 when disabled. Re-enabling requires implementing the provider's webhook signature verification first (called out in code). Chosen over guessing a signature scheme that could break a dormant integration.

## Verification
- `npm run typecheck:fast` — pass
- `npx next lint` on changed files — clean
- `npm test` — 7 suites, 46 passed / 12 skipped

https://claude.ai/code/session_01BzFfG6AUZyj9TXkqwXYr5F

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed orphan session detection to prevent incorrectly hiding valid instances.
  * Improved error handling with correct HTTP status codes for failed operations.
  * Added HTML escaping in PDF and worksheet exports to prevent data injection issues.
  * Strengthened cron endpoint authentication to validate credentials only from request headers.

* **New Features**
  * Email webhook endpoint now includes safety feature flag (disabled by default).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->