### PR TITLE
feat(auth): Google SSO sign-in with a pre-provisioned-account gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,17 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 
 # Google SSO (Optional)
-# Restricts the "Continue with Google" button to a single Google Workspace
-# domain (the `hd` hint). Leave unset for multi-district deployments — the
-# provisioning gate in app/auth/callback already blocks any account we haven't
-# created. See docs/auth-google-sso.md for enablement steps.
+# Canonical public origin used to build OAuth redirect URLs (the /auth/callback
+# return). Set in PRODUCTION so redirects land on the real domain; leave unset
+# locally to fall back to the request origin. The callback does NOT trust the
+# x-forwarded-host header.
+# NEXT_PUBLIC_SITE_URL=https://www.speddy.xyz
+#
+# Optional Google Workspace domain HINT (the `hd` param) — only pre-selects the
+# Google account chooser toward one domain. It is NOT a security boundary; the
+# provisioning gate in app/auth/callback is what blocks any account we haven't
+# created. Leave unset for multi-district deployments.
+# See docs/auth-google-sso.md for enablement steps.
 # NEXT_PUBLIC_GOOGLE_HD=yourdistrict.org
 
 # AI Services (Optional)

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,13 @@ NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 
+# Google SSO (Optional)
+# Restricts the "Continue with Google" button to a single Google Workspace
+# domain (the `hd` hint). Leave unset for multi-district deployments — the
+# provisioning gate in app/auth/callback already blocks any account we haven't
+# created. See docs/auth-google-sso.md for enablement steps.
+# NEXT_PUBLIC_GOOGLE_HD=yourdistrict.org
+
 # AI Services (Optional)
 ANTHROPIC_API_KEY=your-anthropic-api-key
 OPENAI_API_KEY=your-openai-api-key

--- a/__tests__/unit/app/auth-callback-route.test.ts
+++ b/__tests__/unit/app/auth-callback-route.test.ts
@@ -130,4 +130,18 @@ describe('Google SSO callback provisioning gate', () => {
       else process.env.NEXT_PUBLIC_SITE_URL = prev;
     }
   });
+
+  it('fails closed (redirects, no 500) when the supabase client setup throws', async () => {
+    mockCreateClient.mockRejectedValue(new Error('env missing'));
+    const res = await call('?code=abc');
+    expect(location(res).searchParams.get('error')).toBe('oauth_failed');
+  });
+
+  it('still deletes the orphan when sign-out throws for an unprovisioned user', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+    mockSignOut.mockRejectedValue(new Error('signout failed'));
+    const res = await call('?code=abc');
+    expect(mockDeleteUser).toHaveBeenCalledWith('user-1');
+    expect(location(res).searchParams.get('error')).toBe('not_provisioned');
+  });
 });

