### PR TITLE
perf(chat): compute conversation list DB-side (SPE-200)

### DIFF
--- a/lib/supabase/queries/chat.ts
+++ b/lib/supabase/queries/chat.ts
@@ -93,180 +93,63 @@ export function toChatMessage(row: {
 // ---------------------------------------------------------------------------
 
 /**
- * For a set of conversation ids, fetch the latest non-deleted message per
- * conversation and the caller's own read cursors. Shared by the student-chat and
- * DM list builders. (DB-side aggregation is tracked as a follow-up — SPE-200.)
- */
-async function lastMessageAndReadMaps(ids: string[]) {
-  const supabase = createClient();
-  const { data: msgs, error: msgsError } = await supabase
-    .from('messages')
-    .select('conversation_id, body, created_at')
-    .in('conversation_id', ids)
-    .is('deleted_at', null)
-    .order('created_at', { ascending: false });
-  if (msgsError) throw msgsError;
-
-  const lastByConvo = new Map<string, { body: string; created_at: string }>();
-  for (const m of msgs ?? []) {
-    if (!lastByConvo.has(m.conversation_id)) {
-      lastByConvo.set(m.conversation_id, { body: m.body, created_at: m.created_at });
-    }
-  }
-
-  const { data: reads, error: readsError } = await supabase
-    .from('conversation_read_state')
-    .select('conversation_id, last_read_at')
-    .in('conversation_id', ids);
-  if (readsError) throw readsError;
-  const readBy = new Map<string, string | null>(
-    (reads ?? []).map((r) => [r.conversation_id, r.last_read_at]),
-  );
-
-  return { lastByConvo, readBy };
-}
-
-function isUnread(
-  last: { created_at: string } | null,
-  lastRead: string | null | undefined,
-): boolean {
-  return !!last && (!lastRead || new Date(last.created_at) > new Date(lastRead));
-}
-
-const byMostRecent = (a: ChatConversationSummary, b: ChatConversationSummary) =>
-  (b.lastMessageAt ?? b.createdAt).localeCompare(a.lastMessageAt ?? a.createdAt);
-
-export async function listMyStudentChats(
-  schoolId?: string | null,
-): Promise<ChatConversationSummary[]> {
-  const supabase = createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return [];
-
-  let query = supabase
-    .from('conversations')
-    .select(
-      'id, student_id, created_at, students!conversations_student_id_fkey(initials, grade_level)',
-    )
-    .eq('type', 'student_group');
-  // Scope to the active school (from the school dropdown) when one is selected.
-  if (schoolId) query = query.eq('school_id', schoolId);
-  const { data: convos, error } = await query;
-  if (error) throw error;
-
-  const conversations = convos ?? [];
-  const ids = conversations.map((c) => c.id);
-  if (ids.length === 0) return [];
-
-  const { lastByConvo, readBy } = await lastMessageAndReadMaps(ids);
-
-  const summaries: ChatConversationSummary[] = conversations.map((c) => {
-    // Supabase returns the FK relation as an object or array depending on shape.
-    const studentRel = c.students as
-      | { initials: string; grade_level: string | null }
-      | { initials: string; grade_level: string | null }[]
-      | null;
-    const student = Array.isArray(studentRel) ? studentRel[0] : studentRel;
-    const initials = student?.initials ?? '—';
-    const last = lastByConvo.get(c.id) ?? null;
-    return {
-      id: c.id,
-      kind: 'student',
-      title: initials,
-      subtitle: student?.grade_level ?? null,
-      avatarText: initials,
-      studentId: c.student_id as string,
-      lastMessageAt: last?.created_at ?? null,
-      createdAt: c.created_at as string,
-      lastMessagePreview: last?.body ?? null,
-      unread: isUnread(last, readBy.get(c.id)),
-    };
-  });
-
-  return summaries.sort(byMostRecent);
-}
-
-/**
- * List the current user's 1:1 direct messages. RLS returns only DMs the user is
- * a participant of. Each summary shows the *other* participant's name and role.
- * Scoped to the active school (the DM's shared site) when one is selected, so
- * the conversation list tracks the school dropdown like student chats do.
- */
-export async function listMyDirectMessages(
-  schoolId?: string | null,
-): Promise<ChatConversationSummary[]> {
-  const supabase = createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return [];
-
-  let query = supabase
-    .from('conversations')
-    .select('id, created_at, conversation_participants(profile_id)')
-    .eq('type', 'direct');
-  if (schoolId) query = query.eq('school_id', schoolId);
-  const { data: convos, error } = await query;
-  if (error) throw error;
-
-  const conversations = convos ?? [];
-  const ids = conversations.map((c) => c.id);
-  if (ids.length === 0) return [];
-
-  // The other participant (the one who isn't me) for each DM.
-  const otherByConvo = new Map<string, string>();
-  for (const c of conversations) {
-    const parts = (c.conversation_participants ?? []) as { profile_id: string }[];
-    const other = parts.find((p) => p.profile_id !== user.id);
-    if (other) otherByConvo.set(c.id, other.profile_id);
-  }
-
-  const otherIds = [...new Set(otherByConvo.values())];
-  const { data: profiles, error: profilesError } = await supabase
-    .from('profiles')
-    .select('id, full_name, role')
-    .in('id', otherIds.length ? otherIds : ['00000000-0000-0000-0000-000000000000']);
-  if (profilesError) throw profilesError;
-  const profById = new Map((profiles ?? []).map((p) => [p.id, p]));
-
-  const { lastByConvo, readBy } = await lastMessageAndReadMaps(ids);
-
-  const summaries: ChatConversationSummary[] = conversations.map((c) => {
-    const otherId = otherByConvo.get(c.id);
-    const prof = otherId ? profById.get(otherId) : null;
-    const name = prof?.full_name ?? 'Unknown';
-    const last = lastByConvo.get(c.id) ?? null;
-    return {
-      id: c.id,
-      kind: 'direct',
-      title: name,
-      subtitle: prof?.role ? formatRoleLabel(prof.role) : null,
-      avatarText: initialsOf(name),
-      studentId: null,
-      lastMessageAt: last?.created_at ?? null,
-      createdAt: c.created_at as string,
-      lastMessagePreview: last?.body ?? null,
-      unread: isUnread(last, readBy.get(c.id)),
-    };
-  });
-
-  return summaries.sort(byMostRecent);
-}
-
-/**
- * The unified conversation list: the user's student group chats plus their
- * direct messages, both scoped to the active school, most-recent first.
+ * The unified conversation list — the user's student group chats and direct
+ * messages, scoped to the active school, most-recent first. Backed by the
+ * get_my_conversations RPC, which computes the latest-message preview and unread
+ * flag DB-side in one round-trip (no full message-history scan — see SPE-200).
  */
 export async function listMyConversations(
   schoolId?: string | null,
 ): Promise<ChatConversationSummary[]> {
-  const [students, dms] = await Promise.all([
-    listMyStudentChats(schoolId),
-    listMyDirectMessages(schoolId),
-  ]);
-  return [...students, ...dms].sort(byMostRecent);
+  const supabase = createClient();
+  const { data, error } = await supabase.rpc('get_my_conversations', {
+    p_school_id: schoolId ?? undefined,
+  });
+  if (error) throw error;
+  const rows = (data ?? []) as Array<{
+    id: string;
+    kind: 'student' | 'direct';
+    student_id: string | null;
+    student_initials: string | null;
+    student_grade: string | null;
+    other_name: string | null;
+    other_role: string | null;
+    last_message_at: string | null;
+    last_message_preview: string | null;
+    created_at: string;
+    unread: boolean;
+  }>;
+  // The RPC already orders rows by recency (latest message, else creation time).
+  return rows.map((r) => {
+    if (r.kind === 'direct') {
+      const name = r.other_name ?? 'Unknown';
+      return {
+        id: r.id,
+        kind: 'direct',
+        title: name,
+        subtitle: r.other_role ? formatRoleLabel(r.other_role) : null,
+        avatarText: initialsOf(name),
+        studentId: null,
+        lastMessageAt: r.last_message_at,
+        createdAt: r.created_at,
+        lastMessagePreview: r.last_message_preview,
+        unread: r.unread,
+      };
+    }
+    const initials = r.student_initials ?? '—';
+    return {
+      id: r.id,
+      kind: 'student',
+      title: initials,
+      subtitle: r.student_grade,
+      avatarText: initials,
+      studentId: r.student_id,
+      lastMessageAt: r.last_message_at,
+      createdAt: r.created_at,
+      lastMessagePreview: r.last_message_preview,
+      unread: r.unread,
+    };
+  });
 }
 
 export interface OpenedConversation {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -4136,16 +4136,16 @@ export type Database = {
         Args: { p_school_id?: string }
         Returns: {
           id: string
-          kind: string
-          student_id: string
-          school_id: string
-          student_initials: string
-          student_grade: string
-          other_id: string
-          other_name: string
-          other_role: string
-          last_message_at: string
-          last_message_preview: string
+          kind: 'student' | 'direct'
+          student_id: string | null
+          school_id: string | null
+          student_initials: string | null
+          student_grade: string | null
+          other_id: string | null
+          other_name: string | null
+          other_role: string | null
+          last_message_at: string | null
+          last_message_preview: string | null
           created_at: string
           unread: boolean
         }[]

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -4132,6 +4132,24 @@ export type Database = {
           school_id: string
         }[]
       }
+      get_my_conversations: {
+        Args: { p_school_id?: string }
+        Returns: {
+          id: string
+          kind: string
+          student_id: string
+          school_id: string
+          student_initials: string
+          student_grade: string
+          other_id: string
+          other_name: string
+          other_role: string
+          last_message_at: string
+          last_message_preview: string
+          created_at: string
+          unread: boolean
+        }[]
+      }
       get_my_school_ids: {
         Args: never
         Returns: {

--- a/supabase/migrations/20260627_get_my_conversations.sql
+++ b/supabase/migrations/20260627_get_my_conversations.sql
@@ -1,0 +1,95 @@
+-- SPE-200: get_my_conversations(p_school_id) — DB-side conversation list.
+--
+-- Replaces the client-side approach (fetch all conversations, then fetch EVERY
+-- non-deleted message for them and reduce in the browser to find the latest per
+-- conversation, plus separate read-state and profile lookups). That scaled with
+-- total message history. This single RPC returns one row per conversation the
+-- caller can access — student group chats and DMs — with the latest message
+-- (DISTINCT ON), the unread flag computed server-side against the caller's read
+-- cursor, and the display fields for both kinds.
+--
+-- SECURITY DEFINER so it can read the display fields (student initials, the other
+-- DM participant's profile) without per-table RLS, while gating membership itself
+-- via is_chat_eligible + chat_is_student_participant + direct-participant check —
+-- the same predicates as can_access_conversation. Output is equivalent to the
+-- prior client builders. Idempotent.
+CREATE OR REPLACE FUNCTION public.get_my_conversations(p_school_id varchar DEFAULT NULL)
+RETURNS TABLE(
+  id uuid,
+  kind text,
+  student_id uuid,
+  school_id varchar,
+  student_initials text,
+  student_grade text,
+  other_id uuid,
+  other_name text,
+  other_role text,
+  last_message_at timestamptz,
+  last_message_preview text,
+  created_at timestamptz,
+  unread boolean
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  WITH my_convos AS (
+    SELECT c.id, c.type, c.student_id, c.school_id, c.created_at
+    FROM public.conversations c
+    WHERE public.is_chat_eligible(auth.uid())
+      AND (p_school_id IS NULL OR c.school_id = p_school_id)
+      AND (
+        (c.type = 'student_group'
+          AND public.chat_is_student_participant(c.student_id, auth.uid()))
+        OR
+        (c.type = 'direct' AND EXISTS (
+          SELECT 1 FROM public.conversation_participants cp
+          WHERE cp.conversation_id = c.id AND cp.profile_id = auth.uid()))
+      )
+  ),
+  last_msg AS (
+    SELECT DISTINCT ON (m.conversation_id) m.conversation_id, m.body, m.created_at
+    FROM public.messages m
+    WHERE m.conversation_id IN (SELECT mc.id FROM my_convos mc)
+      AND m.deleted_at IS NULL
+    ORDER BY m.conversation_id, m.created_at DESC, m.id DESC
+  ),
+  reads AS (
+    SELECT crs.conversation_id, crs.last_read_at
+    FROM public.conversation_read_state crs
+    WHERE crs.profile_id = auth.uid()
+      AND crs.conversation_id IN (SELECT mc.id FROM my_convos mc)
+  ),
+  other AS (
+    SELECT cp.conversation_id, cp.profile_id AS other_id
+    FROM public.conversation_participants cp
+    JOIN my_convos mc ON mc.id = cp.conversation_id AND mc.type = 'direct'
+    WHERE cp.profile_id <> auth.uid()
+  )
+  SELECT
+    mc.id,
+    CASE WHEN mc.type = 'student_group' THEN 'student' ELSE 'direct' END AS kind,
+    mc.student_id,
+    mc.school_id,
+    s.initials AS student_initials,
+    s.grade_level AS student_grade,
+    o.other_id,
+    op.full_name AS other_name,
+    op.role AS other_role,
+    lm.created_at AS last_message_at,
+    lm.body AS last_message_preview,
+    mc.created_at,
+    (lm.created_at IS NOT NULL
+      AND (r.last_read_at IS NULL OR lm.created_at > r.last_read_at)) AS unread
+  FROM my_convos mc
+  LEFT JOIN public.students s ON s.id = mc.student_id
+  LEFT JOIN other o ON o.conversation_id = mc.id
+  LEFT JOIN public.profiles op ON op.id = o.other_id
+  LEFT JOIN last_msg lm ON lm.conversation_id = mc.id
+  LEFT JOIN reads r ON r.conversation_id = mc.id
+  ORDER BY COALESCE(lm.created_at, mc.created_at) DESC;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_my_conversations(varchar) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_my_conversations(varchar) TO authenticated, service_role;


### PR DESCRIPTION
## What

Internal perf refactor of the chat conversation list (no UX change). Follow-up tracked as **SPE-200**.

The sidebar previously fetched all conversations, then **every** non-deleted message for them, and reduced client-side to find the latest message per conversation — plus separate read-state and profile round-trips. That scaled with total message history.

This replaces it with a single **`get_my_conversations(p_school_id)`** RPC that returns one row per accessible conversation (student group + DM) with:
- the latest message preview (`DISTINCT ON (conversation_id) … ORDER BY created_at DESC`),
- the `unread` flag computed **server-side** against the caller's read cursor,
- the display fields for both kinds (student initials/grade, or the other DM participant's name/role).

`SECURITY DEFINER`, gated by the same predicates as `can_access_conversation` (`is_chat_eligible` + `chat_is_student_participant` + direct-participant check). The client mapper keeps the exact same `ChatConversationSummary` shape, so the rendered list is unchanged — this just collapses 3+ round-trips into 1 and removes the full-history scan.

Removes the now-unused client builders (`listMyStudentChats`, `listMyDirectMessages`, `lastMessageAndReadMaps`).

## Validation
- ✅ `tsc --noEmit` clean, `eslint` clean
- ✅ **Output-equivalence verified against the live DB** as the test user: the RPC's accessible set exactly matches `can_access_conversation` (0 rows in either direction), and its `DISTINCT ON` latest message matches the true `max(created_at)` per conversation (0 mismatches). School scoping returns the correct per-school subsets.
- Migration already applied to the DB via MCP (repo runs migrations manually, not `db push`).

## Linear
SPE-200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZM6d3BG8FkDrfWjyR5oKq

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZM6d3BG8FkDrfWjyR5oKq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversations now load from a single server-generated source, improving consistency across chat lists.
  * Conversation previews now include the latest message, timestamp, participant details, and unread status.

* **Bug Fixes**
  * Improved unread indicators by calculating them centrally, reducing mismatches across different chat views.
  * Streamlined access checks so only eligible conversations appear in the user’s list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->