### PR TITLE
test(roles): cover normalizeDeliveredBy and formatRoleLabel

### DIFF
--- a/lib/auth/role-utils.test.ts
+++ b/lib/auth/role-utils.test.ts
@@ -1,0 +1,66 @@
+import {
+  normalizeDeliveredBy,
+  isSpecialistSourceRole,
+  SPECIALIST_SOURCE_ROLES,
+} from './role-utils';
+
+describe('SPECIALIST_SOURCE_ROLES', () => {
+  it('matches the roles documented in ARCHITECTURE.md §1', () => {
+    expect([...SPECIALIST_SOURCE_ROLES].sort()).toEqual(
+      ['counseling', 'intervention', 'ot', 'psychologist', 'resource', 'specialist', 'speech'].sort(),
+    );
+  });
+});
+
+describe('isSpecialistSourceRole', () => {
+  it('recognizes every specialist source role', () => {
+    for (const role of SPECIALIST_SOURCE_ROLES) {
+      expect(isSpecialistSourceRole(role)).toBe(true);
+    }
+  });
+
+  it('rejects non-specialist roles', () => {
+    expect(isSpecialistSourceRole('sea')).toBe(false);
+    expect(isSpecialistSourceRole('teacher')).toBe(false);
+    expect(isSpecialistSourceRole('site_admin')).toBe(false);
+    expect(isSpecialistSourceRole('')).toBe(false);
+  });
+
+  it('is case-sensitive (expects already-normalized input)', () => {
+    // The guard does not lowercase; normalizeDeliveredBy handles casing upstream.
+    expect(isSpecialistSourceRole('Speech')).toBe(false);
+  });
+});
+
+describe('normalizeDeliveredBy', () => {
+  it('maps sea → sea', () => {
+    expect(normalizeDeliveredBy('sea')).toBe('sea');
+  });
+
+  it('maps every specialist source role → specialist', () => {
+    for (const role of SPECIALIST_SOURCE_ROLES) {
+      expect(normalizeDeliveredBy(role)).toBe('specialist');
+    }
+  });
+
+  it('maps teacher / admins / unknown → provider', () => {
+    expect(normalizeDeliveredBy('teacher')).toBe('provider');
+    expect(normalizeDeliveredBy('site_admin')).toBe('provider');
+    expect(normalizeDeliveredBy('district_admin')).toBe('provider');
+    expect(normalizeDeliveredBy('provider')).toBe('provider');
+    expect(normalizeDeliveredBy('something_new')).toBe('provider');
+  });
+
+  it('normalizes casing and surrounding whitespace', () => {
+    expect(normalizeDeliveredBy('  SEA ')).toBe('sea');
+    expect(normalizeDeliveredBy('Speech')).toBe('specialist');
+    expect(normalizeDeliveredBy(' OT ')).toBe('specialist');
+  });
+
+  it('defaults empty / falsy input to provider', () => {
+    expect(normalizeDeliveredBy('')).toBe('provider');
+    // Defensive: the signature is string, but guard against nullish at runtime.
+    expect(normalizeDeliveredBy(undefined as unknown as string)).toBe('provider');
+    expect(normalizeDeliveredBy(null as unknown as string)).toBe('provider');
+  });
+});

--- a/lib/utils/role-utils.test.ts
+++ b/lib/utils/role-utils.test.ts
@@ -1,0 +1,35 @@
+import { formatRoleLabel } from './role-utils';
+
+describe('formatRoleLabel', () => {
+  it('renders the documented provider labels', () => {
+    expect(formatRoleLabel('speech')).toBe('Speech');
+    expect(formatRoleLabel('ot')).toBe('OT');
+    expect(formatRoleLabel('counseling')).toBe('Counseling');
+    expect(formatRoleLabel('resource')).toBe('Resource');
+    expect(formatRoleLabel('psychologist')).toBe('Psych');
+    expect(formatRoleLabel('specialist')).toBe('Specialist');
+    expect(formatRoleLabel('sea')).toBe('SEA');
+    expect(formatRoleLabel('site_admin')).toBe('Site Admin');
+    expect(formatRoleLabel('district_admin')).toBe('District Admin');
+  });
+
+  it('is case-insensitive for known roles', () => {
+    expect(formatRoleLabel('Speech')).toBe('Speech');
+    expect(formatRoleLabel('OT')).toBe('OT');
+    expect(formatRoleLabel('Site_Admin')).toBe('Site Admin');
+  });
+
+  it('returns "Unknown" for null / empty / whitespace', () => {
+    expect(formatRoleLabel(null)).toBe('Unknown');
+    expect(formatRoleLabel('')).toBe('Unknown');
+    expect(formatRoleLabel('   ')).toBe('Unknown');
+  });
+
+  it('title-cases unknown roles, splitting snake/kebab/space', () => {
+    expect(formatRoleLabel('teacher')).toBe('Teacher');
+    expect(formatRoleLabel('intervention')).toBe('Intervention');
+    expect(formatRoleLabel('some_new_role')).toBe('Some New Role');
+    expect(formatRoleLabel('kebab-case-role')).toBe('Kebab Case Role');
+    expect(formatRoleLabel('multi   space')).toBe('Multi Space');
+  });
+});


### PR DESCRIPTION
## Summary

Pure additive tests for two central, previously-untested role helpers — no source changes. First of a few small cleanup PRs.

- **`lib/auth/role-utils.ts`** — `normalizeDeliveredBy` / `isSpecialistSourceRole` / `SPECIALIST_SOURCE_ROLES`. This is the `delivered_by` derivation used across the scheduling model, so it's worth pinning.
- **`lib/utils/role-utils.ts`** — `formatRoleLabel` (role display labels).

## Coverage

- Full specialist-role set → `specialist`; `sea` → `sea`; teacher/admins/unknown → `provider`.
- Casing + surrounding-whitespace normalization; null/empty/falsy fallbacks.
- `formatRoleLabel`: documented labels, case-insensitivity, `Unknown` for empty, and snake/kebab/space title-casing for unknown roles.

Assertions track the behavior documented in `docs/ARCHITECTURE.md` §1.

## Verification

- ✅ `jest lib/auth/role-utils.test.ts lib/utils/role-utils.test.ts` — **13 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8HNtSrKY5AR8uQU1sHc8b)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for role normalization and role-label formatting behavior.
  * Verified expected mappings for specialist, provider, and sea roles, including handling of casing, whitespace, empty values, and unknown inputs.
  * Added checks to ensure documented role lists stay aligned with the app’s behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->