### PR TITLE
chore: record unsubscribe_pr_activity tool permission in local settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -98,7 +98,8 @@
       "mcp__52287d5e-942b-4bb1-a760-a897e4851102__get_issue",
       "mcp__Linear__save_issue",
       "mcp__Linear__save_project",
-      "mcp__Supabase__create_branch"
+      "mcp__Supabase__create_branch",
+      "mcp__bf7c680d-5fdc-5ef4-b4a0-abadb619bf0a__unsubscribe_pr_activity"
     ],
     "deny": []
   },


### PR DESCRIPTION
## Summary

Housekeeping follow-up after #680 merged: commits the harness-recorded permission allowlist entry (`unsubscribe_pr_activity`) in `.claude/settings.local.json`, matching the existing pattern of tracked tool permissions in that file. One line, no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3djpxrRYap64jnxSEYc97

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3djpxrRYap64jnxSEYc97)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded allowed automation actions in local settings, enabling an additional PR activity unsubscribe capability.
  * No visible product behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->