### PR TITLE
feat(iep-meetings): site setup — meeting rules & teacher availability (SPE-207)

### DIFF
--- a/app/(dashboard)/dashboard/admin/meetings/page.tsx
+++ b/app/(dashboard)/dashboard/admin/meetings/page.tsx
@@ -72,6 +72,19 @@ export default function AdminMeetingsPage() {
 
   const handleSave = async () => {
     if (!schoolId) return;
+    const invalidWindow = windows.some(
+      w => !w.start_time || !w.end_time || w.start_time >= w.end_time
+    );
+    const invalidBlackout = blackouts.some(
+      b => !b.start_date || !b.end_date || b.start_date > b.end_date
+    );
+    if (invalidWindow || invalidBlackout) {
+      setError(
+        'Each meeting window needs a start time before its end time, and each blackout needs a valid date range.'
+      );
+      return;
+    }
+    const parsedMaxPerDay = maxPerDay ? parseInt(maxPerDay, 10) : NaN;
     setSaving(true);
     setError(null);
     try {
@@ -83,7 +96,7 @@ export default function AdminMeetingsPage() {
         allowed_windows: windows,
         blackout_ranges: blackouts,
         rooms: rooms.length ? rooms : null,
-        max_meetings_per_day: maxPerDay ? parseInt(maxPerDay, 10) : null,
+        max_meetings_per_day: parsedMaxPerDay > 0 ? parsedMaxPerDay : null,
         external_iep_calendar_id: calendarId.trim() || null,
       });
       setSavedAt(new Date());

--- a/app/(dashboard)/dashboard/admin/meetings/page.tsx
+++ b/app/(dashboard)/dashboard/admin/meetings/page.tsx
@@ -1,0 +1,388 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card } from '@/app/components/ui/card';
+import { Button } from '@/app/components/ui/button';
+import { getCurrentAdminPermissions } from '@/lib/supabase/queries/admin-accounts';
+import {
+  getSiteMeetingRules,
+  upsertSiteMeetingRules,
+  type MeetingWindow,
+  type BlackoutRange,
+} from '@/lib/supabase/queries/iep-meeting-setup';
+
+const DAY_NAMES: Record<number, string> = {
+  1: 'Monday',
+  2: 'Tuesday',
+  3: 'Wednesday',
+  4: 'Thursday',
+  5: 'Friday',
+};
+
+export default function AdminMeetingsPage() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [schoolId, setSchoolId] = useState<string | null>(null);
+  const [isDistrictAdmin, setIsDistrictAdmin] = useState(false);
+
+  const [windows, setWindows] = useState<MeetingWindow[]>([]);
+  const [blackouts, setBlackouts] = useState<BlackoutRange[]>([]);
+  const [roomsText, setRoomsText] = useState('');
+  const [maxPerDay, setMaxPerDay] = useState<string>('');
+  const [calendarId, setCalendarId] = useState('');
+
+  const [saving, setSaving] = useState(false);
+  const [savedAt, setSavedAt] = useState<Date | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const permissions = await getCurrentAdminPermissions();
+        const siteAdminPerm = permissions?.find(p => p.role === 'site_admin');
+        if (!siteAdminPerm?.school_id) {
+          const districtPerm = permissions?.find(p => p.role === 'district_admin');
+          if (districtPerm) {
+            setIsDistrictAdmin(true);
+            setLoading(false);
+            return;
+          }
+          setError('Site admin access required');
+          setLoading(false);
+          return;
+        }
+        setSchoolId(siteAdminPerm.school_id);
+
+        const rules = await getSiteMeetingRules(siteAdminPerm.school_id);
+        if (rules) {
+          setWindows((rules.allowed_windows as unknown as MeetingWindow[]) ?? []);
+          setBlackouts((rules.blackout_ranges as unknown as BlackoutRange[]) ?? []);
+          setRoomsText((rules.rooms ?? []).join(', '));
+          setMaxPerDay(rules.max_meetings_per_day?.toString() ?? '');
+          setCalendarId(rules.external_iep_calendar_id ?? '');
+        }
+      } catch (err) {
+        console.error('Failed to load meeting settings:', err);
+        setError('Failed to load meeting settings');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  const handleSave = async () => {
+    if (!schoolId) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const rooms = roomsText
+        .split(',')
+        .map(r => r.trim())
+        .filter(Boolean);
+      await upsertSiteMeetingRules(schoolId, {
+        allowed_windows: windows,
+        blackout_ranges: blackouts,
+        rooms: rooms.length ? rooms : null,
+        max_meetings_per_day: maxPerDay ? parseInt(maxPerDay, 10) : null,
+        external_iep_calendar_id: calendarId.trim() || null,
+      });
+      setSavedAt(new Date());
+    } catch (err) {
+      console.error('Failed to save meeting settings:', err);
+      setError('Failed to save meeting settings');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="flex justify-center py-12">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isDistrictAdmin) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-2xl font-bold text-gray-900 mb-6">Meetings</h1>
+        <Card>
+          <p className="text-gray-600">
+            IEP meeting settings are configured per school by each site admin.
+            District-wide views will appear here as scheduling features roll
+            out.
+          </p>
+        </Card>
+      </div>
+    );
+  }
+
+  if (error && !schoolId) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="flex items-center justify-between mb-2">
+        <h1 className="text-2xl font-bold text-gray-900">Meetings</h1>
+        <div className="flex items-center gap-3">
+          {savedAt && !saving && (
+            <span className="text-sm text-green-600">Settings saved</span>
+          )}
+          <Button onClick={handleSave} isLoading={saving}>
+            Save settings
+          </Button>
+        </div>
+      </div>
+      <p className="text-gray-500 mb-6">
+        Site rules for scheduling IEP meetings. The planner only proposes
+        times inside these windows and never double-books the site.
+      </p>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700 mb-6">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-6">
+        <Card>
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">
+            Meeting windows
+          </h2>
+          <p className="text-sm text-gray-500 mb-4">
+            When can IEP meetings be held at this school?
+          </p>
+          <div className="space-y-2">
+            {windows.map((w, i) => (
+              <div key={i} className="flex items-center gap-3">
+                <select
+                  value={w.day_of_week}
+                  onChange={e =>
+                    setWindows(ws =>
+                      ws.map((x, j) =>
+                        j === i
+                          ? { ...x, day_of_week: parseInt(e.target.value, 10) }
+                          : x
+                      )
+                    )
+                  }
+                  className="border border-gray-300 rounded-md px-3 py-2 text-sm"
+                  aria-label="Day of week"
+                >
+                  {Object.entries(DAY_NAMES).map(([num, name]) => (
+                    <option key={num} value={num}>
+                      {name}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  type="time"
+                  value={w.start_time}
+                  onChange={e =>
+                    setWindows(ws =>
+                      ws.map((x, j) =>
+                        j === i ? { ...x, start_time: e.target.value } : x
+                      )
+                    )
+                  }
+                  className="border border-gray-300 rounded-md px-3 py-2 text-sm"
+                  aria-label="Window start time"
+                />
+                <span className="text-gray-400">to</span>
+                <input
+                  type="time"
+                  value={w.end_time}
+                  onChange={e =>
+                    setWindows(ws =>
+                      ws.map((x, j) =>
+                        j === i ? { ...x, end_time: e.target.value } : x
+                      )
+                    )
+                  }
+                  className="border border-gray-300 rounded-md px-3 py-2 text-sm"
+                  aria-label="Window end time"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setWindows(ws => ws.filter((_, j) => j !== i))}
+                  aria-label={`Remove window ${i + 1}`}
+                >
+                  Remove
+                </Button>
+              </div>
+            ))}
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="mt-3"
+            onClick={() =>
+              setWindows(ws => [
+                ...ws,
+                { day_of_week: 2, start_time: '07:30', end_time: '08:15' },
+              ])
+            }
+          >
+            + Add window
+          </Button>
+        </Card>
+
+        <Card>
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">
+            Blackout dates
+          </h2>
+          <p className="text-sm text-gray-500 mb-4">
+            Date ranges when no IEP meetings should be scheduled (testing
+            windows, breaks).
+          </p>
+          <div className="space-y-2">
+            {blackouts.map((b, i) => (
+              <div key={i} className="flex items-center gap-3">
+                <input
+                  type="date"
+                  value={b.start_date}
+                  onChange={e =>
+                    setBlackouts(bs =>
+                      bs.map((x, j) =>
+                        j === i ? { ...x, start_date: e.target.value } : x
+                      )
+                    )
+                  }
+                  className="border border-gray-300 rounded-md px-3 py-2 text-sm"
+                  aria-label="Blackout start date"
+                />
+                <span className="text-gray-400">to</span>
+                <input
+                  type="date"
+                  value={b.end_date}
+                  onChange={e =>
+                    setBlackouts(bs =>
+                      bs.map((x, j) =>
+                        j === i ? { ...x, end_date: e.target.value } : x
+                      )
+                    )
+                  }
+                  className="border border-gray-300 rounded-md px-3 py-2 text-sm"
+                  aria-label="Blackout end date"
+                />
+                <input
+                  type="text"
+                  placeholder="Label (e.g. State testing)"
+                  value={b.label}
+                  onChange={e =>
+                    setBlackouts(bs =>
+                      bs.map((x, j) =>
+                        j === i ? { ...x, label: e.target.value } : x
+                      )
+                    )
+                  }
+                  className="border border-gray-300 rounded-md px-3 py-2 text-sm flex-1"
+                  aria-label="Blackout label"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() =>
+                    setBlackouts(bs => bs.filter((_, j) => j !== i))
+                  }
+                  aria-label={`Remove blackout ${i + 1}`}
+                >
+                  Remove
+                </Button>
+              </div>
+            ))}
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="mt-3"
+            onClick={() =>
+              setBlackouts(bs => [
+                ...bs,
+                { start_date: '', end_date: '', label: '' },
+              ])
+            }
+          >
+            + Add blackout
+          </Button>
+        </Card>
+
+        <Card>
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+            Capacity & calendar
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <label
+                htmlFor="rooms"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Meeting rooms
+              </label>
+              <input
+                id="rooms"
+                type="text"
+                placeholder="Conference room, Library office"
+                value={roomsText}
+                onChange={e => setRoomsText(e.target.value)}
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                Comma-separated. Leave blank if rooms aren&apos;t a constraint.
+              </p>
+            </div>
+            <div>
+              <label
+                htmlFor="maxPerDay"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Max meetings per day
+              </label>
+              <input
+                id="maxPerDay"
+                type="number"
+                min="1"
+                placeholder="No limit"
+                value={maxPerDay}
+                onChange={e => setMaxPerDay(e.target.value)}
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+              />
+            </div>
+            <div className="md:col-span-2">
+              <label
+                htmlFor="calendarId"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Existing IEP calendar (optional)
+              </label>
+              <input
+                id="calendarId"
+                type="text"
+                placeholder="Google Calendar ID, e.g. abc123@group.calendar.google.com"
+                value={calendarId}
+                onChange={e => setCalendarId(e.target.value)}
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                If your school already keeps a shared IEP calendar, Speddy will
+                treat its events as busy time once calendar integration is
+                connected.
+              </p>
+            </div>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/teacher/page.tsx
+++ b/app/(dashboard)/dashboard/teacher/page.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/supabase/queries/teacher-portal';
 import Link from 'next/link';
 import { Card } from '@/app/components/ui/card';
+import { AvailabilityPromptCard } from '@/app/components/teacher/availability-prompt-card';
 
 const DAYS_OF_WEEK = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
@@ -244,6 +245,8 @@ export default function TeacherDashboardPage() {
           Manage your students in resource and coordinate with resource specialists
         </p>
       </div>
+
+      <AvailabilityPromptCard />
 
       {/* Quick Stats */}
       <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 mb-8">

--- a/app/components/navigation/navbar.tsx
+++ b/app/components/navigation/navbar.tsx
@@ -123,6 +123,7 @@ export default function Navbar() {
       return [
         { name: 'Dashboard', href: '/dashboard/admin' },
         { name: 'Master Schedule', href: '/dashboard/admin/master-schedule' },
+        { name: 'Meetings', href: '/dashboard/admin/meetings' },
         { name: 'Teachers', href: '/dashboard/admin/teachers' },
         { name: 'Providers', href: '/dashboard/admin/providers' },
         { name: 'Staff', href: '/dashboard/admin/staff' },

--- a/app/components/teacher/availability-prompt-card.tsx
+++ b/app/components/teacher/availability-prompt-card.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/app/components/ui/button';
+import { getCurrentSchoolYear } from '@/lib/school-year';
+import {
+  getMyTeacherAvailabilityPref,
+  upsertMyTeacherAvailabilityPref,
+} from '@/lib/supabase/queries/iep-meeting-setup';
+
+type Preference = 'before_school' | 'after_school' | 'prep' | 'any';
+
+const PREFERENCE_OPTIONS: { value: Preference; label: string }[] = [
+  { value: 'before_school', label: 'Before school' },
+  { value: 'after_school', label: 'After school' },
+  { value: 'prep', label: 'During my prep' },
+  { value: 'any', label: 'Any of these' },
+];
+
+/**
+ * Once-a-year prompt asking teachers when IEP meetings work for them.
+ * Renders nothing if the teacher already answered for the current school
+ * year, or dismissed the prompt this year ("remind me later").
+ */
+export function AvailabilityPromptCard() {
+  const schoolYear = getCurrentSchoolYear();
+  const dismissKey = `iep-availability-prompt-dismissed-${schoolYear}`;
+
+  const [visible, setVisible] = useState(false);
+  const [preference, setPreference] = useState<Preference | null>(null);
+  const [prepStart, setPrepStart] = useState('');
+  const [prepEnd, setPrepEnd] = useState('');
+  const [prepDescription, setPrepDescription] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function check() {
+      try {
+        if (localStorage.getItem(dismissKey)) return;
+        const pref = await getMyTeacherAvailabilityPref(schoolYear);
+        if (!pref) setVisible(true);
+      } catch {
+        // Non-critical prompt: stay hidden on any failure
+      }
+    }
+    check();
+  }, [dismissKey, schoolYear]);
+
+  const showPrepFields = preference === 'prep' || preference === 'any';
+
+  const handleSave = async () => {
+    if (!preference) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await upsertMyTeacherAvailabilityPref({
+        school_year: schoolYear,
+        meeting_time_preference: preference,
+        prep_start: showPrepFields && prepStart ? prepStart : null,
+        prep_end: showPrepFields && prepEnd ? prepEnd : null,
+        prep_description:
+          showPrepFields && prepDescription.trim()
+            ? prepDescription.trim()
+            : null,
+      });
+      setSaved(true);
+      setTimeout(() => setVisible(false), 2500);
+    } catch (err) {
+      console.error('Failed to save availability preference:', err);
+      setError('Could not save — please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDismiss = () => {
+    localStorage.setItem(dismissKey, '1');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  if (saved) {
+    return (
+      <div className="mb-8 bg-green-50 border border-green-200 rounded-lg p-4 text-green-700">
+        Thanks — your IEP meeting availability is saved for {schoolYear}.
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-8 bg-blue-50 border border-blue-200 rounded-lg p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-medium text-blue-800">
+            When do IEP meetings work for you this year?
+          </h3>
+          <p className="mt-1 text-sm text-blue-700">
+            Answer once and meeting organizers will only propose times that
+            fit your day.
+          </p>
+        </div>
+        <button
+          onClick={handleDismiss}
+          className="text-blue-400 hover:text-blue-600 text-xl leading-none flex-shrink-0"
+          aria-label="Remind me later"
+          title="Remind me later"
+        >
+          ×
+        </button>
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {PREFERENCE_OPTIONS.map(opt => (
+          <button
+            key={opt.value}
+            onClick={() => setPreference(opt.value)}
+            className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-colors ${
+              preference === opt.value
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-white text-gray-700 border-gray-300 hover:border-blue-400'
+            }`}
+            aria-pressed={preference === opt.value}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {showPrepFields && (
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <label className="text-sm text-gray-700" htmlFor="prep-start">
+            My prep is
+          </label>
+          <input
+            id="prep-start"
+            type="time"
+            value={prepStart}
+            onChange={e => setPrepStart(e.target.value)}
+            className="border border-gray-300 rounded-md px-3 py-1.5 text-sm"
+            aria-label="Prep start time"
+          />
+          <span className="text-gray-400 text-sm">to</span>
+          <input
+            type="time"
+            value={prepEnd}
+            onChange={e => setPrepEnd(e.target.value)}
+            className="border border-gray-300 rounded-md px-3 py-1.5 text-sm"
+            aria-label="Prep end time"
+          />
+          <input
+            type="text"
+            placeholder="e.g. 4th period (optional)"
+            value={prepDescription}
+            onChange={e => setPrepDescription(e.target.value)}
+            className="border border-gray-300 rounded-md px-3 py-1.5 text-sm flex-1 min-w-[180px]"
+            aria-label="Prep description"
+          />
+        </div>
+      )}
+
+      {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+
+      <div className="mt-4">
+        <Button size="sm" onClick={handleSave} disabled={!preference} isLoading={saving}>
+          Save availability
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/teacher/availability-prompt-card.tsx
+++ b/app/components/teacher/availability-prompt-card.tsx
@@ -49,9 +49,14 @@ export function AvailabilityPromptCard() {
   }, [dismissKey, schoolYear]);
 
   const showPrepFields = preference === 'prep' || preference === 'any';
+  // Prep times are the scheduler's only availability source for secondary
+  // teachers — a prep preference without times would be unusable and the
+  // prompt never re-asks once a row exists.
+  const prepTimesMissing = showPrepFields && (!prepStart || !prepEnd);
+  const canSave = !!preference && !prepTimesMissing;
 
   const handleSave = async () => {
-    if (!preference) return;
+    if (!canSave || !preference) return;
     setSaving(true);
     setError(null);
     try {
@@ -76,7 +81,11 @@ export function AvailabilityPromptCard() {
   };
 
   const handleDismiss = () => {
-    localStorage.setItem(dismissKey, '1');
+    try {
+      localStorage.setItem(dismissKey, '1');
+    } catch {
+      // Storage unavailable (e.g. private mode) — still hide for this session
+    }
     setVisible(false);
   };
 
@@ -163,10 +172,15 @@ export function AvailabilityPromptCard() {
 
       {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
 
-      <div className="mt-4">
-        <Button size="sm" onClick={handleSave} disabled={!preference} isLoading={saving}>
+      <div className="mt-4 flex items-center gap-3">
+        <Button size="sm" onClick={handleSave} disabled={!canSave} isLoading={saving}>
           Save availability
         </Button>
+        {preference && prepTimesMissing && (
+          <span className="text-sm text-blue-700">
+            Enter your prep start and end times to save.
+          </span>
+        )}
       </div>
     </div>
   );

--- a/lib/supabase/queries/iep-meeting-setup.ts
+++ b/lib/supabase/queries/iep-meeting-setup.ts
@@ -106,11 +106,17 @@ export async function upsertMyTeacherAvailabilityPref(pref: {
   if (!user) throw new Error('Not authenticated');
 
   // school_id denormalized from the teacher's own profile for RLS reads
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from('profiles')
     .select('school_id')
     .eq('id', user.id)
     .single();
+
+  if (profileError) {
+    // Without school_id the pref would be invisible to organizers' scoped reads
+    console.error('Error fetching profile for availability pref:', profileError);
+    throw profileError;
+  }
 
   const { data, error } = await supabase
     .from('teacher_availability_prefs')

--- a/lib/supabase/queries/iep-meeting-setup.ts
+++ b/lib/supabase/queries/iep-meeting-setup.ts
@@ -1,0 +1,137 @@
+import { createClient } from '@/lib/supabase/client';
+import type {
+  Database,
+  SiteMeetingRules,
+  TeacherAvailabilityPref,
+} from '@/src/types';
+import type { Json } from '@/src/types/database';
+
+export interface MeetingWindow {
+  day_of_week: number; // 1 = Monday … 5 = Friday
+  start_time: string; // 'HH:MM'
+  end_time: string; // 'HH:MM'
+}
+
+export interface BlackoutRange {
+  start_date: string; // 'YYYY-MM-DD'
+  end_date: string; // 'YYYY-MM-DD'
+  label: string;
+}
+
+export async function getSiteMeetingRules(
+  schoolId: string
+): Promise<SiteMeetingRules | null> {
+  const supabase = createClient<Database>();
+  const { data, error } = await supabase
+    .from('site_meeting_rules')
+    .select('*')
+    .eq('school_id', schoolId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Error fetching site meeting rules:', error);
+    throw error;
+  }
+  return data;
+}
+
+export async function upsertSiteMeetingRules(
+  schoolId: string,
+  updates: {
+    allowed_windows: MeetingWindow[];
+    blackout_ranges: BlackoutRange[];
+    rooms: string[] | null;
+    max_meetings_per_day: number | null;
+    external_iep_calendar_id: string | null;
+  }
+): Promise<SiteMeetingRules> {
+  const supabase = createClient<Database>();
+  const { data, error } = await supabase
+    .from('site_meeting_rules')
+    .upsert(
+      {
+        school_id: schoolId,
+        allowed_windows: updates.allowed_windows as unknown as Json,
+        blackout_ranges: updates.blackout_ranges as unknown as Json,
+        rooms: updates.rooms,
+        max_meetings_per_day: updates.max_meetings_per_day,
+        external_iep_calendar_id: updates.external_iep_calendar_id,
+      },
+      { onConflict: 'school_id' }
+    )
+    .select()
+    .single();
+
+  if (error) {
+    console.error('Error saving site meeting rules:', error);
+    throw error;
+  }
+  return data;
+}
+
+export async function getMyTeacherAvailabilityPref(
+  schoolYear: string
+): Promise<TeacherAvailabilityPref | null> {
+  const supabase = createClient<Database>();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data, error } = await supabase
+    .from('teacher_availability_prefs')
+    .select('*')
+    .eq('profile_id', user.id)
+    .eq('school_year', schoolYear)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Error fetching teacher availability pref:', error);
+    throw error;
+  }
+  return data;
+}
+
+export async function upsertMyTeacherAvailabilityPref(pref: {
+  school_year: string;
+  meeting_time_preference: 'before_school' | 'after_school' | 'prep' | 'any';
+  prep_start: string | null; // 'HH:MM'
+  prep_end: string | null;
+  prep_description: string | null;
+}): Promise<TeacherAvailabilityPref> {
+  const supabase = createClient<Database>();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  // school_id denormalized from the teacher's own profile for RLS reads
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('school_id')
+    .eq('id', user.id)
+    .single();
+
+  const { data, error } = await supabase
+    .from('teacher_availability_prefs')
+    .upsert(
+      {
+        profile_id: user.id,
+        school_id: profile?.school_id ?? null,
+        school_year: pref.school_year,
+        meeting_time_preference: pref.meeting_time_preference,
+        prep_start: pref.prep_start,
+        prep_end: pref.prep_end,
+        prep_description: pref.prep_description,
+      },
+      { onConflict: 'profile_id,school_year' }
+    )
+    .select()
+    .single();
+
+  if (error) {
+    console.error('Error saving teacher availability pref:', error);
+    throw error;
+  }
+  return data;
+}


### PR DESCRIPTION
## Summary

Implements [SPE-207](https://linear.app/speddy/issue/SPE-207): the one-time-per-year setup surfaces for IEP meeting scheduling, per spec §4 (site admin walkthrough), §4.5 (navigation), §6 (site rules), and §8 (teacher availability). Builds on the SPE-203 data model merged in #684 (tables are live in Supabase).

### Site admin — `/dashboard/admin/meetings` (new page + nav item)

- **Meeting windows**: day + start/end time rows (add/remove) → `site_meeting_rules.allowed_windows` (JSONB).
- **Blackout dates**: date ranges with labels (testing windows, breaks) → `blackout_ranges`.
- **Capacity & calendar**: rooms (comma-separated), max meetings/day, and the optional existing "IEP Calendar" Google Calendar ID (spec §6: optional input, never a dependency).
- Scope via `getCurrentAdminPermissions()` (the established admin-page pattern — not `useSchool`); RLS enforces the role-gated writes from the migration.
- **District admins** get a graceful informational state (site rules are per-school; district-wide views arrive with the compliance dashboard, SPE-211). "Meetings" is added to the **site-admin nav only** for now — happy to add it for district admins once there's content for them.

### Teacher — availability prompt card (teacher dashboard)

- Dismissible once-a-year card: "When do IEP meetings work for you this year?" — four preference chips (before school / after school / during prep / any), with optional prep window + free-text description (secondary schools' path, spec §8).
- Writes `teacher_availability_prefs` (keyed on profile + school year via `getCurrentSchoolYear()`); hides forever once answered; "×" = remind-later via localStorage for the year.
- Renders nothing on any fetch failure — the prompt is never load-bearing for the dashboard.

### Plumbing

- `lib/supabase/queries/iep-meeting-setup.ts` — typed getters/upserts for both tables, following the repo's query-module conventions (`createClient` per call, plain-arg signatures).

### Verification

- `npm run typecheck` clean; `npm run lint` clean on new files; `npm test` 121 passed.
- The SPE-203 migration was applied to the live Supabase project before this work; both tables exist with RLS verified and security advisors clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3djpxrRYap64jnxSEYc97

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3djpxrRYap64jnxSEYc97)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin **Meetings** page to configure school-level IEP scheduling rules, including allowed meeting windows, blackout date ranges, room constraints, maximum meetings per day, and optional external calendar ID.
  * Added a one-time teacher **availability prompt** to capture preferred meeting timing and optional prep time details.
  * Added a role-based navigation link to the new admin meetings settings.
* **Bug Fixes**
  * Enhanced loading/access/error handling and input validation when loading and saving meeting and availability settings, with clear success confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->