### PR TITLE
SPE-143: account/student deletion, retention, and extension-cache bounding

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -97,7 +97,8 @@
       "mcp__52287d5e-942b-4bb1-a760-a897e4851102__list_issue_statuses",
       "mcp__52287d5e-942b-4bb1-a760-a897e4851102__get_issue",
       "mcp__Linear__save_issue",
-      "mcp__Linear__save_project"
+      "mcp__Linear__save_project",
+      "mcp__Supabase__create_branch"
     ],
     "deny": []
   },

--- a/app/(dashboard)/dashboard/admin/students/page.tsx
+++ b/app/(dashboard)/dashboard/admin/students/page.tsx
@@ -16,6 +16,12 @@ import { StudentScheduleModal } from '@/app/components/admin/student-schedule-mo
 import { ConfirmationModal } from '@/app/components/ui/confirmation-modal';
 import { useToast } from '@/app/contexts/toast-context';
 
+interface CareMatch {
+  id: string;
+  student_name: string;
+  referral_reason: string | null;
+}
+
 export default function AdminStudentsPage() {
   const [students, setStudents] = useState<AdminStudentView[]>([]);
   const [loading, setLoading] = useState(true);
@@ -25,6 +31,7 @@ export default function AdminStudentsPage() {
   const [schoolId, setSchoolId] = useState<string | null>(null);
   const [scheduleModalStudent, setScheduleModalStudent] = useState<GroupedStudent | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<GroupedStudent | null>(null);
+  const [careMatches, setCareMatches] = useState<CareMatch[]>([]);
   const { showToast } = useToast();
 
   const fetchStudents = async () => {
@@ -94,18 +101,48 @@ export default function AdminStudentsPage() {
       setConfirmDelete(null);
 
       // Delete all provider records for this student
-      await Promise.all(
+      const results = await Promise.all(
         confirmDelete.providerRecords.map(r => deleteStudentAsAdmin(r.id, schoolId))
       );
 
       // Remove all related student records from local state
       const idsToRemove = new Set(confirmDelete.providerRecords.map(r => r.id));
       setStudents(prev => prev.filter(s => !idsToRemove.has(s.id)));
+
+      // CARE referrals are matched by name (not FK), so they are surfaced rather
+      // than auto-deleted. Dedupe matches across the grouped provider records.
+      const matchMap = new Map<string, CareMatch>();
+      results.forEach(res => (res.careMatches ?? []).forEach(m => matchMap.set(m.id, m)));
+      if (matchMap.size > 0) {
+        setCareMatches(Array.from(matchMap.values()));
+      }
     } catch (err) {
       console.error('Error deleting student:', err);
       showToast(err instanceof Error ? err.message : 'Failed to delete student', 'error');
     } finally {
       setDeletingGroupKey(null);
+    }
+  };
+
+  const deleteCareMatches = async () => {
+    const matches = careMatches;
+    setCareMatches([]);
+    try {
+      await Promise.all(
+        matches.map(async (m) => {
+          const res = await fetch(`/api/admin/care-referrals/${encodeURIComponent(m.id)}`, {
+            method: 'DELETE',
+          });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({}));
+            throw new Error(body?.error || 'Failed to delete CARE referral');
+          }
+        })
+      );
+      showToast('Related CARE records deleted', 'success');
+    } catch (err) {
+      console.error('Error deleting CARE records:', err);
+      showToast(err instanceof Error ? err.message : 'Failed to delete CARE records', 'error');
     }
   };
 
@@ -348,6 +385,23 @@ export default function AdminStudentsPage() {
             : ''
         }
         confirmLabel="Delete"
+        variant="danger"
+      />
+
+      {/* CARE records follow-up: matched by name, confirmed separately */}
+      <ConfirmationModal
+        isOpen={careMatches.length > 0}
+        onClose={() => setCareMatches([])}
+        onConfirm={deleteCareMatches}
+        title="Delete related CARE records?"
+        message={
+          careMatches.length > 0
+            ? `We found ${careMatches.length} CARE referral(s) matching this student's name (${careMatches
+                .map(m => m.student_name)
+                .join(', ')}). These hold special-education referral data and are not removed automatically. Delete them too? This cannot be undone.`
+            : ''
+        }
+        confirmLabel="Delete CARE records"
         variant="danger"
       />
     </div>

--- a/app/(dashboard)/dashboard/admin/students/page.tsx
+++ b/app/(dashboard)/dashboard/admin/students/page.tsx
@@ -126,7 +126,6 @@ export default function AdminStudentsPage() {
 
   const deleteCareMatches = async () => {
     const matches = careMatches;
-    setCareMatches([]);
     try {
       await Promise.all(
         matches.map(async (m) => {
@@ -139,6 +138,8 @@ export default function AdminStudentsPage() {
           }
         })
       );
+      // Clear only after success, so a partial failure keeps the modal open to retry.
+      setCareMatches([]);
       showToast('Related CARE records deleted', 'success');
     } catch (err) {
       console.error('Error deleting CARE records:', err);

--- a/app/api/admin/care-referrals/[referralId]/route.ts
+++ b/app/api/admin/care-referrals/[referralId]/route.ts
@@ -1,0 +1,53 @@
+import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
+import { withRoute } from '@/lib/api/with-route';
+import { isAdminForSchool } from '@/lib/api/admin-authz';
+
+const log = logger.child({ module: 'admin-care-referral-delete' });
+
+/**
+ * DELETE /api/admin/care-referrals/[referralId]
+ *
+ * SPE-143: the "admin-confirmed CARE" step of a student deletion. CARE referrals
+ * are linked to a student only by free-text name, so they are surfaced (not
+ * auto-deleted) by the student-delete route and removed here once the admin
+ * confirms. Deleting the referral cascades its case, meeting notes, action items,
+ * and status history (all ON DELETE CASCADE from care_referrals / care_cases).
+ *
+ * Authorized for any admin over the referral's school. The delete runs with the
+ * service role after the scope check so it also covers the district-admin-over-a-
+ * different-school case that the table's own RLS delete policy does not.
+ */
+export const DELETE = withRoute<{ referralId: string }>({}, async ({ userId, params }) => {
+  const { referralId } = params;
+
+  const service = createServiceClient();
+
+  const { data: referral, error } = await service
+    .from('care_referrals')
+    .select('id, school_id, student_name')
+    .eq('id', referralId)
+    .single();
+
+  if (error || !referral) {
+    return NextResponse.json({ error: 'CARE referral not found' }, { status: 404 });
+  }
+
+  const rls = await createClient();
+  if (!referral.school_id || !(await isAdminForSchool(rls, userId, referral.school_id))) {
+    return NextResponse.json(
+      { error: 'You do not have permission to delete this CARE referral' },
+      { status: 403 }
+    );
+  }
+
+  const { error: delErr } = await service.from('care_referrals').delete().eq('id', referralId);
+  if (delErr) {
+    log.error('Failed to delete CARE referral', delErr);
+    return NextResponse.json({ error: 'Failed to delete CARE referral' }, { status: 500 });
+  }
+
+  log.info('CARE referral deleted by admin', { referralId, deletedBy: userId });
+  return NextResponse.json({ success: true });
+});

--- a/app/api/admin/providers/[providerId]/route.ts
+++ b/app/api/admin/providers/[providerId]/route.ts
@@ -1,0 +1,192 @@
+import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
+import { withRoute } from '@/lib/api/with-route';
+import { isAdminForSchool } from '@/lib/api/admin-authz';
+
+const log = logger.child({ module: 'admin-provider-delete' });
+
+/**
+ * DELETE /api/admin/providers/[providerId]
+ *
+ * SPE-143: admin-initiated account deletion (sufficient for the admin-created-
+ * accounts model). Deleting the profile cascades the provider's students and all
+ * of their data; we then delete the Supabase Auth user. Because `profiles.id ->
+ * auth.users.id` is ON DELETE NO ACTION (no cascade either direction), both
+ * deletes are explicit and must run with the service role.
+ *
+ * Several other tables reference the provider via NO ACTION foreign keys:
+ *   - Nullable references are nulled first so they don't block the delete.
+ *   - NOT NULL provenance references that do NOT cascade (CARE referrals/notes/
+ *     status changes the provider authored, school-year activations) are reported
+ *     as blockers for the admin to reassign or remove first — we never silently
+ *     rewrite authorship.
+ *
+ * Storage objects do not cascade, so provider-owned objects are removed explicitly.
+ */
+export const DELETE = withRoute<{ providerId: string }>({}, async ({ userId, params }) => {
+  const { providerId } = params;
+
+  if (providerId === userId) {
+    return NextResponse.json({ error: 'You cannot delete your own account' }, { status: 400 });
+  }
+
+  const service = createServiceClient();
+
+  const { data: provider, error: provErr } = await service
+    .from('profiles')
+    .select('id, school_id, role, full_name')
+    .eq('id', providerId)
+    .single();
+
+  if (provErr || !provider) {
+    return NextResponse.json({ error: 'Account not found' }, { status: 404 });
+  }
+
+  // Authorization: a Speddy super-admin, or an admin over this provider's school.
+  const rls = await createClient();
+  const { data: me } = await rls
+    .from('profiles')
+    .select('is_speddy_admin')
+    .eq('id', userId)
+    .single();
+
+  const allowed =
+    me?.is_speddy_admin === true ||
+    (!!provider.school_id && (await isAdminForSchool(rls, userId, provider.school_id)));
+
+  if (!allowed) {
+    return NextResponse.json(
+      { error: 'You do not have permission to delete this account' },
+      { status: 403 }
+    );
+  }
+
+  // --- Preflight: NOT NULL references that do not cascade would hard-block the delete. ---
+  const blockerSpecs: Array<{ label: string; table: string; column: string }> = [
+    { label: 'CARE referral(s) created', table: 'care_referrals', column: 'referring_user_id' },
+    { label: 'CARE meeting note(s)', table: 'care_meeting_notes', column: 'created_by' },
+    { label: 'CARE case status change(s)', table: 'care_case_status_history', column: 'changed_by' },
+    { label: 'school year activation(s)', table: 'activated_school_years', column: 'activated_by' },
+  ];
+
+  const blockers: Array<{ label: string; count: number }> = [];
+  for (const spec of blockerSpecs) {
+    const { count } = await service
+      .from(spec.table)
+      .select('id', { count: 'exact', head: true })
+      .eq(spec.column, providerId);
+    if (count && count > 0) blockers.push({ label: spec.label, count });
+  }
+
+  if (blockers.length) {
+    return NextResponse.json(
+      {
+        error: 'Account has records that must be reassigned or removed first',
+        canDelete: false,
+        blockerReason: blockers.map((b) => `${b.count} ${b.label}`).join(', '),
+        dependencyCounts: blockers,
+      },
+      { status: 409 }
+    );
+  }
+
+  // --- Collect provider-owned Storage paths BEFORE deleting (Storage never cascades). ---
+  const { data: saved } = await service
+    .from('saved_worksheets')
+    .select('file_path')
+    .eq('provider_id', providerId);
+  const savedPaths = (saved ?? []).map((s) => s.file_path).filter((p): p is string => !!p);
+
+  const { data: docs } = await service
+    .from('documents')
+    .select('file_path')
+    .eq('created_by', providerId);
+  const docPaths = (docs ?? []).map((d) => d.file_path).filter((p): p is string => !!p);
+
+  const { data: provStudents } = await service
+    .from('students')
+    .select('id')
+    .eq('provider_id', providerId);
+  const studentIds = (provStudents ?? []).map((s) => s.id);
+
+  let worksheetPaths: string[] = [];
+  let submissionPaths: string[] = [];
+  if (studentIds.length) {
+    const { data: ws } = await service
+      .from('worksheets')
+      .select('id, uploaded_file_path')
+      .in('student_id', studentIds);
+    const wsIds = (ws ?? []).map((w) => w.id);
+    worksheetPaths = (ws ?? []).map((w) => w.uploaded_file_path).filter((p): p is string => !!p);
+    if (wsIds.length) {
+      const { data: subs } = await service
+        .from('worksheet_submissions')
+        .select('image_url')
+        .in('worksheet_id', wsIds);
+      submissionPaths = (subs ?? []).map((s) => s.image_url).filter((p): p is string => !!p);
+    }
+  }
+
+  // --- Null the nullable NO ACTION references to this provider so the delete isn't blocked. ---
+  await Promise.all([
+    service.from('admin_permissions').update({ granted_by: null }).eq('granted_by', providerId),
+    service.from('bell_schedules').update({ created_by_id: null }).eq('created_by_id', providerId),
+    service.from('care_action_items').update({ assignee_id: null }).eq('assignee_id', providerId),
+    service.from('care_cases').update({ assigned_to: null }).eq('assigned_to', providerId),
+    service.from('schedule_sessions').update({ completed_by: null }).eq('completed_by', providerId),
+    service.from('special_activities').update({ created_by_id: null }).eq('created_by_id', providerId),
+    service.from('analytics_events').update({ user_id: null }).eq('user_id', providerId),
+    service.from('holidays').update({ created_by: null }).eq('created_by', providerId),
+    service.from('worksheet_submissions').update({ submitted_by: null }).eq('submitted_by', providerId),
+  ]);
+
+  // --- Delete the profile (cascades the provider's students + owned data) ---
+  const { error: profileDelErr } = await service.from('profiles').delete().eq('id', providerId);
+  if (profileDelErr) {
+    log.error('Failed to delete provider profile', profileDelErr);
+    return NextResponse.json(
+      { error: `Failed to delete account: ${profileDelErr.message}` },
+      { status: 500 }
+    );
+  }
+
+  // --- Delete the Auth user ---
+  const { error: authDelErr } = await service.auth.admin.deleteUser(providerId);
+  if (authDelErr) {
+    // Profile (and all data) is already gone; the login could not be fully removed.
+    log.error('Profile deleted but auth user removal failed', authDelErr);
+    return NextResponse.json({
+      success: true,
+      warning:
+        'Account data was deleted, but the login could not be fully removed. Please retry or remove the auth user manually.',
+    });
+  }
+
+  // --- Remove Storage objects (best effort; logged on failure) ---
+  let storageErrors = 0;
+  const removals: Array<[string, string[]]> = [
+    ['saved-worksheets', savedPaths],
+    ['documents', docPaths],
+    ['worksheet-submissions', submissionPaths],
+    ['worksheets', worksheetPaths],
+  ];
+  for (const [bucket, paths] of removals) {
+    if (paths.length) {
+      const { error } = await service.storage.from(bucket).remove(paths);
+      if (error) {
+        storageErrors++;
+        log.error('Failed to remove Storage objects during account delete', error, { bucket });
+      }
+    }
+  }
+
+  log.info('Provider account deleted by admin', { providerId, deletedBy: userId, storageErrors });
+
+  return NextResponse.json({
+    success: true,
+    storageObjectsRemoved:
+      savedPaths.length + docPaths.length + submissionPaths.length + worksheetPaths.length,
+    storageErrors: storageErrors || undefined,
+  });
+});

--- a/app/api/admin/providers/[providerId]/route.ts
+++ b/app/api/admin/providers/[providerId]/route.ts
@@ -129,7 +129,7 @@ export const DELETE = withRoute<{ providerId: string }>({}, async ({ userId, par
   }
 
   // --- Null the nullable NO ACTION references to this provider so the delete isn't blocked. ---
-  await Promise.all([
+  const nullResults = await Promise.all([
     service.from('admin_permissions').update({ granted_by: null }).eq('granted_by', providerId),
     service.from('bell_schedules').update({ created_by_id: null }).eq('created_by_id', providerId),
     service.from('care_action_items').update({ assignee_id: null }).eq('assignee_id', providerId),
@@ -140,6 +140,16 @@ export const DELETE = withRoute<{ providerId: string }>({}, async ({ userId, par
     service.from('holidays').update({ created_by: null }).eq('created_by', providerId),
     service.from('worksheet_submissions').update({ submitted_by: null }).eq('submitted_by', providerId),
   ]);
+  const nullErr = nullResults.find((r) => r.error)?.error;
+  if (nullErr) {
+    // Stop before the profile delete; otherwise it would fail with a confusing
+    // foreign-key violation instead of this clear message.
+    log.error('Failed to null provider references before delete', nullErr);
+    return NextResponse.json(
+      { error: `Failed to prepare account for deletion: ${nullErr.message}` },
+      { status: 500 }
+    );
+  }
 
   // --- Delete the profile (cascades the provider's students + owned data) ---
   const { error: profileDelErr } = await service.from('profiles').delete().eq('id', providerId);

--- a/app/api/admin/providers/[providerId]/route.ts
+++ b/app/api/admin/providers/[providerId]/route.ts
@@ -2,7 +2,6 @@ import { createClient, createServiceClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
 import { withRoute } from '@/lib/api/with-route';
-import { isAdminForSchool } from '@/lib/api/admin-authz';
 
 const log = logger.child({ module: 'admin-provider-delete' });
 
@@ -43,7 +42,10 @@ export const DELETE = withRoute<{ providerId: string }>({}, async ({ userId, par
     return NextResponse.json({ error: 'Account not found' }, { status: 404 });
   }
 
-  // Authorization: a Speddy super-admin, or an admin over this provider's school.
+  // Authorization: a Speddy super-admin, or a district admin whose district(s)
+  // cover EVERY school the provider serves. Deleting an account removes that
+  // provider's data across all of their schools, so a single-school (site) admin
+  // must not be able to trigger it (SPE-143 review).
   const rls = await createClient();
   const { data: me } = await rls
     .from('profiles')
@@ -51,13 +53,46 @@ export const DELETE = withRoute<{ providerId: string }>({}, async ({ userId, par
     .eq('id', userId)
     .single();
 
-  const allowed =
-    me?.is_speddy_admin === true ||
-    (!!provider.school_id && (await isAdminForSchool(rls, userId, provider.school_id)));
+  let allowed = me?.is_speddy_admin === true;
+
+  if (!allowed) {
+    // Every school the provider serves: their primary school plus provider_schools.
+    const { data: provSchools } = await service
+      .from('provider_schools')
+      .select('school_id')
+      .eq('provider_id', providerId);
+    const providerSchoolIds = new Set<string>();
+    if (provider.school_id) providerSchoolIds.add(provider.school_id);
+    (provSchools ?? []).forEach((r) => r.school_id && providerSchoolIds.add(r.school_id));
+
+    // The requester's district_admin districts (site admins cannot delete accounts).
+    const { data: perms } = await rls
+      .from('admin_permissions')
+      .select('district_id')
+      .eq('admin_id', userId)
+      .eq('role', 'district_admin');
+    const myDistrictIds = new Set((perms ?? []).map((p) => p.district_id).filter(Boolean));
+
+    if (myDistrictIds.size > 0 && providerSchoolIds.size > 0) {
+      const { data: schools } = await service
+        .from('schools')
+        .select('id, district_id')
+        .in('id', Array.from(providerSchoolIds));
+      // Allow only if every one of the provider's schools resolved and belongs to
+      // one of the requester's districts.
+      allowed =
+        !!schools &&
+        schools.length === providerSchoolIds.size &&
+        schools.every((s) => myDistrictIds.has(s.district_id));
+    }
+  }
 
   if (!allowed) {
     return NextResponse.json(
-      { error: 'You do not have permission to delete this account' },
+      {
+        error:
+          "You do not have permission to delete this account. Account deletion requires a district admin covering all of the provider's schools, or a Speddy admin.",
+      },
       { status: 403 }
     );
   }

--- a/app/api/admin/students/[studentId]/route.ts
+++ b/app/api/admin/students/[studentId]/route.ts
@@ -1,0 +1,150 @@
+import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logger } from '@/lib/logger';
+import { withRoute } from '@/lib/api/with-route';
+import { isAdminForSchool } from '@/lib/api/admin-authz';
+
+const log = logger.child({ module: 'admin-student-delete' });
+
+const querySchema = z.object({ schoolId: z.string().uuid() });
+
+/**
+ * DELETE /api/admin/students/[studentId]?schoolId=<uuid>
+ *
+ * SPE-143: admin "delete student". The row delete runs under the admin's own RLS
+ * session (preserving the database authorization backstop); the cascade removes
+ * every FK-linked child (details, assessments, exit tickets, progress, schedule,
+ * worksheet rows, etc.). The service-role client is used ONLY to reach what RLS +
+ * cascade cannot:
+ *   1. Storage objects — Postgres cascade deletes rows, never Storage objects, and
+ *      the admin is not the object owner. Worksheet images live in the private
+ *      `worksheet-submissions` (path in worksheet_submissions.image_url) and
+ *      `worksheets` (worksheets.uploaded_file_path) buckets.
+ *   2. CARE referrals — linked to the student by free-text name, not a foreign key,
+ *      so they never cascade. We surface name matches for the admin to confirm
+ *      (handled by /api/admin/care-referrals/[referralId]); we never auto-delete
+ *      them, since a name match can be ambiguous.
+ */
+export const DELETE = withRoute<{ studentId: string }, undefined, { schoolId: string }>(
+  { query: querySchema },
+  async ({ userId, params, query }) => {
+    const { studentId } = params;
+    const { schoolId } = query;
+
+    const rls = await createClient();
+    if (!(await isAdminForSchool(rls, userId, schoolId))) {
+      return NextResponse.json(
+        { error: 'You do not have permission to delete students at this school' },
+        { status: 403 }
+      );
+    }
+
+    const service = createServiceClient();
+
+    // Verify the student exists and belongs to this school (service role is authoritative).
+    const { data: student, error: studentErr } = await service
+      .from('students')
+      .select('id, school_id')
+      .eq('id', studentId)
+      .single();
+
+    if (studentErr || !student) {
+      return NextResponse.json({ error: 'Student not found' }, { status: 404 });
+    }
+    if (student.school_id !== schoolId) {
+      return NextResponse.json({ error: 'Student does not belong to this school' }, { status: 403 });
+    }
+
+    // --- Collect everything that does NOT cascade, BEFORE deleting the rows ---
+
+    // (1) Storage object paths for this student's worksheets + submissions.
+    const { data: worksheets } = await service
+      .from('worksheets')
+      .select('id, uploaded_file_path')
+      .eq('student_id', studentId);
+
+    const worksheetIds = (worksheets ?? []).map((w) => w.id);
+    const worksheetPaths = (worksheets ?? [])
+      .map((w) => w.uploaded_file_path)
+      .filter((p): p is string => !!p);
+
+    let submissionPaths: string[] = [];
+    if (worksheetIds.length) {
+      const { data: subs } = await service
+        .from('worksheet_submissions')
+        .select('image_url')
+        .in('worksheet_id', worksheetIds);
+      submissionPaths = (subs ?? [])
+        .map((s) => s.image_url)
+        .filter((p): p is string => !!p);
+    }
+
+    // (2) CARE referrals matched by the student's full name within this school.
+    const { data: details } = await service
+      .from('student_details')
+      .select('first_name, last_name')
+      .eq('student_id', studentId)
+      .maybeSingle();
+
+    let careMatches: Array<{ id: string; student_name: string; referral_reason: string | null }> = [];
+    const fullName = `${details?.first_name ?? ''} ${details?.last_name ?? ''}`.trim();
+    if (fullName) {
+      const { data: refs } = await service
+        .from('care_referrals')
+        .select('id, student_name, referral_reason')
+        .eq('school_id', schoolId)
+        .ilike('student_name', fullName);
+      careMatches = refs ?? [];
+    }
+
+    // --- Delete the student under RLS (keeps the database authorization backstop) ---
+    // schedule_sessions would cascade from students; delete explicitly to match the
+    // prior behavior and to fail loudly here if the admin lacks permission.
+    const { error: sessErr } = await rls
+      .from('schedule_sessions')
+      .delete()
+      .eq('student_id', studentId);
+    if (sessErr) {
+      log.error('Failed to delete student schedule sessions', sessErr);
+      return NextResponse.json({ error: 'Failed to delete student sessions' }, { status: 500 });
+    }
+
+    const { error: delErr } = await rls.from('students').delete().eq('id', studentId);
+    if (delErr) {
+      log.error('Failed to delete student', delErr);
+      return NextResponse.json({ error: 'Failed to delete student' }, { status: 500 });
+    }
+
+    // --- Remove Storage objects (service role; admin is not the object owner) ---
+    let storageErrors = 0;
+    if (submissionPaths.length) {
+      const { error } = await service.storage.from('worksheet-submissions').remove(submissionPaths);
+      if (error) {
+        storageErrors++;
+        log.error('Failed to remove worksheet-submission images', error);
+      }
+    }
+    if (worksheetPaths.length) {
+      const { error } = await service.storage.from('worksheets').remove(worksheetPaths);
+      if (error) {
+        storageErrors++;
+        log.error('Failed to remove worksheet images', error);
+      }
+    }
+
+    log.info('Student deleted by admin', {
+      studentId,
+      deletedBy: userId,
+      storageObjectsRemoved: submissionPaths.length + worksheetPaths.length,
+      careMatches: careMatches.length,
+    });
+
+    return NextResponse.json({
+      success: true,
+      careMatches,
+      storageObjectsRemoved: submissionPaths.length + worksheetPaths.length,
+      storageErrors: storageErrors || undefined,
+    });
+  }
+);

--- a/app/api/cron/cleanup-worksheet-images/route.ts
+++ b/app/api/cron/cleanup-worksheet-images/route.ts
@@ -1,0 +1,154 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServiceClient } from '@/lib/supabase/server';
+
+// SPE-143: retention/TTL for worksheet-submission images (scanned student work).
+// Submissions older than this are deleted along with their Storage objects.
+const RETENTION_MONTHS = 12;
+
+// storage.remove() takes an array; chunk large deletes to keep each call bounded.
+const STORAGE_REMOVE_CHUNK = 100;
+
+/**
+ * GET /api/cron/cleanup-worksheet-images
+ *
+ * Deletes worksheet_submissions older than RETENTION_MONTHS and removes their
+ * images from the private `worksheet-submissions` bucket (path stored in
+ * `image_url`). Storage objects are removed first; the rows are deleted only
+ * after, so a Storage failure never orphans an image behind a deleted row.
+ *
+ * Auth mirrors the existing cleanup cron: a shared secret in the `x-cron-secret`
+ * header or `Authorization: Bearer <secret>` form, compared against CRON_SECRET.
+ * Scheduling is wired by the cron provider (e.g. a vercel.json `crons` entry or
+ * an external scheduler that sends the secret) — see docs/offboarding-runbook.md.
+ */
+export async function GET(request: NextRequest) {
+  const startTime = Date.now();
+
+  try {
+    const authHeader = request.headers.get('authorization');
+    const bearerToken = authHeader?.toLowerCase().startsWith('bearer ')
+      ? authHeader.slice(7).trim()
+      : null;
+    const token = request.headers.get('x-cron-secret') || bearerToken;
+
+    const expectedToken = process.env.CRON_SECRET;
+
+    if (!expectedToken) {
+      console.error('CRON_SECRET environment variable not set');
+      return NextResponse.json(
+        { success: false, error: 'Server configuration error', timestamp: new Date().toISOString() },
+        { status: 500 }
+      );
+    }
+
+    if (!token || token !== expectedToken) {
+      console.warn('Unauthorized worksheet-image cleanup attempt');
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized', timestamp: new Date().toISOString() },
+        { status: 401 }
+      );
+    }
+
+    const supabase = createServiceClient();
+
+    const cutoffDate = new Date();
+    cutoffDate.setMonth(cutoffDate.getMonth() - RETENTION_MONTHS);
+
+    // Find expired submissions and their Storage paths.
+    const { data: expired, error: selectError } = await supabase
+      .from('worksheet_submissions')
+      .select('id, image_url')
+      .lt('submitted_at', cutoffDate.toISOString());
+
+    if (selectError) {
+      console.error('Error selecting expired worksheet submissions:', selectError);
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Database error during cleanup',
+          details: selectError.message,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 500 }
+      );
+    }
+
+    const rows = expired ?? [];
+    const paths = rows.map((r) => r.image_url).filter((p): p is string => !!p);
+
+    // Remove Storage objects first, in bounded chunks.
+    let storageRemoved = 0;
+    let storageErrors = 0;
+    for (let i = 0; i < paths.length; i += STORAGE_REMOVE_CHUNK) {
+      const chunk = paths.slice(i, i + STORAGE_REMOVE_CHUNK);
+      const { error: removeError } = await supabase.storage
+        .from('worksheet-submissions')
+        .remove(chunk);
+      if (removeError) {
+        storageErrors++;
+        console.error('Error removing worksheet-submission images:', removeError);
+      } else {
+        storageRemoved += chunk.length;
+      }
+    }
+
+    // Delete the rows.
+    let rowsDeleted = 0;
+    const ids = rows.map((r) => r.id);
+    if (ids.length) {
+      const { error: deleteError, count } = await supabase
+        .from('worksheet_submissions')
+        .delete({ count: 'exact' })
+        .in('id', ids);
+
+      if (deleteError) {
+        console.error('Error deleting expired worksheet submissions:', deleteError);
+        return NextResponse.json(
+          {
+            success: false,
+            error: 'Database error during cleanup',
+            details: deleteError.message,
+            timestamp: new Date().toISOString(),
+          },
+          { status: 500 }
+        );
+      }
+      rowsDeleted = count ?? 0;
+    }
+
+    const processingTime = Date.now() - startTime;
+    console.log(
+      `Worksheet-image cleanup completed: ${rowsDeleted} rows, ${storageRemoved} images removed in ${processingTime}ms`
+    );
+
+    return NextResponse.json(
+      {
+        success: true,
+        rowsDeleted,
+        storageRemoved,
+        storageErrors: storageErrors || undefined,
+        retentionMonths: RETENTION_MONTHS,
+        cutoffDate: cutoffDate.toISOString(),
+        processingTimeMs: processingTime,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 }
+    );
+  } catch (error: any) {
+    console.error('Unexpected error in worksheet-image cleanup cron job:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Unexpected error during cleanup',
+        details: error.message || 'Unknown error',
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 }
+    );
+  }
+}
+
+// Also support POST for flexibility with different cron services.
+export async function POST(request: NextRequest) {
+  return GET(request);
+}

--- a/app/api/cron/cleanup-worksheet-images/route.ts
+++ b/app/api/cron/cleanup-worksheet-images/route.ts
@@ -8,6 +8,11 @@ const RETENTION_MONTHS = 12;
 // storage.remove() takes an array; chunk large deletes to keep each call bounded.
 const STORAGE_REMOVE_CHUNK = 100;
 
+// Bound how many rows one run processes so a large backlog (e.g. first deploy or
+// missed schedules) can't exhaust memory; the response sets `moreRemaining` so
+// the scheduler can re-run until the backlog clears.
+const SELECT_BATCH = 10000;
+
 /**
  * GET /api/cron/cleanup-worksheet-images
  *
@@ -59,7 +64,9 @@ export async function GET(request: NextRequest) {
     const { data: expired, error: selectError } = await supabase
       .from('worksheet_submissions')
       .select('id, image_url')
-      .lt('submitted_at', cutoffDate.toISOString());
+      .lt('submitted_at', cutoffDate.toISOString())
+      .order('submitted_at', { ascending: true })
+      .limit(SELECT_BATCH);
 
     if (selectError) {
       console.error('Error selecting expired worksheet submissions:', selectError);
@@ -134,6 +141,8 @@ export async function GET(request: NextRequest) {
         rowsDeleted,
         storageRemoved,
         storageErrors: storageErrors || undefined,
+        // True when this run hit the batch cap — re-trigger to clear the backlog.
+        moreRemaining: rows.length === SELECT_BATCH,
         retentionMonths: RETENTION_MONTHS,
         cutoffDate: cutoffDate.toISOString(),
         processingTimeMs: processingTime,

--- a/app/api/cron/cleanup-worksheet-images/route.ts
+++ b/app/api/cron/cleanup-worksheet-images/route.ts
@@ -13,8 +13,9 @@ const STORAGE_REMOVE_CHUNK = 100;
  *
  * Deletes worksheet_submissions older than RETENTION_MONTHS and removes their
  * images from the private `worksheet-submissions` bucket (path stored in
- * `image_url`). Storage objects are removed first; the rows are deleted only
- * after, so a Storage failure never orphans an image behind a deleted row.
+ * `image_url`). Storage objects are removed first, and a row is deleted only once
+ * its image is gone (or it never had one), so a Storage failure never orphans an
+ * image behind a deleted row — failed paths are retried on the next run.
  *
  * Auth mirrors the existing cleanup cron: a shared secret in the `x-cron-secret`
  * header or `Authorization: Bearer <secret>` form, compared against CRON_SECRET.
@@ -74,10 +75,12 @@ export async function GET(request: NextRequest) {
     }
 
     const rows = expired ?? [];
-    const paths = rows.map((r) => r.image_url).filter((p): p is string => !!p);
 
-    // Remove Storage objects first, in bounded chunks.
-    let storageRemoved = 0;
+    // Remove Storage objects first, in bounded chunks. Track which paths were
+    // actually removed so we never delete a row whose image survived (that would
+    // orphan student work in the private bucket).
+    const paths = rows.map((r) => r.image_url).filter((p): p is string => !!p);
+    const removedPaths = new Set<string>();
     let storageErrors = 0;
     for (let i = 0; i < paths.length; i += STORAGE_REMOVE_CHUNK) {
       const chunk = paths.slice(i, i + STORAGE_REMOVE_CHUNK);
@@ -88,13 +91,17 @@ export async function GET(request: NextRequest) {
         storageErrors++;
         console.error('Error removing worksheet-submission images:', removeError);
       } else {
-        storageRemoved += chunk.length;
+        chunk.forEach((p) => removedPaths.add(p));
       }
     }
+    const storageRemoved = removedPaths.size;
 
-    // Delete the rows.
+    // Delete only rows whose image is gone (or that never had one); keep rows whose
+    // image failed to remove so the next run retries them without orphaning the object.
     let rowsDeleted = 0;
-    const ids = rows.map((r) => r.id);
+    const ids = rows
+      .filter((r) => !r.image_url || removedPaths.has(r.image_url))
+      .map((r) => r.id);
     if (ids.length) {
       const { error: deleteError, count } = await supabase
         .from('worksheet_submissions')

--- a/docs/data-inventory.md
+++ b/docs/data-inventory.md
@@ -87,10 +87,11 @@ recipient — see [`subprocessors.md`](./subprocessors.md)), but it **is** a
 second storage location that the Schedule of Data must disclose.
 
 **NDPA implication:** honoring a data-return/deletion request requires clearing
-or bounding this local cache too (TTL, clear-on-logout, or not persisting
-identifiers). Tracked as in-scope for **SPE-143**. Until then, this data can
-persist on every provider device that ever scanned a given student, even after
-the student is removed backend-side.
+or bounding this local cache too. **Addressed in SPE-143:** the cache now expires
+after a **7-day TTL** (pruned on read and via an hourly alarm) and is cleared on
+logout — manual disconnect, or automatically when the provider's API key is
+invalidated server-side. To force-clear during offboarding, revoke the provider's
+extension API key (`api_keys`); see [`offboarding-runbook.md`](./offboarding-runbook.md).
 
 ## Notable points (for the NDPA / due diligence)
 

--- a/docs/offboarding-runbook.md
+++ b/docs/offboarding-runbook.md
@@ -24,10 +24,12 @@ operational half of the NDPA deletion obligation tracked in **SPE-143**.
 
 Student and CARE-referral deletes are gated by `isAdminForSchool` (site/district
 admin), and the student row delete runs under the admin's own RLS session.
-Account (provider) deletion is allowed for a Speddy super-admin (`is_speddy_admin`)
-or an admin over the provider's school. Across all routes, destructive steps use
-the service-role client only where RLS + cascade cannot reach (Storage, cross-RLS
-cleanup).
+Account (provider) deletion is restricted to a Speddy super-admin
+(`is_speddy_admin`) or a district admin whose district(s) cover **every** school
+the provider serves — because deleting an account removes that provider's data
+across all of their schools, a single-school (site) admin cannot trigger it.
+Across all routes, destructive steps use the service-role client only where RLS +
+cascade cannot reach (Storage, cross-RLS cleanup).
 
 ---
 
@@ -97,7 +99,9 @@ rows) older than **12 months**. It is gated by `CRON_SECRET` (sent as the
 
 **Scheduling is not wired automatically.** Register it with the same scheduler that
 runs the other cron routes (an external scheduler that sends `CRON_SECRET`, or a
-`vercel.json` `crons` entry). Recommended cadence: daily.
+`vercel.json` `crons` entry). Recommended cadence: daily. Each run processes up to
+10,000 submissions; if the response reports `moreRemaining: true` (e.g. after a
+first deployment or a long gap), re-trigger until it clears.
 
 ---
 

--- a/docs/offboarding-runbook.md
+++ b/docs/offboarding-runbook.md
@@ -22,10 +22,12 @@ operational half of the NDPA deletion obligation tracked in **SPE-143**.
 | **Worksheet-image retention** | `app/api/cron/cleanup-worksheet-images` (cron, `CRON_SECRET`) | Deletes `worksheet_submissions` + their images older than **12 months**. |
 | **Bulk export** | **See [SPE-60](https://linear.app/speddy/issue/SPE-60)** | Export is tracked separately and is **not** rebuilt here. |
 
-All deletion routes are gated by `isAdminForSchool` (site/district admin) and run
-destructive steps with the service-role client only where RLS + cascade cannot
-reach (Storage, cross-RLS cleanup). The student row delete itself runs under the
-admin's own RLS session.
+Student and CARE-referral deletes are gated by `isAdminForSchool` (site/district
+admin), and the student row delete runs under the admin's own RLS session.
+Account (provider) deletion is allowed for a Speddy super-admin (`is_speddy_admin`)
+or an admin over the provider's school. Across all routes, destructive steps use
+the service-role client only where RLS + cascade cannot reach (Storage, cross-RLS
+cleanup).
 
 ---
 

--- a/docs/offboarding-runbook.md
+++ b/docs/offboarding-runbook.md
@@ -1,0 +1,110 @@
+# District Offboarding & Data-Deletion Runbook
+
+Operational steps for honoring a district's data-return/deletion request, an
+individual deletion request, or a full district offboarding. This is the
+companion to [`data-inventory.md`](./data-inventory.md) (what data exists and
+where) and [`subprocessors.md`](./subprocessors.md) (who it flows to), and the
+operational half of the NDPA deletion obligation tracked in **SPE-143**.
+
+> Student data lives in **two** places — the Supabase backend **and** the Chrome
+> extension's on-device cache. A deletion request is not fully honored until both
+> are addressed. See the "Extension cache" section below.
+
+---
+
+## Tooling built for SPE-143
+
+| Capability | How | Notes |
+|---|---|---|
+| **Delete a student** (cascade + Storage) | Admin UI → Students → Delete, or `DELETE /api/admin/students/[studentId]?schoolId=<uuid>` | Cascades all FK-linked rows under RLS; removes worksheet images from the `worksheet-submissions` and `worksheets` buckets (service role); surfaces name-matched CARE referrals to confirm. |
+| **Delete CARE referral** | `DELETE /api/admin/care-referrals/[referralId]` (or the follow-up prompt after a student delete) | Cascades the case, meeting notes, action items, and status history. CARE is linked to students by **name**, not FK, so it is confirmed separately. |
+| **Delete an account** (provider) | `DELETE /api/admin/providers/[providerId]` | Deletes the profile (cascading the provider's students + data) and the Auth user; nulls nullable references; removes provider-owned Storage. Reports hard blockers (CARE/records the provider authored) instead of rewriting authorship. **API only — no UI yet.** |
+| **Worksheet-image retention** | `app/api/cron/cleanup-worksheet-images` (cron, `CRON_SECRET`) | Deletes `worksheet_submissions` + their images older than **12 months**. |
+| **Bulk export** | **See [SPE-60](https://linear.app/speddy/issue/SPE-60)** | Export is tracked separately and is **not** rebuilt here. |
+
+All deletion routes are gated by `isAdminForSchool` (site/district admin) and run
+destructive steps with the service-role client only where RLS + cascade cannot
+reach (Storage, cross-RLS cleanup). The student row delete itself runs under the
+admin's own RLS session.
+
+---
+
+## A. Single deletion request (one student)
+
+1. Export the student's data first if the district requested return — **SPE-60**.
+2. Admin → **Students** → **Delete** for the student (removes all provider records,
+   schedule, assessments, progress, worksheet rows **and** worksheet images).
+3. If prompted, confirm deletion of **matched CARE referrals** (special-ed
+   referral data, matched by name — review before confirming).
+4. **Extension cache** (see below) — confirm the providers who served this student
+   no longer hold a stale on-device copy.
+
+## B. Offboard a single provider / account
+
+1. Export first if requested — **SPE-60**.
+2. `DELETE /api/admin/providers/[providerId]`.
+   - If it returns `409` with `blockerReason`, the provider authored CARE
+     referrals/notes/status changes or activated a school year (NOT NULL, non-
+     cascading). Reassign or delete those first, then retry.
+3. **Extension cache**: ensure the provider's device cache is cleared — it clears
+   on disconnect or when their API key is revoked. Revoke the provider's
+   extension **API key** (`api_keys`) to force a clear-on-logout on next use.
+
+## C. Full district offboarding
+
+1. **Export** the district's data — **SPE-60** (do not skip; deletion is
+   irreversible).
+2. Enumerate the district's schools (`schools` where `district_id = …`), and for
+   each school its students and providers.
+3. **Bulk delete** by looping the per-student and per-account steps above
+   (the same API routes). Run server-side with the service role / `CRON_SECRET`
+   tooling; do **not** hand-run SQL against production.
+4. Revoke all district **extension API keys** so on-device caches clear.
+5. Confirm Storage is empty for the district's objects (worksheet/document
+   buckets) and that no orphaned rows remain.
+6. Update [`subprocessors.md`](./subprocessors.md) / notify per the executed NDPA
+   if the offboarding changes anything externally disclosed.
+
+---
+
+## Extension cache (second storage location)
+
+The Chrome extension caches student data (SEIS ID, name, grade, school) in
+`chrome.storage.local` during passive discrepancy detection. This sits **outside**
+the backend, RLS, and the tooling above. Per SPE-143 it is now bounded by:
+
+- **TTL** — cached discrepancies expire after **7 days** (pruned on read and via
+  an hourly alarm).
+- **Clear-on-logout** — the cache is wiped on manual disconnect, and automatically
+  when the API key is invalidated server-side (a `401/403` from the compare
+  endpoint drops the key and clears the cache).
+
+**To force-clear a provider's device cache during offboarding:** revoke their
+extension API key (`api_keys`). The next passive request returns `401/403`, which
+disconnects the extension and clears the local cache. Absent any request, the TTL
+removes it within 7 days.
+
+---
+
+## Retention / TTL job
+
+`app/api/cron/cleanup-worksheet-images` deletes worksheet-submission images (and
+rows) older than **12 months**. It is gated by `CRON_SECRET` (sent as the
+`x-cron-secret` header or `Authorization: Bearer <secret>`), matching the existing
+`cleanup-uploads` cron.
+
+**Scheduling is not wired automatically.** Register it with the same scheduler that
+runs the other cron routes (an external scheduler that sends `CRON_SECRET`, or a
+`vercel.json` `crons` entry). Recommended cadence: daily.
+
+---
+
+## Safety notes
+
+- Deletion is **irreversible** — always complete any requested export (SPE-60) first.
+- Never hand-run deletes against production; use the routes/tooling above.
+- The schema migration `supabase/migrations/20260612_student_account_deletion_retention.sql`
+  (lesson_performance_history → `ON DELETE CASCADE`) must be applied for student
+  deletion to be reliable.
+
+_Related: SPE-143 (this tooling), SPE-59 (NDPA), SPE-60 (bulk export)._

--- a/lib/api/admin-authz.ts
+++ b/lib/api/admin-authz.ts
@@ -27,15 +27,18 @@ export async function isAdminForSchool(
     return true;
   }
 
-  // District admin whose district owns the school
-  const districtAdmin = permissions.find((p) => p.role === 'district_admin');
-  if (districtAdmin?.district_id) {
+  // District admin whose district owns the school. A user can hold district_admin
+  // for multiple districts, so check all of them, not just the first.
+  const districtAdmins = permissions.filter((p) => p.role === 'district_admin' && p.district_id);
+  if (districtAdmins.length) {
     const { data: school } = await rls
       .from('schools')
       .select('district_id')
       .eq('id', schoolId)
       .single();
-    if (school) return school.district_id === districtAdmin.district_id;
+    if (school) {
+      return districtAdmins.some((p) => p.district_id === school.district_id);
+    }
   }
 
   return false;

--- a/lib/api/admin-authz.ts
+++ b/lib/api/admin-authz.ts
@@ -1,0 +1,42 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Server-side mirror of the client `isAdminForSchool` check in
+ * `lib/supabase/queries/admin-accounts.ts`. Pass the request-scoped RLS client
+ * (from `createClient()`), the authenticated user id, and the target school.
+ *
+ * Returns true when the user is a site_admin for that exact school, or a
+ * district_admin whose district owns the school. This is the authorization gate
+ * for destructive admin routes that then use the service-role client to reach
+ * data/Storage outside the admin's own RLS scope.
+ */
+export async function isAdminForSchool(
+  rls: SupabaseClient,
+  userId: string,
+  schoolId: string
+): Promise<boolean> {
+  const { data: permissions } = await rls
+    .from('admin_permissions')
+    .select('role, school_id, district_id')
+    .eq('admin_id', userId);
+
+  if (!permissions?.length) return false;
+
+  // Site admin for this specific school
+  if (permissions.some((p) => p.role === 'site_admin' && p.school_id === schoolId)) {
+    return true;
+  }
+
+  // District admin whose district owns the school
+  const districtAdmin = permissions.find((p) => p.role === 'district_admin');
+  if (districtAdmin?.district_id) {
+    const { data: school } = await rls
+      .from('schools')
+      .select('district_id')
+      .eq('id', schoolId)
+      .single();
+    if (school) return school.district_id === districtAdmin.district_id;
+  }
+
+  return false;
+}

--- a/lib/supabase/queries/admin-accounts.ts
+++ b/lib/supabase/queries/admin-accounts.ts
@@ -1289,74 +1289,40 @@ export async function updateStudentAsAdmin(
  * @param studentId - The student ID
  * @param schoolId - The school ID (for permission check)
  */
-export async function deleteStudentAsAdmin(studentId: string, schoolId: string) {
-  const supabase = createClient<Database>();
+export interface DeleteStudentResult {
+  success: boolean;
+  /**
+   * CARE referrals matched to this student by name (not by FK, so they are not
+   * deleted automatically). Surfaced for the admin to confirm and remove via
+   * /api/admin/care-referrals/[referralId].
+   */
+  careMatches?: Array<{ id: string; student_name: string; referral_reason: string | null }>;
+  storageObjectsRemoved?: number;
+}
 
-  // Verify admin has permission
-  const hasPermission = await isAdminForSchool(schoolId);
-  if (!hasPermission) {
-    throw new Error('You do not have permission to delete students at this school');
-  }
-
-  // Verify student belongs to this school
-  const studentCheck = await safeQuery(
-    async () => {
-      const { data, error } = await supabase
-        .from('students')
-        .select('id, school_id')
-        .eq('id', studentId)
-        .single();
-      if (error) throw error;
-      return data;
-    },
-    { operation: 'verify_student_school_for_delete', studentId }
+/**
+ * Delete a student (and all their data, including Storage objects) as an admin.
+ *
+ * SPE-143: this now routes through the server (`DELETE /api/admin/students/[id]`)
+ * so it can remove the student's Storage objects and surface CARE referrals —
+ * neither of which a browser/RLS client can reach. The row delete itself still
+ * runs under the admin's RLS session server-side. Returns any name-matched CARE
+ * referrals for the caller to confirm.
+ */
+export async function deleteStudentAsAdmin(
+  studentId: string,
+  schoolId: string
+): Promise<DeleteStudentResult> {
+  const res = await fetch(
+    `/api/admin/students/${encodeURIComponent(studentId)}?schoolId=${encodeURIComponent(schoolId)}`,
+    { method: 'DELETE' }
   );
 
-  if (studentCheck.error || !studentCheck.data) {
-    throw new Error('Student not found');
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(body?.error || 'Failed to delete student');
   }
-
-  if (studentCheck.data.school_id !== schoolId) {
-    throw new Error('Student does not belong to this school');
-  }
-
-  const deletePerf = measurePerformanceWithAlerts('delete_student_admin', 'database');
-
-  // First delete schedule_sessions
-  const deleteSessionsResult = await safeQuery(
-    async () => {
-      const { error } = await supabase
-        .from('schedule_sessions')
-        .delete()
-        .eq('student_id', studentId);
-      if (error) throw error;
-      return null;
-    },
-    { operation: 'delete_student_sessions_admin', studentId }
-  );
-
-  if (deleteSessionsResult.error) {
-    deletePerf.end();
-    throw deleteSessionsResult.error;
-  }
-
-  // Then delete the student
-  const deleteResult = await safeQuery(
-    async () => {
-      const { error } = await supabase
-        .from('students')
-        .delete()
-        .eq('id', studentId);
-      if (error) throw error;
-      return true;
-    },
-    { operation: 'delete_student_admin', studentId }
-  );
-
-  deletePerf.end();
-
-  if (deleteResult.error) throw deleteResult.error;
-  return true;
+  return body as DeleteStudentResult;
 }
 
 // ============================================================================

--- a/speddy-chrome-extension/manifest.json
+++ b/speddy-chrome-extension/manifest.json
@@ -5,7 +5,8 @@
   "description": "Automatically detect discrepancies between SEIS and Speddy IEP data",
   "permissions": [
     "storage",
-    "activeTab"
+    "activeTab",
+    "alarms"
   ],
   "host_permissions": [
     "https://*.seis.org/*",

--- a/speddy-chrome-extension/service-worker.js
+++ b/speddy-chrome-extension/service-worker.js
@@ -6,6 +6,13 @@
 // API endpoint
 const API_BASE_URL = 'https://speddy.xyz';
 
+// SPE-143: bound the on-device cache of student data (SEIS ID, name, grade,
+// school) so backend deletion/retention isn't undermined by stale local copies.
+// Cached discrepancies expire after this TTL, and the cache is cleared on logout
+// (manual disconnect, or an invalidated API key — see handlePassiveExtraction).
+const DISCREPANCY_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const PRUNE_ALARM_NAME = 'prune-discrepancies';
+
 // Listen for installation
 chrome.runtime.onInstalled.addListener((details) => {
   console.log('Speddy extension installed', details.reason);
@@ -94,6 +101,16 @@ async function handlePassiveExtraction(student, pageType, url) {
       body: JSON.stringify({ student }),
     });
 
+    // Clear-on-logout: if the API key has been revoked/invalidated server-side,
+    // treat it as a logout — drop the key and wipe the on-device student cache so
+    // it can't linger after backend access is gone.
+    if (response.status === 401 || response.status === 403) {
+      await chrome.storage.local.remove('apiKey');
+      await clearDiscrepancies();
+      console.warn('API key invalid — disconnected and cleared local cache');
+      return { error: 'API key invalid — disconnected' };
+    }
+
     if (!response.ok) {
       let errorMessage = 'Compare API error';
       try {
@@ -153,10 +170,33 @@ async function storeDiscrepancy(student, compareResult, url) {
 }
 
 /**
- * Get all stored discrepancies
+ * Drop cached discrepancies older than the TTL. Returns the surviving set.
+ * Persists only when something was actually removed.
+ */
+async function pruneExpiredDiscrepancies() {
+  const { discrepancies = {} } = await chrome.storage.local.get('discrepancies');
+  const now = Date.now();
+  let changed = false;
+
+  for (const [key, entry] of Object.entries(discrepancies)) {
+    const detectedAt = entry?.detectedAt ? Date.parse(entry.detectedAt) : NaN;
+    if (Number.isNaN(detectedAt) || now - detectedAt > DISCREPANCY_TTL_MS) {
+      delete discrepancies[key];
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    await chrome.storage.local.set({ discrepancies });
+  }
+  return discrepancies;
+}
+
+/**
+ * Get all stored discrepancies (expired entries are pruned first)
  */
 async function getStoredDiscrepancies() {
-  const { discrepancies = {} } = await chrome.storage.local.get('discrepancies');
+  const discrepancies = await pruneExpiredDiscrepancies();
   return { discrepancies };
 }
 
@@ -183,7 +223,7 @@ async function clearDiscrepancies(studentKey) {
  * Update the extension badge with discrepancy count
  */
 async function updateBadge() {
-  const { discrepancies = {} } = await chrome.storage.local.get('discrepancies');
+  const discrepancies = await pruneExpiredDiscrepancies();
   const count = Object.keys(discrepancies).length;
 
   if (count > 0) {
@@ -196,7 +236,17 @@ async function updateBadge() {
   }
 }
 
-// Initialize badge on startup
+// Periodically prune expired cached discrepancies (TTL enforcement), even when
+// the popup is never opened.
+chrome.alarms.create(PRUNE_ALARM_NAME, { periodInMinutes: 60 });
+chrome.alarms.onAlarm.addListener(async (alarm) => {
+  if (alarm.name === PRUNE_ALARM_NAME) {
+    await pruneExpiredDiscrepancies();
+    await updateBadge();
+  }
+});
+
+// Initialize badge on startup (also prunes expired entries)
 updateBadge();
 
 // Log that service worker started

--- a/supabase/migrations/20260612_student_account_deletion_retention.sql
+++ b/supabase/migrations/20260612_student_account_deletion_retention.sql
@@ -1,0 +1,37 @@
+-- SPE-143: privacy / data-deletion tooling
+--
+-- Make lesson_performance_history cascade when its student is deleted.
+--
+-- Why: every other child of `students` already deletes via ON DELETE CASCADE, so
+-- an admin "delete student" sweeps them up automatically (cascade deletes are
+-- performed by the system and bypass the child tables' RLS). lesson_performance_history
+-- was the lone exception (ON DELETE NO ACTION). It also has NO delete RLS policy for
+-- authenticated users, so even the owning provider cannot remove these rows — meaning
+-- a single row here makes its student permanently undeletable through the app. The data
+-- is derived analytics (lesson effectiveness history), safe to remove with the student.
+--
+-- This is the only schema change required for the deletion/retention work; the row
+-- deletes themselves continue to run under RLS, and Storage cleanup is handled in
+-- application code (Postgres cascade never touches Storage objects).
+
+DO $$
+DECLARE
+  v_conname text;
+BEGIN
+  SELECT con.conname
+    INTO v_conname
+  FROM pg_constraint con
+  JOIN pg_class c  ON c.oid  = con.conrelid
+  JOIN pg_class cf ON cf.oid = con.confrelid
+  WHERE con.contype = 'f'
+    AND c.relname  = 'lesson_performance_history'
+    AND cf.relname = 'students';
+
+  IF v_conname IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE public.lesson_performance_history DROP CONSTRAINT %I', v_conname);
+  END IF;
+
+  ALTER TABLE public.lesson_performance_history
+    ADD CONSTRAINT lesson_performance_history_student_id_fkey
+    FOREIGN KEY (student_id) REFERENCES public.students(id) ON DELETE CASCADE;
+END $$;


### PR DESCRIPTION
## Why

Privacy/compliance tooling required to honor NDPA data-return/deletion obligations — the last engineering blocker for the CITE/CSPA NDPA (blocks SPE-59). Until now, honoring a deletion request meant hand-running SQL against production.

**Student data lives in two places**, and both are addressed: the Supabase backend (system of record) and the Chrome extension's on-device cache (`chrome.storage.local`).

## Design

Row deletes run under the **admin's own RLS session** (the database authorization backstop is preserved); Postgres cascade sweeps every FK-linked child. The **service role** is used *only* where RLS + cascade structurally cannot reach:
- **Storage objects** — cascade deletes rows, never Storage objects, and the admin isn't the object owner.
- **CARE referrals** — linked to a student by free-text name, not a foreign key, so they never cascade. Surfaced for admin confirmation, never auto-deleted on a fuzzy match.

## What's included (the 5 ticket items)

1. **Admin "delete student"** — `DELETE /api/admin/students/[studentId]`: RLS cascade + removes worksheet images from the `worksheet-submissions`/`worksheets` buckets + surfaces name-matched CARE referrals. `deleteStudentAsAdmin` repointed at it; the admin students page gains the CARE-confirmation step (`DELETE /api/admin/care-referrals/[referralId]`).
2. **Account deletion** — `DELETE /api/admin/providers/[providerId]`: nulls nullable references, deletes the profile (cascade) + Auth user, removes provider-owned Storage; reports non-cascading provenance (CARE the provider authored, school-year activations) as `409` blockers rather than rewriting authorship. **API only — no UI yet** (intended for the offboarding flow).
3. **Offboarding runbook** — `docs/offboarding-runbook.md`; export step **references SPE-60**, not rebuilt.
4. **Retention/TTL job** — `app/api/cron/cleanup-worksheet-images`: deletes worksheet-submission images + rows older than **12 months** (`CRON_SECRET`-gated, mirrors `cleanup-uploads`).
5. **Extension cache** — `service-worker.js`: **7-day TTL** (pruned on read + hourly alarm) and **clear-on-logout** hardened (manual disconnect already cleared; now also clears when the API key is invalidated server-side). Adds the `alarms` permission.

Plus a shared `isAdminForSchool` server-side authz helper and a `data-inventory.md` update marking the extension-cache item addressed.

## Migration

`supabase/migrations/20260612_student_account_deletion_retention.sql` sets `lesson_performance_history.student_id` → `ON DELETE CASCADE` — the lone FK that could permanently block a student delete (the table has no DELETE RLS policy, so even the owning provider can't clear it). 0 rows in prod; zero-risk DDL.

## Validation

- `tsc --noEmit` and `next lint` on all changed files: **clean**.
- **Database dry-run against the real schema** (synthetic test rows only, fully cleaned up, schema restored, $0 cost):

| Test | Result |
|---|---|
| Student delete **before** migration | ✅ Blocked by `lesson_performance_history_student_id_fkey` (proves migration needed) |
| Student delete **after** migration | ✅ Cascades fully; CARE referral survives (handled separately) |
| Account-delete preflight | ✅ Detects authored CARE → would 409 |
| Profile delete with CARE present (nullable refs already nulled) | ✅ Still blocked by `care_referrals_referring_user_id_fkey` (proves "report, don't force") |
| Resolve CARE → delete profile + auth user | ✅ Both succeed |
| Bystander provider's rows | ✅ Survive with their references to the deleted provider nulled |

Not exercised by the DB dry-run (conventional glue, covered by review): the `isAdminForSchool` HTTP gate, the `auth.admin.deleteUser()` SDK wrapper, and the Storage `.remove()` API call.

## Follow-ups / deploy notes

- **Apply the migration** through the normal pipeline before relying on student deletion.
- **Wire the retention cron schedule** — no `vercel.json` exists; register it wherever `cleanup-uploads` runs (recommended: daily). Documented in the runbook.
- **Provider-delete UI** is a deliberate follow-up; the route is ready for the offboarding script.

https://claude.ai/code/session_017taTXfHkJYXZfARJ4bMeuo

---
_Generated by [Claude Code](https://claude.ai/code/session_017taTXfHkJYXZfARJ4bMeuo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CARE referral confirmation when deleting students; option to remove matched CARE records
  * Improved admin deletion flows for providers and students with preflight checks, storage cleanup, and clearer outcomes
  * Cron endpoint to purge expired worksheet submission images
  * Chrome extension: 7-day cache TTL with hourly pruning and periodic badge refresh; manifest alarms permission added

* **Bug Fixes**
  * Extension clears cached data and API key on authorization failures

* **Documentation**
  * Added offboarding runbook and updated data-inventory to document cache/TTL and deletion procedures

* **Chores**
  * DB migration to cascade lesson performance history on student deletion
<!-- end of auto-generated comment: release notes by coderabbit.ai -->