### PR TITLE
feat(iep-meetings): availability engine + bulk planner & case-manager Meetings page (SPE-206, SPE-208)

### DIFF
--- a/app/(dashboard)/dashboard/meetings/page.tsx
+++ b/app/(dashboard)/dashboard/meetings/page.tsx
@@ -113,7 +113,8 @@ export default function MeetingsPage() {
   const dueSoonCount = useMemo(() => {
     const cutoff = new Date();
     cutoff.setDate(cutoff.getDate() + 60);
-    const cutoffStr = cutoff.toISOString().slice(0, 10);
+    // Local-date string, consistent with todayStr()/dueDate comparisons
+    const cutoffStr = `${cutoff.getFullYear()}-${String(cutoff.getMonth() + 1).padStart(2, '0')}-${String(cutoff.getDate()).padStart(2, '0')}`;
     return unscheduled.filter(s => s.dueDate! <= cutoffStr).length;
   }, [unscheduled]);
 
@@ -161,8 +162,17 @@ export default function MeetingsPage() {
     setReserving(true);
     setError(null);
     try {
-      const count = await reserveMeetings(schoolId, drafts, planning.leaRep);
-      setReservedCount(count);
+      const { reserved, attendeesFailed } = await reserveMeetings(
+        schoolId,
+        drafts,
+        planning.leaRep
+      );
+      setReservedCount(reserved);
+      if (attendeesFailed) {
+        setError(
+          'Meetings were reserved, but some attendees could not be added — check each meeting and re-add missing team members.'
+        );
+      }
       setResults(null);
       setPlannerOpen(false);
       await load();

--- a/app/(dashboard)/dashboard/meetings/page.tsx
+++ b/app/(dashboard)/dashboard/meetings/page.tsx
@@ -5,6 +5,7 @@ import { Card } from '@/app/components/ui/card';
 import { Button } from '@/app/components/ui/button';
 import { useSchool } from '@/app/components/providers/school-context';
 import {
+  DEFAULT_MEETING_WINDOWS,
   minutesToTime,
   planMeetings,
   type AttendeeConstraints,
@@ -127,11 +128,16 @@ export default function MeetingsPage() {
       }
       return { key: student.id, dueDate: student.dueDate, attendees };
     });
+    // No admin-configured windows yet? Case managers aren't blocked —
+    // fall back to general school-day hours and say so in the UI.
+    const site = planning.hasSiteRules
+      ? planning.site
+      : { ...planning.site, windows: DEFAULT_MEETING_WINDOWS };
     const planned = planMeetings(requests, {
       from: todayStr(),
       to: horizon,
       durationMinutes: 60,
-      site: planning.site,
+      site,
       existingMeetings: planning.existingMeetings,
     });
     setResults(planned);
@@ -274,13 +280,14 @@ export default function MeetingsPage() {
           <h2 className="text-lg font-semibold text-gray-900 mb-1">
             Plan meetings
           </h2>
-          {!planning?.hasSiteRules ? (
-            <p className="text-gray-600 text-sm">
-              Your site admin hasn&apos;t set meeting windows yet — planning
-              needs the school&apos;s allowed meeting times. Ask them to fill
-              in Meetings settings on the admin dashboard.
-            </p>
-          ) : unscheduled.length === 0 ? (
+          {planning && !planning.hasSiteRules && (
+            <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 text-amber-800 text-sm mb-4">
+              Your site admin hasn&apos;t set meeting windows yet, so drafts
+              use general school-day hours (Mon–Fri, 8:00–4:00). Once site
+              rules are configured, planning will respect them automatically.
+            </div>
+          )}
+          {unscheduled.length === 0 ? (
             <p className="text-gray-600 text-sm">
               Nothing to plan — every student with an upcoming IEP due date
               already has a meeting scheduled. Students without due dates on

--- a/app/(dashboard)/dashboard/meetings/page.tsx
+++ b/app/(dashboard)/dashboard/meetings/page.tsx
@@ -1,0 +1,466 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Card } from '@/app/components/ui/card';
+import { Button } from '@/app/components/ui/button';
+import { useSchool } from '@/app/components/providers/school-context';
+import {
+  minutesToTime,
+  planMeetings,
+  type AttendeeConstraints,
+  type PlanResult,
+} from '@/lib/iep-meetings/availability';
+import {
+  cancelMeeting,
+  getMyMeetings,
+  getPlanningData,
+  reserveMeetings,
+  type MeetingListItem,
+  type MeetingDraft,
+  type PlanningData,
+} from '@/lib/supabase/queries/iep-meetings';
+
+const STATUS_STYLES: Record<string, string> = {
+  reserved: 'bg-slate-100 text-slate-700 border-slate-300',
+  confirming: 'bg-amber-50 text-amber-700 border-amber-300',
+  confirmed: 'bg-green-50 text-green-700 border-green-300',
+  held: 'bg-gray-100 text-gray-500 border-gray-300',
+  draft: 'bg-gray-100 text-gray-500 border-gray-300',
+};
+
+function formatSlotDate(dateStr: string): string {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  return new Date(y, m - 1, d).toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatTimestamp(ts: string | null): string {
+  if (!ts) return '—';
+  const d = new Date(ts);
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  }) +
+    ' · ' +
+    d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+}
+
+function defaultHorizon(): string {
+  // End of the current school year (June 30)
+  const now = new Date();
+  const year = now.getMonth() >= 7 ? now.getFullYear() + 1 : now.getFullYear();
+  return `${year}-06-30`;
+}
+
+function todayStr(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+export default function MeetingsPage() {
+  const { currentSchool, loading: schoolLoading } = useSchool();
+  const schoolId = currentSchool?.school_id ?? null;
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [meetings, setMeetings] = useState<MeetingListItem[]>([]);
+  const [planning, setPlanning] = useState<PlanningData | null>(null);
+
+  const [plannerOpen, setPlannerOpen] = useState(false);
+  const [horizon, setHorizon] = useState(defaultHorizon());
+  const [results, setResults] = useState<PlanResult[] | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [reserving, setReserving] = useState(false);
+  const [reservedCount, setReservedCount] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    if (!schoolId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const [meetingList, planningData] = await Promise.all([
+        getMyMeetings(),
+        getPlanningData(schoolId),
+      ]);
+      setMeetings(meetingList);
+      setPlanning(planningData);
+    } catch (err) {
+      console.error('Failed to load meetings:', err);
+      setError('Failed to load meetings');
+    } finally {
+      setLoading(false);
+    }
+  }, [schoolId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const unscheduled = useMemo(
+    () =>
+      (planning?.caseload ?? []).filter(
+        s => !s.hasUpcomingMeeting && s.dueDate && s.dueDate >= todayStr()
+      ),
+    [planning]
+  );
+
+  const dueSoonCount = useMemo(() => {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() + 60);
+    const cutoffStr = cutoff.toISOString().slice(0, 10);
+    return unscheduled.filter(s => s.dueDate! <= cutoffStr).length;
+  }, [unscheduled]);
+
+  const runPlanner = useCallback(() => {
+    if (!planning) return;
+    const requests = unscheduled.map(student => {
+      const attendees: AttendeeConstraints[] = [
+        { key: 'organizer', busy: planning.organizerBusy },
+      ];
+      if (student.teacherProfileId) {
+        const teacher = planning.teacherConstraints.get(student.teacherProfileId);
+        if (teacher) attendees.push(teacher);
+      }
+      return { key: student.id, dueDate: student.dueDate, attendees };
+    });
+    const planned = planMeetings(requests, {
+      from: todayStr(),
+      to: horizon,
+      durationMinutes: 60,
+      site: planning.site,
+      existingMeetings: planning.existingMeetings,
+    });
+    setResults(planned);
+    setSelected(new Set(planned.filter(r => r.slot).map(r => r.key)));
+    setReservedCount(null);
+  }, [planning, unscheduled, horizon]);
+
+  const handleReserve = async () => {
+    if (!planning || !results || !schoolId) return;
+    const drafts: MeetingDraft[] = results
+      .filter(r => r.slot && selected.has(r.key))
+      .map(r => ({
+        student: planning.caseload.find(s => s.id === r.key)!,
+        slot: r.slot!,
+      }));
+    if (drafts.length === 0) return;
+    setReserving(true);
+    setError(null);
+    try {
+      const count = await reserveMeetings(schoolId, drafts, planning.leaRep);
+      setReservedCount(count);
+      setResults(null);
+      setPlannerOpen(false);
+      await load();
+    } catch (err) {
+      console.error('Failed to reserve meetings:', err);
+      setError('Failed to reserve meetings');
+    } finally {
+      setReserving(false);
+    }
+  };
+
+  const handleCancel = async (meeting: MeetingListItem) => {
+    if (
+      !window.confirm(
+        `Cancel the ${meeting.meeting_type} meeting for ${meeting.students?.initials ?? 'this student'}?`
+      )
+    )
+      return;
+    try {
+      await cancelMeeting(meeting.id);
+      await load();
+    } catch {
+      setError('Failed to cancel meeting');
+    }
+  };
+
+  if (schoolLoading || (loading && !planning)) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="flex justify-center py-12">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!schoolId) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Card>
+          <p className="text-gray-600">Select a school to manage meetings.</p>
+        </Card>
+      </div>
+    );
+  }
+
+  const upcoming = meetings.filter(
+    m => m.scheduled_start && new Date(m.scheduled_start) >= new Date()
+  );
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="flex items-center justify-between mb-2">
+        <h1 className="text-2xl font-bold text-gray-900">Meetings</h1>
+        <Button
+          onClick={() => {
+            setPlannerOpen(o => !o);
+            setResults(null);
+          }}
+        >
+          {plannerOpen ? 'Close planner' : 'Plan meetings'}
+        </Button>
+      </div>
+      <p className="text-gray-500 mb-6">
+        IEP meetings for your caseload at {currentSchool?.display_name ?? 'this school'}.
+      </p>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700 mb-6">
+          {error}
+        </div>
+      )}
+      {reservedCount !== null && (
+        <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-green-700 mb-6">
+          Reserved {reservedCount} meeting{reservedCount === 1 ? '' : 's'}.
+          Family confirmations come later — these are internal holds.
+        </div>
+      )}
+
+      {/* Attention strip */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
+        <Card padding="sm">
+          <div className="flex items-center gap-3 px-2">
+            <span
+              className={`text-2xl font-bold tabular-nums ${dueSoonCount > 0 ? 'text-red-600' : 'text-gray-400'}`}
+            >
+              {dueSoonCount}
+            </span>
+            <div>
+              <p className="text-sm font-semibold text-gray-900">
+                Due soon, unscheduled
+              </p>
+              <p className="text-xs text-gray-500">
+                IEP due within 60 days and no meeting on the books
+              </p>
+            </div>
+          </div>
+        </Card>
+        <Card padding="sm">
+          <div className="flex items-center gap-3 px-2">
+            <span className="text-2xl font-bold tabular-nums text-gray-700">
+              {unscheduled.length}
+            </span>
+            <div>
+              <p className="text-sm font-semibold text-gray-900">
+                Unscheduled with due dates
+              </p>
+              <p className="text-xs text-gray-500">
+                Students the planner can place right now
+              </p>
+            </div>
+          </div>
+        </Card>
+      </div>
+
+      {/* Planner */}
+      {plannerOpen && (
+        <Card className="mb-8">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">
+            Plan meetings
+          </h2>
+          {!planning?.hasSiteRules ? (
+            <p className="text-gray-600 text-sm">
+              Your site admin hasn&apos;t set meeting windows yet — planning
+              needs the school&apos;s allowed meeting times. Ask them to fill
+              in Meetings settings on the admin dashboard.
+            </p>
+          ) : unscheduled.length === 0 ? (
+            <p className="text-gray-600 text-sm">
+              Nothing to plan — every student with an upcoming IEP due date
+              already has a meeting scheduled. Students without due dates on
+              file need one added in their student details first.
+            </p>
+          ) : (
+            <>
+              <div className="flex flex-wrap items-end gap-4 mb-4">
+                <div>
+                  <label
+                    htmlFor="horizon"
+                    className="block text-sm font-medium text-gray-700 mb-1"
+                  >
+                    Plan meetings due through
+                  </label>
+                  <input
+                    id="horizon"
+                    type="date"
+                    value={horizon}
+                    onChange={e => setHorizon(e.target.value)}
+                    className="border border-gray-300 rounded-md px-3 py-2 text-sm"
+                  />
+                </div>
+                <Button variant="secondary" onClick={runPlanner}>
+                  Draft placements
+                </Button>
+              </div>
+
+              {results && (
+                <>
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full text-sm">
+                      <thead>
+                        <tr className="text-left text-xs uppercase tracking-wide text-gray-500 border-b border-gray-200">
+                          <th className="py-2 pr-3"></th>
+                          <th className="py-2 pr-4">Student</th>
+                          <th className="py-2 pr-4">Type</th>
+                          <th className="py-2 pr-4">Due</th>
+                          <th className="py-2 pr-4">Proposed</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {results.map(r => {
+                          const student = planning!.caseload.find(
+                            s => s.id === r.key
+                          );
+                          if (!student) return null;
+                          return (
+                            <tr key={r.key} className="border-b border-gray-100">
+                              <td className="py-2 pr-3">
+                                <input
+                                  type="checkbox"
+                                  disabled={!r.slot}
+                                  checked={selected.has(r.key)}
+                                  onChange={e =>
+                                    setSelected(prev => {
+                                      const next = new Set(prev);
+                                      if (e.target.checked) next.add(r.key);
+                                      else next.delete(r.key);
+                                      return next;
+                                    })
+                                  }
+                                  aria-label={`Include ${student.initials}`}
+                                />
+                              </td>
+                              <td className="py-2 pr-4 font-medium text-gray-900">
+                                {student.initials}
+                                <span className="text-gray-400 font-normal">
+                                  {' '}
+                                  · Gr {student.grade_level}
+                                  {student.teacherName
+                                    ? ` · ${student.teacherName}`
+                                    : ''}
+                                </span>
+                              </td>
+                              <td className="py-2 pr-4 capitalize">
+                                {student.meetingType}
+                              </td>
+                              <td className="py-2 pr-4 tabular-nums">
+                                {student.dueDate}
+                              </td>
+                              <td className="py-2 pr-4">
+                                {r.slot ? (
+                                  <span className="tabular-nums">
+                                    {formatSlotDate(r.slot.date)} ·{' '}
+                                    {minutesToTime(r.slot.start_minutes)}–
+                                    {minutesToTime(r.slot.end_minutes)}
+                                  </span>
+                                ) : (
+                                  <span className="text-red-600">
+                                    {r.reason === 'no_due_date'
+                                      ? 'No due date on file'
+                                      : 'No valid slot found'}
+                                  </span>
+                                )}
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                  <div className="mt-4 flex items-center gap-3">
+                    <Button
+                      onClick={handleReserve}
+                      isLoading={reserving}
+                      disabled={selected.size === 0}
+                    >
+                      Reserve {selected.size} meeting
+                      {selected.size === 1 ? '' : 's'}
+                    </Button>
+                    <span className="text-xs text-gray-500">
+                      Creates internal holds — no invites go to families yet.
+                    </span>
+                  </div>
+                </>
+              )}
+            </>
+          )}
+        </Card>
+      )}
+
+      {/* Upcoming meetings */}
+      <h2 className="text-xs font-bold uppercase tracking-wider text-gray-500 mb-2">
+        Upcoming
+      </h2>
+      <Card padding="none">
+        {upcoming.length === 0 ? (
+          <p className="text-gray-500 text-sm p-6">
+            No upcoming meetings. Use “Plan meetings” to draft your caseload&apos;s
+            IEP meetings from their due dates.
+          </p>
+        ) : (
+          upcoming.map((meeting, i) => (
+            <div
+              key={meeting.id}
+              className={`flex items-center gap-4 px-5 py-3 ${i > 0 ? 'border-t border-gray-100' : ''}`}
+            >
+              <div className="w-44 tabular-nums text-sm">
+                <span className="font-semibold text-gray-900">
+                  {formatTimestamp(meeting.scheduled_start)}
+                </span>
+              </div>
+              <div className="flex-1">
+                <span className="font-medium text-gray-900">
+                  {meeting.students?.initials ?? '—'}
+                </span>
+                <span className="text-gray-400 text-sm">
+                  {' '}
+                  · <span className="capitalize">{meeting.meeting_type}</span>
+                  {meeting.students?.grade_level
+                    ? ` · Gr ${meeting.students.grade_level}`
+                    : ''}
+                  {meeting.due_date ? ` · due ${meeting.due_date}` : ''}
+                </span>
+              </div>
+              <span
+                className={`inline-flex items-center gap-1.5 text-[11px] font-semibold tracking-wide rounded-full px-2.5 py-0.5 border uppercase ${STATUS_STYLES[meeting.status] ?? STATUS_STYLES.draft}`}
+              >
+                {meeting.status}
+              </span>
+              <span className="text-xs text-gray-400 tabular-nums w-14 text-right">
+                {
+                  meeting.iep_meeting_attendees.filter(
+                    a => a.rsvp_status === 'accepted'
+                  ).length
+                }
+                /{meeting.iep_meeting_attendees.length} in
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => handleCancel(meeting)}
+              >
+                Cancel
+              </Button>
+            </div>
+          ))
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/meetings/page.tsx
+++ b/app/(dashboard)/dashboard/meetings/page.tsx
@@ -51,9 +51,10 @@ function formatTimestamp(ts: string | null): string {
 }
 
 function defaultHorizon(): string {
-  // End of the current school year (June 30)
+  // End of the current school year: June 30, rolling to next year from
+  // July onward so the default is never in the past.
   const now = new Date();
-  const year = now.getMonth() >= 7 ? now.getFullYear() + 1 : now.getFullYear();
+  const year = now.getMonth() >= 6 ? now.getFullYear() + 1 : now.getFullYear();
   return `${year}-06-30`;
 }
 
@@ -84,7 +85,7 @@ export default function MeetingsPage() {
     setError(null);
     try {
       const [meetingList, planningData] = await Promise.all([
-        getMyMeetings(),
+        getMyMeetings(schoolId),
         getPlanningData(schoolId),
       ]);
       setMeetings(meetingList);
@@ -118,7 +119,10 @@ export default function MeetingsPage() {
 
   const runPlanner = useCallback(() => {
     if (!planning) return;
-    const requests = unscheduled.map(student => {
+    // The horizon filters by DUE DATE (spec §2.1): "plan meetings due
+    // through [date]" — students due later wait for the next planning pass.
+    const inHorizon = unscheduled.filter(s => s.dueDate! <= horizon);
+    const requests = inHorizon.map(student => {
       const attendees: AttendeeConstraints[] = [
         { key: 'organizer', busy: planning.organizerBusy },
       ];

--- a/app/(dashboard)/dashboard/meetings/page.tsx
+++ b/app/(dashboard)/dashboard/meetings/page.tsx
@@ -110,6 +110,15 @@ export default function MeetingsPage() {
     [planning]
   );
 
+  const missingDueDateCount = useMemo(
+    () =>
+      (planning?.caseload ?? []).filter(
+        s =>
+          !s.hasUpcomingMeeting && (!s.dueDate || s.dueDate < todayStr())
+      ).length,
+    [planning]
+  );
+
   const dueSoonCount = useMemo(() => {
     const cutoff = new Date();
     cutoff.setDate(cutoff.getDate() + 60);
@@ -303,9 +312,21 @@ export default function MeetingsPage() {
           )}
           {unscheduled.length === 0 ? (
             <p className="text-gray-600 text-sm">
-              Nothing to plan — every student with an upcoming IEP due date
-              already has a meeting scheduled. Students without due dates on
-              file need one added in their student details first.
+              {missingDueDateCount > 0 ? (
+                <>
+                  Nothing to plan yet — {missingDueDateCount} of your{' '}
+                  {planning?.caseload.length ?? 0} students{' '}
+                  {missingDueDateCount === 1 ? 'has' : 'have'} no upcoming IEP
+                  date on file. Add an Upcoming IEP or Triennial date in each
+                  student&apos;s details (or run the SEIS import) and they&apos;ll
+                  appear here ready to schedule.
+                </>
+              ) : (
+                <>
+                  Nothing to plan — every student with an upcoming IEP due
+                  date already has a meeting scheduled.
+                </>
+              )}
             </p>
           ) : (
             <>

--- a/app/components/navigation/navbar.tsx
+++ b/app/components/navigation/navbar.tsx
@@ -161,6 +161,7 @@ export default function Navbar() {
             { name: 'Special Activities', href: '/dashboard/special-activities' }
           ]
         },
+        { name: 'Meetings', href: '/dashboard/meetings' },
         { name: 'Plan', href: '/dashboard/plan' },
         { name: 'Chat', href: '/dashboard/chat' },
         { name: 'CARE', href: '/dashboard/care' },
@@ -179,6 +180,7 @@ export default function Navbar() {
             { name: 'Special Activities', href: '/dashboard/special-activities' }
           ]
         },
+        { name: 'Meetings', href: '/dashboard/meetings' },
         { name: 'Plan', href: '/dashboard/plan' },
         { name: 'Chat', href: '/dashboard/chat' },
       ];
@@ -196,6 +198,7 @@ export default function Navbar() {
             { name: 'Special Activities', href: '/dashboard/special-activities' }
           ]
         },
+        { name: 'Meetings', href: '/dashboard/meetings' },
         { name: 'Plan', href: '/dashboard/plan' },
         { name: 'Chat', href: '/dashboard/chat' },
       ];

--- a/lib/iep-meetings/availability.test.ts
+++ b/lib/iep-meetings/availability.test.ts
@@ -1,0 +1,212 @@
+import {
+  addDays,
+  findSlots,
+  getSlotConflicts,
+  isoDayOfWeek,
+  minutesToTime,
+  planMeetings,
+  timeToMinutes,
+  type AttendeeConstraints,
+  type FindSlotsParams,
+  type SiteConstraints,
+} from './availability';
+
+// Tue + Thu afternoons; Wednesday 2027-03-10 through Fri 2027-03-12 blacked out
+const SITE: SiteConstraints = {
+  windows: [
+    { day_of_week: 2, start_time: '14:45', end_time: '16:00' },
+    { day_of_week: 4, start_time: '07:30', end_time: '08:15' },
+  ],
+  blackouts: [
+    { start_date: '2027-03-08', end_date: '2027-03-12', label: 'Testing' },
+  ],
+  maxMeetingsPerDay: 1,
+};
+
+const FREE_ATTENDEE: AttendeeConstraints = { key: 'organizer', busy: [] };
+
+function baseParams(overrides: Partial<FindSlotsParams> = {}): FindSlotsParams {
+  return {
+    from: '2027-03-01', // a Monday
+    to: '2027-03-19',
+    durationMinutes: 60,
+    site: SITE,
+    attendees: [FREE_ATTENDEE],
+    existingMeetings: [],
+    ...overrides,
+  };
+}
+
+describe('time helpers', () => {
+  it('converts between HH:MM and minutes', () => {
+    expect(timeToMinutes('07:30')).toBe(450);
+    expect(minutesToTime(450)).toBe('07:30');
+    expect(minutesToTime(885)).toBe('14:45');
+  });
+
+  it('computes ISO day of week and date arithmetic', () => {
+    expect(isoDayOfWeek('2027-03-01')).toBe(1); // Monday
+    expect(isoDayOfWeek('2027-03-07')).toBe(7); // Sunday
+    expect(addDays('2027-02-28', 1)).toBe('2027-03-01');
+  });
+});
+
+describe('findSlots', () => {
+  it('only proposes slots inside site windows on matching weekdays', () => {
+    const slots = findSlots(baseParams());
+    expect(slots.length).toBeGreaterThan(0);
+    for (const slot of slots) {
+      const dow = isoDayOfWeek(slot.date);
+      expect([2, 4]).toContain(dow);
+      if (dow === 2) {
+        expect(slot.start_minutes).toBeGreaterThanOrEqual(timeToMinutes('14:45'));
+        expect(slot.end_minutes).toBeLessThanOrEqual(timeToMinutes('16:00'));
+      }
+    }
+  });
+
+  it('skips blackout dates', () => {
+    const slots = findSlots(baseParams());
+    // Tue 2027-03-09 falls inside the testing blackout
+    expect(slots.some(s => s.date === '2027-03-09')).toBe(false);
+    // Tuesdays outside the blackout are fine
+    expect(slots.some(s => s.date === '2027-03-02')).toBe(true);
+    expect(slots.some(s => s.date === '2027-03-16')).toBe(true);
+  });
+
+  it('never proposes a Thursday slot longer than the morning window', () => {
+    const slots = findSlots(baseParams({ durationMinutes: 60 }));
+    // Thursday window is only 45 minutes — no 60-minute slot fits
+    expect(slots.every(s => isoDayOfWeek(s.date) !== 4)).toBe(true);
+  });
+
+  it('respects attendee recurring busy blocks (weekly sessions)', () => {
+    const busyProvider: AttendeeConstraints = {
+      key: 'slp',
+      busy: [
+        // Sessions every Tuesday 14:30–15:30
+        { day_of_week: 2, start_minutes: 870, end_minutes: 930, source: 'session' },
+      ],
+    };
+    const slots = findSlots(baseParams({ attendees: [busyProvider] }));
+    for (const slot of slots.filter(s => isoDayOfWeek(s.date) === 2)) {
+      expect(slot.start_minutes).toBeGreaterThanOrEqual(930);
+    }
+  });
+
+  it('respects attendee available windows (teacher prep)', () => {
+    const prepTeacher: AttendeeConstraints = {
+      key: 'teacher',
+      busy: [],
+      availableWindows: [{ start_minutes: 900, end_minutes: 960 }], // 15:00–16:00
+    };
+    const slots = findSlots(baseParams({ attendees: [prepTeacher] }));
+    expect(slots.length).toBeGreaterThan(0);
+    for (const slot of slots) {
+      expect(slot.start_minutes).toBeGreaterThanOrEqual(900);
+      expect(slot.end_minutes).toBeLessThanOrEqual(960);
+    }
+  });
+
+  it('blocks overlap with existing meetings and enforces daily capacity', () => {
+    const existing = [
+      { date: '2027-03-02', start_minutes: 885, end_minutes: 945 },
+    ];
+    const slots = findSlots(baseParams({ existingMeetings: existing }));
+    // maxMeetingsPerDay = 1 → the whole day is consumed
+    expect(slots.some(s => s.date === '2027-03-02')).toBe(false);
+  });
+});
+
+describe('getSlotConflicts', () => {
+  it('names the failing constraint', () => {
+    const conflicts = getSlotConflicts(
+      { date: '2027-03-11', start_minutes: 450, end_minutes: 510 },
+      { site: SITE, attendees: [FREE_ATTENDEE], existingMeetings: [] }
+    );
+    expect(conflicts.map(c => c.kind)).toContain('blackout');
+  });
+
+  it('returns empty for a valid slot', () => {
+    const conflicts = getSlotConflicts(
+      { date: '2027-03-02', start_minutes: 885, end_minutes: 945 },
+      { site: SITE, attendees: [FREE_ATTENDEE], existingMeetings: [] }
+    );
+    expect(conflicts).toEqual([]);
+  });
+});
+
+describe('planMeetings', () => {
+  const base = {
+    from: '2027-03-01',
+    to: '2027-05-28',
+    durationMinutes: 60,
+    site: SITE,
+    existingMeetings: [],
+  };
+
+  it('places meetings inside the 2–6 week lead window before the due date', () => {
+    const [result] = planMeetings(
+      [{ key: 'student-1', dueDate: '2027-04-20', attendees: [FREE_ATTENDEE] }],
+      base
+    );
+    expect(result.slot).not.toBeNull();
+    expect(result.slot!.date >= '2027-03-09').toBe(true); // due - 42d
+    expect(result.slot!.date <= '2027-04-06').toBe(true); // due - 14d
+  });
+
+  it('never double-books its own placements', () => {
+    const requests = Array.from({ length: 4 }, (_, i) => ({
+      key: `student-${i}`,
+      dueDate: '2027-04-20',
+      attendees: [FREE_ATTENDEE],
+    }));
+    const results = planMeetings(requests, base);
+    const placed = results.filter(r => r.slot).map(r => `${r.slot!.date}`);
+    // maxMeetingsPerDay = 1 → all four land on distinct dates
+    expect(new Set(placed).size).toBe(placed.length);
+    expect(placed.length).toBe(4);
+  });
+
+  it('schedules earliest-due students first', () => {
+    const results = planMeetings(
+      [
+        { key: 'late', dueDate: '2027-05-20', attendees: [FREE_ATTENDEE] },
+        { key: 'soon', dueDate: '2027-03-25', attendees: [FREE_ATTENDEE] },
+      ],
+      base
+    );
+    const soon = results.find(r => r.key === 'soon')!;
+    const late = results.find(r => r.key === 'late')!;
+    expect(soon.slot!.date < late.slot!.date).toBe(true);
+  });
+
+  it('falls back to any pre-due slot when the ideal window is dry', () => {
+    // Due date so soon that [due-42, due-14] is entirely before the range
+    const [result] = planMeetings(
+      [{ key: 'urgent', dueDate: '2027-03-05', attendees: [FREE_ATTENDEE] }],
+      base
+    );
+    expect(result.slot).not.toBeNull();
+    expect(result.slot!.date < '2027-03-05').toBe(true);
+  });
+
+  it('reports unplaceable and missing-due-date students', () => {
+    const busyEverywhere: AttendeeConstraints = {
+      key: 'teacher',
+      busy: [
+        { day_of_week: 2, start_minutes: 0, end_minutes: 1440, source: 'session' },
+        { day_of_week: 4, start_minutes: 0, end_minutes: 1440, source: 'session' },
+      ],
+    };
+    const results = planMeetings(
+      [
+        { key: 'stuck', dueDate: '2027-04-20', attendees: [busyEverywhere] },
+        { key: 'no-date', dueDate: null, attendees: [FREE_ATTENDEE] },
+      ],
+      base
+    );
+    expect(results.find(r => r.key === 'stuck')!.reason).toBe('no_valid_slot');
+    expect(results.find(r => r.key === 'no-date')!.reason).toBe('no_due_date');
+  });
+});

--- a/lib/iep-meetings/availability.test.ts
+++ b/lib/iep-meetings/availability.test.ts
@@ -127,6 +127,43 @@ describe('getSlotConflicts', () => {
     expect(conflicts.map(c => c.kind)).toContain('blackout');
   });
 
+  it('names site_capacity and meeting_overlap conflicts', () => {
+    const conflicts = getSlotConflicts(
+      { date: '2027-03-02', start_minutes: 885, end_minutes: 945 },
+      {
+        site: SITE,
+        attendees: [FREE_ATTENDEE],
+        existingMeetings: [
+          { date: '2027-03-02', start_minutes: 900, end_minutes: 960 },
+        ],
+      }
+    );
+    expect(conflicts.map(c => c.kind)).toEqual(
+      expect.arrayContaining(['site_capacity', 'meeting_overlap'])
+    );
+  });
+
+  it('names attendee_busy and attendee_unavailable conflicts', () => {
+    const busyTeacher: AttendeeConstraints = {
+      key: 'busy-teacher',
+      busy: [
+        { day_of_week: 2, start_minutes: 885, end_minutes: 945, source: 'session' },
+      ],
+    };
+    const prepOnlyTeacher: AttendeeConstraints = {
+      key: 'prep-teacher',
+      busy: [],
+      availableWindows: [{ start_minutes: 0, end_minutes: 800 }],
+    };
+    const conflicts = getSlotConflicts(
+      { date: '2027-03-02', start_minutes: 885, end_minutes: 945 },
+      { site: SITE, attendees: [busyTeacher, prepOnlyTeacher], existingMeetings: [] }
+    );
+    const kinds = conflicts.map(c => c.kind);
+    expect(kinds).toContain('attendee_busy');
+    expect(kinds).toContain('attendee_unavailable');
+  });
+
   it('returns empty for a valid slot', () => {
     const conflicts = getSlotConflicts(
       { date: '2027-03-02', start_minutes: 885, end_minutes: 945 },

--- a/lib/iep-meetings/availability.ts
+++ b/lib/iep-meetings/availability.ts
@@ -78,6 +78,16 @@ export interface FindSlotsParams {
   limit?: number;
 }
 
+/**
+ * Fallback when a site has no admin-configured meeting windows yet:
+ * general school-day hours, all weekdays. Attendee constraints (sessions,
+ * prep windows) still apply; the UI shows a notice that these are
+ * defaults, not site rules.
+ */
+export const DEFAULT_MEETING_WINDOWS: DayWindow[] = [1, 2, 3, 4, 5].map(
+  day_of_week => ({ day_of_week, start_time: '08:00', end_time: '16:00' })
+);
+
 export function timeToMinutes(hhmm: string): number {
   const [h, m] = hhmm.split(':').map(Number);
   return h * 60 + (m || 0);

--- a/lib/iep-meetings/availability.ts
+++ b/lib/iep-meetings/availability.ts
@@ -1,0 +1,325 @@
+/**
+ * IEP meeting availability engine (SPE-206).
+ *
+ * Pure functions — no I/O. A slot is valid when it fits inside a site
+ * meeting window, avoids blackouts and the site's meeting-capacity rules,
+ * and works for every attendee: outside their busy intervals and inside
+ * their available windows (when they have declared any).
+ *
+ * Availability is the union of whatever constraint sources exist per
+ * person (spec §5). Sources are assembled by the query layer; the Google
+ * free/busy source plugs in as one more BusyInterval producer when
+ * calendar integration lands (SPE-205).
+ *
+ * Times are minutes-from-midnight on a local calendar date ('YYYY-MM-DD')
+ * to keep the math timezone-free; conversion to timestamps happens at
+ * persistence time.
+ */
+
+export interface DayWindow {
+  day_of_week: number; // 1 = Monday … 5 = Friday (matches site_meeting_rules)
+  start_time: string; // 'HH:MM'
+  end_time: string; // 'HH:MM'
+}
+
+export interface DateRange {
+  start_date: string; // 'YYYY-MM-DD' inclusive
+  end_date: string; // 'YYYY-MM-DD' inclusive
+  label?: string;
+}
+
+export interface SiteConstraints {
+  windows: DayWindow[];
+  blackouts: DateRange[];
+  maxMeetingsPerDay: number | null;
+}
+
+/** Busy interval on a specific date, in minutes from midnight. */
+export interface BusyBlock {
+  date?: string; // 'YYYY-MM-DD' — omit for weekly-recurring blocks
+  day_of_week?: number; // 1-5 for weekly-recurring blocks (e.g. sessions)
+  start_minutes: number;
+  end_minutes: number;
+  source: string; // 'session' | 'meeting' | 'google' | …
+  label?: string;
+}
+
+export interface AttendeeConstraints {
+  key: string; // profile id or stable identifier
+  busy: BusyBlock[];
+  /**
+   * When present, slots must fall entirely inside one of these windows
+   * (e.g. a teacher's prep block). Recurring weekly, all weekdays.
+   */
+  availableWindows?: { start_minutes: number; end_minutes: number }[] | null;
+}
+
+export interface ProposedSlot {
+  date: string; // 'YYYY-MM-DD'
+  start_minutes: number;
+  end_minutes: number;
+}
+
+export interface FindSlotsParams {
+  /** Inclusive search range, 'YYYY-MM-DD'. */
+  from: string;
+  to: string;
+  durationMinutes: number;
+  site: SiteConstraints;
+  attendees: AttendeeConstraints[];
+  /**
+   * Already-scheduled meetings: consume site capacity and block overlap
+   * (one IEP meeting at a time per site — the LEA rep can't be in two rooms).
+   */
+  existingMeetings: { date: string; start_minutes: number; end_minutes: number }[];
+  /** Step between candidate start times. Default 15. */
+  stepMinutes?: number;
+  /** Stop after this many slots. Default 100. */
+  limit?: number;
+}
+
+export function timeToMinutes(hhmm: string): number {
+  const [h, m] = hhmm.split(':').map(Number);
+  return h * 60 + (m || 0);
+}
+
+export function minutesToTime(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+/** ISO day of week for a 'YYYY-MM-DD' string: 1 = Monday … 7 = Sunday. */
+export function isoDayOfWeek(date: string): number {
+  const [y, m, d] = date.split('-').map(Number);
+  const dow = new Date(Date.UTC(y, m - 1, d)).getUTCDay(); // 0 = Sunday
+  return dow === 0 ? 7 : dow;
+}
+
+export function addDays(date: string, days: number): string {
+  const [y, m, d] = date.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + days);
+  return dt.toISOString().slice(0, 10);
+}
+
+function overlaps(
+  aStart: number,
+  aEnd: number,
+  bStart: number,
+  bEnd: number
+): boolean {
+  return aStart < bEnd && bStart < aEnd;
+}
+
+function inBlackout(date: string, blackouts: DateRange[]): DateRange | null {
+  return (
+    blackouts.find(b => b.start_date <= date && date <= b.end_date) ?? null
+  );
+}
+
+/** Reason a specific slot doesn't work; empty array = slot is valid. */
+export interface SlotConflict {
+  kind:
+    | 'blackout'
+    | 'outside_windows'
+    | 'site_capacity'
+    | 'meeting_overlap'
+    | 'attendee_busy'
+    | 'attendee_unavailable';
+  attendeeKey?: string;
+  label?: string;
+}
+
+export function getSlotConflicts(
+  slot: ProposedSlot,
+  params: Pick<FindSlotsParams, 'site' | 'attendees' | 'existingMeetings'>
+): SlotConflict[] {
+  const conflicts: SlotConflict[] = [];
+  const { site, attendees, existingMeetings } = params;
+  const dow = isoDayOfWeek(slot.date);
+
+  const blackout = inBlackout(slot.date, site.blackouts);
+  if (blackout) {
+    conflicts.push({ kind: 'blackout', label: blackout.label });
+  }
+
+  const fitsWindow = site.windows.some(
+    w =>
+      w.day_of_week === dow &&
+      timeToMinutes(w.start_time) <= slot.start_minutes &&
+      slot.end_minutes <= timeToMinutes(w.end_time)
+  );
+  if (!fitsWindow) conflicts.push({ kind: 'outside_windows' });
+
+  const sameDay = existingMeetings.filter(m => m.date === slot.date);
+  if (
+    site.maxMeetingsPerDay !== null &&
+    sameDay.length >= site.maxMeetingsPerDay
+  ) {
+    conflicts.push({ kind: 'site_capacity' });
+  }
+  if (
+    sameDay.some(m =>
+      overlaps(slot.start_minutes, slot.end_minutes, m.start_minutes, m.end_minutes)
+    )
+  ) {
+    conflicts.push({ kind: 'meeting_overlap' });
+  }
+
+  for (const attendee of attendees) {
+    const busyHit = attendee.busy.find(b => {
+      const applies =
+        b.date === slot.date || (!b.date && b.day_of_week === dow);
+      return (
+        applies &&
+        overlaps(slot.start_minutes, slot.end_minutes, b.start_minutes, b.end_minutes)
+      );
+    });
+    if (busyHit) {
+      conflicts.push({
+        kind: 'attendee_busy',
+        attendeeKey: attendee.key,
+        label: busyHit.label ?? busyHit.source,
+      });
+      continue;
+    }
+    if (attendee.availableWindows && attendee.availableWindows.length > 0) {
+      const inside = attendee.availableWindows.some(
+        w =>
+          w.start_minutes <= slot.start_minutes &&
+          slot.end_minutes <= w.end_minutes
+      );
+      if (!inside) {
+        conflicts.push({ kind: 'attendee_unavailable', attendeeKey: attendee.key });
+      }
+    }
+  }
+
+  return conflicts;
+}
+
+/**
+ * All valid slots in the range, chronological. Weekends are skipped
+ * implicitly (site windows only cover Mon–Fri).
+ */
+export function findSlots(params: FindSlotsParams): ProposedSlot[] {
+  const {
+    from,
+    to,
+    durationMinutes,
+    site,
+    stepMinutes = 15,
+    limit = 100,
+  } = params;
+  const slots: ProposedSlot[] = [];
+  if (from > to || site.windows.length === 0) return slots;
+
+  for (let date = from; date <= to; date = addDays(date, 1)) {
+    if (inBlackout(date, site.blackouts)) continue;
+    const dow = isoDayOfWeek(date);
+    const dayWindows = site.windows.filter(w => w.day_of_week === dow);
+    for (const window of dayWindows) {
+      const winStart = timeToMinutes(window.start_time);
+      const winEnd = timeToMinutes(window.end_time);
+      for (
+        let start = winStart;
+        start + durationMinutes <= winEnd;
+        start += stepMinutes
+      ) {
+        const slot: ProposedSlot = {
+          date,
+          start_minutes: start,
+          end_minutes: start + durationMinutes,
+        };
+        if (getSlotConflicts(slot, params).length === 0) {
+          slots.push(slot);
+          if (slots.length >= limit) return slots;
+        }
+      }
+    }
+  }
+  return slots;
+}
+
+export interface PlanRequest {
+  key: string; // e.g. student id
+  dueDate: string | null; // 'YYYY-MM-DD' compliance deadline
+  attendees: AttendeeConstraints[];
+}
+
+export interface PlanResult {
+  key: string;
+  slot: ProposedSlot | null;
+  reason?: 'no_valid_slot' | 'no_due_date';
+}
+
+/** Target scheduling 2–6 weeks before the due date (clamped to range). */
+export const DUE_DATE_LEAD_DAYS_MIN = 14;
+export const DUE_DATE_LEAD_DAYS_MAX = 42;
+
+/**
+ * Draft one meeting per request, earliest-due first. Placed meetings are
+ * added to the occupied set so later placements can't collide (the
+ * planner is the site's own busy source while it runs). Idempotent by
+ * construction: requests already scheduled are excluded by the caller.
+ */
+export function planMeetings(
+  requests: PlanRequest[],
+  base: Omit<FindSlotsParams, 'attendees'>
+): PlanResult[] {
+  const occupied = [...base.existingMeetings];
+  const results: PlanResult[] = [];
+
+  const ordered = [...requests].sort((a, b) =>
+    (a.dueDate ?? '9999').localeCompare(b.dueDate ?? '9999')
+  );
+
+  for (const request of ordered) {
+    if (!request.dueDate) {
+      results.push({ key: request.key, slot: null, reason: 'no_due_date' });
+      continue;
+    }
+    // Ideal window: [due - 6wk, due - 2wk], clamped to the search range;
+    // fall back to anything before the due date if the ideal window is dry.
+    const idealFrom = maxDate(base.from, addDays(request.dueDate, -DUE_DATE_LEAD_DAYS_MAX));
+    const idealTo = minDate(base.to, addDays(request.dueDate, -DUE_DATE_LEAD_DAYS_MIN));
+    const fallbackTo = minDate(base.to, addDays(request.dueDate, -1));
+
+    const attempt = (from: string, to: string): ProposedSlot | null => {
+      if (from > to) return null;
+      const [slot] = findSlots({
+        ...base,
+        from,
+        to,
+        attendees: request.attendees,
+        existingMeetings: occupied,
+        limit: 1,
+      });
+      return slot ?? null;
+    };
+
+    const slot =
+      attempt(idealFrom, idealTo) ?? attempt(base.from, fallbackTo);
+
+    if (slot) {
+      occupied.push({
+        date: slot.date,
+        start_minutes: slot.start_minutes,
+        end_minutes: slot.end_minutes,
+      });
+      results.push({ key: request.key, slot });
+    } else {
+      results.push({ key: request.key, slot: null, reason: 'no_valid_slot' });
+    }
+  }
+  return results;
+}
+
+function maxDate(a: string, b: string): string {
+  return a > b ? a : b;
+}
+
+function minDate(a: string, b: string): string {
+  return a < b ? a : b;
+}

--- a/lib/supabase/queries/iep-meetings.ts
+++ b/lib/supabase/queries/iep-meetings.ts
@@ -45,8 +45,14 @@ export interface PlanningData {
   leaRep: { admin_id: string; full_name: string } | null;
 }
 
-/** Meetings this user organizes, soonest first (cancelled/deleted excluded). */
-export async function getMyMeetings(): Promise<MeetingListItem[]> {
+/**
+ * Meetings this user organizes at one school, soonest first
+ * (cancelled/deleted excluded). School-scoped so itinerant providers see
+ * only the active school's meetings.
+ */
+export async function getMyMeetings(
+  schoolId: string
+): Promise<MeetingListItem[]> {
   const supabase = createClient<Database>();
   const {
     data: { user },
@@ -59,6 +65,7 @@ export async function getMyMeetings(): Promise<MeetingListItem[]> {
       '*, students(initials, grade_level), iep_meeting_attendees(id, attendee_role, rsvp_status, display_name, profile_id)'
     )
     .eq('organizer_id', user.id)
+    .eq('school_id', schoolId)
     .neq('status', 'cancelled')
     .is('deleted_at', null)
     .order('scheduled_start', { ascending: true });

--- a/lib/supabase/queries/iep-meetings.ts
+++ b/lib/supabase/queries/iep-meetings.ts
@@ -1,0 +1,377 @@
+import { createClient } from '@/lib/supabase/client';
+import type { Database, IepMeeting } from '@/src/types';
+import { getCurrentSchoolYear } from '@/lib/school-year';
+import {
+  timeToMinutes,
+  type AttendeeConstraints,
+  type BusyBlock,
+  type DayWindow,
+  type DateRange,
+  type ProposedSlot,
+  type SiteConstraints,
+} from '@/lib/iep-meetings/availability';
+import type { SiteMeetingRules } from '@/src/types';
+
+export interface MeetingListItem extends IepMeeting {
+  students: { initials: string; grade_level: string } | null;
+  iep_meeting_attendees: {
+    id: string;
+    attendee_role: string;
+    rsvp_status: string;
+    display_name: string | null;
+    profile_id: string | null;
+  }[];
+}
+
+export interface CaseloadStudent {
+  id: string;
+  initials: string;
+  grade_level: string;
+  teacher_id: string | null;
+  teacherName: string | null;
+  teacherProfileId: string | null;
+  dueDate: string | null; // earlier of upcoming IEP / triennial
+  meetingType: 'annual' | 'triennial';
+  hasUpcomingMeeting: boolean;
+}
+
+export interface PlanningData {
+  caseload: CaseloadStudent[];
+  site: SiteConstraints;
+  hasSiteRules: boolean;
+  organizerBusy: BusyBlock[];
+  teacherConstraints: Map<string, AttendeeConstraints>; // by teacher profile id
+  existingMeetings: { date: string; start_minutes: number; end_minutes: number }[];
+  leaRep: { admin_id: string; full_name: string } | null;
+}
+
+/** Meetings this user organizes, soonest first (cancelled/deleted excluded). */
+export async function getMyMeetings(): Promise<MeetingListItem[]> {
+  const supabase = createClient<Database>();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return [];
+
+  const { data, error } = await supabase
+    .from('iep_meetings')
+    .select(
+      '*, students(initials, grade_level), iep_meeting_attendees(id, attendee_role, rsvp_status, display_name, profile_id)'
+    )
+    .eq('organizer_id', user.id)
+    .neq('status', 'cancelled')
+    .is('deleted_at', null)
+    .order('scheduled_start', { ascending: true });
+
+  if (error) {
+    console.error('Error fetching meetings:', error);
+    throw error;
+  }
+  return (data ?? []) as MeetingListItem[];
+}
+
+function toLocalParts(timestamp: string): {
+  date: string;
+  start_minutes: number;
+} {
+  const d = new Date(timestamp);
+  const date = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  return { date, start_minutes: d.getHours() * 60 + d.getMinutes() };
+}
+
+/** Everything the planner needs for one school, in one assembly pass. */
+export async function getPlanningData(schoolId: string): Promise<PlanningData> {
+  const supabase = createClient<Database>();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const [rulesRes, studentsRes, sessionsRes, meetingsRes, adminsRes] =
+    await Promise.all([
+      supabase
+        .from('site_meeting_rules')
+        .select('*')
+        .eq('school_id', schoolId)
+        .maybeSingle(),
+      supabase
+        .from('students')
+        .select(
+          'id, initials, grade_level, teacher_id, teachers(id, account_id, first_name, last_name), student_details(upcoming_iep_date, upcoming_triennial_date)'
+        )
+        .eq('provider_id', user.id)
+        .eq('school_id', schoolId),
+      supabase
+        .from('schedule_sessions')
+        .select('day_of_week, start_time, end_time')
+        .eq('provider_id', user.id)
+        .is('deleted_at', null)
+        .not('day_of_week', 'is', null),
+      supabase
+        .from('iep_meetings')
+        .select('id, student_id, scheduled_start, scheduled_end, status')
+        .eq('school_id', schoolId)
+        .neq('status', 'cancelled')
+        .is('deleted_at', null)
+        .not('scheduled_start', 'is', null),
+      supabase.rpc('get_school_site_admins', { p_school_id: schoolId }),
+    ]);
+
+  if (studentsRes.error) {
+    console.error('Error fetching caseload:', studentsRes.error);
+    throw studentsRes.error;
+  }
+
+  const rules = rulesRes.data as SiteMeetingRules | null;
+  const site: SiteConstraints = {
+    windows: ((rules?.allowed_windows ?? []) as unknown as DayWindow[]) || [],
+    blackouts: ((rules?.blackout_ranges ?? []) as unknown as DateRange[]) || [],
+    maxMeetingsPerDay: rules?.max_meetings_per_day ?? null,
+  };
+
+  const organizerBusy: BusyBlock[] = (sessionsRes.data ?? [])
+    .filter(s => s.start_time && s.end_time)
+    .map(s => ({
+      day_of_week: s.day_of_week as number,
+      start_minutes: timeToMinutes(s.start_time as string),
+      end_minutes: timeToMinutes(s.end_time as string),
+      source: 'session',
+      label: 'Session',
+    }));
+
+  const existingMeetings = (meetingsRes.data ?? []).map(m => {
+    const start = toLocalParts(m.scheduled_start as string);
+    const end = m.scheduled_end
+      ? toLocalParts(m.scheduled_end as string)
+      : { start_minutes: start.start_minutes + 60 };
+    return {
+      date: start.date,
+      start_minutes: start.start_minutes,
+      end_minutes: end.start_minutes,
+    };
+  });
+
+  const studentsWithMeetings = new Set(
+    (meetingsRes.data ?? [])
+      .filter(m => (m.scheduled_start as string) >= new Date().toISOString())
+      .map(m => m.student_id)
+  );
+
+  type StudentRow = {
+    id: string;
+    initials: string;
+    grade_level: string;
+    teacher_id: string | null;
+    teachers: {
+      id: string;
+      account_id: string | null;
+      first_name: string | null;
+      last_name: string | null;
+    } | null;
+    student_details: {
+      upcoming_iep_date: string | null;
+      upcoming_triennial_date: string | null;
+    } | null;
+  };
+
+  const caseload: CaseloadStudent[] = ((studentsRes.data ?? []) as unknown as StudentRow[]).map(s => {
+    const details = Array.isArray(s.student_details)
+      ? s.student_details[0]
+      : s.student_details;
+    const iepDue = details?.upcoming_iep_date ?? null;
+    const triDue = details?.upcoming_triennial_date ?? null;
+    // Authoritative deadlines (spec §10): earlier of the two decides the
+    // next meeting and its type.
+    let dueDate = iepDue;
+    let meetingType: 'annual' | 'triennial' = 'annual';
+    if (triDue && (!iepDue || triDue <= iepDue)) {
+      dueDate = triDue;
+      meetingType = 'triennial';
+    }
+    const teacher = Array.isArray(s.teachers) ? s.teachers[0] : s.teachers;
+    return {
+      id: s.id,
+      initials: s.initials,
+      grade_level: s.grade_level,
+      teacher_id: s.teacher_id,
+      teacherName: teacher
+        ? [teacher.first_name, teacher.last_name].filter(Boolean).join(' ') || null
+        : null,
+      teacherProfileId: teacher?.account_id ?? null,
+      dueDate,
+      meetingType,
+      hasUpcomingMeeting: studentsWithMeetings.has(s.id),
+    };
+  });
+
+  // Teacher availability prefs → engine constraints, by teacher profile id
+  const teacherProfileIds = Array.from(
+    new Set(caseload.map(s => s.teacherProfileId).filter(Boolean))
+  ) as string[];
+  const teacherConstraints = new Map<string, AttendeeConstraints>();
+  if (teacherProfileIds.length > 0) {
+    const { data: prefs } = await supabase
+      .from('teacher_availability_prefs')
+      .select('*')
+      .in('profile_id', teacherProfileIds)
+      .eq('school_year', getCurrentSchoolYear());
+    for (const pref of prefs ?? []) {
+      // Prep windows are hard constraints when times exist; before/after
+      // school preferences stay soft until bell-schedule/school-hours
+      // derivation lands, so they don't over-restrict.
+      const windows =
+        pref.meeting_time_preference === 'prep' &&
+        pref.prep_start &&
+        pref.prep_end
+          ? [
+              {
+                start_minutes: timeToMinutes(pref.prep_start),
+                end_minutes: timeToMinutes(pref.prep_end),
+              },
+            ]
+          : null;
+      teacherConstraints.set(pref.profile_id, {
+        key: pref.profile_id,
+        busy: [],
+        availableWindows: windows,
+      });
+    }
+  }
+
+  const leaRepRow = (adminsRes.data ?? [])[0] ?? null;
+
+  return {
+    caseload,
+    site,
+    hasSiteRules: !!rules && site.windows.length > 0,
+    organizerBusy,
+    teacherConstraints,
+    existingMeetings,
+    leaRep: leaRepRow
+      ? { admin_id: leaRepRow.admin_id, full_name: leaRepRow.full_name }
+      : null,
+  };
+}
+
+export interface MeetingDraft {
+  student: CaseloadStudent;
+  slot: ProposedSlot;
+}
+
+function slotToTimestamps(slot: ProposedSlot): { start: string; end: string } {
+  const [y, m, d] = slot.date.split('-').map(Number);
+  const start = new Date(
+    y,
+    m - 1,
+    d,
+    Math.floor(slot.start_minutes / 60),
+    slot.start_minutes % 60
+  );
+  const end = new Date(
+    y,
+    m - 1,
+    d,
+    Math.floor(slot.end_minutes / 60),
+    slot.end_minutes % 60
+  );
+  return { start: start.toISOString(), end: end.toISOString() };
+}
+
+/**
+ * Persist reserved meetings + their attendee rows. Parents are added later
+ * during the confirmation pass (SPE-209); admins honor holds (spec §13.2).
+ */
+export async function reserveMeetings(
+  schoolId: string,
+  drafts: MeetingDraft[],
+  leaRep: { admin_id: string; full_name: string } | null
+): Promise<number> {
+  const supabase = createClient<Database>();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const meetingRows = drafts.map(d => {
+    const { start, end } = slotToTimestamps(d.slot);
+    return {
+      student_id: d.student.id,
+      school_id: schoolId,
+      organizer_id: user.id,
+      meeting_type: d.student.meetingType,
+      due_date: d.student.dueDate,
+      scheduled_start: start,
+      scheduled_end: end,
+      status: 'reserved',
+    };
+  });
+
+  const { data: inserted, error } = await supabase
+    .from('iep_meetings')
+    .insert(meetingRows)
+    .select('id, student_id');
+
+  if (error) {
+    console.error('Error reserving meetings:', error);
+    throw error;
+  }
+
+  const attendeeRows = (inserted ?? []).flatMap(meeting => {
+    const draft = drafts.find(d => d.student.id === meeting.student_id);
+    const rows: Database['public']['Tables']['iep_meeting_attendees']['Insert'][] =
+      [
+        {
+          meeting_id: meeting.id,
+          profile_id: user.id,
+          attendee_role: 'case_manager',
+          rsvp_status: 'accepted',
+          rsvp_source: 'speddy',
+        },
+      ];
+    if (leaRep) {
+      rows.push({
+        meeting_id: meeting.id,
+        profile_id: leaRep.admin_id,
+        attendee_role: 'lea_rep',
+      });
+    }
+    if (draft?.student.teacherProfileId) {
+      rows.push({
+        meeting_id: meeting.id,
+        profile_id: draft.student.teacherProfileId,
+        attendee_role: 'teacher',
+      });
+    } else if (draft?.student.teacherName) {
+      rows.push({
+        meeting_id: meeting.id,
+        display_name: draft.student.teacherName,
+        attendee_role: 'teacher',
+      });
+    }
+    return rows;
+  });
+
+  if (attendeeRows.length > 0) {
+    const { error: attendeeError } = await supabase
+      .from('iep_meeting_attendees')
+      .insert(attendeeRows);
+    if (attendeeError) {
+      // Meetings exist; attendees can be re-added from the meeting view
+      console.error('Error adding attendees:', attendeeError);
+    }
+  }
+
+  return inserted?.length ?? 0;
+}
+
+export async function cancelMeeting(meetingId: string): Promise<void> {
+  const supabase = createClient<Database>();
+  const { error } = await supabase
+    .from('iep_meetings')
+    .update({ status: 'cancelled' })
+    .eq('id', meetingId);
+  if (error) {
+    console.error('Error cancelling meeting:', error);
+    throw error;
+  }
+}

--- a/lib/supabase/queries/iep-meetings.ts
+++ b/lib/supabase/queries/iep-meetings.ts
@@ -68,6 +68,7 @@ export async function getMyMeetings(
     .eq('school_id', schoolId)
     .neq('status', 'cancelled')
     .is('deleted_at', null)
+    .gte('scheduled_start', new Date().toISOString())
     .order('scheduled_start', { ascending: true });
 
   if (error) {
@@ -124,9 +125,20 @@ export async function getPlanningData(schoolId: string): Promise<PlanningData> {
       supabase.rpc('get_school_site_admins', { p_school_id: schoolId }),
     ]);
 
-  if (studentsRes.error) {
-    console.error('Error fetching caseload:', studentsRes.error);
-    throw studentsRes.error;
+  // Every source feeds planning constraints — a silently-failed fetch would
+  // produce a plan that looks valid but ignores real conflicts.
+  const failures: [string, unknown][] = [
+    ['caseload', studentsRes.error],
+    ['site rules', rulesRes.error],
+    ['sessions', sessionsRes.error],
+    ['meetings', meetingsRes.error],
+    ['site admins', adminsRes.error],
+  ];
+  for (const [what, err] of failures) {
+    if (err) {
+      console.error(`Error fetching ${what}:`, err);
+      throw err;
+    }
   }
 
   const rules = rulesRes.data as SiteMeetingRules | null;
@@ -158,9 +170,10 @@ export async function getPlanningData(schoolId: string): Promise<PlanningData> {
     };
   });
 
+  const now = Date.now();
   const studentsWithMeetings = new Set(
     (meetingsRes.data ?? [])
-      .filter(m => (m.scheduled_start as string) >= new Date().toISOString())
+      .filter(m => new Date(m.scheduled_start as string).getTime() >= now)
       .map(m => m.student_id)
   );
 
@@ -292,7 +305,7 @@ export async function reserveMeetings(
   schoolId: string,
   drafts: MeetingDraft[],
   leaRep: { admin_id: string; full_name: string } | null
-): Promise<number> {
+): Promise<{ reserved: number; attendeesFailed: boolean }> {
   const supabase = createClient<Database>();
   const {
     data: { user },
@@ -358,25 +371,35 @@ export async function reserveMeetings(
     return rows;
   });
 
+  let attendeesFailed = false;
   if (attendeeRows.length > 0) {
     const { error: attendeeError } = await supabase
       .from('iep_meeting_attendees')
       .insert(attendeeRows);
     if (attendeeError) {
-      // Meetings exist; attendees can be re-added from the meeting view
+      // Meetings exist; surface the partial failure so the caller can warn
       console.error('Error adding attendees:', attendeeError);
+      attendeesFailed = true;
     }
   }
 
-  return inserted?.length ?? 0;
+  return { reserved: inserted?.length ?? 0, attendeesFailed };
 }
 
 export async function cancelMeeting(meetingId: string): Promise<void> {
   const supabase = createClient<Database>();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  // RLS scopes updates to the school; restrict cancellation to the
+  // organizer at the query level as well.
   const { error } = await supabase
     .from('iep_meetings')
     .update({ status: 'cancelled' })
-    .eq('id', meetingId);
+    .eq('id', meetingId)
+    .eq('organizer_id', user.id);
   if (error) {
     console.error('Error cancelling meeting:', error);
     throw error;

--- a/lib/supabase/queries/iep-meetings.ts
+++ b/lib/supabase/queries/iep-meetings.ts
@@ -230,11 +230,16 @@ export async function getPlanningData(schoolId: string): Promise<PlanningData> {
   ) as string[];
   const teacherConstraints = new Map<string, AttendeeConstraints>();
   if (teacherProfileIds.length > 0) {
-    const { data: prefs } = await supabase
+    const { data: prefs, error: prefsError } = await supabase
       .from('teacher_availability_prefs')
       .select('*')
       .in('profile_id', teacherProfileIds)
       .eq('school_year', getCurrentSchoolYear());
+    if (prefsError) {
+      // A swallowed failure would silently drop teachers' prep constraints
+      console.error('Error fetching teacher availability prefs:', prefsError);
+      throw prefsError;
+    }
     for (const pref of prefs ?? []) {
       // Prep windows are hard constraints when times exist; before/after
       // school preferences stay soft until bell-schedule/school-hours


### PR DESCRIPTION
## Summary

Implements [SPE-206](https://linear.app/speddy/issue/SPE-206) (availability engine, internal-sources-first — resequenced ahead of OAuth per the ticket note) and a working v1 of [SPE-208](https://linear.app/speddy/issue/SPE-208) (bulk planner + the case-manager Meetings page). This is the first PR that puts the feature on a **provider's** screen.

### Availability engine — `lib/iep-meetings/availability.ts` (pure, no I/O)

- **Constraint model per spec §5:** site meeting windows + blackouts + max-meetings/day; per-attendee busy blocks (weekly-recurring like sessions, or dated) and hard available-windows (teacher prep); one-meeting-at-a-time site overlap.
- `findSlots` (chronological valid slots), `getSlotConflicts` (names *why* a slot fails — feeds future UI), and `planMeetings` — earliest-due-first placement targeting the **2–6-week lead window** before each due date with pre-due fallback, never double-booking its own placements.
- **15 unit tests** (`availability.test.ts`) covering windows, blackouts, recurring busy, prep windows, capacity, lead-window placement, self-collision, ordering, and unplaceable reporting.
- Google free/busy plugs in later as one more `BusyBlock` producer (SPE-205) — the engine doesn't know or care.

### Case-manager Meetings page — `/dashboard/meetings` (SPE-208 v1)

- New **"Meetings" nav item for all provider roles** (resource, speech/OT/counseling/psych, specialist), deliberately **not** in `SECONDARY_HIDDEN_HREFS` — works K-12 (spec §4.5).
- **Attention counts:** due-within-60-days-unscheduled, and total plannable students.
- **Planner:** horizon date ("plan meetings due through…", defaults to end of school year), drafts placements from `student_details.upcoming_iep_date`/`upcoming_triennial_date` (earlier date decides annual vs triennial), per-student include checkboxes, unplaceable rows show the reason. Graceful empty states when site rules aren't configured or nothing needs planning.
- **Reserve** inserts `iep_meetings` (status `reserved`) + attendee rows: case manager (accepted), **LEA rep** via the existing `get_school_site_admins` RPC (no busy data — admins honor holds, spec §13.2), and the **teacher** via roster `account_id` when they have a Speddy account or `display_name` otherwise (the manual path). Copy makes explicit that no family invites go out — these are internal holds.
- **Upcoming list:** date/time, student initials + type + due date, status chip, attendee RSVP tally, cancel (status → `cancelled`, preserving the row).

### v1 cuts (deliberate, tracked)

- Teacher **before/after-school** preferences are soft-skipped (no school-hours derivation yet) — only prep windows are hard constraints; noted in SPE-206.
- Reschedule flow, parent confirmation, detail drawer, and calendar view are SPE-209/210 and later UI passes.
- Timestamps constructed in the browser's local timezone (single-district CA reality; revisit if multi-TZ ever matters).

### Verification

- `npm test`: 136 passed (15 new engine tests) · `npm run typecheck` clean · lint clean on new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3djpxrRYap64jnxSEYc97

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3djpxrRYap64jnxSEYc97)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Meetings dashboard to view upcoming meetings, highlight due/unscheduled counts, and manage meeting planning suggestions.
  * Introduced automated slot planning with blackout, capacity, and conflict-aware scheduling, plus reservation and cancellation actions with refreshed results.
  * Added a **Meetings** link to role-based navigation.
* **Tests**
  * Added unit tests covering slot availability, conflict detection, and meeting planning behavior (lead-window selection, capacity limits, and failure reasons).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->