### PR TITLE
fix(auth): enforce idle-logout window across tab/browser close

### DIFF
--- a/__tests__/unit/components/LoginForm.test.tsx
+++ b/__tests__/unit/components/LoginForm.test.tsx
@@ -30,6 +30,13 @@ describe('LoginForm', () => {
     expect(screen.getByText(/don't have an account/i)).toBeInTheDocument()
   })
 
+  it('clears stale lastActivity on mount so a fresh login is not auto-timed-out', () => {
+    const removeItemSpy = jest.spyOn(Storage.prototype, 'removeItem')
+    render(<LoginForm />)
+    expect(removeItemSpy).toHaveBeenCalledWith('lastActivity')
+    removeItemSpy.mockRestore()
+  })
+
   it('validates email format', async () => {
     const user = userEvent.setup()
     render(<LoginForm />)

--- a/__tests__/unit/lib/hooks/use-activity-tracker.test.ts
+++ b/__tests__/unit/lib/hooks/use-activity-tracker.test.ts
@@ -157,4 +157,31 @@ describe('useActivityTracker', () => {
       activityType: 'test-activity'
     });
   });
+
+  it('logs out immediately on mount when stored activity is older than the timeout (closed-tab idle)', () => {
+    // Simulate reopening after being idle longer than the timeout window.
+    const staleTime = Date.now() - (mockConfig.timeout + 60000);
+    localStorageMock.getItem.mockReturnValue(String(staleTime));
+
+    renderHook(() => useActivityTracker(mockConfig));
+
+    expect(mockConfig.onTimeout).toHaveBeenCalled();
+  });
+
+  it('does not log out on mount when stored activity is within the timeout window', () => {
+    const recent = Date.now() - 5000; // 5s ago, well within the 30s window
+    localStorageMock.getItem.mockReturnValue(String(recent));
+
+    renderHook(() => useActivityTracker(mockConfig));
+
+    expect(mockConfig.onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('does not log out on mount when there is no stored activity (fresh login)', () => {
+    localStorageMock.getItem.mockReturnValue(null);
+
+    renderHook(() => useActivityTracker(mockConfig));
+
+    expect(mockConfig.onTimeout).not.toHaveBeenCalled();
+  });
 });

--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -18,8 +18,14 @@ export default function LoginForm() {
   const [forgotSubmitted, setForgotSubmitted] = useState(false);
   const router = useRouter();
 
-  // Surface errors handed back by the OAuth callback (?error=...).
   useEffect(() => {
+    // We're on the login page (unauthenticated), so any leftover idle-timeout
+    // timestamp is from a prior, now-ended session (e.g. cookies expired without
+    // a clean sign-out). Clear it so a fresh login isn't immediately signed out
+    // by the cross-close idle check in use-activity-tracker.
+    localStorage.removeItem('lastActivity');
+
+    // Surface errors handed back by the OAuth callback (?error=...).
     const err = new URLSearchParams(window.location.search).get('error');
     if (err === 'not_provisioned') {
       setError(

--- a/lib/hooks/use-activity-tracker.ts
+++ b/lib/hooks/use-activity-tracker.ts
@@ -108,7 +108,20 @@ export function useActivityTracker({
     if (!isEnabledRef.current) {
       return;
     }
-    
+
+    // Enforce the idle window across tab/browser close. The timeout timer only
+    // runs while a tab is open, so on (re)mount check the last recorded
+    // activity: if it's already older than the timeout, the user was idle past
+    // the limit while away — log them out now instead of starting a fresh
+    // window. (Placed before the listeners are attached so there's nothing to
+    // clean up on the early return.)
+    const storedActivity = localStorage.getItem('lastActivity');
+    const storedActivityTime = storedActivity ? parseInt(storedActivity, 10) : NaN;
+    if (!Number.isNaN(storedActivityTime) && Date.now() - storedActivityTime >= timeout) {
+      onTimeout();
+      return;
+    }
+
     // Activity events to monitor
     const events = [
       'mousedown',
@@ -165,7 +178,7 @@ export function useActivityTracker({
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
       if (warningRef.current) clearTimeout(warningRef.current);
     };
-  }, [handleActivity, checkCrossTabActivity, updateActivity, timeout]);
+  }, [handleActivity, checkCrossTabActivity, updateActivity, timeout, onTimeout]);
 
   // Method to manually extend session
   const extendSession = useCallback((options: KeepAliveOptions = {}) => {


### PR DESCRIPTION
## Problem

The session idle-logout (default 45 min, `NEXT_PUBLIC_SESSION_TIMEOUT`) only fired **while a tab stayed open**. On mount, `useActivityTracker` called `updateActivity()`, which reset `lastActivity` to *now* and armed a fresh timer — it never checked the *stored* timestamp. So:

- Tab open, idle 45 min → logs out ✅
- **Close the tab, reopen later → not logged out** ❌ (the Supabase session persists in cookies + auto-refreshes; closing a tab doesn't log out, and the tracker just reset its clock)

Surfaced while testing Google SSO, but it's **not OAuth-specific** — the tracker treats all authenticated sessions identically.

## Fix (Option B)

On (re)mount, before arming anything, check the stored `lastActivity`: if `now - lastActivity >= timeout`, the user was idle past the limit while away → **log out immediately** (`/login?timeout=true`) instead of starting a fresh window. Fresh logins (no stored value, or recent activity) are unaffected, and the open-tab idle behavior is unchanged.

This makes the 45-min idle window hold across tab/browser close — the right posture for shared/school devices.

## Tests
`use-activity-tracker.test.ts`: + closed-tab-idle → logout, within-window → no logout, no-stored → no logout. 11/11 pass · typecheck ✅ · lint ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaiZnH1dFnLTBqWuNLsPFK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaiZnH1dFnLTBqWuNLsPFK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity tracking so users idle beyond the timeout are signed out immediately on return.
  * Prevented unnecessary timeout triggers when recent activity exists or when no stored activity is present.
  * Cleared stored idle-tracking data on login form mount to avoid incorrect cross-close sign-outs.
  * Updated timeout behavior to stay in sync when the timeout handler changes.
* **Tests**
  * Added unit coverage for mount behavior with expired, recent, and missing stored activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->