--- a/__tests__/unit/app/auth-callback-route.test.ts
+++ b/__tests__/unit/app/auth-callback-route.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for the Google SSO callback provisioning gate
+ * (`app/auth/callback/route.ts`).
+ *
+ * Contract: a social sign-in may only proceed when we ALREADY have an account
+ * (a `profiles` row) for the user. An unprovisioned identity must be signed out,
+ * have its orphan auth user deleted, and be bounced to /login?error=not_provisioned.
+ * SSO can never create a usable new account.
+ */
+
+// jest requires factory-referenced vars to be prefixed with `mock`.
+const mockExchange = jest.fn();
+const mockSignOut = jest.fn();
+const mockCreateClient = jest.fn();
+
+const mockMaybeSingle = jest.fn();
+const mockDeleteUser = jest.fn();
+const mockCreateServiceClient = jest.fn();
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: (...args: unknown[]) => mockCreateClient(...args),
+  createServiceClient: (...args: unknown[]) => mockCreateServiceClient(...args),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { GET } from '@/app/auth/callback/route';
+
+function buildAdminClient() {
+  const eq = jest.fn(() => ({ maybeSingle: mockMaybeSingle }));
+  const select = jest.fn(() => ({ eq }));
+  const from = jest.fn(() => ({ select }));
+  return { from, auth: { admin: { deleteUser: mockDeleteUser } } };
+}
+
+const call = (qs: string) =>
+  GET(new Request(`http://localhost:3000/auth/callback${qs}`));
+
+const location = (res: Response) => new URL(res.headers.get('location') as string);
+
+describe('Google SSO callback provisioning gate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateClient.mockResolvedValue({
+      auth: { exchangeCodeForSession: mockExchange, signOut: mockSignOut },
+    });
+    mockCreateServiceClient.mockReturnValue(buildAdminClient());
+    mockExchange.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockMaybeSingle.mockResolvedValue({ data: { id: 'user-1' }, error: null });
+    mockDeleteUser.mockResolvedValue({ data: {}, error: null });
+    mockSignOut.mockResolvedValue({ error: null });
+  });
+
+  it('rejects when no code is present, without exchanging', async () => {
+    const res = await call('');
+    expect(location(res).pathname).toBe('/login');
+    expect(location(res).searchParams.get('error')).toBe('oauth_failed');
+    expect(mockExchange).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the provider returns an error, without exchanging', async () => {
+    const res = await call('?error=access_denied');
+    expect(location(res).searchParams.get('error')).toBe('oauth_failed');
+    expect(mockExchange).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the code exchange fails', async () => {
+    mockExchange.mockResolvedValue({ data: { user: null }, error: { message: 'bad code' } });
+    const res = await call('?code=abc');
+    expect(location(res).searchParams.get('error')).toBe('oauth_failed');
+  });
+
+  it('lets a provisioned user through and never deletes them', async () => {
+    const res = await call('?code=abc');
+    expect(location(res).pathname).toBe('/dashboard');
+    expect(location(res).searchParams.get('error')).toBeNull();
+    expect(mockDeleteUser).not.toHaveBeenCalled();
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unprovisioned user: signs out, deletes the orphan, bounces to login', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+    const res = await call('?code=abc');
+    expect(location(res).pathname).toBe('/login');
+    expect(location(res).searchParams.get('error')).toBe('not_provisioned');
+    expect(mockSignOut).toHaveBeenCalled();
+    expect(mockDeleteUser).toHaveBeenCalledWith('user-1');
+  });
+
+  it('fails closed if provisioning cannot be verified', async () => {
+    mockMaybeSingle.mockRejectedValue(new Error('db down'));
+    const res = await call('?code=abc');
+    expect(location(res).searchParams.get('error')).toBe('oauth_failed');
+    expect(mockDeleteUser).not.toHaveBeenCalled();
+  });
+
+  it('honors a safe internal next param', async () => {
+    const res = await call('?code=abc&next=/dashboard/admin');
+    expect(location(res).pathname).toBe('/dashboard/admin');
+  });
+
+  it('ignores an external next param (open-redirect guard)', async () => {
+    const res = await call('?code=abc&next=https://evil.example.com');
+    expect(location(res).host).toBe('localhost:3000');
+    expect(location(res).pathname).toBe('/dashboard');
+  });
+});

--- a/__tests__/unit/app/auth-callback-route.test.ts
+++ b/__tests__/unit/app/auth-callback-route.test.ts
@@ -93,6 +93,7 @@ describe('Google SSO callback provisioning gate', () => {
     mockMaybeSingle.mockRejectedValue(new Error('db down'));
     const res = await call('?code=abc');
     expect(location(res).searchParams.get('error')).toBe('oauth_failed');
+    expect(mockSignOut).toHaveBeenCalled();
     expect(mockDeleteUser).not.toHaveBeenCalled();
   });
 
