### PR TITLE
docs: note OpenAI + Anthropic DPAs on file (subprocessor exhibit)

### DIFF
--- a/docs/subprocessors.md
+++ b/docs/subprocessors.md
@@ -34,8 +34,11 @@ _Last reviewed: 2026-06-11._
 Both providers are hard-gated off by `AI_FEATURES_ENABLED` (default off; see
 SPE-162): the AI routes return 404 (before auth or handler logic) and make
 **zero** provider calls unless the env var is set to exactly the string `'true'`.
-**Do not enable until provider DPAs (no-training / zero-retention) are executed —
-SPE-163.**
+
+**DPAs executed and on file (2026-06-12):** OpenAI signed (self-serve), Anthropic
+incorporated via Commercial Terms + dated copy saved; both US-processed on standard
+tiers (SPE-163). **Still do not enable AI** until Zero Data Retention is requested
+(SPE-163) and prompt de-identification lands (SPE-61).
 
 | Service | Role (when enabled) | Student data (when enabled) | Where (code) |
 |---|---|---|---|


### PR DESCRIPTION
Docs-only. Updates the "Planned / not enabled" AI-subprocessor note now that both DPAs are executed and on file:

- **OpenAI** — DPA signed (self-serve, countersigned copy received).
- **Anthropic** — DPA incorporated via Commercial Terms; dated copy saved.

Both US-processed on standard tiers. AI stays hard-gated off; enabling remains gated on **Zero Data Retention** (SPE-163) and prompt **de-identification** (SPE-61). Keeps the subprocessor exhibit accurate for the CITE/CSPA NDPA (SPE-59).

https://claude.ai/code/session_017taTXfHkJYXZfARJ4bMeuo

---
_Generated by [Claude Code](https://claude.ai/code/session_017taTXfHkJYXZfARJ4bMeuo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI provider disclosure documentation to reflect executed Data Processing Agreements with OpenAI and Anthropic. Clarified that AI features remain disabled pending completion of required privacy and security implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->