### PR TITLE
refactor: remove PDF.co integration from ai-upload (SPE-164)

### DIFF
--- a/app/api/ai-upload/route.ts
+++ b/app/api/ai-upload/route.ts
@@ -76,7 +76,7 @@ export const POST = withRoute(
       return NextResponse.json(
         {
           error:
-            "Unsupported file type. Please upload PDF, Word, Excel, CSV, or text files.",
+            "Unsupported file type. Please upload Word, Excel, CSV, or text files.",
         },
         { status: 400 },
       );

--- a/app/api/ai-upload/route.ts
+++ b/app/api/ai-upload/route.ts
@@ -18,7 +18,6 @@ export const maxDuration = 300; // 5 minutes
 
 // Supported file types - expanded list
 const SUPPORTED_TYPES = [
-  "application/pdf",
   "application/msword",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   "application/vnd.ms-excel",
@@ -57,6 +56,20 @@ export const POST = withRoute(
       return NextResponse.json({ error: "No file provided" }, { status: 400 });
     }
 
+    // Reject PDFs up front, before reading the file. PDF text extraction is
+    // intentionally not supported: the prior path uploaded the raw PDF to an
+    // external service (PDF.co) that is not a disclosed subprocessor for student
+    // data; removed in SPE-164. When PDF parsing is needed again, prefer an
+    // in-house parser (pdfjs-dist, already a dependency) or a disclosed
+    // subprocessor before re-enabling.
+    if (file.type === 'application/pdf') {
+      log.info('Rejected unsupported PDF upload', { userId, fileName: file.name });
+      return NextResponse.json(
+        { error: 'PDF upload is not currently supported. Please upload a Word, Excel, CSV, or text file.' },
+        { status: 400 }
+      );
+    }
+
     // Check if file type is supported
     if (
       !SUPPORTED_TYPES.includes(file.type) &&
@@ -90,18 +103,7 @@ export const POST = withRoute(
     const bytes = await file.arrayBuffer();
     const buffer = Buffer.from(bytes);
 
-    if (file.type === 'application/pdf') {
-      // PDF text extraction is intentionally not supported. The prior path
-      // uploaded the raw PDF to an external service (PDF.co) that is not a
-      // disclosed subprocessor for student data; removed in SPE-164. When PDF
-      // parsing is needed again, prefer an in-house parser (pdfjs-dist, already
-      // a dependency) or a disclosed subprocessor before re-enabling.
-      log.info('Rejected unsupported PDF upload', { userId, fileName: file.name });
-      return NextResponse.json(
-        { error: 'PDF upload is not currently supported. Please upload a Word, Excel, CSV, or text file.' },
-        { status: 400 }
-      );
-    } else if (file.type.includes("sheet") || file.type.includes("excel")) {
+    if (file.type.includes("sheet") || file.type.includes("excel")) {
       // Process Excel files
       extractionMethod = "Excel";
 
@@ -159,7 +161,7 @@ export const POST = withRoute(
             fileName: file.name
           });
           return NextResponse.json(
-            { error: "Failed to process Word document. Please try converting to PDF or text." },
+            { error: "Failed to process Word document. Please try converting to text." },
             { status: 500 }
           );
         }

--- a/app/api/ai-upload/route.ts
+++ b/app/api/ai-upload/route.ts
@@ -11,9 +11,9 @@ import { withRoute } from '@/lib/api/with-route';
 // Force Node.js runtime for file processing
 export const runtime = "nodejs";
 
-// This route does a two-step PDF.co conversion plus an 8k-token Anthropic call,
-// which far exceeds the platform default (~10-15s). Requires platform support
-// (Vercel Pro = 300s); falls back to the platform cap on lower tiers.
+// This route runs an 8k-token Anthropic completion, which can far exceed the
+// platform default (~10-15s). Requires platform support (Vercel Pro = 300s);
+// falls back to the platform cap on lower tiers.
 export const maxDuration = 300; // 5 minutes
 
 // Supported file types - expanded list
@@ -29,8 +29,8 @@ const SUPPORTED_TYPES = [
   "text/rtf",
 ];
 
-// Each request runs a paid external conversion (PDF.co) plus an Anthropic
-// completion, so cap how often a single user can invoke it.
+// Each request runs a paid Anthropic completion, so cap how often a single
+// user can invoke it.
 export const POST = withRoute(
   { aiGated: true, rateLimit: { requests: 20, windowSeconds: 3600, name: 'ai-upload', failClosed: true } },
   async ({ req: request, userId }) => {
@@ -91,111 +91,16 @@ export const POST = withRoute(
     const buffer = Buffer.from(bytes);
 
     if (file.type === 'application/pdf') {
-      extractionMethod = 'PDF';
-
-      try {
-        log.info('Processing PDF via PDF.co API', { userId, fileName: file.name });
-
-        const API_KEY = process.env.PDF_API_KEY;
-        if (!API_KEY) {
-          log.error('PDF API key not configured', null, { userId });
-          return NextResponse.json({ 
-            error: 'PDF processing not configured. Please add PDF_API_KEY to environment variables.' 
-          }, { status: 500 });
-        }
-
-        // Step 1: Upload the file to PDF.co
-        const uploadPerf = measurePerformanceWithAlerts('pdf_upload', 'api');
-        const formData = new FormData();
-        const blob = new Blob([bytes], { type: 'application/pdf' });
-        formData.append('file', blob, file.name);
-
-        const uploadResponse = await fetch('https://api.pdf.co/v1/file/upload', {
-          method: 'POST',
-          headers: {
-            'x-api-key': API_KEY
-          },
-          body: formData
-        });
-
-        const uploadResult = await uploadResponse.json();
-        uploadPerf.end({ success: !uploadResult.error });
-        
-        log.info('PDF upload result', {
-          userId,
-          success: !uploadResult.error,
-          fileUrl: uploadResult.url ? 'URL generated' : 'No URL'
-        });
-
-        if (uploadResult.error || !uploadResult.url) {
-          throw new Error(uploadResult.message || 'Failed to upload file');
-        }
-
-        // Step 2: Convert the uploaded file to text
-        const convertPerf = measurePerformanceWithAlerts('pdf_convert', 'api');
-        const convertResponse = await fetch('https://api.pdf.co/v1/pdf/convert/to/text', {
-          method: 'POST',
-          headers: {
-            'x-api-key': API_KEY,
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({
-            url: uploadResult.url,
-            inline: true,
-            async: false
-          })
-        });
-
-        const convertResult = await convertResponse.json();
-        convertPerf.end({ success: convertResult.error === false });
-        
-        log.info('PDF conversion result', {
-          userId,
-          success: convertResult.error === false,
-          textLength: convertResult.body?.length || 0
-        });
-
-        if (convertResult.error === false && convertResult.body) {
-          fileContent = convertResult.body;
-          log.info('PDF text extracted successfully', {
-            userId,
-            contentLength: fileContent.length
-          });
-          
-          // Additional validation for PDF content
-          if (!fileContent || fileContent.length === 0) {
-            throw new Error('PDF conversion returned empty content');
-          }
-          
-          // Check if the PDF might be scanned/image-based
-          const words = fileContent.trim().split(/\s+/);
-          if (words.length < 10) {
-            log.warn('PDF appears to contain very little text', {
-              userId,
-              wordCount: words.length,
-              contentPreview: fileContent.substring(0, 200)
-            });
-            throw new Error('PDF appears to be image-based or contains very little text. Please use a text-based PDF or convert to Word format.');
-          }
-        } else {
-          throw new Error(convertResult.message || 'Failed to extract text');
-        }
-
-      } catch (error: any) {
-        log.error('PDF API error', error, {
-          userId,
-          fileName: file.name
-        });
-        
-        track.event('pdf_processing_failed', {
-          userId,
-          error: error.message
-        });
-        
-        return NextResponse.json({ 
-          error: 'Failed to process PDF. Please try converting to Word format.' 
-        }, { status: 500 });
-      }
+      // PDF text extraction is intentionally not supported. The prior path
+      // uploaded the raw PDF to an external service (PDF.co) that is not a
+      // disclosed subprocessor for student data; removed in SPE-164. When PDF
+      // parsing is needed again, prefer an in-house parser (pdfjs-dist, already
+      // a dependency) or a disclosed subprocessor before re-enabling.
+      log.info('Rejected unsupported PDF upload', { userId, fileName: file.name });
+      return NextResponse.json(
+        { error: 'PDF upload is not currently supported. Please upload a Word, Excel, CSV, or text file.' },
+        { status: 400 }
+      );
     } else if (file.type.includes("sheet") || file.type.includes("excel")) {
       // Process Excel files
       extractionMethod = "Excel";

--- a/app/components/ai-upload/ai-upload-examples.tsx
+++ b/app/components/ai-upload/ai-upload-examples.tsx
@@ -26,7 +26,7 @@ Mike Wilson,5,Davis,1,45`
         },
         {
           icon: <FileText className="h-5 w-5 text-blue-500" />,
-          name: 'Word/PDF Format',
+          name: 'Word Format',
           example: `Class Roster - Smith - Grade 3
 Students:
 - John Doe (2 sessions/week, 30 min each)

--- a/app/components/ai-upload/ai-upload-modal.tsx
+++ b/app/components/ai-upload/ai-upload-modal.tsx
@@ -485,16 +485,16 @@ export default function AIUploadModal({
                 Upload a file containing {uploadTypeLabels[uploadType].toLowerCase()} data
               </p>
               <p className="text-xs text-gray-500 mt-1">
-                Supported: CSV, Excel (.xlsx, .xls), Word (.docx, .doc), PDF, Text files
+                Supported: CSV, Excel (.xlsx, .xls), Word (.docx, .doc), Text files
               </p>
               <div className="mt-2 text-xs text-gray-400 space-y-1">
                 <p>• Excel: All sheets will be processed</p>
-                <p>• PDF/Word: Tables and lists will be extracted</p>
+                <p>• Word: Tables and lists will be extracted</p>
                 <p>• Can handle various formats - structured or unstructured</p>
               </div>
               <input
                 type="file"
-                accept=".csv,.txt,.doc,.docx,.xls,.xlsx,.pdf"
+                accept=".csv,.txt,.doc,.docx,.xls,.xlsx"
                 onChange={handleFileSelect}
                 className="hidden"
                 id="ai-file-upload"


### PR DESCRIPTION
## Summary

Removes the **PDF.co** integration from `app/api/ai-upload/route.ts`. PDF.co was an external service that received the **raw uploaded PDF bytes** (typically IEP-at-a-glance / assessment docs containing full student names + goals), yet it was never on our CA-NDPA subprocessor disclosure. This rips out the dormant, undisclosed egress so the code matches the disclosure.

Tracked as [SPE-164](https://linear.app/speddy/issue/SPE-164).

## Context

The `ai-upload` route is already AI-gated (404s while `AI_FEATURES_ENABLED !== 'true'`, per SPE-162), so there was no active runtime risk — this is about **code-matching-disclosure integrity**: a security reviewer grepping the repo should not find `fetch('https://api.pdf.co/...')` when our position is "PDF.co is not a subprocessor."

## Changes (single file: `app/api/ai-upload/route.ts`)

- Deleted the two-step PDF.co upload→convert flow and the `PDF_API_KEY` usage. **No `api.pdf.co` reference remains anywhere in the repo** (verified by grep).
- PDF uploads now return a clear **400**: *"PDF upload is not currently supported. Please upload a Word, Excel, CSV, or text file."* — a graceful, PDF-specific message rather than a silent break or generic error.
- Reworded two stale comments that referenced PDF.co.
- Left the route structure intact so PDF parsing can be re-added later as a localized change.

## When PDF parsing is needed again (months out)
Prefer an **in-house parser** — `pdfjs-dist` is already a dependency, which means **no subprocessor at all** — or, if a vendor is chosen, **disclose it first**. Noted in a code comment and on SPE-164. The prior implementation remains recoverable from git history and the design doc at `docs/star-assessment-pdf-upload-plan.md`.

## Testing
- `npm run typecheck:fast` passes.
- Full jest suite passes (9 suites, 59 passed).

https://claude.ai/code/session_01FqcsNtzhKDBsXyGTpawQf9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqcsNtzhKDBsXyGTpawQf9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PDF uploads are now explicitly rejected with a 400 response; please upload Word, Excel, CSV, or text files instead.

* **Documentation / UI**
  * Updated upload examples and modal messaging to remove PDF from supported formats and restrict the file chooser to .csv, .txt, .doc, .docx, .xls, and .xlsx.

* **Documentation**
  * API docs updated to reflect timeout/rate-limit behavior (driven by the platform completion/tier) and removed references to an external PDF conversion step; Word-extraction failure now recommends converting to text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->