### PR TITLE
docs: chat module design (SPE-195)

### DIFF
--- a/docs/CHAT_MODULE_DESIGN.md
+++ b/docs/CHAT_MODULE_DESIGN.md
@@ -128,6 +128,10 @@ flowchart TD
 - **Site admin** — anyone with a `site_admin` grant in `admin_permissions`
   scoped to the student's `school_id`. Always included.
 
+**District admins are *not* chat participants** (decided 2026-06-26). Only
+**site** admins are auto-added. District admins retain their oversight access to
+the underlying data via existing RLS, but are not added to student chats.
+
 ### The account caveat (must be surfaced in UI, not hidden)
 A teacher (`teachers.account_id`) or SEA can be **linked to a student but have no
 login**. Someone with no account literally cannot be a chat participant. So
@@ -136,9 +140,6 @@ login**. Someone with no account literally cannot be a chat participant. So
 members have accounts") rather than implying full coverage.
 
 ### Decisions deferred to §10
-- Whether **district admins** are auto-participants (could be many; leaning *no*
-  by default — they retain oversight access, but aren't auto-added to every
-  student chat in their district).
 - **Secondary / many-teachers (SPE-194):** today `students.teacher_id` is a
   single FK, so on secondary sites the "linked teachers" set is structurally
   incomplete. The roster will inherit that gap until rostering lands; the
@@ -314,22 +315,23 @@ student's team, and orthogonal to their lesson view-only restriction.
 
 ## 10. Open questions (need a decision before / during build)
 
-1. **District admins in student group chats** — auto-participants or not?
-   (Leaning: **no** auto-add; oversight access can be separate.)
-2. **Audit granularity** — log sends + opens only, or also edits/deletes? What's
+1. **Audit granularity** — log sends + opens only, or also edits/deletes? What's
    the retention of the audit rows themselves?
-3. **Message retention** — keep student-group history forever, or age it out
+2. **Message retention** — keep student-group history forever, or age it out
    (e.g. with the student record / at year transition)?
-4. **Moderation** — can a sender edit/delete their own message? Can a site admin
+3. **Moderation** — can a sender edit/delete their own message? Can a site admin
    remove a message? (`messages.edited_at` / `deleted_at` are provisioned for
    this but the policy is undecided.)
-5. **Empty/again-eligible chats** — if a student temporarily has only one linked
+4. **Empty/again-eligible chats** — if a student temporarily has only one linked
    account, the chat exists but is a monologue. Acceptable? (Probably yes.)
-6. **Notifications** — the Hub flags a "digest model that respects teacher time."
+5. **Notifications** — the Hub flags a "digest model that respects teacher time."
    What's the v-next trigger (in-app only at first; email digest later)?
-7. **DM eligibility precision** — "share a site" via `provider_schools` ∪
+6. **DM eligibility precision** — "share a site" via `provider_schools` ∪
    `profiles.school_id`? Confirm the exact set, and whether cross-site for
    itinerant providers counts.
+
+**Resolved:** *District admins are not chat participants* — only site admins are
+auto-added (decided 2026-06-26; see §4).
 
 ---
 

--- a/docs/CHAT_MODULE_DESIGN.md
+++ b/docs/CHAT_MODULE_DESIGN.md
@@ -111,7 +111,7 @@ real account.
 flowchart TD
     S["students row"] --> P1["students.provider_id<br/>(case manager / resource specialist)"]
     S --> P2["students.teacher_id → teachers.account_id<br/>(linked classroom teacher)"]
-    S --> P3["schedule_sessions where student_id = S<br/>provider_id, assigned_to_specialist_id, assigned_to_sea_id"]
+    S --> P3["schedule_sessions ACTIVE TEMPLATES for student S<br/>(is_template=true / session_date IS NULL, deleted_at IS NULL)<br/>provider_id, assigned_to_specialist_id, assigned_to_sea_id"]
     S --> P4["admin_permissions where role='site_admin'<br/>AND school_id = students.school_id<br/>(site admin — always)"]
     P1 --> U["DISTINCT profiles.id<br/>WITH an account = roster"]
     P2 --> U
