### PR TITLE
feat: server-side AI kill-switch to gate all external-LLM routes (SPE-162)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 ANTHROPIC_API_KEY=your-anthropic-api-key
 OPENAI_API_KEY=your-openai-api-key
 
+# AI Feature Kill-Switch
+# Master switch for all AI features (lesson / exit-ticket / progress-check /
+# worksheet generation and AI document upload). Disabled by default: gated AI
+# routes return 404 and make NO external LLM/provider calls unless this is 'true'.
+AI_FEATURES_ENABLED=false
+
 # AI Privacy and Security (Optional)
 # WARNING: These flags control storage of sensitive data including prompts and responses
 # Only enable for debugging purposes in non-production environments

--- a/__tests__/unit/lib/api/with-route.test.ts
+++ b/__tests__/unit/lib/api/with-route.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for the AI kill-switch in `withRoute` (SPE-162).
+ *
+ * Contract: a route with `aiGated: true` must 404 *before* any auth/client or
+ * handler logic runs whenever `AI_FEATURES_ENABLED !== 'true'`, and must leave
+ * non-gated routes untouched.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+
+// Mock the Supabase server client so we can assert whether the auth/client step
+// ran, without hitting a real backend. (jest requires factory-referenced vars to
+// be prefixed with `mock`.)
+const mockGetUser = jest.fn();
+const mockCreateClient = jest.fn();
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: (...args: unknown[]) => mockCreateClient(...args),
+}));
+
+import { withRoute } from '@/lib/api/with-route';
+
+const makeRequest = () =>
+  new NextRequest('http://localhost/api/test', { method: 'POST' });
+
+describe('withRoute AI kill-switch (aiGated)', () => {
+  const original = process.env.AI_FEATURES_ENABLED;
+
+  beforeEach(() => {
+    mockCreateClient.mockReset();
+    mockGetUser.mockReset();
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockCreateClient.mockResolvedValue({ auth: { getUser: mockGetUser } });
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.AI_FEATURES_ENABLED;
+    else process.env.AI_FEATURES_ENABLED = original;
+  });
+
+  it('404s a gated route and skips auth + handler when AI is disabled', async () => {
+    delete process.env.AI_FEATURES_ENABLED;
+    const handler = jest.fn();
+    const route = withRoute({ aiGated: true }, handler as any);
+
+    const res = await route(makeRequest());
+
+    expect(res.status).toBe(404);
+    expect(handler).not.toHaveBeenCalled();
+    // The gate must short-circuit before the auth/client step.
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it('treats any value other than "true" as disabled', async () => {
+    process.env.AI_FEATURES_ENABLED = 'false';
+    const handler = jest.fn();
+    const route = withRoute({ aiGated: true }, handler as any);
+
+    const res = await route(makeRequest());
+
+    expect(res.status).toBe(404);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('runs auth + handler on a gated route when AI is enabled', async () => {
+    process.env.AI_FEATURES_ENABLED = 'true';
+    const handler = jest.fn(async () => NextResponse.json({ ok: true }));
+    const route = withRoute({ aiGated: true }, handler as any);
+
+    const res = await route(makeRequest());
+
+    expect(res.status).toBe(200);
+    expect(mockCreateClient).toHaveBeenCalledTimes(1); // auth/client step ran
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not gate routes that opt out of aiGated', async () => {
+    delete process.env.AI_FEATURES_ENABLED;
+    const handler = jest.fn(async () => NextResponse.json({ ok: true }));
+    const route = withRoute({ auth: false }, handler as any);
+
+    const res = await route(makeRequest());
+
+    expect(res.status).toBe(200);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/api/ai-upload/route.ts
+++ b/app/api/ai-upload/route.ts
@@ -32,7 +32,7 @@ const SUPPORTED_TYPES = [
 // Each request runs a paid external conversion (PDF.co) plus an Anthropic
 // completion, so cap how often a single user can invoke it.
 export const POST = withRoute(
-  { rateLimit: { requests: 20, windowSeconds: 3600, name: 'ai-upload', failClosed: true } },
+  { aiGated: true, rateLimit: { requests: 20, windowSeconds: 3600, name: 'ai-upload', failClosed: true } },
   async ({ req: request, userId }) => {
   const perf = measurePerformanceWithAlerts('ai_upload', 'api');
   

--- a/app/api/exit-tickets/generate/route.ts
+++ b/app/api/exit-tickets/generate/route.ts
@@ -14,6 +14,7 @@ const generateExitTicketsSchema = z
 
 export const POST = withRoute(
   {
+    aiGated: true,
     body: generateExitTicketsSchema,
     rateLimit: { requests: 30, windowSeconds: 3600, name: 'exit-tickets/generate', failClosed: true },
   },

--- a/app/api/lessons/generate/route.ts
+++ b/app/api/lessons/generate/route.ts
@@ -37,7 +37,7 @@ const CAPTURE_AI_RAW = process.env.CAPTURE_AI_RAW === 'true';
 const SHOULD_CAPTURE_METADATA = CAPTURE_FULL_PROMPTS || CAPTURE_AI_RAW;
 
 export const POST = withRoute(
-  { rateLimit: { requests: 30, windowSeconds: 3600, name: 'lessons/generate', failClosed: true } },
+  { aiGated: true, rateLimit: { requests: 30, windowSeconds: 3600, name: 'lessons/generate', failClosed: true } },
   async ({ req, userId }) => {
     try {
       // Create supabase client for database operations

--- a/app/api/lessons/v2/generate/route.ts
+++ b/app/api/lessons/v2/generate/route.ts
@@ -12,7 +12,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export const POST = withRoute(
-  { rateLimit: { requests: 30, windowSeconds: 3600, name: 'lessons/v2/generate', failClosed: true } },
+  { aiGated: true, rateLimit: { requests: 30, windowSeconds: 3600, name: 'lessons/v2/generate', failClosed: true } },
   async ({ req, userId }) => {
   try {
     // Parse request body

--- a/app/api/progress-check/generate/route.ts
+++ b/app/api/progress-check/generate/route.ts
@@ -22,6 +22,7 @@ interface Worksheet {
 
 export const POST = withRoute(
   {
+    aiGated: true,
     body: generateProgressCheckSchema,
     rateLimit: { requests: 30, windowSeconds: 3600, name: 'progress-check/generate', failClosed: true },
   },

--- a/app/api/submit-worksheet/route.ts
+++ b/app/api/submit-worksheet/route.ts
@@ -27,7 +27,7 @@ interface AnalysisResult {
 
 // Public endpoint: QR-scan uploads are unauthenticated (auth is enforced
 // in-handler only for non-QR direct uploads), and it has its own IP rate limit.
-export const POST = withRoute({ auth: false }, async ({ req: request }) => {
+export const POST = withRoute({ auth: false, aiGated: true }, async ({ req: request }) => {
   const startTime = Date.now();
   let imageSize = 0;
   let source: string | undefined;

--- a/lib/api/with-route.ts
+++ b/lib/api/with-route.ts
@@ -4,6 +4,12 @@ import { createClient } from '@/lib/supabase/server';
 import { log } from '@/lib/monitoring/logger';
 import { checkUserRateLimit, type RateLimitRule } from './rate-limit-user';
 
+// Server-side AI kill-switch. AI features are disabled by default; any route
+// that reaches an external LLM / document-processing provider opts in via
+// `aiGated` (see below) and 404s unless AI_FEATURES_ENABLED === 'true'. The flag
+// is read per request (not cached at module load) so a change takes effect on
+// the next request rather than requiring a fresh process.
+
 interface WithRouteConfig<TBody, TQuery> {
   /** Require an authenticated user (default true). When false, `userId` is ''. */
   auth?: boolean;
@@ -13,6 +19,13 @@ interface WithRouteConfig<TBody, TQuery> {
   query?: ZodType<TQuery, any, any>;
   /** Per-user rate limit. Applied only on authenticated routes. */
   rateLimit?: RateLimitRule & { name?: string };
+  /**
+   * Gate this route behind the AI feature kill-switch. When AI is disabled
+   * (AI_FEATURES_ENABLED !== 'true'), the route 404s before any handler logic
+   * runs — so no external LLM/provider call is made. Apply to routes that reach
+   * OpenAI / Anthropic / document-processing providers.
+   */
+  aiGated?: boolean;
 }
 
 interface RouteHandlerArgs<TBody, TQuery, TParams> {
@@ -50,6 +63,13 @@ export function withRoute<
 ) {
   return async (req: NextRequest, context?: NextContext<TParams>): Promise<NextResponse> => {
     try {
+      // AI kill-switch: gated routes do not exist while AI features are off.
+      // Checked before auth so the feature is fully hidden and makes no
+      // provider calls regardless of who calls it.
+      if (config.aiGated && process.env.AI_FEATURES_ENABLED !== 'true') {
+        return NextResponse.json({ error: 'Not found' }, { status: 404 });
+      }
+
       let userId = '';
       if (config.auth !== false) {
         const supabase = await createClient();


### PR DESCRIPTION
## Summary

AI features are hidden in the UI, but the API routes that reach **OpenAI / Anthropic / PDF.co** were still live — a direct authenticated call (or the unauthenticated QR worksheet path) would still produce student-data egress to those providers. This adds a single server-side kill-switch so "AI is disabled" is true in code, not just the UI.

Tracked as [SPE-162](https://linear.app/speddy/issue/SPE-162). This is the prerequisite for truthfully telling a district "AI providers are disclosed but not enabled," and lets us re-enable with one env flag (no redeploy of disclosures).

## How it works

- New `aiGated?: boolean` option on `withRoute` (`lib/api/with-route.ts`).
- When a route sets `aiGated: true` and `process.env.AI_FEATURES_ENABLED !== 'true'`, the wrapper returns **404 before any handler logic runs** — so no provider call is made, regardless of caller.
- The check sits **before** auth, so it also covers the unauthenticated `submit-worksheet` QR path.
- The flag is read **per-request** (not cached at module load), so flipping it takes effect on the next request.
- Default is **off** (disabled).

## Gated routes (reach a provider)

| Route | Provider |
|---|---|
| `lessons/generate` | OpenAI (default) / Anthropic |
| `lessons/v2/generate` | Anthropic |
| `exit-tickets/generate` | Anthropic |
| `progress-check/generate` | Anthropic |
| `ai-upload` | PDF.co + Anthropic |
| `submit-worksheet` | Anthropic Vision |

## Intentionally NOT gated

`import-iep-goals`, `import-students`, and `extension/import` call `scrubPIIFromGoals(goals, first, last)` **without** the `useAI` flag → local regex scrubbing, **no provider call**. These are core non-AI import workflows and stay available.

## ⚠️ Behavior change (intended)

Once merged with `AI_FEATURES_ENABLED` unset, the six routes above return **404**. Since the AI features are already hidden in the UI, no live flow should hit them — **but note `submit-worksheet` is hard-gated**, so the QR worksheet-submission path (which also stores the image + records a submission, not just the Vision call) is fully disabled while AI is off. Flagging in case any worksheet QR codes are in the wild; the alternative is a soft-gate (accept/store the upload, skip the AI analysis). Happy to switch to soft-gate if you'd prefer.

## Re-enabling
Set `AI_FEATURES_ENABLED=true` in the server env (documented in `.env.example`). Provider/model selection is unchanged (`AI_PROVIDER`, `ANTHROPIC_MODEL`, `OPENAI_MODEL`).

## Testing
- `npm run typecheck:fast` passes.
- Full jest suite passes (8 suites, 55 passed); no tests exercise the gated routes, so none regress.

https://claude.ai/code/session_01FqcsNtzhKDBsXyGTpawQf9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqcsNtzhKDBsXyGTpawQf9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a global AI feature flag (disabled by default) to control availability of AI-powered functionality.

* **Chores**
  * Applied AI gating to AI-related API endpoints so they respect the global flag and remain unavailable when disabled.

* **Tests**
  * Added unit tests to verify AI gating behavior and correct handling when the flag is enabled or disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->