### PR TITLE
privacy: minimize Sentry data footprint for district pilot (SPE-167)

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -9,30 +9,25 @@ import { scrubSentryEvent, scrubSentryLog } from '@/lib/monitoring/sentry-scrub'
 if (process.env.NODE_ENV === 'production') {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN || 'https://dfe4322e91dde4865165f296d9264784@o4509770864787457.ingest.us.sentry.io/4509837723631616',
-    
+
     // Adjust this value in production, or use tracesSampler for greater control
     tracesSampleRate: 1.0,
-    
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
-    
+
+    // Never attach default request PII (cookies, headers, IP, bodies) to events.
+    // Explicit per SPE-167 even though the SDK default is already false.
+    sendDefaultPii: false,
+
+    // Sentry Logs disabled (SPE-167): forwarded console output can carry student
+    // context. During the district pilot we keep Sentry to exception capture only.
+    enableLogs: false,
+
     // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,
-    
-    // Replays are disabled by default
-    replaysOnErrorSampleRate: 1.0,
-    
-    // You can remove this option if you're not planning to use the Sentry Session Replay feature
-    replaysSessionSampleRate: 0.1,
-    
-    integrations: [
-      Sentry.replayIntegration({
-        // Mask all text and inputs by default
-        maskAllText: true,
-        maskAllInputs: true,
-      }),
-    ],
-    
+
+    // Session Replay intentionally disabled (SPE-167): even with text/input
+    // masking it is a session-capture feature we don't want recording
+    // special-ed / IEP workflows during the district pilot.
+
     // Filter out specific errors
     beforeSend(event, hint) {
       // Don't send errors in development

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -18,16 +18,18 @@ class Logger {
 
   setContext(context: LogContext) {
     this.context = { ...this.context, ...context };
-    Sentry.setContext('logger', this.context);
+    // Context is retained for console output (Vercel logs) only. It is
+    // intentionally NOT pushed to Sentry (no Sentry.setContext): a LogContext
+    // is free-form and can carry student PII. See SPE-167.
   }
 
   private formatMessage(level: LogLevel, message: string, meta?: any): string {
     const timestamp = new Date().toISOString();
-    const contextStr = Object.keys(this.context).length 
-      ? ` [${JSON.stringify(this.context)}]` 
+    const contextStr = Object.keys(this.context).length
+      ? ` [${JSON.stringify(this.context)}]`
       : '';
     const metaStr = meta ? ` ${JSON.stringify(meta)}` : '';
-    
+
     return `[${timestamp}] [${level.toUpperCase()}]${contextStr} ${message}${metaStr}`;
   }
 
@@ -39,41 +41,40 @@ class Logger {
 
   info(message: string, meta?: any) {
     console.info(this.formatMessage(LogLevel.INFO, message, meta));
-    
-    // Send important info logs to Sentry as breadcrumbs
+
+    // Breadcrumb trail to Sentry uses the developer-authored `message` only —
+    // never `meta`, which can carry student PII (SPE-167).
     Sentry.addBreadcrumb({
       message,
       level: 'info',
-      data: meta,
     });
   }
 
   warn(message: string, meta?: any) {
     console.warn(this.formatMessage(LogLevel.WARN, message, meta));
-    
-    // Send warnings to Sentry as breadcrumbs
+
+    // Breadcrumb trail to Sentry uses the developer-authored `message` only —
+    // never `meta`, which can carry student PII (SPE-167).
     Sentry.addBreadcrumb({
       message,
       level: 'warning',
-      data: meta,
     });
   }
 
   error(message: string, error?: unknown, meta?: any) {
-    const formattedMessage = this.formatMessage(LogLevel.ERROR, message, meta);
-    console.error(formattedMessage, error);
-    
-    // Send errors to Sentry
+    // Full message + meta + context go to the console (Vercel logs) only.
+    console.error(this.formatMessage(LogLevel.ERROR, message, meta), error);
+
+    // To Sentry we send the exception (stack trace) and the developer-authored
+    // `message` only — never `meta`/`context`, which can carry student PII (SPE-167).
     if (error instanceof Error) {
       Sentry.captureException(error, {
         extra: {
           message,
-          ...meta,
-          context: this.context,
         },
       });
     } else {
-      Sentry.captureMessage(formattedMessage, 'error');
+      Sentry.captureMessage(message, 'error');
     }
   }
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -74,7 +74,13 @@ class Logger {
         },
       });
     } else {
-      Sentry.captureMessage(message, 'error');
+      // No Error instance to capture. Record the value's *type* only — never the
+      // value itself, which can carry student PII — so Sentry can distinguish a
+      // missing error from a non-Error rejection reason (SPE-167).
+      Sentry.captureMessage(message, {
+        level: 'error',
+        extra: { errorType: typeof error },
+      });
     }
   }
 

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -9,11 +9,17 @@ import { scrubSentryEvent, scrubSentryLog } from '@/lib/monitoring/sentry-scrub'
 Sentry.init({
   dsn: 'https://dfe4322e91dde4865165f296d9264784@o4509770864787457.ingest.us.sentry.io/4509837723631616',
 
+  // Never attach default request PII (cookies, headers, IP, request bodies) to
+  // events. Explicit per SPE-167 even though the SDK default is already false.
+  sendDefaultPii: false,
+
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
 
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+  // Sentry Logs disabled (SPE-167): structured logs / forwarded console output
+  // can carry student context. During the district pilot we keep Sentry to
+  // exception capture only. beforeSendLog stays wired for if/when this is re-enabled.
+  enableLogs: false,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -8,11 +8,17 @@ import { scrubSentryEvent, scrubSentryLog } from '@/lib/monitoring/sentry-scrub'
 Sentry.init({
   dsn: 'https://dfe4322e91dde4865165f296d9264784@o4509770864787457.ingest.us.sentry.io/4509837723631616',
 
+  // Never attach default request PII (cookies, headers, IP, request bodies) to
+  // events. Explicit per SPE-167 even though the SDK default is already false.
+  sendDefaultPii: false,
+
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
 
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+  // Sentry Logs disabled (SPE-167): structured logs / forwarded console output
+  // can carry student context. During the district pilot we keep Sentry to
+  // exception capture only. beforeSendLog stays wired for if/when this is re-enabled.
+  enableLogs: false,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,


### PR DESCRIPTION
## Summary

Trims Sentry down to **exception capture only** for the district pilot, removing the data-heavy features that can carry student (IEP / special-ed) PII. Sentry stays valuable for what actually protects a pilot — proactive alerts + source-mapped stack traces — while holding essentially operational error data.

Tracked in [SPE-167](https://linear.app/speddy/issue/SPE-167); complements SPE-136 (email scrubber, done), SPE-91 (console PII, done), SPE-97 (stop-logging-at-source), and the disclosure work in SPE-134 / SPE-165.

## Why

Our published FERPA page claims *"data minimization – only essential information is collected"* (`app/ferpa/page.tsx:104`). The previous Sentry config contradicted that: it shipped structured logs, session replays, and free-form log `meta`/`context`, scrubbed only for email addresses. This change makes the claim true for the Sentry path and shrinks breach-notification scope for highly-sensitive special-ed data.

## Changes

**Sentry configs** (`sentry.server.config.ts`, `sentry.edge.config.ts`, `instrumentation-client.ts`)
- `enableLogs: false` — disables the Sentry Logs stream (incl. forwarded `console.*` output).
- Removed **Session Replay** entirely (integration + both sample rates) from the client config.
- `sendDefaultPii: false` set **explicitly** in all three (was relying on the SDK default).
- Kept exception capture + the email `beforeSend` scrubber; left `beforeSendLog` wired (dormant) so re-enabling logs later is a one-line flip.

**Application logger** (`lib/logger.ts`)
- Stopped forwarding free-form `meta`/`context` to Sentry. Previously: `captureException({ extra: { ...meta, context } })`, `addBreadcrumb({ data: meta })`, `captureMessage(formattedMessage)` (which embedded stringified context+meta), and `Sentry.setContext('logger', ...)`.
- Now: Sentry gets the exception (stack trace) + the developer-authored `message` only; breadcrumbs keep the `message`, drop the payload; `setContext` no longer pushes to Sentry.
- **Console output is unchanged** — full `meta`/`context` still flow to Vercel runtime logs for debugging.

## What this does NOT change
- Error tracking, alerting, and source-mapped stack traces are intact.
- Email scrubbing (`lib/monitoring/sentry-scrub.ts`) is unchanged.
- No UX/behavior change; production-only (client init is prod-gated).

## Residual / follow-ups (tracked)
- Disclosing Sentry as a subprocessor in the public privacy policy (currently names only Anthropic) — SPE-165 / SPE-134.
- Broad "stop logging PII at source" cleanup — SPE-97.

## Testing
- `npm run typecheck:fast` passes (validates the Sentry option names).
- Logger public API (`logger`, `createRequestLogger`, `LogLevel`, `child`) is unchanged — no call-site changes needed.

https://claude.ai/code/session_01FqcsNtzhKDBsXyGTpawQf9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqcsNtzhKDBsXyGTpawQf9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy by preventing default/request PII from being attached to error tracking events
  * Disabled session replay recording and Sentry log forwarding for enhanced data protection
  * Streamlined error reporting to capture only essential exception details
  * Updated logging to exclude free-form context/meta from error-tracking breadcrumbs and events
<!-- end of auto-generated comment: release notes by coderabbit.ai -->