@@ -122,9 +122,19 @@ flowchart TD
 - **Case manager / resource specialist** — `students.provider_id`. Almost always
   present.
 - **Linked classroom teacher** — `students.teacher_id → teachers.account_id`.
-- **Assigned providers / specialists / SEAs** — distinct ids from non-deleted
-  `schedule_sessions` for the student (`provider_id`,
-  `assigned_to_specialist_id`, `assigned_to_sea_id`).
+- **Assigned providers / specialists / SEAs** — distinct ids from the student's
+  **active *template*** `schedule_sessions` (`provider_id`,
+  `assigned_to_specialist_id`, `assigned_to_sea_id`), where
+  **`is_template = true` (equivalently `session_date IS NULL`) and
+  `deleted_at IS NULL`**. **Not** all non-deleted session rows.
+  > **Why templates only:** `schedule_sessions` retains dated *instance* rows as
+  > history (completed/past occurrences are not always soft-deleted), and the
+  > scheduler models a *current* assignment as the template row, not its
+  > instances (`session_date IS NULL` — see `lib/services/session-update-service.ts:493`,
+  > `lib/scheduling/optimized-scheduler.ts:734`, `lib/scheduling/session-requirement-sync.ts:149`).
+  > Unioning all non-deleted rows would keep a **former** assignee in the roster
+  > via their leftover historical instances, contradicting §3 (lost linkage →
+  > lost access). Narrowing to active templates makes "currently assigned" exact.
 - **Site admin** — anyone with a `site_admin` grant in `admin_permissions`
   scoped to the student's `school_id`. Always included.
 