@@ -115,5 +116,18 @@ describe('Google SSO callback provisioning gate', () => {
     const res = await call('?code=abc&next=https://evil.example.com');
     expect(location(res).host).toBe('localhost:3000');
     expect(location(res).pathname).toBe('/dashboard');
+  });
+
+  it('uses NEXT_PUBLIC_SITE_URL as the redirect origin when set (not x-forwarded-host)', async () => {
+    const prev = process.env.NEXT_PUBLIC_SITE_URL;
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://www.speddy.xyz';
+    try {
+      const res = await call('?code=abc');
+      expect(location(res).host).toBe('www.speddy.xyz');
+      expect(location(res).pathname).toBe('/dashboard');
+    } finally {
+      if (prev === undefined) delete process.env.NEXT_PUBLIC_SITE_URL;
+      else process.env.NEXT_PUBLIC_SITE_URL = prev;
+    }
   });
 });

--- a/__tests__/unit/app/auth-callback-route.test.ts
+++ b/__tests__/unit/app/auth-callback-route.test.ts
@@ -89,10 +89,20 @@ describe('Google SSO callback provisioning gate', () => {
     expect(mockDeleteUser).toHaveBeenCalledWith('user-1');
   });
 
-  it('fails closed if provisioning cannot be verified', async () => {
+  it('fails closed if the provisioning lookup throws', async () => {
     mockMaybeSingle.mockRejectedValue(new Error('db down'));
     const res = await call('?code=abc');
     expect(location(res).searchParams.get('error')).toBe('oauth_failed');
+    expect(mockDeleteUser).not.toHaveBeenCalled();
+  });
+
+  it('fails closed WITHOUT deleting when the lookup resolves an error (transient DB failure)', async () => {
+    // maybeSingle() returns { data: null, error } on a PostgREST/DB error
+    // rather than throwing. A real provisioned user must NOT be deleted here.
+    mockMaybeSingle.mockResolvedValue({ data: null, error: { message: 'timeout' } });
+    const res = await call('?code=abc');
+    expect(location(res).searchParams.get('error')).toBe('oauth_failed');
+    expect(mockSignOut).toHaveBeenCalled();
     expect(mockDeleteUser).not.toHaveBeenCalled();
   });
 

--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { PasswordInput } from "../../components/auth/password-input";
 import { logger } from '@/lib/logger';
 import { handleClientError } from '@/lib/error-handler';
+import { getSupabaseClient } from '@/lib/supabase/client';
 
 export default function LoginForm() {
   const [email, setEmail] = useState('');
@@ -16,6 +17,52 @@ export default function LoginForm() {
   const [forgotEmail, setForgotEmail] = useState('');
   const [forgotSubmitted, setForgotSubmitted] = useState(false);
   const router = useRouter();
+
+  // Surface errors handed back by the OAuth callback (?error=...).
+  useEffect(() => {
+    const err = new URLSearchParams(window.location.search).get('error');
+    if (err === 'not_provisioned') {
+      setError(
+        "This Google account isn't set up in Speddy yet. Ask your administrator to create your account first, then sign in."
+      );
+    } else if (err === 'oauth_failed') {
+      setError("Google sign-in didn't complete. Please try again.");
+    }
+  }, []);
+
+  const handleGoogleSignIn = async () => {
+    setError('');
+    setLoading(true);
+    logger.info('Google sign-in attempt');
+
+    try {
+      const supabase = getSupabaseClient();
+      const hostedDomain = process.env.NEXT_PUBLIC_GOOGLE_HD;
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: {
+          redirectTo: `${window.location.origin}/auth/callback`,
+          queryParams: {
+            access_type: 'offline',
+            prompt: 'select_account',
+            ...(hostedDomain ? { hd: hostedDomain } : {}),
+          },
+        },
+      });
+
+      if (error) {
+        logger.warn('Google sign-in failed to start', { error: error.message });
+        setError('Could not start Google sign-in. Please try again.');
+        setLoading(false);
+      }
+      // On success the browser is redirected to Google.
+    } catch (err) {
+      handleClientError(err, 'login-form-google');
+      logger.error('Google sign-in error', err);
+      setError('An unexpected error occurred. Please try again.');
+      setLoading(false);
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -211,6 +258,30 @@ export default function LoginForm() {
         className="w-full flex justify-center py-2 px-4 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {loading ? 'Signing in...' : 'Sign in'}
+      </button>
+
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center" aria-hidden="true">
+          <div className="w-full border-t border-gray-200" />
+        </div>
+        <div className="relative flex justify-center text-sm">
+          <span className="bg-gray-50 px-2 text-gray-500">or</span>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={handleGoogleSignIn}
+        disabled={loading}
+        className="w-full flex items-center justify-center gap-2 py-2 px-4 border border-gray-300 rounded-lg shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <svg className="h-5 w-5" viewBox="0 0 48 48" aria-hidden="true">
+          <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z" />
+          <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z" />
+          <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z" />
+          <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z" />
+        </svg>
+        Continue with Google
       </button>
 
       <p className="hidden text-center text-sm text-gray-600">

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server';
+import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { logger } from '@/lib/logger';
+
+/**
+ * OAuth callback for Supabase social sign-in (currently Google).
+ *
+ * Provisioning gate: Speddy accounts are created by admins (and, for some
+ * provider roles, self-signup) — never implicitly by SSO. We only allow a
+ * social sign-in to proceed if we ALREADY have an account for the user,
+ * detected by the presence of a `profiles` row. There is no trigger on
+ * `auth.users` (profiles are created by explicit RPC during signup/admin
+ * creation — see 20250117_create_profile_on_signup.sql), so a brand-new
+ * Google user has an auth row but no profile. When there's no profile we
+ * delete the just-created orphan auth user and bounce them back to /login
+ * with an explanation. Net effect: SSO can sign existing users in, but can
+ * never create a new account.
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get('code');
+  const oauthError = url.searchParams.get('error');
+  const nextParam = url.searchParams.get('next');
+  // Only allow internal redirects to avoid open-redirect abuse.
+  const next = nextParam && nextParam.startsWith('/') ? nextParam : '/dashboard';
+
+  // Honor the proxy host in production (Vercel) so redirects stay on the public origin.
+  const forwardedHost = request.headers.get('x-forwarded-host');
+  const isLocalEnv = process.env.NODE_ENV === 'development';
+  const base = isLocalEnv || !forwardedHost ? url.origin : `https://${forwardedHost}`;
+  const redirectTo = (path: string) => NextResponse.redirect(`${base}${path}`);
+
+  if (oauthError) {
+    logger.warn('OAuth callback returned a provider error', { oauthError });
+    return redirectTo('/login?error=oauth_failed');
+  }
+  if (!code) {
+    return redirectTo('/login?error=oauth_failed');
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+  if (error || !data.user) {
+    logger.warn('OAuth code exchange failed', { error: error?.message });
+    return redirectTo('/login?error=oauth_failed');
+  }
+
+  const user = data.user;
+
+  try {
+    // Authoritative provisioning check via the service role (bypasses RLS so a
+    // legitimately provisioned user is never falsely rejected).
+    const admin = createServiceClient();
+    const { data: profile } = await admin
+      .from('profiles')
+      .select('id')
+      .eq('id', user.id)
+      .maybeSingle();
+
+    if (!profile) {
+      // No Speddy account for this identity. Sign out and remove the orphan
+      // auth user that Supabase created for this OAuth sign-in.
+      await supabase.auth.signOut();
+      await admin.auth.admin.deleteUser(user.id);
+      logger.warn('Rejected SSO sign-in for an unprovisioned account', { userId: user.id });
+      return redirectTo('/login?error=not_provisioned');
+    }
+  } catch (e) {
+    // Fail closed: if provisioning can't be verified, do not grant access.
+    logger.error('SSO provisioning check failed; rejecting sign-in', e);
+    try {
+      await supabase.auth.signOut();
+    } catch {
+      // best effort
+    }
+    return redirectTo('/login?error=oauth_failed');
+  }
+
+  logger.info('SSO sign-in succeeded for a provisioned account');
+  return redirectTo(next);
+}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -42,16 +42,23 @@ export async function GET(request: Request) {
     return redirectTo('/login?error=oauth_failed');
   }
 
-  const supabase = await createClient();
-  const { data, error } = await supabase.auth.exchangeCodeForSession(code);
-  if (error || !data.user) {
-    logger.warn('OAuth code exchange failed', { error: error?.message });
-    return redirectTo('/login?error=oauth_failed');
-  }
-
-  const user = data.user;
-
+  // Everything that touches Supabase runs inside this try so any throw — client
+  // setup, code exchange, or the provisioning lookup — fails closed with a
+  // redirect rather than bubbling into a 500. `supabaseRef` is captured so the
+  // catch can still attempt a best-effort sign-out.
+  let supabaseRef: Awaited<ReturnType<typeof createClient>> | null = null;
   try {
+    const supabase = await createClient();
+    supabaseRef = supabase;
+
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+    if (error || !data.user) {
+      logger.warn('OAuth code exchange failed', { error: error?.message });
+      return redirectTo('/login?error=oauth_failed');
+    }
+
+    const user = data.user;
+
     // Authoritative provisioning check via the service role (bypasses RLS so a
     // legitimately provisioned user is never falsely rejected).
     const admin = createServiceClient();
@@ -74,18 +81,25 @@ export async function GET(request: Request) {
     }
 
     if (!profile) {
-      // Confirmed: no Speddy account for this identity. Sign out and remove the
-      // orphan auth user that Supabase created for this OAuth sign-in.
-      await supabase.auth.signOut();
+      // Confirmed: no Speddy account for this identity. Remove the orphan auth
+      // user that Supabase created for this OAuth sign-in. Sign-out is best
+      // effort — its failure must NOT skip the deletion, which is the whole
+      // point of this branch.
+      try {
+        await supabase.auth.signOut();
+      } catch (signOutError) {
+        logger.warn('Failed to clear SSO session for an unprovisioned account', signOutError);
+      }
       await admin.auth.admin.deleteUser(user.id);
       logger.warn('Rejected SSO sign-in for an unprovisioned account', { userId: user.id });
       return redirectTo('/login?error=not_provisioned');
     }
   } catch (e) {
-    // Fail closed on any unexpected throw too.
+    // Fail closed on any unexpected throw (client setup, code exchange,
+    // provisioning lookup).
     logger.error('SSO provisioning check failed; rejecting sign-in', e);
     try {
-      await supabase.auth.signOut();
+      if (supabaseRef) await supabaseRef.auth.signOut();
     } catch {
       // best effort
     }

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -51,22 +51,34 @@ export async function GET(request: Request) {
     // Authoritative provisioning check via the service role (bypasses RLS so a
     // legitimately provisioned user is never falsely rejected).
     const admin = createServiceClient();
-    const { data: profile } = await admin
+    const { data: profile, error: lookupError } = await admin
       .from('profiles')
       .select('id')
       .eq('id', user.id)
       .maybeSingle();
 
+    if (lookupError) {
+      // Couldn't verify provisioning (e.g. a transient PostgREST/DB error).
+      // maybeSingle() RESOLVES errors here rather than throwing, so this must
+      // be handled before the !profile branch — otherwise a momentary read
+      // failure would look like "no account" and delete a real user. Fail
+      // closed WITHOUT deleting: never destroy an account we can't confirm is
+      // unprovisioned.
+      logger.error('SSO provisioning lookup failed; rejecting without deleting', lookupError);
+      await supabase.auth.signOut();
+      return redirectTo('/login?error=oauth_failed');
+    }
+
     if (!profile) {
-      // No Speddy account for this identity. Sign out and remove the orphan
-      // auth user that Supabase created for this OAuth sign-in.
+      // Confirmed: no Speddy account for this identity. Sign out and remove the
+      // orphan auth user that Supabase created for this OAuth sign-in.
       await supabase.auth.signOut();
       await admin.auth.admin.deleteUser(user.id);
       logger.warn('Rejected SSO sign-in for an unprovisioned account', { userId: user.id });
       return redirectTo('/login?error=not_provisioned');
     }
   } catch (e) {
-    // Fail closed: if provisioning can't be verified, do not grant access.
+    // Fail closed on any unexpected throw too.
     logger.error('SSO provisioning check failed; rejecting sign-in', e);
     try {
       await supabase.auth.signOut();

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -24,10 +24,14 @@ export async function GET(request: Request) {
   // Only allow internal redirects to avoid open-redirect abuse.
   const next = nextParam && nextParam.startsWith('/') ? nextParam : '/dashboard';
 
-  // Honor the proxy host in production (Vercel) so redirects stay on the public origin.
-  const forwardedHost = request.headers.get('x-forwarded-host');
-  const isLocalEnv = process.env.NODE_ENV === 'development';
-  const base = isLocalEnv || !forwardedHost ? url.origin : `https://${forwardedHost}`;
+  // Build the redirect base from a configured canonical origin when set,
+  // otherwise the request's own origin. We intentionally do NOT trust the raw
+  // `x-forwarded-host` header — it's client-controllable and would be an
+  // open-redirect primitive. Set NEXT_PUBLIC_SITE_URL to the public origin
+  // (e.g. https://www.speddy.xyz) in production so redirects land on the
+  // canonical domain regardless of proxy host resolution.
+  const configuredOrigin = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, '');
+  const base = configuredOrigin || url.origin;
   const redirectTo = (path: string) => NextResponse.redirect(`${base}${path}`);
 
   if (oauthError) {

--- a/docs/auth-google-sso.md
+++ b/docs/auth-google-sso.md
@@ -1,0 +1,70 @@
+# Google SSO ("Continue with Google")
+
+Lets existing Speddy users sign in with their school Google account. It is
+**additive** — email/password login is unchanged — and it is **sign-in only**:
+a Google sign-in can attach to an account we already created, but it can never
+create a new account.
+
+## How it works
+
+1. The login page shows a **Continue with Google** button
+   (`app/(auth)/login/login-form.tsx`) that calls
+   `supabase.auth.signInWithOAuth({ provider: 'google', ... })`.
+2. Google → Supabase → redirects back to **`/auth/callback`**
+   (`app/auth/callback/route.ts`), which exchanges the code for a session.
+3. **Provisioning gate:** the callback checks (service role) whether a
+   `profiles` row exists for the signed-in user.
+   - **Exists** → the user was provisioned (admin-created, or a prior
+     self-signup). Supabase auto-linked the Google identity to that account by
+     verified email, so they land on their existing role/school. ✅
+   - **Missing** → brand-new Google identity we don't have an account for. The
+     callback signs them out, **deletes the orphan auth user**, and returns to
+     `/login?error=not_provisioned` with an "ask your admin" message. 🚫
+
+Why the gate is a `profiles` check: there is no trigger on `auth.users`
+(`supabase/migrations/20250117_create_profile_on_signup.sql`), so a brand-new
+OAuth user has an auth row but **no** profile — making "has a profile" a
+reliable "do we have an account for them" signal.
+
+## Enablement steps (manual — not done by the code)
+
+These touch Google Cloud and the Supabase dashboard and must be done by a
+project owner. The provider stays off until step 2 is saved, so deploy the code
+first, then enable.
+
+1. **Google Cloud Console → APIs & Services → Credentials**
+   - Create an **OAuth 2.0 Client ID** (type: Web application).
+   - Authorized redirect URI: `https://<PROJECT-REF>.supabase.co/auth/v1/callback`
+     (your Supabase project's callback, *not* the app's `/auth/callback`).
+   - Note the **Client ID** and **Client secret**.
+
+2. **Supabase Dashboard → Authentication → Providers → Google**
+   - Enable Google, paste the Client ID + secret, save.
+
+3. **Supabase Dashboard → Authentication → URL Configuration**
+   - Ensure the app origin(s) are in **Redirect URLs** (e.g.
+     `https://<your-app-domain>/auth/callback`, plus `http://localhost:3000/auth/callback`
+     for local dev).
+
+4. **(Optional) Single-district lockdown:** set `NEXT_PUBLIC_GOOGLE_HD` to the
+   district's Google Workspace domain to pass Google the `hd` hint. Not required
+   for security — the provisioning gate already rejects accounts we didn't
+   create — but tidy for single-district deployments.
+
+## Notes / known edges
+
+- **Account model unchanged.** Admins still create accounts (which creates the
+  `auth.users` row with a confirmed email). Google just adds a second way for
+  those users to sign in.
+- **`must_change_password`.** Defaults to `FALSE`, so the common path is
+  unaffected. If an account currently has a *pending* password reset
+  (`must_change_password = TRUE`) and the user signs in with Google, middleware
+  will still route them to `/change-password`. Acceptable for v1; revisit if it
+  becomes a support issue.
+- **Hardening (future).** The gate currently creates-then-deletes the orphan
+  auth user on rejection, because Supabase creates the user before our callback
+  runs. A `before-user-created` Auth Hook would reject *atomically* (no orphan
+  ever created). Tracked under the SSO backbone work (SPE-178).
+- **Not SAML.** This is native Google OAuth (auto-links by email). Clever /
+  ClassLink go through Supabase SAML, which is **excluded** from auto-linking
+  and needs explicit reconciliation — tracked separately (SPE-180).

--- a/docs/auth-google-sso.md
+++ b/docs/auth-google-sso.md
@@ -53,10 +53,14 @@ first, then enable.
      - `http://localhost:3000/**` (local dev/testing)
      - the existing `*.vercel.app` previews stay.
 
-4. **(Optional) Single-district lockdown:** set `NEXT_PUBLIC_GOOGLE_HD` to the
-   district's Google Workspace domain to pass Google the `hd` hint. Not required
-   for security — the provisioning gate already rejects accounts we didn't
-   create — but tidy for single-district deployments.
+4. **App env (Vercel) → `NEXT_PUBLIC_SITE_URL`:** set to the canonical public
+   origin (`https://www.speddy.xyz`) so the callback builds redirect URLs on the
+   real domain. The callback does **not** trust the `x-forwarded-host` header.
+
+5. **(Optional) Account-chooser hint:** set `NEXT_PUBLIC_GOOGLE_HD` to the
+   district's Google Workspace domain to pass Google the `hd` param. This only
+   pre-selects the account chooser toward that domain — it is **not** a security
+   boundary (the provisioning gate is). Tidy for single-district deployments.
 
 ## Notes / known edges
 

--- a/docs/auth-google-sso.md
+++ b/docs/auth-google-sso.md
@@ -34,17 +34,24 @@ first, then enable.
 
 1. **Google Cloud Console → APIs & Services → Credentials**
    - Create an **OAuth 2.0 Client ID** (type: Web application).
-   - Authorized redirect URI: `https://<PROJECT-REF>.supabase.co/auth/v1/callback`
-     (your Supabase project's callback, *not* the app's `/auth/callback`).
+   - Authorized redirect URI: `https://qkcruccytmmdajfavpgb.supabase.co/auth/v1/callback`
+     (the Supabase project's callback, *not* the app's `/auth/callback`).
+   - Consent screen / Audience: **External**, **Published / In production**. Scopes
+     are just `email`/`profile`/`openid`, which need **no Google verification**.
    - Note the **Client ID** and **Client secret**.
 
 2. **Supabase Dashboard → Authentication → Providers → Google**
    - Enable Google, paste the Client ID + secret, save.
+   - Leave **Skip nonce checks** and **Allow users without an email** OFF.
 
 3. **Supabase Dashboard → Authentication → URL Configuration**
-   - Ensure the app origin(s) are in **Redirect URLs** (e.g.
-     `https://<your-app-domain>/auth/callback`, plus `http://localhost:3000/auth/callback`
-     for local dev).
+   - **Site URL:** `https://www.speddy.xyz` (bare origin — no path; used as the
+     fallback redirect and as the base for auth email links).
+   - **Redirect URLs** (allowlist) — must include:
+     - `https://www.speddy.xyz/**` (production)
+     - `https://speddy.xyz/**` (apex, optional)
+     - `http://localhost:3000/**` (local dev/testing)
+     - the existing `*.vercel.app` previews stay.
 
 4. **(Optional) Single-district lockdown:** set `NEXT_PUBLIC_GOOGLE_HD` to the
    district's Google Workspace domain to pass Google the `hd` hint. Not required

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,7 +7,7 @@ export async function middleware(request: NextRequest) {
 
   // Define public routes that don't require authentication
   // '/' is the marketing landing page and is open to everyone.
-  const publicRoutes = ['/', '/how-it-works', '/login', '/signup', '/terms', '/privacy', '/ferpa']
+  const publicRoutes = ['/', '/how-it-works', '/login', '/signup', '/terms', '/privacy', '/ferpa', '/auth/callback']
   const isPublicRoute = publicRoutes.some(route => pathname === route)
 
   // Routes allowed for users who must change their password


### PR DESCRIPTION
## What

Adds **"Continue with Google"** to the login page. It's **additive** (email/password login is unchanged) and **sign-in only** — a Google sign-in can attach to an account we already have, but it can never create a new account.

## How the gate works

1. Login page button → `signInWithOAuth({ provider: 'google' })` → Google → Supabase → back to a new **`/auth/callback`** route.
2. The callback exchanges the code, then checks (service role, so RLS can't false-reject) whether a **`profiles` row exists** for the user. This is a reliable "do we already have an account?" signal because there's no trigger on `auth.users` (profiles are created only by explicit RPC during admin/self-signup), so a brand-new Google user has an auth row but no profile.
3. **Provisioned** → Supabase auto-linked the Google identity by verified email → lands on the existing role/school. **Unprovisioned** → signed out, the orphan auth user is **deleted**, and they're bounced to `/login?error=not_provisioned` ("ask your admin"). Fail-closed; `next` is open-redirect-guarded.

## Files
- `app/auth/callback/route.ts` — code exchange + provisioning gate
- `app/(auth)/login/login-form.tsx` — Google button + error surfacing (optional `NEXT_PUBLIC_GOOGLE_HD` domain hint)
- `middleware.ts` — `/auth/callback` made public
- `docs/auth-google-sso.md` — setup runbook (filled with the real project ref + `www.speddy.xyz`)
- `__tests__/unit/app/auth-callback-route.test.ts` — 8 gate tests

## Verification
`tsc --noEmit` ✅ · `next lint` ✅ · new gate tests 8/8 ✅ · existing LoginForm tests ✅

## Dashboard config (already done out-of-band)
Google Cloud OAuth client created; Supabase Google provider enabled; Site URL = `https://www.speddy.xyz`; redirect allowlist includes `www`, apex, and localhost. **So merging + deploying is the final switch.**

## Known edge
`must_change_password` defaults to `FALSE`, so the common path is fine. An account with a *pending* password reset who signs in via Google still routes to `/change-password`. Acceptable for v1.

## Notes
- Native Google OAuth only (no plan change). Clever/ClassLink (SAML) is excluded from auto-linking and tracked separately — SPE-180.
- Atomic `before-user-created` hook (vs the current create-then-delete on rejection) is the hardening follow-up — SPE-178.
- Domain audit spun off two tickets: SPE-182 (worksheet QR codes hardcode `app.speddy.com`), SPE-183 (extension uses apex).

Refs SPE-179, SPE-178, SPE-176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaiZnH1dFnLTBqWuNLsPFK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaiZnH1dFnLTBqWuNLsPFK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Continue with Google” OAuth sign-in on the login page, including optional Google hosted-domain hint support.
* **Bug Fixes**
  * Improved the OAuth callback with safe in-app redirects, fail-closed handling, and consistent login error outcomes.
  * Enforced the provisioning gate: unprovisioned users are signed out, their orphan account is deleted, and they’re redirected to the “not provisioned” error.
  * Updated route access so the OAuth callback completes without session-blocking middleware.
* **Tests**
  * Added unit coverage for callback success/failure, redirect safety, and provisioning outcomes.
* **Documentation**
  * Documented Google SSO setup and provisioning behavior, and updated the environment example with hosted-domain and redirect guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->