### PR TITLE
reliability: fail closed on rate-limiter errors for paid AI endpoints (SPE-135)

### DIFF
--- a/app/api/ai-upload/route.ts
+++ b/app/api/ai-upload/route.ts
@@ -27,7 +27,7 @@ const SUPPORTED_TYPES = [
 // Each request runs a paid external conversion (PDF.co) plus an Anthropic
 // completion, so cap how often a single user can invoke it.
 export const POST = withRoute(
-  { rateLimit: { requests: 20, windowSeconds: 3600, name: 'ai-upload' } },
+  { rateLimit: { requests: 20, windowSeconds: 3600, name: 'ai-upload', failClosed: true } },
   async ({ req: request, userId }) => {
   const perf = measurePerformanceWithAlerts('ai_upload', 'api');
   

--- a/app/api/exit-tickets/generate/route.ts
+++ b/app/api/exit-tickets/generate/route.ts
@@ -15,7 +15,7 @@ const generateExitTicketsSchema = z
 export const POST = withRoute(
   {
     body: generateExitTicketsSchema,
-    rateLimit: { requests: 30, windowSeconds: 3600, name: 'exit-tickets/generate' },
+    rateLimit: { requests: 30, windowSeconds: 3600, name: 'exit-tickets/generate', failClosed: true },
   },
   async ({ userId, body }) => {
     try {

--- a/app/api/lessons/generate/route.ts
+++ b/app/api/lessons/generate/route.ts
@@ -37,7 +37,7 @@ const CAPTURE_AI_RAW = process.env.CAPTURE_AI_RAW === 'true';
 const SHOULD_CAPTURE_METADATA = CAPTURE_FULL_PROMPTS || CAPTURE_AI_RAW;
 
 export const POST = withRoute(
-  { rateLimit: { requests: 30, windowSeconds: 3600, name: 'lessons/generate' } },
+  { rateLimit: { requests: 30, windowSeconds: 3600, name: 'lessons/generate', failClosed: true } },
   async ({ req, userId }) => {
     try {
       // Create supabase client for database operations

--- a/app/api/lessons/v2/generate/route.ts
+++ b/app/api/lessons/v2/generate/route.ts
@@ -12,7 +12,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export const POST = withRoute(
-  { rateLimit: { requests: 30, windowSeconds: 3600, name: 'lessons/v2/generate' } },
+  { rateLimit: { requests: 30, windowSeconds: 3600, name: 'lessons/v2/generate', failClosed: true } },
   async ({ req, userId }) => {
   try {
     // Parse request body

--- a/app/api/progress-check/generate/route.ts
+++ b/app/api/progress-check/generate/route.ts
@@ -23,7 +23,7 @@ interface Worksheet {
 export const POST = withRoute(
   {
     body: generateProgressCheckSchema,
-    rateLimit: { requests: 30, windowSeconds: 3600, name: 'progress-check/generate' },
+    rateLimit: { requests: 30, windowSeconds: 3600, name: 'progress-check/generate', failClosed: true },
   },
   async ({ userId, body }) => {
     try {

--- a/lib/api/rate-limit-user.ts
+++ b/lib/api/rate-limit-user.ts
@@ -6,6 +6,13 @@ export interface RateLimitRule {
   requests: number;
   /** Window length in seconds. */
   windowSeconds: number;
+  /**
+   * When the limiter itself errors (DB unavailable, etc.), deny the request
+   * instead of allowing it. Use for expensive endpoints (paid AI/third-party
+   * calls) where fail-open turns a DB hiccup into uncapped spend. Defaults to
+   * false (fail open) to preserve availability on cheap endpoints.
+   */
+  failClosed?: boolean;
 }
 
 export interface RateLimitOutcome {
@@ -33,6 +40,13 @@ export async function checkUserRateLimit(
     resetSeconds: rule.windowSeconds,
   });
 
+  // On a limiter error, fail closed for endpoints that opt in (deny), otherwise
+  // fail open (allow) so a transient DB issue doesn't block cheap traffic.
+  const onError = (): RateLimitOutcome =>
+    rule.failClosed
+      ? { allowed: false, remaining: 0, resetSeconds: rule.windowSeconds }
+      : allow();
+
   try {
     const supabase = createServiceClient();
     const windowStart = new Date(Date.now() - rule.windowSeconds * 1000).toISOString();
@@ -54,8 +68,8 @@ export async function checkUserRateLimit(
       .gte('created_at', windowStart);
 
     if (error) {
-      log.error('Rate limit check failed; allowing request', error, { userId, endpoint });
-      return allow();
+      log.error('Rate limit check failed', error, { userId, endpoint, failClosed: !!rule.failClosed });
+      return onError();
     }
 
     const used = count ?? 0;
@@ -67,12 +81,12 @@ export async function checkUserRateLimit(
       .from('api_rate_limits')
       .insert({ user_id: userId, endpoint });
     if (insertError) {
-      log.error('Rate limit insert failed; allowing request', insertError, { userId, endpoint });
-      return allow();
+      log.error('Rate limit insert failed', insertError, { userId, endpoint, failClosed: !!rule.failClosed });
+      return onError();
     }
     return allow(rule.requests - used - 1);
   } catch (err) {
-    log.error('Rate limit check threw; allowing request', err, { userId, endpoint });
-    return allow();
+    log.error('Rate limit check threw', err, { userId, endpoint, failClosed: !!rule.failClosed });
+    return onError();
   }
 }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -46,8 +46,10 @@ export async function checkRateLimit(
 
     if (ipError) {
       console.error('Error checking IP rate limit:', ipError);
-      // On error, be conservative and allow the upload
-      return { allowed: true, reason: 'Rate limit check failed' };
+      // Fail closed: this endpoint is unauthenticated and each accepted upload
+      // triggers a paid AI vision call, so a broken limiter must not allow
+      // uncapped uploads. Reject and let the caller retry shortly.
+      return { allowed: false, reason: 'Upload temporarily unavailable. Please try again shortly.' };
     }
 
     const ipUploadCount = ipUploads?.length || 0;
@@ -74,8 +76,8 @@ export async function checkRateLimit(
 
   } catch (error) {
     console.error('Error in rate limit check:', error);
-    // On unexpected error, allow the upload to avoid blocking legitimate users
-    return { allowed: true, reason: 'Rate limit check error' };
+    // Fail closed (paid AI on an unauthenticated path; see above).
+    return { allowed: false, reason: 'Upload temporarily unavailable. Please try again shortly.' };
   }
 }
 
@@ -96,7 +98,8 @@ async function checkWorksheetLimit(
 
   if (worksheetError) {
     console.error('Error checking worksheet rate limit:', worksheetError);
-    return { allowed: true, reason: 'Worksheet limit check failed' };
+    // Fail closed (paid AI on an unauthenticated path; see checkRateLimit).
+    return { allowed: false, reason: 'Upload temporarily unavailable. Please try again shortly.' };
   }
 
   const worksheetUploadCount = worksheetUploads?.length || 0;


### PR DESCRIPTION
## SPE-135 — rate limiters fail open on error

Both rate limiters allowed the request whenever the limiter check itself errored. That meant a DB hiccup — exactly what happens under load — turned every expensive AI endpoint into **uncapped spend** at the worst possible moment.

### Per-user limiter (`lib/api/rate-limit-user.ts`)
- Added an opt-in `failClosed` flag to `RateLimitRule`. On a limiter error (count query, insert, or unexpected throw), it now **denies** instead of allowing. Default stays fail-open so cheap endpoints keep availability on transient errors.
- Enabled `failClosed: true` on the five paid-AI routes: `lessons/generate`, `lessons/v2/generate`, `exit-tickets/generate`, `progress-check/generate`, `ai-upload`.

### IP limiter (`lib/rate-limit.ts`)
- Its sole consumer is the **unauthenticated** QR `submit-worksheet` path, where each accepted upload triggers a paid Claude Vision call. Changed the three error paths (IP query, worksheet query, unexpected throw) to **fail closed**.
- The "no IP header" case is unchanged — that's not an error, and it still enforces the per-worksheet limit.
- A denied request returns the existing clean **429** with a retry message.

## Verification
- `npm run typecheck:fast` — pass
- `npx next lint` on changed files — clean
- `npm test` — 7 suites, 46 passed / 12 skipped

## Note
SPE-132 (the other High item in this slice) was intentionally **not** included — it's an auth-architecture change that interacts with SPE-5's auth-connection cap, so it's being deferred to be designed together with SPE-5.

https://claude.ai/code/session_01BzFfG6AUZyj9TXkqwXYr5F

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzFfG6AUZyj9TXkqwXYr5F)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated rate-limiting configuration across AI upload, lessons, exit tickets, and progress check endpoints.
  * Modified rate-limiting behavior to deny requests when rate-limit checks cannot be determined, rather than allowing them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->