--- a/docs/CHAT_MODULE_DESIGN.md
+++ b/docs/CHAT_MODULE_DESIGN.md
@@ -1,0 +1,365 @@
+# Speddy — Chat Module Design
+
+> **Status:** Design draft (2026-06-26). Not yet built. This is the design of
+> record for the in-app messaging module; it realizes and generalizes the
+> **Communications Hub** Linear project
+> (<https://linear.app/speddy/project/communications-hub-c70cbc2328e1>).
+>
+> **Companion docs:** `docs/ARCHITECTURE.md` (domain model — roles, scoping,
+> RLS, the student↔team links this module derives from).
+>
+> **Author:** Blair Stewart (product) + Claude Code (design). Decisions in §3 are
+> locked per the 2026-06-26 design conversation; items in §10 are still open.
+
+---
+
+## 1. Summary
+
+A chat module, available in the **site-admin, teacher, and provider** portals,
+that gives people who already share context two ways to talk:
+
+1. **Direct messages (DMs)** — 1:1 conversations between any two people who share
+   a **site**.
+2. **Student group chats** — one chat per **student**, whose participants are
+   **automatically derived** from everyone currently linked to that student
+   (site admin, case manager / resource specialist, assigned providers/SEAs, and
+   the linked teacher). The student is the spine; the roster is a live projection
+   of the existing assignment data and is **not hand-editable**.
+
+This is **greenfield** — there is no existing messaging, chat, notification, or
+Supabase Realtime code in the repo today (verified 2026-06-26). Every primitive
+below is new.
+
+### How this relates to the Communications Hub project
+The Communications Hub project framed a **case-manager ↔ gen-ed-teacher**,
+per-student, logged channel as the long-term secondary north star, sequenced
+*after* SSO and the Middle/High module. This module **pulls that forward and
+generalizes it**: it's elementary-first too, includes the full student team (not
+just CM↔teacher), and adds same-site DMs. The Hub's principles still hold and are
+adopted here: anchored to a student, not a compliance/enforcement tool, case
+manager owns the truth (chat does not edit accommodations).
+
+**Sequencing:** this module may be built **before or in parallel with SSO**
+(decided 2026-06-26) — it is not gated on the SSO project. Login friction for
+teachers without accounts is handled by the account caveat (§4), not by blocking
+the build.
+
+---
+
+## 2. Conversation types
+
+| | **Direct (DM)** | **Student group** |
+|---|---|---|
+| Cardinality | Exactly 2 people | N people (derived) |
+| Who's eligible | Two people who **share a site** | Everyone currently **linked to the student** who has an account |
+| Membership source | **Explicit** (stored) | **Derived** (computed live, not stored) |
+| Editable roster | n/a (always the 2) | **No** — not hand-editable |
+| Anchored to | nothing | a `students` row (one chat per student) |
+| Created | on first message between the pair | lazily, on first open/message for the student |
+
+DMs are **1:1 only** in v1. Ad-hoc multi-person DMs are explicitly out of scope
+(see §11).
+
+---
+
+## 3. Locked decisions (the load-bearing ones)
+
+These were decided in the 2026-06-26 design conversation and drive the schema.
+
+1. **Roster is a live projection, not a snapshot.** Student-group membership is
+   recomputed from current assignments on every access. Reassign a provider and
+   they drop off; assign a new one and they appear — with no background job and no
+   stored roster to drift.
+
+2. **Messages belong to the student and are never deleted on membership change.**
+   History is permanent regardless of who comes or goes. A message from a case
+   manager who later gets reassigned **stays** in the chat.
+
+3. **Access follows current linkage — for the *whole* conversation, history
+   included.**
+   - **Lose your link** to the student → you lose access to the entire chat,
+     including everything you previously wrote and read. (Your messages remain
+     visible to those still linked; you just can't see the chat anymore.)
+   - **Gain a link** to the student → you immediately get access to the **full
+     back-history** of that student's chat, including messages sent before you
+     arrived. This is intentional: you're now on the student's team.
+
+4. **DMs are 1:1, between people who share a site.**
+
+5. **Realtime is in v1, polish is not.** Core live message streaming (Supabase
+   Realtime) ships in v1 because realtime is the end goal and it's *additive* on
+   top of the same schema/RLS. Deferred: typing indicators, presence/online
+   dots, read receipts, push/email notifications.
+
+> **Why "derive, don't materialize" is the right call.** Decisions 1–3 together
+> mean access is a pure function of *current linkage*, and history is immutable.
+> That is exactly what a derived-membership model gives you for free: there is no
+> participant table to keep in sync with assignment changes (which would require
+> fragile triggers on `students` and `schedule_sessions`), and there is no
+> per-message access bookkeeping. One function answers "can this user see this
+> conversation right now?" and it's always correct.
+
+---
+
+## 4. Who is "linked to a student"
+
+The student-group roster is the union of four existing link sources (see
+`docs/ARCHITECTURE.md` §3, §6). Each must resolve to a `profiles.id` that has a
+real account.
+
+```mermaid
+flowchart TD
+    S["students row"] --> P1["students.provider_id<br/>(case manager / resource specialist)"]
+    S --> P2["students.teacher_id → teachers.account_id<br/>(linked classroom teacher)"]
+    S --> P3["schedule_sessions where student_id = S<br/>provider_id, assigned_to_specialist_id, assigned_to_sea_id"]
+    S --> P4["admin_permissions where role='site_admin'<br/>AND school_id = students.school_id<br/>(site admin — always)"]
+    P1 --> U["DISTINCT profiles.id<br/>WITH an account = roster"]
+    P2 --> U
+    P3 --> U
+    P4 --> U
+```
+
+- **Case manager / resource specialist** — `students.provider_id`. Almost always
+  present.
+- **Linked classroom teacher** — `students.teacher_id → teachers.account_id`.
+- **Assigned providers / specialists / SEAs** — distinct ids from non-deleted
+  `schedule_sessions` for the student (`provider_id`,
+  `assigned_to_specialist_id`, `assigned_to_sea_id`).
+- **Site admin** — anyone with a `site_admin` grant in `admin_permissions`
+  scoped to the student's `school_id`. Always included.
+
+### The account caveat (must be surfaced in UI, not hidden)
+A teacher (`teachers.account_id`) or SEA can be **linked to a student but have no
+login**. Someone with no account literally cannot be a chat participant. So
+"everyone linked is automatically included" carries an asterisk: *everyone linked
+**who has an account***. The UI should state this honestly (e.g. "4 of 6 team
+members have accounts") rather than implying full coverage.
+
+### Decisions deferred to §10
+- Whether **district admins** are auto-participants (could be many; leaning *no*
+  by default — they retain oversight access, but aren't auto-added to every
+  student chat in their district).
+- **Secondary / many-teachers (SPE-194):** today `students.teacher_id` is a
+  single FK, so on secondary sites the "linked teachers" set is structurally
+  incomplete. The roster will inherit that gap until rostering lands; the
+  function should be written so it picks up multiple teachers automatically once
+  the data model supports it.
+
+---
+
+## 5. Data model
+
+Three new tables. No participant table for student groups (membership is
+derived); DMs store their two participants.
+
+```mermaid
+erDiagram
+    CONVERSATIONS ||--o{ MESSAGES : "has"
+    CONVERSATIONS ||--o{ CONVERSATION_PARTICIPANTS : "DM only: 2 rows"
+    CONVERSATIONS ||--o{ CONVERSATION_READ_STATE : "per opener"
+    STUDENTS ||--o| CONVERSATIONS : "student_group: 1 per student"
+    PROFILES ||--o{ MESSAGES : "sender"
+
+    CONVERSATIONS {
+        uuid id PK
+        text type "direct | student_group"
+        uuid student_id FK "null for direct; UNIQUE for student_group"
+        varchar school_id "scope"
+        uuid created_by FK
+        timestamptz created_at
+    }
+    MESSAGES {
+        uuid id PK
+        uuid conversation_id FK
+        uuid sender_id FK
+        text body
+        timestamptz created_at
+        timestamptz edited_at
+        timestamptz deleted_at "soft delete of a single message"
+    }
+    CONVERSATION_PARTICIPANTS {
+        uuid conversation_id FK
+        uuid profile_id FK
+        timestamptz added_at
+    }
+    CONVERSATION_READ_STATE {
+        uuid conversation_id FK
+        uuid profile_id FK
+        timestamptz last_read_at
+    }
+```
+
+- **`conversations`** — `type` is `direct | student_group`. For `student_group`,
+  `student_id` is set and **unique** (one chat per student); created lazily on
+  first open/message. For `direct`, `student_id` is null. `school_id` carries
+  scope for RLS and cleanup. A DM pair should be deduped (a unique index on the
+  normalized participant pair, or a deterministic lookup before insert) so two
+  people can't accidentally start two DM threads.
+- **`messages`** — append-only in spirit. `deleted_at` allows soft-deleting a
+  *single* message (author/admin moderation) without breaking history; it does
+  **not** model the membership-driven access in §3 (that's RLS).
+- **`conversation_participants`** — **DM only.** Exactly two rows per direct
+  conversation. Student groups have **no** rows here; their membership is the
+  function in §6.
+- **`conversation_read_state`** — one row per (conversation, person who has
+  opened it), holding `last_read_at`. Drives unread badges/counts. Written when a
+  user opens a conversation. Works identically for both types.
+
+---
+
+## 6. Access control (RLS)
+
+RLS is the real authorization layer (`docs/ARCHITECTURE.md` §2). Two helper
+functions, both `SECURITY DEFINER`:
+
+1. **`chat_is_student_participant(student_id uuid, uid uuid) returns boolean`** —
+   true iff `uid` is in the union of the four sources in §4 for that student,
+   *right now*. This is the live-membership check.
+2. **`get_student_chat_participants(student_id uuid) returns setof uuid`** — the
+   same union, returned as a set, for **display** ("who's in this chat") and for
+   the account-coverage note.
+
+A single boolean gate per conversation drives all message RLS:
+
+```text
+can_access(conversation c, uid) :=
+    c.type = 'direct'
+      ? EXISTS (conversation_participants where conversation_id = c.id and profile_id = uid)
+  : c.type = 'student_group'
+      ? chat_is_student_participant(c.student_id, uid)
+  : false
+```
+
+Policy sketch (illustrative, not final SQL):
+
+- **`conversations` SELECT** — `can_access(row, auth.uid())`.
+- **`messages` SELECT / INSERT** — the message's conversation passes
+  `can_access(...)` for `auth.uid()`; INSERT additionally requires
+  `sender_id = auth.uid()`.
+- **`conversation_participants`** — visible to the two members; inserted only via
+  the DM-creation path (server-side), constrained to same-site eligibility.
+- **`conversation_read_state`** — a user may read/write **only their own** row.
+
+> **Performance.** `chat_is_student_participant` runs inside RLS, so it must be
+> cheap: indexed lookups on `students.provider_id`, `students.teacher_id`,
+> `schedule_sessions(student_id)`, and `admin_permissions(school_id, role)`, and
+> marked `STABLE`. If per-row RLS evaluation becomes hot (e.g. listing many
+> messages), the message-list query should gate **once at the conversation
+> level** in the API layer and rely on the conversation-scoped `WHERE` rather
+> than re-evaluating membership per message row.
+
+> **Why a reassigned person loses history access "for free":** they simply stop
+> satisfying `chat_is_student_participant`, so `can_access` returns false for the
+> whole conversation on their next request. Nothing is deleted; visibility is
+> recomputed. Symmetrically, a newly-assigned person starts satisfying it and
+> sees the full history. This is decision §3.3 implemented as one predicate.
+
+---
+
+## 7. Realtime
+
+- **In v1:** Supabase Realtime on `messages` (Postgres changes), so new messages
+  stream into an open conversation without a refresh. Realtime respects RLS, so
+  the same `can_access` gate governs what a subscriber receives — no separate
+  authorization path. Work involved: enable replication on `messages`, a client
+  subscription hook scoped to the open `conversation_id`, and
+  reconnection/backfill handling (on reconnect, fetch messages since the last
+  seen `created_at`).
+- **Deferred (post-v1 polish):** typing indicators, presence/online status, read
+  receipts, and out-of-app notifications (push/email/digest). None block a
+  usable chat.
+
+---
+
+## 8. FERPA, retention, and audit
+
+These messages are **student-linked PII**. This module is a natural first
+consumer of real audit logging.
+
+- **Audit (SPE-169).** Audit logging is currently scaffolded but unwired
+  (`audit_logs` table empty, `logAccess()` never called). A named-student chat is
+  a strong candidate to be the **first** surface that actually writes audit rows
+  — at minimum log message sends and conversation opens (who/when/which
+  student). Decision in §10 on exact granularity. Per the Hub principle, audit
+  must **not** turn into a teacher "scorecard."
+- **Retention / deletion.** Student deletion (`app/api/admin/students/[studentId]`,
+  `docs/ARCHITECTURE.md` §7) must account for the student's chat: cascade-delete
+  the `student_group` conversation and its messages (and Realtime publication
+  stays consistent). DMs are not student-anchored and are unaffected by student
+  deletion. A retention window (keep forever vs. N months) is an open question
+  (§10).
+- **Scope containment.** A `direct` conversation is constrained to two people who
+  share a site at creation time; a `student_group` is school-scoped via
+  `students.school_id`. RLS never lets a message escape these scopes.
+
+---
+
+## 9. Surfaces (where it lives)
+
+Available in the **site-admin, teacher, and provider** portals (not the public
+site, not `/internal`). Likely shape:
+
+- A **chat entry point** in the navbar (with an unread badge) opening a
+  conversation list: student group chats the user is in + their DMs.
+- A **per-student chat** reachable from the student's detail view, so the chat
+  sits next to the student context it's about (matches the Hub's "messages live
+  in context, not a generic inbox").
+- **Middleware** route guard for the chat routes; RLS is the real gate.
+
+SEAs deliver sessions, so they appear in the group chats for students they serve
+(via `schedule_sessions.assigned_to_sea_id`) — consistent with their being on the
+student's team, and orthogonal to their lesson view-only restriction.
+
+---
+
+## 10. Open questions (need a decision before / during build)
+
+1. **District admins in student group chats** — auto-participants or not?
+   (Leaning: **no** auto-add; oversight access can be separate.)
+2. **Audit granularity** — log sends + opens only, or also edits/deletes? What's
+   the retention of the audit rows themselves?
+3. **Message retention** — keep student-group history forever, or age it out
+   (e.g. with the student record / at year transition)?
+4. **Moderation** — can a sender edit/delete their own message? Can a site admin
+   remove a message? (`messages.edited_at` / `deleted_at` are provisioned for
+   this but the policy is undecided.)
+5. **Empty/again-eligible chats** — if a student temporarily has only one linked
+   account, the chat exists but is a monologue. Acceptable? (Probably yes.)
+6. **Notifications** — the Hub flags a "digest model that respects teacher time."
+   What's the v-next trigger (in-app only at first; email digest later)?
+7. **DM eligibility precision** — "share a site" via `provider_schools` ∪
+   `profiles.school_id`? Confirm the exact set, and whether cross-site for
+   itinerant providers counts.
+
+---
+
+## 11. Out of scope (for now)
+
+- Ad-hoc / hand-picked group DMs (only 1:1 DMs and derived student groups).
+- Editable student-group rosters (membership is always derived).
+- Family-facing channel — a later Hub phase, gated on DPA/FERPA work (SPE-59).
+- File/image attachments in messages.
+- Typing indicators, presence, read receipts, push notifications (post-v1 polish).
+- Cross-student or cohort chats.
+
+---
+
+## 12. Rough phasing
+
+| Phase | Scope |
+|---|---|
+| **0 — Foundation** | Schema (`conversations`, `messages`, `conversation_participants`, `conversation_read_state`), RLS, `chat_is_student_participant` + `get_student_chat_participants`. No UI. |
+| **1 — Student group chats** | Derived group chat read/send, Realtime streaming, unread badges, participant + account-coverage display, surfaces in the 3 portals. |
+| **2 — Direct messages** | 1:1 DMs with same-site eligibility, DM dedupe, conversation list. |
+| **3 — Trust & polish** | Audit-log wiring (SPE-169), retention/cascade on student delete, moderation policy, then presence/typing/receipts/notifications as appetite allows. |
+
+---
+
+## Source of truth (when this is built, keep in sync)
+
+- Schema: the new `conversations` / `messages` / `conversation_participants` /
+  `conversation_read_state` migrations.
+- Membership: `chat_is_student_participant`, `get_student_chat_participants`.
+- Linkage inputs: `students` (`provider_id`, `teacher_id`), `teachers.account_id`,
+  `schedule_sessions` (`provider_id`, `assigned_to_specialist_id`,
+  `assigned_to_sea_id`), `admin_permissions` — see `docs/ARCHITECTURE.md` §3, §6.

--- a/docs/CHAT_MODULE_DESIGN.md
+++ b/docs/CHAT_MODULE_DESIGN.md
@@ -203,9 +203,10 @@ erDiagram
 - **`conversations`** — `type` is `direct | student_group`. For `student_group`,
   `student_id` is set and **unique** (one chat per student); created lazily on
   first open/message. For `direct`, `student_id` is null. `school_id` carries
-  scope for RLS and cleanup. A DM pair should be deduped (a unique index on the
-  normalized participant pair, or a deterministic lookup before insert) so two
-  people can't accidentally start two DM threads.
+  scope for RLS and cleanup. A DM pair **must** be deduped by a **unique index on
+  the normalized participant pair** (the source of truth, race-safe under
+  concurrent creation); a deterministic pre-insert lookup is only an optimization
+  to avoid a failed insert, not the dedupe guarantee.
 - **`messages`** — append-only in spirit. `deleted_at` allows soft-deleting a
   *single* message (author/admin moderation) without breaking history; it does
   **not** model the membership-driven access in §3 (that's RLS).
@@ -274,8 +275,9 @@ Policy sketch (illustrative, not final SQL):
   the same `can_access` gate governs what a subscriber receives — no separate
   authorization path. Work involved: enable replication on `messages`, a client
   subscription hook scoped to the open `conversation_id`, and
-  reconnection/backfill handling (on reconnect, fetch messages since the last
-  seen `created_at`).
+  reconnection/backfill handling (on reconnect, fetch missed messages using a
+  **stable monotonic cursor** — order and page by `(created_at, id)`, not
+  `created_at` alone, so colliding timestamps can't skip or duplicate a message).
 - **Deferred (post-v1 polish):** typing indicators, presence/online status, read
   receipts, and out-of-app notifications (push/email/digest). None block a
   usable chat.
@@ -295,8 +297,10 @@ consumer of real audit logging.
   must **not** turn into a teacher "scorecard."
 - **Retention / deletion.** Student deletion (`app/api/admin/students/[studentId]`,
   `docs/ARCHITECTURE.md` §7) must account for the student's chat: cascade-delete
-  the `student_group` conversation and its messages (and Realtime publication
-  stays consistent). DMs are not student-anchored and are unaffected by student
+  the `student_group` conversation, its messages, **and all derived
+  per-conversation state** (`conversation_read_state`, and any later
+  per-conversation rows) — `ON DELETE CASCADE` from `conversations` so nothing is
+  orphaned (and Realtime publication stays consistent). DMs are not student-anchored and are unaffected by student
   deletion. A retention window (keep forever vs. N months) is an open question
   (§10).
 - **Scope containment.** A `direct` conversation is constrained to two people who


### PR DESCRIPTION
## What

Adds `docs/CHAT_MODULE_DESIGN.md` — the design of record for the in-app **chat module**: student-anchored group chats + 1:1 same-site DMs, available in the site-admin, teacher, and provider portals.

This is a **docs-only** change (no code/schema). It realizes and generalizes the **Communications Hub** Linear project (pulls it forward, elementary-first, full student team + DMs).

## Design highlights

- **Two conversation types:** 1:1 DMs (same-site) and one **group chat per student** whose roster is **auto-derived** from everyone currently linked to the student (site admin, case manager/resource specialist, assigned providers/SEAs, linked teacher).
- **Locked decisions:**
  - Roster is a **live projection** — derive membership, never materialize it (no sync triggers).
  - Messages **belong to the student**; **never deleted** on membership change.
  - **Access follows current linkage for the whole conversation, history included** — lose your link → lose access; gain a link → get full back-history.
  - **Realtime core in v1** (Supabase Realtime, additive on the same schema/RLS); typing/presence/receipts/notifications deferred.
- **Greenfield:** no messaging/chat/notification/Realtime code exists today (verified 2026-06-26).
- **Caveats surfaced:** teachers/SEAs can be linked but have no login (account caveat); SPE-194 (one-teacher-per-student) limits secondary rosters; FERPA → first consumer of audit logging (SPE-169).
- May be built **before/parallel to SSO**.

## Linear

- Epic: **SPE-195** (under Communications Hub)
- Phases: **SPE-196** (foundation), **SPE-197** (student group chats), **SPE-198** (DMs), **SPE-199** (trust & polish)

## Reviewer asks

Open questions are listed in §10 of the doc — district admins as auto-participants, audit granularity/retention, message retention window, moderation, notification/digest model, and exact DM same-site eligibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZM6d3BG8FkDrfWjyR5oKq

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZM6d3BG8FkDrfWjyR5oKq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a design draft for an in-app chat experience, including one-to-one direct conversations and student-based group chats.
  * Documented core product behavior such as membership recalculation, message history handling across membership changes, access rules, realtime update approach, and retention/audit considerations.
  * Captured planned rollout details, open questions, and out-of-scope items for future implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->