### PR TITLE
feat(chat): student group chat UI with realtime (SPE-197, Phase 1)

### DIFF
--- a/app/(dashboard)/dashboard/chat/page.tsx
+++ b/app/(dashboard)/dashboard/chat/page.tsx
@@ -1,0 +1,12 @@
+import { Suspense } from 'react';
+import { StudentChatPage } from '@/app/components/chat/student-chat-page';
+
+export default function ChatPage() {
+  return (
+    <div className="px-4 py-6 sm:px-6 lg:px-8">
+      <Suspense fallback={<div className="text-sm text-gray-400">Loading chat…</div>}>
+        <StudentChatPage />
+      </Suspense>
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/teacher/my-students/[studentId]/page.tsx
+++ b/app/(dashboard)/dashboard/teacher/my-students/[studentId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { getStudentDetails, getStudentResourceSchedule } from '@/lib/supabase/queries/teacher-portal';
 import { Card } from '@/app/components/ui/card';
 import { useSchool } from '@/app/components/providers/school-context';
+import { TeamChatButton } from '@/app/components/chat/team-chat-button';
 import Link from 'next/link';
 
 type StudentDetail = {
@@ -184,7 +185,10 @@ export default function StudentDetailPage() {
 
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900">Student: {student.initials}</h1>
+        <div className="flex items-center justify-between gap-4">
+          <h1 className="text-3xl font-bold text-gray-900">Student: {student.initials}</h1>
+          <TeamChatButton studentId={studentId} />
+        </div>
         <div className="flex items-center gap-4 mt-2">
           <span className="inline-flex items-center px-3 py-0.5 rounded-full text-sm font-medium bg-blue-100 text-blue-800">
             {student.grade_level}

--- a/app/components/chat/chat-participants-header.tsx
+++ b/app/components/chat/chat-participants-header.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { formatRoleLabel } from '@/lib/utils/role-utils';
+import type { ChatParticipant } from '@/lib/supabase/queries/chat';
+
+interface ChatParticipantsHeaderProps {
+  studentInitials: string;
+  participants: ChatParticipant[];
+}
+
+export function ChatParticipantsHeader({
+  studentInitials,
+  participants,
+}: ChatParticipantsHeaderProps) {
+  return (
+    <div className="border-b border-gray-200 px-4 py-3">
+      <div className="text-sm font-semibold text-gray-900">Team chat · {studentInitials}</div>
+      <div className="text-xs text-gray-500">
+        {participants.length} {participants.length === 1 ? 'member' : 'members'} with a Speddy account
+      </div>
+
+      {participants.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {participants.map((p) => (
+            <span
+              key={p.id}
+              className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-700"
+            >
+              {p.fullName ?? 'Unknown'}
+              {p.role ? ` · ${formatRoleLabel(p.role)}` : ''}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <p className="mt-1 text-[11px] text-gray-400">
+        Only team members with a Speddy account appear here.
+      </p>
+    </div>
+  );
+}

--- a/app/components/chat/chat-thread.tsx
+++ b/app/components/chat/chat-thread.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
+import { Button } from '@/app/components/ui/button';
+import { useAuth } from '@/app/components/providers/auth-provider';
+import { useChatThread } from '@/lib/supabase/hooks/use-chat-thread';
+import {
+  getParticipants,
+  markConversationRead,
+  type ChatParticipant,
+} from '@/lib/supabase/queries/chat';
+import { MessageBubble } from './message-bubble';
+import { ChatParticipantsHeader } from './chat-participants-header';
+
+interface ChatThreadProps {
+  conversationId: string;
+  studentId: string;
+  studentInitials: string;
+}
+
+export function ChatThread({ conversationId, studentId, studentInitials }: ChatThreadProps) {
+  const { user } = useAuth();
+  const { messages, loading, error, sending, send } = useChatThread(conversationId);
+  const [participants, setParticipants] = useState<ChatParticipant[]>([]);
+  const [input, setInput] = useState('');
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  // Participants (for the header and sender-name resolution).
+  useEffect(() => {
+    let cancelled = false;
+    getParticipants(studentId)
+      .then((p) => {
+        if (!cancelled) setParticipants(p);
+      })
+      .catch(() => {
+        /* header simply shows fewer names; non-fatal */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [studentId]);
+
+  // Mark read on open and whenever new messages arrive while open.
+  useEffect(() => {
+    void markConversationRead(conversationId);
+  }, [conversationId, messages.length]);
+
+  // Keep the latest message in view.
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages.length]);
+
+  const nameById = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const p of participants) m.set(p.id, p.fullName ?? 'Unknown');
+    return m;
+  }, [participants]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const body = input;
+    if (!body.trim()) return;
+    setInput('');
+    try {
+      await send(body);
+    } catch {
+      setInput(body); // restore on failure so the user doesn't lose their text
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <ChatParticipantsHeader studentInitials={studentInitials} participants={participants} />
+
+      <div className="flex-1 space-y-2 overflow-y-auto px-4 py-3">
+        {loading ? (
+          <div className="text-sm text-gray-400">Loading messages…</div>
+        ) : error ? (
+          <div className="text-sm text-red-600">{error}</div>
+        ) : messages.length === 0 ? (
+          <div className="mt-8 text-center text-sm text-gray-400">
+            No messages yet. Say hello to the team.
+          </div>
+        ) : (
+          messages.map((m) => (
+            <MessageBubble
+              key={m.id}
+              message={m}
+              isMine={!!user && m.senderId === user.id}
+              senderName={
+                m.senderId ? nameById.get(m.senderId) ?? 'Former team member' : 'Former team member'
+              }
+            />
+          ))
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex gap-2 border-t border-gray-200 p-3">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Write a message…"
+          className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+        <Button type="submit" disabled={!input.trim() || sending} isLoading={sending}>
+          Send
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/app/components/chat/chat-thread.tsx
+++ b/app/components/chat/chat-thread.tsx
@@ -42,7 +42,9 @@ export function ChatThread({ conversationId, studentId, studentInitials }: ChatT
 
   // Mark read on open and whenever new messages arrive while open.
   useEffect(() => {
-    void markConversationRead(conversationId);
+    markConversationRead(conversationId).catch(() => {
+      /* non-fatal: the unread badge may be briefly stale */
+    });
   }, [conversationId, messages.length]);
 
   // Keep the latest message in view.
@@ -64,7 +66,9 @@ export function ChatThread({ conversationId, studentId, studentInitials }: ChatT
     try {
       await send(body);
     } catch {
-      setInput(body); // restore on failure so the user doesn't lose their text
+      // Restore the failed text only if the user hasn't started a new draft
+      // while the request was in flight.
+      setInput((current) => (current === '' ? body : current));
     }
   };
 
@@ -98,6 +102,7 @@ export function ChatThread({ conversationId, studentId, studentInitials }: ChatT
 
       <form onSubmit={handleSubmit} className="flex gap-2 border-t border-gray-200 p-3">
         <input
+          aria-label="Message"
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder="Write a message…"

--- a/app/components/chat/conversation-list.tsx
+++ b/app/components/chat/conversation-list.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import type { ChatConversationSummary } from '@/lib/supabase/queries/chat';
+
+function formatWhen(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  const now = new Date();
+  const sameDay = d.toDateString() === now.toDateString();
+  return sameDay
+    ? d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+    : d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+}
+
+interface ConversationListProps {
+  chats: ChatConversationSummary[];
+  selectedId: string | null;
+  onSelect: (chat: ChatConversationSummary) => void;
+  loading: boolean;
+  error: string | null;
+}
+
+export function ConversationList({
+  chats,
+  selectedId,
+  onSelect,
+  loading,
+  error,
+}: ConversationListProps) {
+  if (loading) {
+    return <div className="px-4 py-6 text-sm text-gray-400">Loading chats…</div>;
+  }
+  if (error) {
+    return <div className="px-4 py-6 text-sm text-red-600">{error}</div>;
+  }
+  if (chats.length === 0) {
+    return (
+      <div className="px-4 py-6 text-sm text-gray-400">
+        No student chats yet. Start one with “New chat”.
+      </div>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-gray-100">
+      {chats.map((chat) => {
+        const isSelected = chat.id === selectedId;
+        return (
+          <li key={chat.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(chat)}
+              className={`flex w-full items-start gap-3 px-4 py-3 text-left transition-colors ${
+                isSelected ? 'bg-blue-50' : 'hover:bg-gray-50'
+              }`}
+            >
+              <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 text-xs font-semibold text-blue-700">
+                {chat.studentInitials}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="truncate text-sm font-medium text-gray-900">
+                    {chat.studentInitials}
+                    {chat.studentGrade ? (
+                      <span className="ml-1 font-normal text-gray-400">· {chat.studentGrade}</span>
+                    ) : null}
+                  </span>
+                  <span className="flex-shrink-0 text-[11px] text-gray-400">
+                    {formatWhen(chat.lastMessageAt)}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between gap-2">
+                  <span className="truncate text-xs text-gray-500">
+                    {chat.lastMessagePreview ?? 'No messages yet'}
+                  </span>
+                  {chat.unread && (
+                    <span className="h-2 w-2 flex-shrink-0 rounded-full bg-blue-500" aria-label="unread" />
+                  )}
+                </div>
+              </div>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/app/components/chat/message-bubble.tsx
+++ b/app/components/chat/message-bubble.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import type { ChatMessage } from '@/lib/supabase/queries/chat';
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}
+
+interface MessageBubbleProps {
+  message: ChatMessage;
+  isMine: boolean;
+  senderName: string;
+}
+
+export function MessageBubble({ message, isMine, senderName }: MessageBubbleProps) {
+  return (
+    <div className={`flex ${isMine ? 'justify-end' : 'justify-start'}`}>
+      <div
+        className={`max-w-[75%] rounded-lg px-3 py-2 ${
+          isMine ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-900'
+        }`}
+      >
+        {!isMine && (
+          <div className="mb-0.5 text-xs font-semibold text-gray-600">{senderName}</div>
+        )}
+        <div className="whitespace-pre-wrap break-words text-sm">{message.body}</div>
+        <div className={`mt-1 text-[10px] ${isMine ? 'text-blue-100' : 'text-gray-400'}`}>
+          {formatTime(message.createdAt)}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/chat/new-chat-dialog.tsx
+++ b/app/components/chat/new-chat-dialog.tsx
@@ -13,19 +13,24 @@ interface NewChatDialogProps {
 export function NewChatDialog({ isOpen, onClose, onPick }: NewChatDialogProps) {
   const [students, setStudents] = useState<ChatStudentOption[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
 
   useEffect(() => {
     if (!isOpen) return;
     let cancelled = false;
     setLoading(true);
+    setError(null);
     setQuery('');
     listChatStudents()
       .then((s) => {
         if (!cancelled) setStudents(s);
       })
-      .catch(() => {
-        if (!cancelled) setStudents([]);
+      .catch((e) => {
+        if (!cancelled) {
+          setStudents([]);
+          setError(e instanceof Error ? e.message : 'Failed to load students');
+        }
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -58,6 +63,8 @@ export function NewChatDialog({ isOpen, onClose, onPick }: NewChatDialogProps) {
         <div className="max-h-72 overflow-y-auto rounded-md border border-gray-200">
           {loading ? (
             <div className="px-3 py-4 text-sm text-gray-400">Loading students…</div>
+          ) : error ? (
+            <div className="px-3 py-4 text-sm text-red-600">{error}</div>
           ) : filtered.length === 0 ? (
             <div className="px-3 py-4 text-sm text-gray-400">No students found.</div>
           ) : (

--- a/app/components/chat/new-chat-dialog.tsx
+++ b/app/components/chat/new-chat-dialog.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Modal } from '@/app/components/ui/modal';
+import { listChatStudents, type ChatStudentOption } from '@/lib/supabase/queries/chat';
+
+interface NewChatDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onPick: (studentId: string) => void;
+}
+
+export function NewChatDialog({ isOpen, onClose, onPick }: NewChatDialogProps) {
+  const [students, setStudents] = useState<ChatStudentOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    setLoading(true);
+    setQuery('');
+    listChatStudents()
+      .then((s) => {
+        if (!cancelled) setStudents(s);
+      })
+      .catch(() => {
+        if (!cancelled) setStudents([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return students;
+    return students.filter(
+      (s) =>
+        s.initials.toLowerCase().includes(q) ||
+        (s.gradeLevel ?? '').toLowerCase().includes(q),
+    );
+  }, [students, query]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Start a student chat">
+      <div className="space-y-3">
+        <input
+          autoFocus
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search students…"
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+        <div className="max-h-72 overflow-y-auto rounded-md border border-gray-200">
+          {loading ? (
+            <div className="px-3 py-4 text-sm text-gray-400">Loading students…</div>
+          ) : filtered.length === 0 ? (
+            <div className="px-3 py-4 text-sm text-gray-400">No students found.</div>
+          ) : (
+            <ul className="divide-y divide-gray-100">
+              {filtered.map((s) => (
+                <li key={s.id}>
+                  <button
+                    type="button"
+                    onClick={() => onPick(s.id)}
+                    className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-gray-50"
+                  >
+                    <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 text-xs font-semibold text-blue-700">
+                      {s.initials}
+                    </div>
+                    <span className="text-sm text-gray-900">
+                      {s.initials}
+                      {s.gradeLevel ? (
+                        <span className="ml-1 text-gray-400">· {s.gradeLevel}</span>
+                      ) : null}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <p className="text-[11px] text-gray-400">
+          You can start a chat for any student on your team. The roster fills in automatically.
+        </p>
+      </div>
+    </Modal>
+  );
+}

--- a/app/components/chat/new-chat-dialog.tsx
+++ b/app/components/chat/new-chat-dialog.tsx
@@ -2,15 +2,17 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { Modal } from '@/app/components/ui/modal';
-import { listChatStudents, type ChatStudentOption } from '@/lib/supabase/queries/chat';
+import { listMyChatStudents, type ChatStudentOption } from '@/lib/supabase/queries/chat';
 
 interface NewChatDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onPick: (studentId: string) => void;
+  /** Active school from the school dropdown; scopes the student list. */
+  schoolId?: string | null;
 }
 
-export function NewChatDialog({ isOpen, onClose, onPick }: NewChatDialogProps) {
+export function NewChatDialog({ isOpen, onClose, onPick, schoolId }: NewChatDialogProps) {
   const [students, setStudents] = useState<ChatStudentOption[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -22,7 +24,7 @@ export function NewChatDialog({ isOpen, onClose, onPick }: NewChatDialogProps) {
     setLoading(true);
     setError(null);
     setQuery('');
-    listChatStudents()
+    listMyChatStudents(schoolId)
       .then((s) => {
         if (!cancelled) setStudents(s);
       })
@@ -38,7 +40,7 @@ export function NewChatDialog({ isOpen, onClose, onPick }: NewChatDialogProps) {
     return () => {
       cancelled = true;
     };
-  }, [isOpen]);
+  }, [isOpen, schoolId]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();

--- a/app/components/chat/student-chat-page.tsx
+++ b/app/components/chat/student-chat-page.tsx
@@ -43,8 +43,12 @@ export function StudentChatPage() {
         setSelected({ conversationId, studentId, studentInitials });
         void refresh();
       } catch (e) {
+        // Log the raw error for diagnosis; show the real message when we have one.
+        console.error('openStudentConversation failed', e);
         setOpenError(
-          e instanceof Error ? e.message : 'Could not open this chat. You may not be on the team.',
+          e instanceof Error
+            ? e.message
+            : 'Could not open this chat. Please try again — if it keeps happening, refresh the page.',
         );
       }
     },

--- a/app/components/chat/student-chat-page.tsx
+++ b/app/components/chat/student-chat-page.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Button } from '@/app/components/ui/button';
+import { useStudentChats } from '@/lib/supabase/hooks/use-student-chats';
+import {
+  openStudentConversation,
+  type ChatConversationSummary,
+} from '@/lib/supabase/queries/chat';
+import { ConversationList } from './conversation-list';
+import { ChatThread } from './chat-thread';
+import { NewChatDialog } from './new-chat-dialog';
+
+interface SelectedChat {
+  conversationId: string;
+  studentId: string;
+  studentInitials: string;
+}
+
+export function StudentChatPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { chats, loading, error, refresh } = useStudentChats();
+  const [selected, setSelected] = useState<SelectedChat | null>(null);
+  const [showNew, setShowNew] = useState(false);
+  const [openError, setOpenError] = useState<string | null>(null);
+
+  const openStudent = useCallback(
+    async (studentId: string) => {
+      setOpenError(null);
+      try {
+        const { conversationId, studentInitials } = await openStudentConversation(studentId);
+        setSelected({ conversationId, studentId, studentInitials });
+        void refresh();
+      } catch (e) {
+        setOpenError(
+          e instanceof Error ? e.message : 'Could not open this chat. You may not be on the team.',
+        );
+      }
+    },
+    [refresh],
+  );
+
+  // Deep link: /dashboard/chat?student=<id> opens (or creates) that chat once.
+  const studentParam = searchParams.get('student');
+  useEffect(() => {
+    if (!studentParam) return;
+    void openStudent(studentParam);
+    // Clear the param so re-renders / back navigation don't re-trigger.
+    router.replace('/dashboard/chat');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [studentParam]);
+
+  const handleSelect = (chat: ChatConversationSummary) => {
+    setSelected({
+      conversationId: chat.id,
+      studentId: chat.studentId,
+      studentInitials: chat.studentInitials,
+    });
+  };
+
+  const handlePick = (studentId: string) => {
+    setShowNew(false);
+    void openStudent(studentId);
+  };
+
+  return (
+    <div className="mx-auto flex h-[calc(100vh-12rem)] max-w-6xl overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+      {/* Left: conversation list */}
+      <aside className="flex w-80 flex-shrink-0 flex-col border-r border-gray-200">
+        <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+          <h1 className="text-sm font-semibold text-gray-900">Chats</h1>
+          <Button size="sm" onClick={() => setShowNew(true)}>
+            New chat
+          </Button>
+        </div>
+        {openError && <div className="px-4 py-2 text-xs text-red-600">{openError}</div>}
+        <div className="flex-1 overflow-y-auto">
+          <ConversationList
+            chats={chats}
+            selectedId={selected?.conversationId ?? null}
+            onSelect={handleSelect}
+            loading={loading}
+            error={error}
+          />
+        </div>
+      </aside>
+
+      {/* Right: active thread */}
+      <section className="flex min-w-0 flex-1 flex-col">
+        {selected ? (
+          <ChatThread
+            key={selected.conversationId}
+            conversationId={selected.conversationId}
+            studentId={selected.studentId}
+            studentInitials={selected.studentInitials}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center px-6 text-center text-sm text-gray-400">
+            Select a chat on the left, or start a new one to message a student’s team.
+          </div>
+        )}
+      </section>
+
+      <NewChatDialog isOpen={showNew} onClose={() => setShowNew(false)} onPick={handlePick} />
+    </div>
+  );
+}

--- a/app/components/chat/student-chat-page.tsx
+++ b/app/components/chat/student-chat-page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Button } from '@/app/components/ui/button';
+import { useSchool } from '@/app/components/providers/school-context';
 import { useStudentChats } from '@/lib/supabase/hooks/use-student-chats';
 import {
   openStudentConversation,
@@ -21,10 +22,18 @@ interface SelectedChat {
 export function StudentChatPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { chats, loading, error, refresh } = useStudentChats();
+  const { currentSchool } = useSchool();
+  const schoolId = currentSchool?.school_id ?? null;
+  const { chats, loading, error, refresh } = useStudentChats(schoolId);
   const [selected, setSelected] = useState<SelectedChat | null>(null);
   const [showNew, setShowNew] = useState(false);
   const [openError, setOpenError] = useState<string | null>(null);
+
+  // When the active school changes, clear the open thread so the right pane
+  // doesn't show a chat from a school the user is no longer viewing.
+  useEffect(() => {
+    setSelected(null);
+  }, [schoolId]);
 
   const openStudent = useCallback(
     async (studentId: string) => {
@@ -103,7 +112,12 @@ export function StudentChatPage() {
         )}
       </section>
 
-      <NewChatDialog isOpen={showNew} onClose={() => setShowNew(false)} onPick={handlePick} />
+      <NewChatDialog
+        isOpen={showNew}
+        onClose={() => setShowNew(false)}
+        onPick={handlePick}
+        schoolId={schoolId}
+      />
     </div>
   );
 }

--- a/app/components/chat/team-chat-button.tsx
+++ b/app/components/chat/team-chat-button.tsx
@@ -61,7 +61,7 @@ export function TeamChatButton({
       leftIcon={ChatIcon}
       onClick={() => {
         onNavigate?.();
-        router.push(`/dashboard/chat?student=${studentId}`);
+        router.push(`/dashboard/chat?student=${encodeURIComponent(studentId)}`);
       }}
     >
       Team chat

--- a/app/components/chat/team-chat-button.tsx
+++ b/app/components/chat/team-chat-button.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/app/components/ui/button';
+import { isStudentChatParticipant } from '@/lib/supabase/queries/chat';
+
+interface TeamChatButtonProps {
+  studentId: string;
+  /** Called just before navigating (e.g. to close an open modal). */
+  onNavigate?: () => void;
+  size?: 'sm' | 'md' | 'lg';
+  variant?: 'primary' | 'secondary' | 'ghost' | 'outline';
+}
+
+const ChatIcon = (
+  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.86 9.86 0 01-4-.8L3 20l1.3-3.9A7.96 7.96 0 013 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+    />
+  </svg>
+);
+
+/**
+ * Contextual entry point into a student's team chat. Renders only for users who
+ * are actually on that student's chat team (so SEAs and unrelated staff never
+ * see it). Deep-links to the dedicated chat page, which opens/creates the chat.
+ */
+export function TeamChatButton({
+  studentId,
+  onNavigate,
+  size = 'sm',
+  variant = 'secondary',
+}: TeamChatButtonProps) {
+  const router = useRouter();
+  const [eligible, setEligible] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    isStudentChatParticipant(studentId)
+      .then((v) => {
+        if (!cancelled) setEligible(v);
+      })
+      .catch(() => {
+        /* hide on failure */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [studentId]);
+
+  if (!eligible) return null;
+
+  return (
+    <Button
+      size={size}
+      variant={variant}
+      leftIcon={ChatIcon}
+      onClick={() => {
+        onNavigate?.();
+        router.push(`/dashboard/chat?student=${studentId}`);
+      }}
+    >
+      Team chat
+    </Button>
+  );
+}

--- a/app/components/navigation/navbar.tsx
+++ b/app/components/navigation/navbar.tsx
@@ -121,6 +121,7 @@ export default function Navbar() {
         { name: 'Providers', href: '/dashboard/admin/providers' },
         { name: 'Staff', href: '/dashboard/admin/staff' },
         { name: 'Students', href: '/dashboard/admin/students' },
+        { name: 'Chat', href: '/dashboard/chat' },
         { name: 'CARE', href: '/dashboard/care' },
       ];
     } else if (role === 'teacher') {
@@ -128,6 +129,7 @@ export default function Navbar() {
       return [
         { name: 'Dashboard', href: '/dashboard/teacher' },
         { name: 'My Students', href: '/dashboard/teacher/my-students' },
+        { name: 'Chat', href: '/dashboard/chat' },
         { name: 'Special Activities', href: '/dashboard/teacher/special-activities' },
       ];
     } else if (role === 'sea') {
@@ -153,6 +155,7 @@ export default function Navbar() {
           ]
         },
         { name: 'Plan', href: '/dashboard/plan' },
+        { name: 'Chat', href: '/dashboard/chat' },
         { name: 'CARE', href: '/dashboard/care' },
       ];
     } else if (role === 'speech' || role === 'ot' || role === 'counseling' || role === 'psychologist') {
@@ -170,6 +173,7 @@ export default function Navbar() {
           ]
         },
         { name: 'Plan', href: '/dashboard/plan' },
+        { name: 'Chat', href: '/dashboard/chat' },
       ];
     } else {
       // Other roles (specialist) see standard navigation
@@ -186,6 +190,7 @@ export default function Navbar() {
           ]
         },
         { name: 'Plan', href: '/dashboard/plan' },
+        { name: 'Chat', href: '/dashboard/chat' },
       ];
     }
   };

--- a/app/components/navigation/navbar.tsx
+++ b/app/components/navigation/navbar.tsx
@@ -104,6 +104,12 @@ export default function Navbar() {
       { name: 'Dashboard', href: '/dashboard' }
     ];
 
+    // While the role is still loading (empty string), show only the base nav so
+    // role-specific items (e.g. Chat) don't flash for roles that exclude them.
+    if (!role) {
+      return baseNavigation;
+    }
+
     if (role === 'district_admin') {
       // District admins see schools overview, dashboard, and CARE
       return [

--- a/app/components/students/student-details-modal.tsx
+++ b/app/components/students/student-details-modal.tsx
@@ -13,6 +13,7 @@ import { StudentAttendanceTab } from './student-attendance-tab';
 import { SharedStudentBadge } from './shared-student-badge';
 import { getIepDateWarning } from '@/lib/utils/iep-date-utils';
 import { useSchool } from '../providers/school-context';
+import { TeamChatButton } from '../chat/team-chat-button';
 
 interface StudentDetailsModalProps {
   isOpen: boolean;
@@ -218,6 +219,7 @@ export function StudentDetailsModal({
                 Student Details: {student.initials}
               </h2>
               <SharedStudentBadge roles={matchingRoles} />
+              <TeamChatButton studentId={student.id} onNavigate={onClose} />
             </div>
             <button
               onClick={onClose}

--- a/docs/CHAT_MODULE_DESIGN.md
+++ b/docs/CHAT_MODULE_DESIGN.md
@@ -111,7 +111,7 @@ real account.
 flowchart TD
     S["students row"] --> P1["students.provider_id<br/>(case manager / resource specialist)"]
     S --> P2["students.teacher_id → teachers.account_id<br/>(linked classroom teacher)"]
-    S --> P3["schedule_sessions ACTIVE TEMPLATES for student S<br/>(is_template=true / session_date IS NULL, deleted_at IS NULL)<br/>provider_id, assigned_to_specialist_id<br/>(NOT assigned_to_sea_id — SEAs excluded)"]
+    S --> P3["schedule_sessions ACTIVE TEMPLATES for student S<br/>(is_template=true / session_date IS NULL, deleted_at IS NULL)<br/>provider_id ONLY<br/>(NOT assigned_to_specialist_id — lesson-planning delegation;<br/>NOT assigned_to_sea_id — SEAs excluded)"]
     S --> P4["admin_permissions where role='site_admin'<br/>AND school_id = students.school_id<br/>(site admin — always)"]
     P1 --> U["DISTINCT profiles.id<br/>WITH an account = roster"]
     P2 --> U
@@ -122,12 +122,16 @@ flowchart TD
 - **Case manager / resource specialist** — `students.provider_id`. Almost always
   present.
 - **Linked classroom teacher** — `students.teacher_id → teachers.account_id`.
-- **Assigned providers / specialists** — distinct ids from the student's
-  **active *template*** `schedule_sessions` (`provider_id`,
-  `assigned_to_specialist_id`; **`assigned_to_sea_id` is deliberately omitted —
-  SEAs are excluded, see below**), where
+- **Providers who deliver the student's sessions** — distinct `provider_id`s from
+  the student's **active *template*** `schedule_sessions`, where
   **`is_template = true` (equivalently `session_date IS NULL`) and
-  `deleted_at IS NULL`**. **Not** all non-deleted session rows.
+  `deleted_at IS NULL`**. This is how a speech/OT/counseling provider (who is
+  never the `students.provider_id` case manager) links to a student they serve.
+  **`assigned_to_specialist_id` is deliberately omitted** — a specialist assigned
+  to a session purely for **lesson planning** on a student owned by another case
+  manager is *not* on that student's chat team (decided 2026-06-26).
+  **`assigned_to_sea_id` is also omitted** — SEAs are excluded (see below).
+  **Not** all non-deleted session rows.
   > **Why templates only:** `schedule_sessions` retains dated *instance* rows as
   > history (completed/past occurrences are not always soft-deleted), and the
   > scheduler models a *current* assignment as the template row, not its
@@ -406,5 +410,6 @@ no student group chats, and no DMs, even for students they serve via
 - Membership / eligibility: `chat_is_student_participant`,
   `get_student_chat_participants`, `is_chat_eligible` (role exclusion, e.g. `sea`).
 - Linkage inputs: `students` (`provider_id`, `teacher_id`), `teachers.account_id`,
-  `schedule_sessions` (`provider_id`, `assigned_to_specialist_id` — **not**
-  `assigned_to_sea_id`), `admin_permissions` — see `docs/ARCHITECTURE.md` §3, §6.
+  `schedule_sessions` (`provider_id` only — **not** `assigned_to_specialist_id`,
+  which is lesson-planning delegation, and **not** `assigned_to_sea_id`),
+  `admin_permissions` — see `docs/ARCHITECTURE.md` §3, §6.

--- a/lib/supabase/hooks/use-chat-thread.ts
+++ b/lib/supabase/hooks/use-chat-thread.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { RealtimeChannel } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase/client';
+import {
+  getMessages,
+  sendMessage,
+  toChatMessage,
+  type ChatMessage,
+} from '@/lib/supabase/queries/chat';
+
+interface UseChatThreadReturn {
+  messages: ChatMessage[];
+  loading: boolean;
+  error: string | null;
+  sending: boolean;
+  send: (body: string) => Promise<void>;
+}
+
+/**
+ * Loads a conversation's messages and subscribes to live INSERTs via Supabase
+ * Realtime (same pattern as use-session-sync). RLS gates which rows the
+ * subscriber receives. New messages are de-duped by id so the sender's own
+ * optimistic append and the Realtime echo don't double up.
+ */
+export function useChatThread(conversationId: string | null): UseChatThreadReturn {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
+  const channelRef = useRef<RealtimeChannel | null>(null);
+  const supabase = createClient();
+
+  const upsertMessage = useCallback((msg: ChatMessage) => {
+    setMessages((prev) => {
+      if (prev.some((m) => m.id === msg.id)) return prev;
+      const next = [...prev, msg];
+      next.sort((a, b) =>
+        a.createdAt === b.createdAt
+          ? a.id.localeCompare(b.id)
+          : a.createdAt.localeCompare(b.createdAt),
+      );
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!conversationId) {
+      setMessages([]);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    getMessages(conversationId)
+      .then((m) => {
+        if (!cancelled) {
+          setMessages(m);
+          setLoading(false);
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Failed to load messages');
+          setLoading(false);
+        }
+      });
+
+    const channel = supabase
+      .channel(`chat-${conversationId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'messages',
+          filter: `conversation_id=eq.${conversationId}`,
+        },
+        (payload) => {
+          if (cancelled) return;
+          upsertMessage(toChatMessage(payload.new as Parameters<typeof toChatMessage>[0]));
+        },
+      )
+      .subscribe();
+    channelRef.current = channel;
+
+    return () => {
+      cancelled = true;
+      void supabase.removeChannel(channel);
+      channelRef.current = null;
+    };
+  }, [conversationId, supabase, upsertMessage]);
+
+  const send = useCallback(
+    async (body: string) => {
+      const trimmed = body.trim();
+      if (!conversationId || !trimmed) return;
+      setSending(true);
+      try {
+        const msg = await sendMessage(conversationId, trimmed);
+        upsertMessage(msg); // Realtime will echo; upsert de-dupes by id.
+        setError(null);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to send message');
+        throw e;
+      } finally {
+        setSending(false);
+      }
+    },
+    [conversationId, upsertMessage],
+  );
+
+  return { messages, loading, error, sending, send };
+}

--- a/lib/supabase/hooks/use-chat-thread.ts
+++ b/lib/supabase/hooks/use-chat-thread.ts
@@ -47,26 +47,42 @@ export function useChatThread(conversationId: string | null): UseChatThreadRetur
     if (!conversationId) {
       setMessages([]);
       setError(null);
+      setLoading(false);
       return;
     }
 
     let cancelled = false;
+    let historyLoaded = false;
     setLoading(true);
     setError(null);
+    setMessages([]); // clear the previous conversation
 
-    getMessages(conversationId)
-      .then((m) => {
-        if (!cancelled) {
-          setMessages(m);
+    // Load the history snapshot only after the channel has resolved, and MERGE
+    // it into state (don't replace) so a live INSERT that arrived during the
+    // subscribe handshake isn't lost. upsertMessage de-dupes by id.
+    const loadHistory = () => {
+      if (cancelled || historyLoaded) return;
+      historyLoaded = true;
+      getMessages(conversationId)
+        .then((history) => {
+          if (cancelled) return;
+          setMessages((prev) => {
+            const byId = new Map(prev.map((m) => [m.id, m]));
+            for (const m of history) if (!byId.has(m.id)) byId.set(m.id, m);
+            return [...byId.values()].sort((a, b) =>
+              a.createdAt === b.createdAt
+                ? a.id.localeCompare(b.id)
+                : a.createdAt.localeCompare(b.createdAt),
+            );
+          });
           setLoading(false);
-        }
-      })
-      .catch((e) => {
-        if (!cancelled) {
+        })
+        .catch((e) => {
+          if (cancelled) return;
           setError(e instanceof Error ? e.message : 'Failed to load messages');
           setLoading(false);
-        }
-      });
+        });
+    };
 
     const channel = supabase
       .channel(`chat-${conversationId}`)
@@ -83,7 +99,15 @@ export function useChatThread(conversationId: string | null): UseChatThreadRetur
           upsertMessage(toChatMessage(payload.new as Parameters<typeof toChatMessage>[0]));
         },
       )
-      .subscribe();
+      .subscribe((status) => {
+        if (status === 'SUBSCRIBED') {
+          loadHistory();
+        } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED') {
+          // Realtime didn't connect; still load history so messages render
+          // (without live updates) rather than spinning forever.
+          loadHistory();
+        }
+      });
     channelRef.current = channel;
 
     return () => {

--- a/lib/supabase/hooks/use-student-chats.ts
+++ b/lib/supabase/hooks/use-student-chats.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   listMyStudentChats,
   type ChatConversationSummary,
@@ -14,25 +14,39 @@ interface UseStudentChatsReturn {
 /**
  * Loads the current user's student-group chats (RLS-scoped to their teams),
  * optionally narrowed to the active school from the school dropdown.
+ *
+ * Each load is tagged with a monotonic request id so only the most recent one
+ * may write state. Without this, switching schools while an earlier fetch is
+ * still in flight could let the slower (older-school) response resolve last and
+ * repopulate the list with the previous school's chats.
  */
 export function useStudentChats(schoolId?: string | null): UseStudentChatsReturn {
   const [chats, setChats] = useState<ChatConversationSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
 
   const refresh = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
     setLoading(true);
     try {
-      setChats(await listMyStudentChats(schoolId));
+      const result = await listMyStudentChats(schoolId);
+      if (requestId !== requestIdRef.current) return; // superseded by a newer load
+      setChats(result);
       setError(null);
     } catch (e) {
+      if (requestId !== requestIdRef.current) return;
+      setChats([]);
       setError(e instanceof Error ? e.message : 'Failed to load chats');
     } finally {
-      setLoading(false);
+      if (requestId === requestIdRef.current) setLoading(false);
     }
   }, [schoolId]);
 
   useEffect(() => {
+    // Clear immediately on school switch so the prior school's chats never
+    // linger under the new selection while the fresh load is in flight.
+    setChats([]);
     void refresh();
   }, [refresh]);
 

--- a/lib/supabase/hooks/use-student-chats.ts
+++ b/lib/supabase/hooks/use-student-chats.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  listMyStudentChats,
+  type ChatConversationSummary,
+} from '@/lib/supabase/queries/chat';
+
+interface UseStudentChatsReturn {
+  chats: ChatConversationSummary[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+/** Loads the current user's student-group chats (RLS-scoped to their teams). */
+export function useStudentChats(): UseStudentChatsReturn {
+  const [chats, setChats] = useState<ChatConversationSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      setChats(await listMyStudentChats());
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load chats');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { chats, loading, error, refresh };
+}

--- a/lib/supabase/hooks/use-student-chats.ts
+++ b/lib/supabase/hooks/use-student-chats.ts
@@ -11,8 +11,11 @@ interface UseStudentChatsReturn {
   refresh: () => Promise<void>;
 }
 
-/** Loads the current user's student-group chats (RLS-scoped to their teams). */
-export function useStudentChats(): UseStudentChatsReturn {
+/**
+ * Loads the current user's student-group chats (RLS-scoped to their teams),
+ * optionally narrowed to the active school from the school dropdown.
+ */
+export function useStudentChats(schoolId?: string | null): UseStudentChatsReturn {
   const [chats, setChats] = useState<ChatConversationSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -20,14 +23,14 @@ export function useStudentChats(): UseStudentChatsReturn {
   const refresh = useCallback(async () => {
     setLoading(true);
     try {
-      setChats(await listMyStudentChats());
+      setChats(await listMyStudentChats(schoolId));
       setError(null);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load chats');
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [schoolId]);
 
   useEffect(() => {
     void refresh();

--- a/lib/supabase/queries/chat.ts
+++ b/lib/supabase/queries/chat.ts
@@ -262,21 +262,18 @@ export async function getParticipants(studentId: string): Promise<ChatParticipan
   }));
 }
 
-/** Mark a conversation read up to now for the current user (drives unread). */
+/**
+ * Mark a conversation read up to now for the current user (drives unread).
+ * Uses the mark_conversation_read RPC so the read cursor is stamped with the
+ * server clock (now()) rather than the browser's — message timestamps are
+ * server-generated, so a skewed device clock would otherwise corrupt unread
+ * state. The RPC forces profile_id = auth.uid() and stays RLS-gated.
+ */
 export async function markConversationRead(conversationId: string): Promise<void> {
   const supabase = createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return;
-  const { error } = await supabase.from('conversation_read_state').upsert(
-    {
-      conversation_id: conversationId,
-      profile_id: user.id,
-      last_read_at: new Date().toISOString(),
-    },
-    { onConflict: 'conversation_id,profile_id' },
-  );
+  const { error } = await supabase.rpc('mark_conversation_read', {
+    p_conversation_id: conversationId,
+  });
   if (error) throw error;
 }
 

--- a/lib/supabase/queries/chat.ts
+++ b/lib/supabase/queries/chat.ts
@@ -273,6 +273,25 @@ export async function markConversationRead(conversationId: string): Promise<void
 }
 
 /**
+ * Whether the current user is on a given student's chat team. Backs the
+ * contextual "Team chat" entry point, so it only shows for actual participants
+ * (and never for SEAs, who are excluded from the membership union).
+ */
+export async function isStudentChatParticipant(studentId: string): Promise<boolean> {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return false;
+  const { data, error } = await supabase.rpc('chat_is_student_participant', {
+    p_student_id: studentId,
+    p_uid: user.id,
+  });
+  if (error) return false;
+  return data === true;
+}
+
+/**
  * Students the current user can start a chat about. RLS on `students` scopes
  * this to their caseload / school. Conversation creation is independently gated
  * by chat_is_student_participant, so this list is only a convenience picker.

--- a/lib/supabase/queries/chat.ts
+++ b/lib/supabase/queries/chat.ts
@@ -191,7 +191,11 @@ export async function openStudentConversation(studentId: string): Promise<Opened
       type: 'student_group',
       student_id: studentId,
       school_id: student?.school_id ?? null,
-      created_by: user.id,
+      // created_by is set server-side via a DEFAULT of auth.uid(). The INSERT RLS
+      // check requires created_by = auth.uid(); deriving it on the server keeps
+      // that true by construction instead of trusting the client's cached user id
+      // (a stale/mismatched session was causing a misleading 42501 "not on the
+      // team" rejection here).
     })
     .select('id')
     .single();

--- a/lib/supabase/queries/chat.ts
+++ b/lib/supabase/queries/chat.ts
@@ -154,67 +154,36 @@ export interface OpenedConversation {
 /**
  * Open the student_group conversation for a student, creating it lazily if it
  * doesn't exist yet, and return it along with the student's display initials.
- * Conversation creation is gated by RLS (chat_is_student_participant), so this
- * only succeeds for a current team member. Handles the create race via the
- * one-chat-per-student unique index.
+ *
+ * Creation goes through the open_student_conversation RPC (SECURITY DEFINER),
+ * which performs the same authorization itself (is_chat_eligible + the
+ * chat_is_student_participant team check) and inserts as the owner. This is the
+ * single reliable write path: a direct client insert against `conversations`
+ * was intermittently rejected by the table's INSERT policy with a misleading
+ * 42501 even for valid team members, whereas the RPC (called like the working
+ * student picker) does not depend on that policy and forces created_by =
+ * auth.uid(). The one-chat-per-student race is handled inside the RPC.
  */
 export async function openStudentConversation(studentId: string): Promise<OpenedConversation> {
   const supabase = createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) throw new Error('Not authenticated');
 
+  // Display details only; the RPC enforces access independently of this read.
   const { data: student, error: studentError } = await supabase
     .from('students')
-    .select('initials, grade_level, school_id')
+    .select('initials, grade_level')
     .eq('id', studentId)
     .single();
-  // Surface the real failure rather than silently proceeding with a null student
-  // (which would then insert a null school_id and fail confusingly downstream).
   if (studentError) throw new Error(`Couldn't load this student: ${describeDbError(studentError)}`);
   const studentInitials = student?.initials ?? '—';
   const studentGrade = student?.grade_level ?? null;
 
-  const { data: existing, error: existingError } = await supabase
-    .from('conversations')
-    .select('id')
-    .eq('type', 'student_group')
-    .eq('student_id', studentId)
-    .maybeSingle();
-  if (existingError) throw new Error(`Couldn't open this chat: ${describeDbError(existingError)}`);
-  if (existing) return { conversationId: existing.id, studentInitials, studentGrade };
+  const { data: conversationId, error } = await supabase.rpc('open_student_conversation', {
+    p_student_id: studentId,
+  });
+  if (error) throw new Error(`Couldn't start this chat: ${describeDbError(error)}`);
+  if (!conversationId) throw new Error("Couldn't start this chat: no conversation returned.");
 
-  const { data: created, error } = await supabase
-    .from('conversations')
-    .insert({
-      type: 'student_group',
-      student_id: studentId,
-      school_id: student?.school_id ?? null,
-      // created_by is set server-side via a DEFAULT of auth.uid(). The INSERT RLS
-      // check requires created_by = auth.uid(); deriving it on the server keeps
-      // that true by construction instead of trusting the client's cached user id
-      // (a stale/mismatched session was causing a misleading 42501 "not on the
-      // team" rejection here).
-    })
-    .select('id')
-    .single();
-
-  if (error) {
-    // Likely a concurrent create hitting the one-chat-per-student unique index;
-    // re-select the winner.
-    const { data: again } = await supabase
-      .from('conversations')
-      .select('id')
-      .eq('type', 'student_group')
-      .eq('student_id', studentId)
-      .maybeSingle();
-    if (again) return { conversationId: again.id, studentInitials, studentGrade };
-    // Not a create race — surface the actual error (RLS denial, constraint, network…)
-    // instead of letting the caller show a generic "not on the team" message.
-    throw new Error(`Couldn't start this chat: ${describeDbError(error)}`);
-  }
-  return { conversationId: created.id, studentInitials, studentGrade };
+  return { conversationId: conversationId as string, studentInitials, studentGrade };
 }
 
 /**

--- a/lib/supabase/queries/chat.ts
+++ b/lib/supabase/queries/chat.ts
@@ -92,12 +92,13 @@ export async function listMyStudentChats(): Promise<ChatConversationSummary[]> {
   if (ids.length === 0) return [];
 
   // Latest non-deleted message per conversation (reduce client-side).
-  const { data: msgs } = await supabase
+  const { data: msgs, error: msgsError } = await supabase
     .from('messages')
     .select('conversation_id, body, created_at')
     .in('conversation_id', ids)
     .is('deleted_at', null)
     .order('created_at', { ascending: false });
+  if (msgsError) throw msgsError;
 
   const lastByConvo = new Map<string, { body: string; created_at: string }>();
   for (const m of msgs ?? []) {
@@ -107,10 +108,11 @@ export async function listMyStudentChats(): Promise<ChatConversationSummary[]> {
   }
 
   // The user's own read cursors (RLS: self-only).
-  const { data: reads } = await supabase
+  const { data: reads, error: readsError } = await supabase
     .from('conversation_read_state')
     .select('conversation_id, last_read_at')
     .in('conversation_id', ids);
+  if (readsError) throw readsError;
   const readBy = new Map((reads ?? []).map((r) => [r.conversation_id, r.last_read_at]));
 
   const summaries: ChatConversationSummary[] = conversations.map((c) => {
@@ -262,7 +264,7 @@ export async function markConversationRead(conversationId: string): Promise<void
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) return;
-  await supabase.from('conversation_read_state').upsert(
+  const { error } = await supabase.from('conversation_read_state').upsert(
     {
       conversation_id: conversationId,
       profile_id: user.id,
@@ -270,6 +272,7 @@ export async function markConversationRead(conversationId: string): Promise<void
     },
     { onConflict: 'conversation_id,profile_id' },
   );
+  if (error) throw error;
 }
 
 /**

--- a/lib/supabase/queries/chat.ts
+++ b/lib/supabase/queries/chat.ts
@@ -165,20 +165,24 @@ export async function openStudentConversation(studentId: string): Promise<Opened
   } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');
 
-  const { data: student } = await supabase
+  const { data: student, error: studentError } = await supabase
     .from('students')
     .select('initials, grade_level, school_id')
     .eq('id', studentId)
     .single();
+  // Surface the real failure rather than silently proceeding with a null student
+  // (which would then insert a null school_id and fail confusingly downstream).
+  if (studentError) throw new Error(`Couldn't load this student: ${describeDbError(studentError)}`);
   const studentInitials = student?.initials ?? '—';
   const studentGrade = student?.grade_level ?? null;
 
-  const { data: existing } = await supabase
+  const { data: existing, error: existingError } = await supabase
     .from('conversations')
     .select('id')
     .eq('type', 'student_group')
     .eq('student_id', studentId)
     .maybeSingle();
+  if (existingError) throw new Error(`Couldn't open this chat: ${describeDbError(existingError)}`);
   if (existing) return { conversationId: existing.id, studentInitials, studentGrade };
 
   const { data: created, error } = await supabase
@@ -202,9 +206,26 @@ export async function openStudentConversation(studentId: string): Promise<Opened
       .eq('student_id', studentId)
       .maybeSingle();
     if (again) return { conversationId: again.id, studentInitials, studentGrade };
-    throw error;
+    // Not a create race — surface the actual error (RLS denial, constraint, network…)
+    // instead of letting the caller show a generic "not on the team" message.
+    throw new Error(`Couldn't start this chat: ${describeDbError(error)}`);
   }
   return { conversationId: created.id, studentInitials, studentGrade };
+}
+
+/**
+ * Turn a Supabase/Postgrest error (a plain object, NOT an Error instance) into a
+ * human-readable string that includes the code, so failures aren't swallowed
+ * behind generic UI messages. Safe for any thrown value.
+ */
+function describeDbError(err: unknown): string {
+  if (err && typeof err === 'object') {
+    const e = err as { message?: string; code?: string; details?: string; hint?: string };
+    const parts = [e.message, e.details, e.hint].filter(Boolean);
+    const text = parts.join(' — ') || 'Unknown database error';
+    return e.code ? `${text} [${e.code}]` : text;
+  }
+  return typeof err === 'string' ? err : 'Unknown error';
 }
 
 /** Fetch the full message history for a conversation (RLS-gated), oldest first. */

--- a/lib/supabase/queries/chat.ts
+++ b/lib/supabase/queries/chat.ts
@@ -167,23 +167,28 @@ export interface OpenedConversation {
 export async function openStudentConversation(studentId: string): Promise<OpenedConversation> {
   const supabase = createClient();
 
-  // Display details only; the RPC enforces access independently of this read.
-  const { data: student, error: studentError } = await supabase
-    .from('students')
-    .select('initials, grade_level')
-    .eq('id', studentId)
-    .single();
-  if (studentError) throw new Error(`Couldn't load this student: ${describeDbError(studentError)}`);
-  const studentInitials = student?.initials ?? '—';
-  const studentGrade = student?.grade_level ?? null;
-
+  // Open (or create) the conversation via the authorized RPC first — it is the
+  // source of truth for access. The student read below is display-only and must
+  // not gate opening: students RLS can be stricter than the chat team check, so
+  // a valid team member (e.g. a serving provider) could otherwise be blocked.
   const { data: conversationId, error } = await supabase.rpc('open_student_conversation', {
     p_student_id: studentId,
   });
   if (error) throw new Error(`Couldn't start this chat: ${describeDbError(error)}`);
   if (!conversationId) throw new Error("Couldn't start this chat: no conversation returned.");
 
-  return { conversationId: conversationId as string, studentInitials, studentGrade };
+  // Best-effort display details; a denied/missing read just falls back to placeholders.
+  const { data: student } = await supabase
+    .from('students')
+    .select('initials, grade_level')
+    .eq('id', studentId)
+    .maybeSingle();
+
+  return {
+    conversationId: conversationId as string,
+    studentInitials: student?.initials ?? '—',
+    studentGrade: student?.grade_level ?? null,
+  };
 }
 
 /**

--- a/lib/supabase/queries/chat.ts
+++ b/lib/supabase/queries/chat.ts
@@ -72,19 +72,24 @@ export function toChatMessage(row: {
  * memberships. Each summary carries the student initials, a last-message
  * preview, and an unread flag (last message newer than the user's read cursor).
  */
-export async function listMyStudentChats(): Promise<ChatConversationSummary[]> {
+export async function listMyStudentChats(
+  schoolId?: string | null,
+): Promise<ChatConversationSummary[]> {
   const supabase = createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) return [];
 
-  const { data: convos, error } = await supabase
+  let query = supabase
     .from('conversations')
     .select(
       'id, student_id, created_at, students!conversations_student_id_fkey(initials, grade_level)',
     )
     .eq('type', 'student_group');
+  // Scope to the active school (from the school dropdown) when one is selected.
+  if (schoolId) query = query.eq('school_id', schoolId);
+  const { data: convos, error } = await query;
   if (error) throw error;
 
   const conversations = convos ?? [];
@@ -295,18 +300,26 @@ export async function isStudentChatParticipant(studentId: string): Promise<boole
 }
 
 /**
- * Students the current user can start a chat about. RLS on `students` scopes
- * this to their caseload / school. Conversation creation is independently gated
- * by chat_is_student_participant, so this list is only a convenience picker.
+ * Students the current user can actually start a chat about — the ones they are
+ * on the team for (participant set), optionally scoped to the active school.
+ * Backed by the get_my_chat_students RPC. Using the participant set (not every
+ * RLS-visible student) means the picker never offers a student whose chat the
+ * user would be denied from opening.
  */
-export async function listChatStudents(): Promise<ChatStudentOption[]> {
+export async function listMyChatStudents(
+  schoolId?: string | null,
+): Promise<ChatStudentOption[]> {
   const supabase = createClient();
-  const { data, error } = await supabase
-    .from('students')
-    .select('id, initials, grade_level')
-    .order('initials', { ascending: true });
+  const { data, error } = await supabase.rpc('get_my_chat_students', {
+    p_school_id: schoolId ?? undefined,
+  });
   if (error) throw error;
-  return (data ?? []).map((s) => ({
+  const rows = (data ?? []) as Array<{
+    id: string;
+    initials: string;
+    grade_level: string | null;
+  }>;
+  return rows.map((s) => ({
     id: s.id,
     initials: s.initials,
     gradeLevel: s.grade_level ?? null,

--- a/lib/supabase/queries/chat.ts
+++ b/lib/supabase/queries/chat.ts
@@ -1,0 +1,292 @@
+import { createClient } from '@/lib/supabase/client';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ChatMessage {
+  id: string;
+  conversationId: string;
+  senderId: string | null;
+  body: string;
+  createdAt: string;
+  editedAt: string | null;
+  deletedAt: string | null;
+}
+
+export interface ChatConversationSummary {
+  id: string;
+  studentId: string;
+  studentInitials: string;
+  studentGrade: string | null;
+  lastMessageAt: string | null;
+  lastMessagePreview: string | null;
+  unread: boolean;
+}
+
+export interface ChatParticipant {
+  id: string;
+  fullName: string | null;
+  role: string;
+}
+
+export interface ChatStudentOption {
+  id: string;
+  initials: string;
+  gradeLevel: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Mappers
+// ---------------------------------------------------------------------------
+
+// Maps a `messages` row (snake_case, e.g. from a query or a Realtime payload)
+// into a ChatMessage. Tolerant of the partial shapes Realtime can deliver.
+export function toChatMessage(row: {
+  id: string;
+  conversation_id: string;
+  sender_id: string | null;
+  body: string;
+  created_at: string;
+  edited_at?: string | null;
+  deleted_at?: string | null;
+}): ChatMessage {
+  return {
+    id: row.id,
+    conversationId: row.conversation_id,
+    senderId: row.sender_id ?? null,
+    body: row.body,
+    createdAt: row.created_at,
+    editedAt: row.edited_at ?? null,
+    deletedAt: row.deleted_at ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/**
+ * List the current user's student-group chats. RLS returns only conversations
+ * the user can currently access, so this is inherently scoped to their team
+ * memberships. Each summary carries the student initials, a last-message
+ * preview, and an unread flag (last message newer than the user's read cursor).
+ */
+export async function listMyStudentChats(): Promise<ChatConversationSummary[]> {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return [];
+
+  const { data: convos, error } = await supabase
+    .from('conversations')
+    .select(
+      'id, student_id, created_at, students!conversations_student_id_fkey(initials, grade_level)',
+    )
+    .eq('type', 'student_group');
+  if (error) throw error;
+
+  const conversations = convos ?? [];
+  const ids = conversations.map((c) => c.id);
+  if (ids.length === 0) return [];
+
+  // Latest non-deleted message per conversation (reduce client-side).
+  const { data: msgs } = await supabase
+    .from('messages')
+    .select('conversation_id, body, created_at')
+    .in('conversation_id', ids)
+    .is('deleted_at', null)
+    .order('created_at', { ascending: false });
+
+  const lastByConvo = new Map<string, { body: string; created_at: string }>();
+  for (const m of msgs ?? []) {
+    if (!lastByConvo.has(m.conversation_id)) {
+      lastByConvo.set(m.conversation_id, { body: m.body, created_at: m.created_at });
+    }
+  }
+
+  // The user's own read cursors (RLS: self-only).
+  const { data: reads } = await supabase
+    .from('conversation_read_state')
+    .select('conversation_id, last_read_at')
+    .in('conversation_id', ids);
+  const readBy = new Map((reads ?? []).map((r) => [r.conversation_id, r.last_read_at]));
+
+  const summaries: ChatConversationSummary[] = conversations.map((c) => {
+    // Supabase returns the FK relation as an object or array depending on shape.
+    const studentRel = c.students as
+      | { initials: string; grade_level: string | null }
+      | { initials: string; grade_level: string | null }[]
+      | null;
+    const student = Array.isArray(studentRel) ? studentRel[0] : studentRel;
+    const last = lastByConvo.get(c.id) ?? null;
+    const lastRead = readBy.get(c.id) ?? null;
+    const unread = !!last && (!lastRead || new Date(last.created_at) > new Date(lastRead));
+    return {
+      id: c.id,
+      studentId: c.student_id as string,
+      studentInitials: student?.initials ?? '—',
+      studentGrade: student?.grade_level ?? null,
+      lastMessageAt: last?.created_at ?? null,
+      lastMessagePreview: last?.body ?? null,
+      unread,
+    };
+  });
+
+  // Most recently active first; chats with no messages sort to the bottom.
+  return summaries.sort((a, b) => (b.lastMessageAt ?? '').localeCompare(a.lastMessageAt ?? ''));
+}
+
+export interface OpenedConversation {
+  conversationId: string;
+  studentInitials: string;
+  studentGrade: string | null;
+}
+
+/**
+ * Open the student_group conversation for a student, creating it lazily if it
+ * doesn't exist yet, and return it along with the student's display initials.
+ * Conversation creation is gated by RLS (chat_is_student_participant), so this
+ * only succeeds for a current team member. Handles the create race via the
+ * one-chat-per-student unique index.
+ */
+export async function openStudentConversation(studentId: string): Promise<OpenedConversation> {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const { data: student } = await supabase
+    .from('students')
+    .select('initials, grade_level, school_id')
+    .eq('id', studentId)
+    .single();
+  const studentInitials = student?.initials ?? '—';
+  const studentGrade = student?.grade_level ?? null;
+
+  const { data: existing } = await supabase
+    .from('conversations')
+    .select('id')
+    .eq('type', 'student_group')
+    .eq('student_id', studentId)
+    .maybeSingle();
+  if (existing) return { conversationId: existing.id, studentInitials, studentGrade };
+
+  const { data: created, error } = await supabase
+    .from('conversations')
+    .insert({
+      type: 'student_group',
+      student_id: studentId,
+      school_id: student?.school_id ?? null,
+      created_by: user.id,
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    // Likely a concurrent create hitting the one-chat-per-student unique index;
+    // re-select the winner.
+    const { data: again } = await supabase
+      .from('conversations')
+      .select('id')
+      .eq('type', 'student_group')
+      .eq('student_id', studentId)
+      .maybeSingle();
+    if (again) return { conversationId: again.id, studentInitials, studentGrade };
+    throw error;
+  }
+  return { conversationId: created.id, studentInitials, studentGrade };
+}
+
+/** Fetch the full message history for a conversation (RLS-gated), oldest first. */
+export async function getMessages(conversationId: string): Promise<ChatMessage[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('messages')
+    .select('id, conversation_id, sender_id, body, created_at, edited_at, deleted_at')
+    .eq('conversation_id', conversationId)
+    .order('created_at', { ascending: true })
+    .order('id', { ascending: true });
+  if (error) throw error;
+  return (data ?? []).map(toChatMessage);
+}
+
+/** Send a message to a conversation. RLS enforces sender = self + access. */
+export async function sendMessage(conversationId: string, body: string): Promise<ChatMessage> {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const { data, error } = await supabase
+    .from('messages')
+    .insert({ conversation_id: conversationId, sender_id: user.id, body })
+    .select('id, conversation_id, sender_id, body, created_at, edited_at, deleted_at')
+    .single();
+  if (error) throw error;
+  return toChatMessage(data);
+}
+
+/**
+ * Chat-eligible participants for a student's chat (those with a Speddy account).
+ * Backed by the get_student_chat_participants RPC, which itself requires the
+ * caller to be on the student's team.
+ */
+export async function getParticipants(studentId: string): Promise<ChatParticipant[]> {
+  const supabase = createClient();
+  const { data: ids, error } = await supabase.rpc('get_student_chat_participants', {
+    p_student_id: studentId,
+  });
+  if (error) throw error;
+  const idList = (ids ?? []) as string[];
+  if (idList.length === 0) return [];
+
+  const { data: profiles } = await supabase
+    .from('profiles')
+    .select('id, full_name, role')
+    .in('id', idList);
+  return (profiles ?? []).map((p) => ({
+    id: p.id,
+    fullName: p.full_name ?? null,
+    role: p.role,
+  }));
+}
+
+/** Mark a conversation read up to now for the current user (drives unread). */
+export async function markConversationRead(conversationId: string): Promise<void> {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return;
+  await supabase.from('conversation_read_state').upsert(
+    {
+      conversation_id: conversationId,
+      profile_id: user.id,
+      last_read_at: new Date().toISOString(),
+    },
+    { onConflict: 'conversation_id,profile_id' },
+  );
+}
+
+/**
+ * Students the current user can start a chat about. RLS on `students` scopes
+ * this to their caseload / school. Conversation creation is independently gated
+ * by chat_is_student_participant, so this list is only a convenience picker.
+ */
+export async function listChatStudents(): Promise<ChatStudentOption[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('students')
+    .select('id, initials, grade_level')
+    .order('initials', { ascending: true });
+  if (error) throw error;
+  return (data ?? []).map((s) => ({
+    id: s.id,
+    initials: s.initials,
+    gradeLevel: s.grade_level ?? null,
+  }));
+}

--- a/lib/utils/role-utils.ts
+++ b/lib/utils/role-utils.ts
@@ -19,8 +19,19 @@ export function formatRoleLabel(role: string | null): string {
       return 'Psych';
     case 'specialist':
       return 'Specialist';
+    case 'sea':
+      return 'SEA';
+    case 'site_admin':
+      return 'Site Admin';
+    case 'district_admin':
+      return 'District Admin';
     default:
-      // Capitalize first letter for unknown roles
-      return role.charAt(0).toUpperCase() + role.slice(1);
+      // Title-case each word, splitting snake_case/kebab-case so codes like
+      // "site_admin" render as "Site Admin" rather than "Site_admin".
+      return role
+        .split(/[_\s-]+/)
+        .filter(Boolean)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
   }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -125,10 +125,13 @@ export async function middleware(request: NextRequest) {
   const isAdminRoute = pathname.startsWith('/dashboard/admin')
   const isTeacherRoute = pathname.startsWith('/dashboard/teacher')
   const isCareRoute = pathname.startsWith('/dashboard/care')
+  const isChatRoute = pathname.startsWith('/dashboard/chat')
   const isDashboardRoute = pathname.startsWith('/dashboard')
 
-  // CARE routes are accessible to all authenticated users
-  if (isCareRoute) {
+  // CARE and Chat are cross-role surfaces: exempt them from the admin/teacher
+  // section redirects below so site admins and teachers can reach them. (Chat
+  // eligibility — e.g. the SEA exclusion — is enforced by RLS and the nav.)
+  if (isCareRoute || isChatRoute) {
     return response
   }
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -4300,6 +4300,10 @@ export type Database = {
         Args: { district_name: string }
         Returns: string
       }
+      open_student_conversation: {
+        Args: { p_student_id: string }
+        Returns: string
+      }
       normalize_existing_school_data: {
         Args: never
         Returns: {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -4115,6 +4115,15 @@ export type Database = {
           user_type: string
         }[]
       }
+      get_my_chat_students: {
+        Args: { p_school_id?: string }
+        Returns: {
+          grade_level: string
+          id: string
+          initials: string
+          school_id: string
+        }[]
+      }
       get_my_school_ids: {
         Args: never
         Returns: {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -4288,6 +4288,10 @@ export type Database = {
         Args: { student_uuid: string }
         Returns: boolean
       }
+      mark_conversation_read: {
+        Args: { p_conversation_id: string }
+        Returns: undefined
+      }
       mark_password_reset: {
         Args: { target_user_id: string }
         Returns: boolean

--- a/supabase/migrations/20260626_conversations_created_by_default.sql
+++ b/supabase/migrations/20260626_conversations_created_by_default.sql
@@ -1,0 +1,17 @@
+-- SPE-197 (Phase 1): default conversations.created_by to auth.uid().
+--
+-- The conversations INSERT RLS policy requires created_by = auth.uid(). Relying
+-- on the browser to send its own id is fragile: if the client's getUser().id
+-- ever drifts from the live access token's auth.uid() (e.g. a stale or
+-- mid-refresh session), or the client sends created_by as null/undefined, the
+-- insert is rejected with a misleading "new row violates row-level security
+-- policy" error — even though the user is a valid team member (this is exactly
+-- the "Couldn't start this chat … [42501]" symptom seen in testing).
+--
+-- Deriving created_by server-side from auth.uid() makes the policy check true by
+-- construction. The client now omits the column and lets this default fill it.
+-- created_by stays nullable (an unauthenticated insert would default to NULL and
+-- then correctly fail the RLS check), so no backfill is required.
+--
+-- Idempotent.
+ALTER TABLE public.conversations ALTER COLUMN created_by SET DEFAULT auth.uid();

--- a/supabase/migrations/20260626_enable_chat_realtime.sql
+++ b/supabase/migrations/20260626_enable_chat_realtime.sql
@@ -1,0 +1,23 @@
+-- SPE-197 (Phase 1): enable Supabase Realtime on chat messages.
+--
+-- Adds public.messages to the `supabase_realtime` publication so clients can
+-- subscribe to INSERTs and stream new messages live. RLS still gates which rows
+-- each subscriber receives (messages_select → can_access_conversation), so a
+-- subscriber only ever sees messages in conversations they can access.
+--
+-- Only INSERTs are needed for live message delivery, so the default REPLICA
+-- IDENTITY is sufficient (the new row is delivered in full on INSERT).
+--
+-- Idempotent / re-runnable.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'messages'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.messages;
+  END IF;
+END $$;

--- a/supabase/migrations/20260626_get_my_chat_students.sql
+++ b/supabase/migrations/20260626_get_my_chat_students.sql
@@ -1,0 +1,49 @@
+-- SPE-197 (Phase 1): get_my_chat_students(p_school_id)
+--
+-- Returns the current user's chat-eligible students — the ones they are actually
+-- on the team for (the same four link sources as chat_is_student_participant),
+-- optionally scoped to a single school. Powers the "New chat" student picker so
+-- it lists only students the user can actually open a chat for, not every
+-- student RLS lets them see (e.g. shared / co-taught students they don't serve),
+-- and so it respects the active school selected in the school dropdown.
+--
+-- Idempotent.
+CREATE OR REPLACE FUNCTION public.get_my_chat_students(p_school_id varchar DEFAULT NULL)
+RETURNS TABLE(id uuid, initials text, grade_level text, school_id varchar)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  WITH participant_ids AS (
+    -- case manager / resource specialist
+    SELECT s.id FROM public.students s WHERE s.provider_id = auth.uid()
+    UNION
+    -- linked classroom teacher (with an account)
+    SELECT s.id FROM public.students s
+      JOIN public.teachers t ON t.id = s.teacher_id
+      WHERE t.account_id = auth.uid()
+    UNION
+    -- a provider who actually delivers an ACTIVE TEMPLATE session for the student
+    -- (this is how speech/OT/etc. providers link to students they serve). NOT
+    -- assigned_to_specialist_id (lesson-planning delegation) and NOT SEAs.
+    SELECT ss.student_id FROM public.schedule_sessions ss
+      WHERE ss.student_id IS NOT NULL
+        AND ss.is_template = TRUE AND ss.deleted_at IS NULL
+        AND ss.provider_id = auth.uid()
+    UNION
+    -- site admin scoped to the student's school
+    SELECT s.id FROM public.students s
+      JOIN public.admin_permissions ap ON ap.school_id = s.school_id
+      WHERE ap.admin_id = auth.uid() AND ap.role = 'site_admin'
+  )
+  SELECT s.id, s.initials, s.grade_level, s.school_id
+  FROM public.students s
+  JOIN participant_ids pi ON pi.id = s.id
+  WHERE public.is_chat_eligible(auth.uid())
+    AND (p_school_id IS NULL OR s.school_id = p_school_id)
+  ORDER BY s.initials;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_my_chat_students(varchar) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_my_chat_students(varchar) TO authenticated, service_role;

--- a/supabase/migrations/20260626_mark_conversation_read.sql
+++ b/supabase/migrations/20260626_mark_conversation_read.sql
@@ -1,0 +1,32 @@
+-- SPE-197 (Phase 1): mark_conversation_read(p_conversation_id)
+--
+-- Persists the current user's read cursor for a conversation using the SERVER
+-- clock (now()), not the browser's. Message timestamps are server-generated, so
+-- comparing them against a device-supplied last_read_at skews unread state: a
+-- fast client clock can suppress real unread badges, a slow one can leave read
+-- messages marked unread. Writing the cursor server-side keeps both on the same
+-- clock.
+--
+-- profile_id is forced to auth.uid(), so a caller can only ever mark their own
+-- read state. SECURITY INVOKER (the default) keeps the existing RLS gating: the
+-- conversation_read_state INSERT policy already requires
+-- can_access_conversation(conversation_id, auth.uid()), so this can't write a
+-- cursor for a conversation the caller isn't a participant of. ON CONFLICT
+-- targets the (conversation_id, profile_id) primary key, matching the prior
+-- client upsert.
+--
+-- Idempotent.
+CREATE OR REPLACE FUNCTION public.mark_conversation_read(p_conversation_id uuid)
+RETURNS void
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  INSERT INTO public.conversation_read_state (conversation_id, profile_id, last_read_at)
+  VALUES (p_conversation_id, auth.uid(), now())
+  ON CONFLICT (conversation_id, profile_id)
+  DO UPDATE SET last_read_at = now();
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.mark_conversation_read(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.mark_conversation_read(uuid) TO authenticated, service_role;

--- a/supabase/migrations/20260626_mark_conversation_read.sql
+++ b/supabase/migrations/20260626_mark_conversation_read.sql
@@ -15,6 +15,12 @@
 -- targets the (conversation_id, profile_id) primary key, matching the prior
 -- client upsert.
 --
+-- The conflict/UPDATE branch is gated too: Postgres applies the INSERT policy's
+-- WITH CHECK to the *proposed* row of an INSERT ... ON CONFLICT DO UPDATE even
+-- when the statement resolves to the UPDATE path, so a caller who has lost
+-- access cannot advance a stale read cursor — the can_access_conversation check
+-- fails and the write is rejected. Verified empirically against the live DB.
+--
 -- Idempotent.
 CREATE OR REPLACE FUNCTION public.mark_conversation_read(p_conversation_id uuid)
 RETURNS void

--- a/supabase/migrations/20260626_membership_exclude_lesson_planning.sql
+++ b/supabase/migrations/20260626_membership_exclude_lesson_planning.sql
@@ -1,0 +1,88 @@
+-- SPE-197: refine chat membership — exclude lesson-planning-only assignments.
+--
+-- A specialist assigned to a session purely for lesson planning
+-- (schedule_sessions.assigned_to_specialist_id) on a student owned by ANOTHER
+-- case manager should NOT be on that student's chat team. Membership is the
+-- student's actual team: the case manager (students.provider_id), providers who
+-- deliver the student's sessions (schedule_sessions.provider_id — how speech/OT/
+-- etc. link to students they serve), the linked classroom teacher, and the site
+-- admin. We drop the assigned_to_specialist_id source (assigned_to_sea_id was
+-- already excluded).
+--
+-- Redefines the Phase 0 functions; runs after 20260626_create_chat_module.sql.
+-- Idempotent.
+
+CREATE OR REPLACE FUNCTION public.chat_is_student_participant(p_student_id UUID, p_uid UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  SELECT EXISTS (
+    -- case manager / owning provider
+    SELECT 1 FROM public.students s
+    WHERE s.id = p_student_id AND s.provider_id = p_uid
+
+    UNION ALL
+    -- linked classroom teacher (only if the teacher has an account)
+    SELECT 1
+    FROM public.students s
+    JOIN public.teachers t ON t.id = s.teacher_id
+    WHERE s.id = p_student_id AND t.account_id = p_uid
+
+    UNION ALL
+    -- a provider who delivers an ACTIVE TEMPLATE session for the student
+    -- (NOT assigned_to_specialist_id / lesson planning, NOT SEAs)
+    SELECT 1 FROM public.schedule_sessions ss
+    WHERE ss.student_id = p_student_id
+      AND ss.is_template = TRUE
+      AND ss.deleted_at IS NULL
+      AND ss.provider_id = p_uid
+
+    UNION ALL
+    -- site admin scoped to the student's school
+    SELECT 1
+    FROM public.students s
+    JOIN public.admin_permissions ap ON ap.school_id = s.school_id
+    WHERE s.id = p_student_id
+      AND ap.admin_id = p_uid
+      AND ap.role = 'site_admin'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_student_chat_participants(p_student_id UUID)
+RETURNS SETOF UUID
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  SELECT DISTINCT uid
+  FROM (
+    SELECT s.provider_id AS uid
+    FROM public.students s
+    WHERE s.id = p_student_id AND s.provider_id IS NOT NULL
+
+    UNION
+    SELECT t.account_id
+    FROM public.students s
+    JOIN public.teachers t ON t.id = s.teacher_id
+    WHERE s.id = p_student_id AND t.account_id IS NOT NULL
+
+    UNION
+    SELECT ss.provider_id
+    FROM public.schedule_sessions ss
+    WHERE ss.student_id = p_student_id
+      AND ss.is_template = TRUE AND ss.deleted_at IS NULL
+      AND ss.provider_id IS NOT NULL
+
+    UNION
+    SELECT ap.admin_id
+    FROM public.students s
+    JOIN public.admin_permissions ap ON ap.school_id = s.school_id
+    WHERE s.id = p_student_id AND ap.role = 'site_admin'
+  ) u
+  WHERE public.is_chat_eligible(u.uid)
+    AND public.chat_is_student_participant(p_student_id, auth.uid());
+$$;

--- a/supabase/migrations/20260626_open_student_conversation.sql
+++ b/supabase/migrations/20260626_open_student_conversation.sql
@@ -1,0 +1,74 @@
+-- SPE-197 (Phase 1): open_student_conversation(p_student_id) RPC.
+--
+-- Creation of a student_group conversation was done client-side (select-or-
+-- insert against public.conversations, gated by the conversations_insert RLS
+-- WITH CHECK). In production that insert intermittently failed with
+-- "new row violates row-level security policy [42501]" for valid team members,
+-- even though the equivalent insert succeeds when run directly in SQL and the
+-- caller passes every membership check — a fragile client/RLS interaction on the
+-- table-insert path.
+--
+-- This RPC is the single, reliable write path: it is SECURITY DEFINER (so the
+-- INSERT runs as the owner and does not depend on the table's INSERT policy),
+-- but it performs the SAME authorization itself — is_chat_eligible + the
+-- chat_is_student_participant team check — and forces created_by = auth.uid().
+-- That is equivalent to (and no weaker than) the RLS policy, and mirrors the
+-- SECURITY DEFINER pattern already used for the chat membership functions and
+-- planned for Phase-2 DM creation. The one-chat-per-student invariant
+-- (ux_conversations_student_group) still holds, with the create race handled via
+-- ON CONFLICT.
+--
+-- Returns the conversation id (existing or newly created).
+-- Idempotent (CREATE OR REPLACE).
+CREATE OR REPLACE FUNCTION public.open_student_conversation(p_student_id uuid)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_conversation_id uuid;
+  v_school_id varchar;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
+  END IF;
+
+  IF NOT public.is_chat_eligible(v_uid) THEN
+    RAISE EXCEPTION 'Not eligible for chat' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT public.chat_is_student_participant(p_student_id, v_uid) THEN
+    RAISE EXCEPTION 'Not on this student''s team' USING ERRCODE = '42501';
+  END IF;
+
+  -- Already exists? (one student_group conversation per student)
+  SELECT id INTO v_conversation_id
+  FROM public.conversations
+  WHERE type = 'student_group' AND student_id = p_student_id;
+  IF v_conversation_id IS NOT NULL THEN
+    RETURN v_conversation_id;
+  END IF;
+
+  SELECT school_id INTO v_school_id FROM public.students WHERE id = p_student_id;
+
+  INSERT INTO public.conversations (type, student_id, school_id, created_by)
+  VALUES ('student_group', p_student_id, v_school_id, v_uid)
+  ON CONFLICT (student_id) WHERE (type = 'student_group')
+  DO NOTHING
+  RETURNING id INTO v_conversation_id;
+
+  -- Lost a create race: re-read the winner.
+  IF v_conversation_id IS NULL THEN
+    SELECT id INTO v_conversation_id
+    FROM public.conversations
+    WHERE type = 'student_group' AND student_id = p_student_id;
+  END IF;
+
+  RETURN v_conversation_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.open_student_conversation(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.open_student_conversation(uuid) TO authenticated, service_role;


### PR DESCRIPTION
## What

First **user-facing** slice of the chat module (Phase 1 of epic SPE-195). A dedicated **`/dashboard/chat`** page where site-admins, teachers, and providers message a student's team. Builds on the Phase 0 data layer (#667).

**Surface decided with the product owner:** dedicated two-pane page + realtime included in v1.

### Included
- **Page** `/dashboard/chat` — two-pane: conversation list (left) + thread (right), wrapped in a `Suspense` boundary for the `?student=` deep link.
- **Data layer** `lib/supabase/queries/chat.ts` — list my chats, open/lazily-create a student conversation, fetch/send messages, participants (via `get_student_chat_participants` RPC), mark-read, and a student picker. All RLS-gated through the browser client.
- **Realtime** — `useChatThread` subscribes to `messages` INSERTs (mirrors the repo's existing `use-session-sync` channel pattern); de-dupes the sender's echo by id. New migration adds `public.messages` to the `supabase_realtime` publication (**RLS still gates delivery**). Applied to the DB and verified.
- **Components** — `ConversationList`, `ChatThread` (participant header + message list + composer), `MessageBubble`, `ChatParticipantsHeader` (with the honest *"members with a Speddy account"* note), `NewChatDialog` (searchable student picker), `StudentChatPage` container.
- **Navbar** — "Chat" entry for `site_admin`, `teacher`, `resource`, `speech/ot/counseling/psychologist`, and `specialist`. **SEA and district_admin excluded** (per the locked decisions).
- **Unread** — per-conversation indicator (last message vs. read cursor), marked read on open.

### Deliberately deferred to the immediate follow-up
- The contextual **"Team chat" button on the student detail view** — that modal is shared with the SEA (chat-excluded) view, so the button needs role-gating done right. The page already supports the `?student=<id>` deep link it will use.
- Typing indicators / presence / read receipts / global unread badge — Phase 3 polish.

## Validation
- ✅ `tsc --noEmit` clean
- ✅ `eslint` clean on all new files
- ✅ `next build` **compiles** (`✓ Compiled successfully`); the local page-data step fails only on a **pre-existing** route (`/api/import-students/confirm`) due to missing Supabase env vars in the sandbox — unrelated to this change; CI/Vercel have the vars.
- ✅ realtime migration applied; `messages` confirmed in `supabase_realtime`.

## Linear
SPE-197 (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZM6d3BG8FkDrfWjyR5oKq

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZM6d3BG8FkDrfWjyR5oKq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dashboard chat experience with conversation list, message thread, participant header, and a modal to start new student chats.
  * Added “Team chat” from student detail views with deep-linking to a selected student.
  * Enabled live incoming messages with auto-scroll, plus read-state tracking.
* **Bug Fixes**
  * Prevented “Chat” navigation from appearing until the role is loaded.
  * Updated route authorization and tightened eligibility rules to exclude lesson-planning-only assignments.
* **Documentation**
  * Updated chat module design notes to reflect the revised “linked to a student” logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->