### PR TITLE
feat(landing): interactive "capabilities reorganization" landing page

### DIFF
--- a/app/components/landing/speddy-landing.tsx
+++ b/app/components/landing/speddy-landing.tsx
@@ -311,7 +311,7 @@ function resolve(sel: Sel): Resolved {
   }
 
   const supporting =
-    'Teachers see when their students are pulled and flag their own class activities; SEAs get a daily plan of exactly where to be; families confirm meeting times by text or phone — no account, ever.';
+    'Teachers see when their students are pulled and flag their own class activities, SEAs get a daily plan of exactly where to be, and families confirm meeting times by phone or email — with no account needed.';
 
   const stamp = (c: RawCap): Cap => {
     const s = ST[c.status];

--- a/app/components/landing/speddy-landing.tsx
+++ b/app/components/landing/speddy-landing.tsx
@@ -418,7 +418,10 @@ export default function SpeddyLanding() {
         background: '#F3F5F8',
         minHeight: '100%',
         width: '100%',
-        overflowX: 'hidden',
+        // `clip` (not `hidden`) guards against horizontal overflow WITHOUT
+        // turning this wrapper into a scroll container — `overflow-x: hidden`
+        // would promote overflow-y to `auto` and break the sticky selector bar.
+        overflowX: 'clip',
       }}
     >
       <style>{RESPONSIVE_CSS}</style>

--- a/app/components/landing/speddy-landing.tsx
+++ b/app/components/landing/speddy-landing.tsx
@@ -1,0 +1,863 @@
+'use client';
+
+// Speddy landing page — "Capabilities reorganization" design direction.
+//
+// Ported from the "Speddy Landing" Claude Design (Speddy Landing.dc.html). A
+// three-axis selector (school type / level / role) drives the hero copy, the
+// product mockups, the capability cards, and a contextual banner — so a public
+// elementary provider and a charter district director each see a page written
+// for them. All content is derived from `resolve(sel)`.
+//
+// Responsive: clamp() handles type/spacing, flex-wrap handles rows, and a small
+// media-query block collapses the two-column grids on narrow screens.
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { SpeddyMark, EmailSignup, type Audience } from './landing-shared';
+import { SpeddyMock, type MockKind, type SchoolType } from './speddy-mock';
+
+type Level = 'elementary' | 'secondary';
+type Role = 'district' | 'site' | 'provider';
+type Sel = { type: SchoolType; level: Level; role: Role };
+type StatusKey = 'live' | 'rolling' | 'dev';
+
+const ST: Record<StatusKey, { label: string; color: string; bg: string }> = {
+  live: { label: 'Available now', color: '#15803D', bg: '#DCFCE7' },
+  rolling: { label: 'Rolling out', color: '#2452F5', bg: '#EFF5FF' },
+  dev: { label: 'In development', color: '#92400E', bg: '#FEF3C7' },
+};
+
+type RawCap = { name: string; status: StatusKey; benefit: string; note: string };
+type Cap = RawCap & { stLabel: string; stColor: string; stBg: string; hasNote: boolean };
+type Banner = { label: string; text: string; bg: string; border: string; dot: string };
+
+type Resolved = {
+  hero: { eyebrow: string; h1: string; h1em: string; sub: string };
+  caps: Cap[];
+  capsHeadline: string;
+  closing: string;
+  placeholder: string;
+  supporting: string;
+  primaryGraphic: MockKind;
+  secondaryGraphic: MockKind | null;
+  hasSecondary: boolean;
+  gridCols: string;
+  appUrl: string;
+  banner: Banner | null;
+};
+
+const SECTION_X = 'clamp(20px, 5vw, 64px)';
+
+const TYPE_OPTS: [SchoolType, string][] = [
+  ['public', 'Public'],
+  ['charter', 'Charter'],
+  ['private', 'Private'],
+];
+const LEVEL_OPTS: [Level, string][] = [
+  ['elementary', 'Elementary'],
+  ['secondary', 'Middle / High'],
+];
+const ROLE_OPTS: [Role, string][] = [
+  ['district', 'District'],
+  ['site', 'Site admin'],
+  ['provider', 'Provider'],
+];
+
+const ROLE_TO_AUDIENCE: Record<Role, Audience> = {
+  provider: 'provider',
+  site: 'admin',
+  district: 'district',
+};
+
+const RESPONSIVE_CSS = `
+.sp-selbar { display: flex; flex-wrap: wrap; gap: 22px 28px; align-items: center; justify-content: center; }
+.sp-heroprod { display: grid; gap: 18px; align-items: start; }
+.sp-caps { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+@media (max-width: 760px) {
+  .sp-heroprod { grid-template-columns: 1fr !important; }
+  .sp-caps { grid-template-columns: 1fr; }
+  .sp-selgroup { justify-content: center; }
+}
+`;
+
+function resolve(sel: Sel): Resolved {
+  const { type, level, role } = sel;
+  const isPriv = type === 'private';
+  const isCharter = type === 'charter';
+  const isSec = level === 'secondary';
+
+  let caps: RawCap[] = [];
+  let hero = { eyebrow: '', h1: '', h1em: '', sub: '' };
+  let primaryGraphic: MockKind = 'schedule';
+  let secondaryGraphic: MockKind | null = null;
+  let capsHeadline = '';
+  let closing = '';
+  let placeholder = 'you@school.edu';
+  let appUrl = 'speddy.xyz / schedule';
+
+  if (role === 'provider') {
+    hero = {
+      eyebrow: 'For SpEd providers',
+      h1: isSec ? 'Your caseload,' : 'Your whole week,',
+      h1em: isSec ? 'organized and in reach.' : 'finally in one place.',
+      sub:
+        'Speddy organizes every session, student and ' +
+        (isPriv ? 'support minute' : 'service minute') +
+        ' so you can focus on the work that matters' +
+        (isSec ? ' — caseload-first for your middle and high schoolers.' : '.'),
+    };
+    capsHeadline = 'The help your day has been missing.';
+    closing = 'Get your week back.';
+    placeholder = 'you@school.edu';
+    primaryGraphic = isSec ? 'care' : 'schedule';
+    secondaryGraphic = isSec ? 'meetings' : 'minutes';
+    appUrl = isSec ? 'speddy.xyz / caseload' : 'speddy.xyz / schedule';
+    caps = [
+      {
+        name: 'Visual weekly schedule',
+        status: isSec ? 'dev' : 'live',
+        benefit: isSec
+          ? 'The scheduler built around a bell-schedule day. Period-based scheduling for middle & high is in active development.'
+          : 'Every session for every student, built by drag-and-drop and color-coded by grade — with conflict detection before you commit.',
+        note: isSec
+          ? 'Today at your level you get everything below: caseload, meetings, referrals and progress.'
+          : '',
+      },
+      {
+        name: isPriv ? 'Support plans & caseload' : 'Students & caseload',
+        status: 'live',
+        benefit: isPriv
+          ? 'Every student you support in one place — goals, accommodations, assessments and support-plan details, imported from the file you already keep.'
+          : 'Every student in one place — grade, teacher, service minutes, goals and due dates. Import in bulk or straight from a SEIS export.',
+        note:
+          isSec && !isPriv
+            ? 'Caseload-first at secondary: goals, accommodations and assessments; session/minute fields are hidden.'
+            : isPriv
+              ? 'IEP-specific fields (triennials, IDEA categories) don’t apply to support plans.'
+              : '',
+      },
+      {
+        name: isPriv ? 'Support-plan meetings' : 'IEP meeting planning',
+        status: 'rolling',
+        benefit: isPriv
+          ? 'Plan support-plan and family meetings around everyone’s availability — the same scheduling engine, without the IDEA compliance clock.'
+          : 'Plan a whole term of meetings that respect the team’s availability and the site’s capacity — families confirm by text or phone, no account. Works K-12.',
+        note: '',
+      },
+      {
+        name: 'Referral tracking (CARE)',
+        status: 'live',
+        benefit: isPriv
+          ? 'A shared queue for student concerns: a teacher or staff concern enters a pending queue and becomes an active learning-support case.'
+          : 'A shared queue for every concern — academic, behavioral, speech, OT — with two intake lanes and the assessment-plan clock calculated for you.',
+        note: isPriv
+          ? 'The statutory compliance lane belongs to the local district, so it’s off here.'
+          : '',
+      },
+      {
+        name: 'Progress monitoring',
+        status: 'live',
+        benefit:
+          'Exit tickets and progress checks turn into per-goal trend dashboards — evidence collected as you work, not reconstructed before a meeting.',
+        note: isSec ? 'Goal-driven tools work at secondary; attendance widgets are hidden.' : '',
+      },
+      {
+        name: 'Multi-school caseloads',
+        status: 'live',
+        benefit:
+          'One login across every building you serve — a separate caseload and schedule per site, each showing that school’s appropriate view.',
+        note: '',
+      },
+    ];
+  } else if (role === 'site') {
+    hero = {
+      eyebrow: 'For site admins — principals & APs',
+      h1: 'Your whole school’s schedule,',
+      h1em: 'in one source of truth.',
+      sub: 'Build bell schedules, special activities, yard duty and SpEd services across every grade — then keep them in sync as the year evolves.',
+    };
+    capsHeadline = 'Everything a principal needs, in one tab.';
+    closing = 'Make every August easier.';
+    placeholder = 'admin@school.edu';
+    primaryGraphic = 'master';
+    secondaryGraphic = 'structural';
+    appUrl = 'speddy.xyz / master-schedule';
+    caps = [
+      {
+        name: 'Master Schedule',
+        status: 'live',
+        benefit:
+          'Bell schedules, special activities and yard-duty rotations for the whole school in one view — filter by grade, activity or zone, and roll it forward to next year.',
+        note: '',
+      },
+      {
+        name: 'The foundation your team builds on',
+        status: 'live',
+        benefit:
+          'Enter the structural data once and every provider schedules against it — no more re-sharing the August spreadsheet.',
+        note: '',
+      },
+      {
+        name: isPriv ? 'Support-plan meeting rules' : 'IEP meeting rules & capacity',
+        status: 'live',
+        benefit:
+          'Set meeting days, room capacity and blackout windows once; teachers answer a one-time availability preference. The year-at-a-glance dashboard is rolling out.',
+        note: '',
+      },
+      {
+        name: 'Referral oversight (CARE)',
+        status: 'live',
+        benefit:
+          'See your school’s whole referral queue — every concern, its status and next step — instead of sticky notes and hallway conversations.',
+        note: isPriv ? 'The statutory compliance lane belongs to the local district.' : '',
+      },
+      {
+        name: 'Staff & account administration',
+        status: isPriv ? 'dev' : 'live',
+        benefit: isPriv
+          ? 'Standalone private-school accounts need the org-model work that’s on the way — today a school sits under a district record.'
+          : 'Create teacher and staff accounts, manage your directories and resolve duplicates — accounts are admin-created, part of the FERPA posture.',
+        note: isCharter ? 'A charter that’s its own LEA is modeled as a one-school district today.' : '',
+      },
+      {
+        name: 'School-wide visibility',
+        status: 'live',
+        benefit:
+          'Live oversight of how SpEd services are running at your site — without asking three people on a Friday afternoon.',
+        note: '',
+      },
+    ];
+  } else {
+    hero = {
+      eyebrow: 'For district SpEd directors',
+      h1: 'Every site at a glance,',
+      h1em: 'without chasing anyone.',
+      sub:
+        'A read-only window into every school in your ' +
+        (isCharter ? 'network' : 'district') +
+        ' — plus the access controls to manage who sees what.',
+    };
+    capsHeadline = 'Visibility and control, zero data entry.';
+    closing = isCharter ? 'Bring Speddy to your network.' : 'Bring Speddy to your district.';
+    placeholder = 'you@district.edu';
+    primaryGraphic = 'district';
+    secondaryGraphic = null;
+    appUrl = 'speddy.xyz / district';
+    caps = [
+      {
+        name: 'District-wide visibility',
+        status: 'live',
+        benefit:
+          'A live, read-only view of every school — schedules, caseloads, who’s serving whom, what’s happening this week.',
+        note: '',
+      },
+      {
+        name: 'User & access management',
+        status: 'live',
+        benefit:
+          'Add, remove and re-role site admins, providers and staff as people change buildings or leave. Scope site admins to their schools.',
+        note: '',
+      },
+      {
+        name: 'Referral oversight across schools',
+        status: 'live',
+        benefit:
+          'The whole ' +
+          (isCharter ? 'network' : 'district') +
+          '’s CARE queue in one place — including the private-school referrals your district receives.',
+        note: '',
+      },
+      {
+        name: 'Caseload & schedule oversight',
+        status: 'live',
+        benefit:
+          'See every site’s caseloads and provider schedules without building or logging anything yourself.',
+        note: '',
+      },
+      {
+        name: 'Meetings dashboard',
+        status: 'dev',
+        benefit:
+          'A year-at-a-glance compliance view — due dates without a meeting, at-risk meetings — is planned as Meetings rolls out.',
+        note: '',
+      },
+      {
+        name: isCharter ? 'The network is your scope' : 'The district is your scope',
+        status: 'live',
+        benefit:
+          'Multi-school by design — everything rolls up to you, deliberately read-oriented so you never touch a schedule.',
+        note: isCharter ? 'A single-LEA charter is represented today as a one-school district.' : '',
+      },
+    ];
+  }
+
+  let banner: Banner | null = null;
+  if (isCharter) {
+    banner = {
+      label: 'For charter schools',
+      text: 'Charters run IEPs under IDEA, so Speddy fits nearly as-is — the difference is who buys. No district sign-off needed, and it runs alongside SEIS (SEIS writes the IEP; Speddy schedules and manages delivery).',
+      bg: '#EFF5FF',
+      border: '#BBD0FF',
+      dot: '#2452F5',
+    };
+  } else if (isPriv) {
+    banner = {
+      label: 'For private & independent schools',
+      text: 'Speddy fits your discretionary learning-support program — learning specialists, support plans and the sessions you choose to deliver. The IEP compliance layer belongs to the local public district, not you. Standalone onboarding is on the way; most mechanics already fit.',
+      bg: '#FDF2F8',
+      border: '#F6C9E0',
+      dot: '#DB2777',
+    };
+  }
+
+  const supporting =
+    'Teachers see when their students are pulled and flag their own class activities; SEAs get a daily plan of exactly where to be; families confirm meeting times by text or phone — no account, ever.';
+
+  const stamp = (c: RawCap): Cap => {
+    const s = ST[c.status];
+    return { ...c, stLabel: s.label, stColor: s.color, stBg: s.bg, hasNote: !!c.note };
+  };
+
+  return {
+    hero,
+    caps: caps.map(stamp),
+    capsHeadline,
+    closing,
+    placeholder,
+    supporting,
+    primaryGraphic,
+    secondaryGraphic,
+    hasSecondary: !!secondaryGraphic,
+    gridCols: secondaryGraphic ? '1.4fr 1fr' : '1fr',
+    appUrl,
+    banner,
+  };
+}
+
+function PillGroup<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  options: [T, string][];
+  value: T;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className="sp-selgroup" style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+      <span
+        style={{
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          color: 'rgba(15,23,42,0.4)',
+        }}
+      >
+        {label}
+      </span>
+      <div
+        style={{
+          display: 'inline-flex',
+          padding: 4,
+          background: '#EEF2F7',
+          borderRadius: 999,
+          gap: 2,
+        }}
+      >
+        {options.map(([key, lbl]) => {
+          const active = value === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              aria-pressed={active}
+              onClick={() => onChange(key)}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                border: 0,
+                padding: '8px 15px',
+                borderRadius: 999,
+                fontSize: 13.5,
+                fontWeight: 600,
+                fontFamily: 'inherit',
+                cursor: 'pointer',
+                whiteSpace: 'nowrap',
+                transition: 'all .15s',
+                background: active ? '#FFFFFF' : 'transparent',
+                color: active ? '#0F172A' : 'rgba(15,23,42,0.55)',
+                boxShadow: active
+                  ? '0 1px 2px rgba(15,23,42,0.08), 0 0 0 1px rgba(15,23,42,0.06)'
+                  : 'none',
+              }}
+            >
+              {lbl}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default function SpeddyLanding() {
+  const [sel, setSel] = useState<Sel>({ type: 'public', level: 'elementary', role: 'site' });
+  const data = resolve(sel);
+  const audience = ROLE_TO_AUDIENCE[sel.role];
+
+  return (
+    <div
+      style={{
+        fontFamily: 'var(--font-dm-sans), system-ui, sans-serif',
+        color: '#0F172A',
+        background: '#F3F5F8',
+        minHeight: '100%',
+        width: '100%',
+        overflowX: 'hidden',
+      }}
+    >
+      <style>{RESPONSIVE_CSS}</style>
+
+      {/* Nav */}
+      <nav
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 16,
+          padding: `clamp(16px, 4vw, 24px) ${SECTION_X}`,
+          background: '#FFF',
+          borderBottom: '1px solid rgba(15,23,42,0.06)',
+          flexWrap: 'wrap',
+        }}
+      >
+        <SpeddyMark size={32} />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 24, fontSize: 15, fontWeight: 600 }}>
+          <a href="#how" style={{ color: '#0F172A', textDecoration: 'none' }}>
+            How it works
+          </a>
+          <Link href="/login" style={{ color: '#0F172A', textDecoration: 'none' }}>
+            Sign in
+          </Link>
+        </div>
+      </nav>
+
+      {/* Selector bar */}
+      <div
+        style={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 20,
+          background: 'rgba(255,255,255,0.9)',
+          backdropFilter: 'blur(10px)',
+          WebkitBackdropFilter: 'blur(10px)',
+          borderBottom: '1px solid rgba(15,23,42,0.08)',
+          padding: `14px ${SECTION_X}`,
+        }}
+      >
+        <div className="sp-selbar">
+          <PillGroup
+            label="School type"
+            options={TYPE_OPTS}
+            value={sel.type}
+            onChange={(type) => setSel((s) => ({ ...s, type }))}
+          />
+          <PillGroup
+            label="Level"
+            options={LEVEL_OPTS}
+            value={sel.level}
+            onChange={(level) => setSel((s) => ({ ...s, level }))}
+          />
+          <PillGroup
+            label="Role"
+            options={ROLE_OPTS}
+            value={sel.role}
+            onChange={(role) => setSel((s) => ({ ...s, role }))}
+          />
+        </div>
+      </div>
+
+      {/* Hero */}
+      <section
+        id="top"
+        style={{
+          background: '#FFF',
+          padding: `clamp(44px, 7vw, 76px) ${SECTION_X} clamp(40px, 6vw, 60px)`,
+          textAlign: 'center',
+        }}
+      >
+        <div
+          style={{
+            fontSize: 14,
+            fontWeight: 700,
+            letterSpacing: '0.02em',
+            color: '#F26B5E',
+            marginBottom: 14,
+          }}
+        >
+          {data.hero.eyebrow}
+        </div>
+        <h1
+          style={{
+            fontSize: 'clamp(34px, 7vw, 60px)',
+            lineHeight: 1.05,
+            fontWeight: 800,
+            letterSpacing: '-0.03em',
+            margin: '0 auto',
+            maxWidth: 760,
+            color: '#0F172A',
+            textWrap: 'balance',
+          }}
+        >
+          {data.hero.h1} <span style={{ color: '#2452F5' }}>{data.hero.h1em}</span>
+        </h1>
+        <p
+          style={{
+            fontSize: 'clamp(16px, 2.2vw, 19px)',
+            lineHeight: 1.5,
+            margin: '22px auto 30px',
+            color: 'rgba(15,23,42,0.65)',
+            maxWidth: 600,
+          }}
+        >
+          {data.hero.sub}
+        </p>
+
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <EmailSignup placeholder={data.placeholder} audience={audience} />
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+            gap: '8px 24px',
+            marginTop: 18,
+            fontSize: 13,
+            color: 'rgba(15,23,42,0.55)',
+          }}
+        >
+          <span>✓ FERPA-compliant</span>
+          <span>✓ Built with SpEd providers</span>
+          <span>✓ Set up in an afternoon</span>
+        </div>
+
+        {data.banner ? (
+          <div
+            style={{
+              margin: '34px auto 0',
+              maxWidth: 760,
+              textAlign: 'left',
+              display: 'flex',
+              gap: 14,
+              padding: '18px 22px',
+              background: data.banner.bg,
+              border: `1px solid ${data.banner.border}`,
+              borderRadius: 14,
+            }}
+          >
+            <span
+              style={{
+                flexShrink: 0,
+                width: 8,
+                height: 8,
+                borderRadius: 999,
+                marginTop: 7,
+                background: data.banner.dot,
+              }}
+            />
+            <div>
+              <span
+                style={{
+                  fontSize: 12,
+                  fontWeight: 800,
+                  letterSpacing: '0.06em',
+                  textTransform: 'uppercase',
+                  color: data.banner.dot,
+                }}
+              >
+                {data.banner.label}
+              </span>
+              <div
+                style={{
+                  fontSize: 14.5,
+                  lineHeight: 1.55,
+                  color: 'rgba(15,23,42,0.72)',
+                  marginTop: 4,
+                }}
+              >
+                {data.banner.text}
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        {/* Product card */}
+        <div
+          style={{
+            margin: 'clamp(40px, 6vw, 60px) auto 0',
+            maxWidth: 1000,
+            background: '#FFF',
+            borderRadius: 20,
+            border: '1px solid rgba(15,23,42,0.08)',
+            boxShadow:
+              '0 40px 80px -40px rgba(15,23,42,0.25), 0 12px 24px -12px rgba(15,23,42,0.08)',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              padding: '12px 16px',
+              borderBottom: '1px solid rgba(15,23,42,0.06)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+            }}
+          >
+            <span style={{ width: 11, height: 11, borderRadius: 999, background: '#F26B5E' }} />
+            <span style={{ width: 11, height: 11, borderRadius: 999, background: '#FBBF24' }} />
+            <span style={{ width: 11, height: 11, borderRadius: 999, background: '#22C55E' }} />
+            <div style={{ flex: 1, textAlign: 'center', fontSize: 12, color: 'rgba(15,23,42,0.45)' }}>
+              {data.appUrl}
+            </div>
+          </div>
+          <div
+            className="sp-heroprod"
+            style={{
+              background: '#F3F5F8',
+              padding: 'clamp(14px, 3vw, 24px)',
+              gridTemplateColumns: data.gridCols,
+            }}
+          >
+            <SpeddyMock kind={data.primaryGraphic} type={sel.type} />
+            {data.hasSecondary && data.secondaryGraphic ? (
+              <SpeddyMock kind={data.secondaryGraphic} type={sel.type} />
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      {/* What you get */}
+      <section id="how" style={{ padding: `clamp(56px, 9vw, 96px) ${SECTION_X}` }}>
+        <div style={{ textAlign: 'center', marginBottom: 'clamp(36px, 5vw, 52px)' }}>
+          <div
+            style={{
+              fontSize: 13,
+              fontWeight: 700,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              color: '#F26B5E',
+            }}
+          >
+            What Speddy does for you
+          </div>
+          <h2
+            style={{
+              fontSize: 'clamp(26px, 5vw, 44px)',
+              fontWeight: 700,
+              letterSpacing: '-0.025em',
+              margin: '12px 0 0',
+              color: '#0F172A',
+              textWrap: 'balance',
+            }}
+          >
+            {data.capsHeadline}
+          </h2>
+        </div>
+        <div className="sp-caps" style={{ maxWidth: 1000, margin: '0 auto' }}>
+          {data.caps.map((cap, i) => (
+            <div
+              key={i}
+              style={{
+                background: '#FFF',
+                border: '1px solid rgba(15,23,42,0.08)',
+                borderRadius: 16,
+                padding: 24,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 10,
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  justifyContent: 'space-between',
+                  gap: 12,
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: 17,
+                    fontWeight: 700,
+                    color: '#0F172A',
+                    letterSpacing: '-0.01em',
+                    lineHeight: 1.3,
+                  }}
+                >
+                  {cap.name}
+                </div>
+                <span
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    flexShrink: 0,
+                    whiteSpace: 'nowrap',
+                    fontSize: 11,
+                    fontWeight: 700,
+                    padding: '4px 10px',
+                    borderRadius: 999,
+                    background: cap.stBg,
+                    color: cap.stColor,
+                  }}
+                >
+                  <span
+                    style={{ width: 5, height: 5, borderRadius: 999, background: cap.stColor }}
+                  />
+                  {cap.stLabel}
+                </span>
+              </div>
+              <div style={{ fontSize: 14, lineHeight: 1.55, color: 'rgba(15,23,42,0.68)' }}>
+                {cap.benefit}
+              </div>
+              {cap.hasNote ? (
+                <div
+                  style={{
+                    fontSize: 12.5,
+                    lineHeight: 1.5,
+                    color: 'rgba(15,23,42,0.5)',
+                    borderTop: '1px dashed rgba(15,23,42,0.1)',
+                    paddingTop: 10,
+                  }}
+                >
+                  {cap.note}
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Supporting cast */}
+      <section
+        style={{
+          background: '#FFF',
+          borderTop: '1px solid rgba(15,23,42,0.06)',
+          padding: `clamp(48px, 7vw, 72px) ${SECTION_X}`,
+          textAlign: 'center',
+        }}
+      >
+        <div style={{ maxWidth: 720, margin: '0 auto' }}>
+          <div
+            style={{
+              fontSize: 12,
+              fontWeight: 700,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              color: 'rgba(15,23,42,0.4)',
+              marginBottom: 12,
+            }}
+          >
+            Everyone around you, included
+          </div>
+          <p
+            style={{
+              fontSize: 'clamp(16px, 2.2vw, 19px)',
+              lineHeight: 1.6,
+              color: 'rgba(15,23,42,0.7)',
+              margin: 0,
+            }}
+          >
+            {data.supporting}
+          </p>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section
+        style={{
+          background: '#0F172A',
+          color: '#FFF',
+          padding: `clamp(56px, 9vw, 96px) ${SECTION_X}`,
+          textAlign: 'center',
+        }}
+      >
+        <h2
+          style={{
+            fontSize: 'clamp(30px, 6vw, 48px)',
+            fontWeight: 700,
+            letterSpacing: '-0.025em',
+            margin: '0 0 12px',
+          }}
+        >
+          {data.closing}
+        </h2>
+        <p
+          style={{
+            fontSize: 'clamp(15px, 2vw, 18px)',
+            color: 'rgba(255,255,255,0.7)',
+            margin: '0 0 32px',
+          }}
+        >
+          Set up in an afternoon. Designed alongside real SpEd providers.
+        </p>
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <div
+            style={{
+              background: '#FFF',
+              padding: 8,
+              borderRadius: 14,
+              width: '100%',
+              maxWidth: 544,
+            }}
+          >
+            <EmailSignup placeholder={data.placeholder} audience={audience} />
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer
+        style={{
+          background: '#0F172A',
+          borderTop: '1px solid rgba(255,255,255,0.08)',
+          padding: `clamp(24px, 4vw, 32px) ${SECTION_X}`,
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 16,
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <SpeddyMark size={24} color="#FFF" />
+          <span style={{ fontSize: 13, color: 'rgba(255,255,255,0.55)' }}>
+            Made by SpEd people, for SpEd people.
+          </span>
+        </div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 24, fontSize: 13 }}>
+          <Link href="/privacy" style={{ color: 'rgba(255,255,255,0.55)', textDecoration: 'none' }}>
+            Privacy
+          </Link>
+          <Link href="/terms" style={{ color: 'rgba(255,255,255,0.55)', textDecoration: 'none' }}>
+            Terms
+          </Link>
+          <Link href="/ferpa" style={{ color: 'rgba(255,255,255,0.55)', textDecoration: 'none' }}>
+            FERPA
+          </Link>
+          <a
+            href="mailto:help@speddy.xyz"
+            style={{ color: 'rgba(255,255,255,0.55)', textDecoration: 'none' }}
+          >
+            Contact
+          </a>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/app/components/landing/speddy-landing.tsx
+++ b/app/components/landing/speddy-landing.tsx
@@ -359,6 +359,8 @@ function PillGroup<T extends string>({
         {label}
       </span>
       <div
+        role="group"
+        aria-label={label}
         style={{
           display: 'inline-flex',
           padding: 4,
@@ -487,6 +489,7 @@ export default function SpeddyLanding() {
           background: '#FFF',
           padding: `clamp(44px, 7vw, 76px) ${SECTION_X} clamp(40px, 6vw, 60px)`,
           textAlign: 'center',
+          scrollMarginTop: 80,
         }}
       >
         <div
@@ -642,7 +645,10 @@ export default function SpeddyLanding() {
       </section>
 
       {/* What you get */}
-      <section id="how" style={{ padding: `clamp(56px, 9vw, 96px) ${SECTION_X}` }}>
+      <section
+        id="how"
+        style={{ padding: `clamp(56px, 9vw, 96px) ${SECTION_X}`, scrollMarginTop: 80 }}
+      >
         <div style={{ textAlign: 'center', marginBottom: 'clamp(36px, 5vw, 52px)' }}>
           <div
             style={{

--- a/app/components/landing/speddy-mock.tsx
+++ b/app/components/landing/speddy-mock.tsx
@@ -888,8 +888,13 @@ function StructuralMock() {
 // ── CARE · referral queue ───────────────────────────────────────────
 function CareMock({ type }: { type: SchoolType }) {
   const priv = type === 'private';
+  // Private schools run a discretionary learning-support program; the statutory
+  // compliance lane (and its clock) belongs to the local district. So for private
+  // we drop the Compliance case + running-clock badge to match the page copy.
   const cases = [
-    { name: 'R. Okafor · 2nd', type: 'Compliance', c: '#DC2626', bg: '#FEE2E2', due: 'Plan due Feb 3', lane: priv ? 'Learning-support review' : 'Assessment plan · 15 days' },
+    priv
+      ? { name: 'R. Okafor · 2nd', type: 'Academic', c: '#3B82F6', bg: '#DBEAFE', due: 'Review Feb 3', lane: 'Learning-support review' }
+      : { name: 'R. Okafor · 2nd', type: 'Compliance', c: '#DC2626', bg: '#FEE2E2', due: 'Plan due Feb 3', lane: 'Assessment plan · 15 days' },
     { name: 'T. Nguyen · 4th', type: 'Behavioral', c: '#F59E0B', bg: '#FEF3C7', due: 'SST Feb 11', lane: 'Action items · 2 open' },
     { name: 'M. Silva · 1st', type: 'Academic', c: '#3B82F6', bg: '#DBEAFE', due: 'Review Feb 18', lane: 'Discussion lane' },
     { name: 'K. Brooks · 5th', type: 'Speech', c: '#A78BFA', bg: '#EDE9FE', due: 'Follow-up Feb 24', lane: 'Active case' },
@@ -914,18 +919,20 @@ function CareMock({ type }: { type: SchoolType }) {
             4 active cases
           </div>
         </div>
-        <span
-          style={{
-            fontSize: 11,
-            fontWeight: 700,
-            padding: '4px 10px',
-            borderRadius: 999,
-            background: '#FEE2E2',
-            color: '#DC2626',
-          }}
-        >
-          1 clock running
-        </span>
+        {priv ? null : (
+          <span
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              padding: '4px 10px',
+              borderRadius: 999,
+              background: '#FEE2E2',
+              color: '#DC2626',
+            }}
+          >
+            1 clock running
+          </span>
+        )}
       </div>
       <div style={{ padding: '6px 12px' }}>
         {cases.map((c, i) => (

--- a/app/components/landing/speddy-mock.tsx
+++ b/app/components/landing/speddy-mock.tsx
@@ -1,0 +1,1082 @@
+'use client';
+
+// Speddy product-mockup graphics for the landing page.
+// Ported from the "Speddy Landing" Claude Design (SpeddyMock.dc.html) — a set of
+// self-contained, non-interactive UI recreations shown in the hero product card.
+// Each graphic is faithful pixel-mock, driven entirely by the local data below.
+//
+// `kind` picks the graphic; `type` (school type) adjusts a few labels so the
+// same mock reads correctly for public / charter / private schools.
+
+import React from 'react';
+
+export type MockKind =
+  | 'schedule'
+  | 'minutes'
+  | 'master'
+  | 'district'
+  | 'structural'
+  | 'care'
+  | 'meetings';
+
+export type SchoolType = 'public' | 'charter' | 'private';
+
+const GRADE = {
+  tk: '#F472B6',
+  k: '#A78BFA',
+  g1: '#3B82F6',
+  g2: '#22D3EE',
+  g3: '#22C55E',
+  g4: '#F59E0B',
+  g5: '#EF4444',
+} as const;
+
+function Card({
+  children,
+  style,
+}: {
+  children: React.ReactNode;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        background: '#FFF',
+        borderRadius: 16,
+        border: '1px solid rgba(15,23,42,0.08)',
+        boxShadow:
+          '0 24px 60px -20px rgba(15,23,42,0.18), 0 8px 18px -8px rgba(15,23,42,0.08)',
+        overflow: 'hidden',
+        fontFamily: 'inherit',
+        width: '100%',
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ── Provider · weekly schedule ──────────────────────────────────────
+type Slot = {
+  day: number;
+  top: number;
+  h: number;
+  c: string;
+  code: string;
+  conflict?: boolean;
+  off?: number;
+};
+
+function ScheduleMock({ type }: { type: SchoolType }) {
+  const priv = type === 'private';
+  const gradeList: [string, string][] = [
+    ['TK', GRADE.tk],
+    ['K', GRADE.k],
+    ['1st', GRADE.g1],
+    ['2nd', GRADE.g2],
+    ['3rd', GRADE.g3],
+    ['4th', GRADE.g4],
+    ['5th', GRADE.g5],
+  ];
+  const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+  const slots: Slot[] = [
+    { day: 0, top: 0, h: 8, c: GRADE.g3, code: 'JW' },
+    { day: 0, top: 8, h: 8, c: GRADE.g3, code: 'SP', conflict: true },
+    { day: 1, top: 0, h: 8, c: GRADE.g3, code: 'SP' },
+    { day: 1, top: 8, h: 8, c: GRADE.g3, code: 'JW' },
+    { day: 2, top: 4, h: 8, c: GRADE.g3, code: 'SP' },
+    { day: 3, top: 0, h: 8, c: GRADE.g3, code: 'JW' },
+    { day: 3, top: 8, h: 8, c: GRADE.g3, code: 'SP' },
+    { day: 4, top: 4, h: 8, c: GRADE.g3, code: 'SP' },
+    { day: 0, top: 22, h: 8, c: GRADE.g4, code: 'AC' },
+    { day: 0, top: 22, h: 8, c: GRADE.g4, code: 'MM', off: 1 },
+    { day: 0, top: 22, h: 16, c: GRADE.g5, code: 'DGI', off: 2 },
+    { day: 0, top: 30, h: 8, c: GRADE.g4, code: 'MFI' },
+    { day: 1, top: 22, h: 8, c: GRADE.g4, code: 'MM' },
+    { day: 1, top: 22, h: 16, c: GRADE.g5, code: 'DGI', off: 1 },
+    { day: 1, top: 30, h: 8, c: GRADE.g4, code: 'MFI' },
+    { day: 2, top: 22, h: 16, c: GRADE.g5, code: 'DGI' },
+    { day: 2, top: 22, h: 8, c: GRADE.g4, code: 'MFI', off: 1 },
+    { day: 3, top: 22, h: 8, c: GRADE.g4, code: 'MFI' },
+    { day: 3, top: 22, h: 16, c: GRADE.g5, code: 'DGI', off: 1 },
+    { day: 4, top: 22, h: 16, c: GRADE.g5, code: 'DGI' },
+    { day: 4, top: 22, h: 8, c: GRADE.g4, code: 'MFI', off: 1 },
+    { day: 0, top: 60, h: 8, c: GRADE.g5, code: 'ER' },
+    { day: 0, top: 60, h: 16, c: GRADE.g5, code: 'DGI', off: 1 },
+    { day: 1, top: 60, h: 8, c: GRADE.g5, code: 'ER' },
+    { day: 1, top: 60, h: 16, c: GRADE.g5, code: 'DGI', off: 1 },
+    { day: 2, top: 60, h: 16, c: GRADE.g5, code: 'DGI' },
+    { day: 3, top: 60, h: 8, c: GRADE.g5, code: 'ER' },
+    { day: 3, top: 60, h: 16, c: GRADE.g5, code: 'DGI', off: 1 },
+    { day: 4, top: 60, h: 8, c: GRADE.g5, code: 'ER' },
+    { day: 4, top: 60, h: 16, c: GRADE.g5, code: 'DGI', off: 1 },
+  ];
+  const times = ['8:00', '9:00', '10:00', '11:00'];
+
+  return (
+    <Card>
+      <div
+        style={{
+          padding: '16px 20px',
+          borderBottom: '1px solid rgba(15,23,42,0.06)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <div>
+          <div style={{ fontSize: 13, color: 'rgba(15,23,42,0.55)', fontWeight: 500 }}>
+            {priv ? 'Support schedule' : 'Main Schedule'}
+          </div>
+          <div style={{ fontSize: 18, color: '#0F172A', fontWeight: 700, marginTop: 2 }}>
+            This week
+          </div>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            gap: 6,
+            flexWrap: 'wrap',
+            justifyContent: 'flex-end',
+          }}
+        >
+          {gradeList.map(([l, c]) => (
+            <span
+              key={l}
+              style={{
+                fontSize: 10,
+                fontWeight: 600,
+                padding: '3px 7px',
+                borderRadius: 999,
+                background: c + '22',
+                color: c,
+              }}
+            >
+              {l}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '44px repeat(5, 1fr)', position: 'relative' }}>
+        <div />
+        {days.map((d) => (
+          <div
+            key={'d' + d}
+            style={{
+              padding: '10px 8px',
+              fontSize: 11,
+              fontWeight: 700,
+              color: '#0F172A',
+              borderBottom: '1px solid rgba(15,23,42,0.06)',
+              textAlign: 'center',
+            }}
+          >
+            {d}
+          </div>
+        ))}
+        {times.map((t, i) => (
+          <div
+            key={'t' + t}
+            style={{
+              gridColumn: '1 / 2',
+              gridRow: `${i + 2} / span 1`,
+              height: 56,
+              padding: '6px 8px',
+              fontSize: 10,
+              color: 'rgba(15,23,42,0.5)',
+              borderTop: i === 0 ? 'none' : '1px dashed rgba(15,23,42,0.06)',
+            }}
+          >
+            {t}
+          </div>
+        ))}
+        {days.map((_, di) => (
+          <div
+            key={'col' + di}
+            style={{
+              gridColumn: `${di + 2} / span 1`,
+              gridRow: '2 / span 4',
+              height: 224,
+              position: 'relative',
+              borderLeft: '1px solid rgba(15,23,42,0.06)',
+            }}
+          >
+            {slots
+              .filter((s) => s.day === di)
+              .map((s, i) => (
+                <div
+                  key={i}
+                  style={{
+                    position: 'absolute',
+                    top: `${(s.top / 80) * 100}%`,
+                    height: `${(s.h / 80) * 100}%`,
+                    left: `${4 + (s.off || 0) * 26}px`,
+                    width: s.code === 'DGI' ? 26 : 22,
+                    background: s.c,
+                    border: '1.5px solid #FFF',
+                    borderRadius: 5,
+                    color: '#FFF',
+                    fontSize: 8,
+                    fontWeight: 700,
+                    padding: '3px 2px 0',
+                    lineHeight: 1.1,
+                    boxShadow: '0 1px 2px rgba(15,23,42,0.18)',
+                  }}
+                >
+                  {s.code}
+                  {s.conflict ? (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        bottom: 2,
+                        right: 2,
+                        width: 9,
+                        height: 9,
+                        borderRadius: 2,
+                        background: '#F59E0B',
+                        border: '1px solid #FFF',
+                        fontSize: 7,
+                        lineHeight: '8px',
+                        textAlign: 'center',
+                        color: '#FFF',
+                        fontWeight: 700,
+                      }}
+                    >
+                      !
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+          </div>
+        ))}
+      </div>
+
+      <div
+        style={{
+          margin: '12px 16px 16px',
+          padding: '10px 14px',
+          background: '#FFF7E6',
+          border: '1px solid #FCD34D',
+          borderRadius: 10,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          fontSize: 13,
+          color: '#92400E',
+        }}
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+          <line x1="12" y1="9" x2="12" y2="13" />
+          <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+        <span>
+          <strong>2 conflicts found</strong> · Mon 8:15 AM · JW / SP overlap
+        </span>
+      </div>
+    </Card>
+  );
+}
+
+// ── Provider · service minutes ──────────────────────────────────────
+function MinutesMock({ type }: { type: SchoolType }) {
+  const priv = type === 'private';
+  const students = [
+    { initials: 'AC', name: 'A. Chen', goal: 120, used: 118, c: GRADE.g3 },
+    { initials: 'MM', name: 'M. Mendez', goal: 90, used: 92, c: GRADE.g4 },
+    { initials: 'DG', name: 'D. Garza', goal: 180, used: 142, c: GRADE.g5 },
+    { initials: 'JW', name: 'J. Wilson', goal: 60, used: 60, c: GRADE.g3 },
+    { initials: 'ER', name: 'E. Rivera', goal: 90, used: 71, c: GRADE.g5 },
+  ];
+
+  return (
+    <Card>
+      <div style={{ padding: '16px 20px', borderBottom: '1px solid rgba(15,23,42,0.06)' }}>
+        <div style={{ fontSize: 13, color: 'rgba(15,23,42,0.55)', fontWeight: 500 }}>
+          {(priv ? 'Support minutes' : 'Service minutes') + ' · this month'}
+        </div>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginTop: 4 }}>
+          <div style={{ fontSize: 26, fontWeight: 800, color: '#0F172A', letterSpacing: '-0.02em' }}>
+            92%
+          </div>
+          <div style={{ fontSize: 13, color: '#22C55E', fontWeight: 600 }}>on track</div>
+        </div>
+      </div>
+      <div style={{ padding: '8px 12px' }}>
+        {students.map((s, i) => {
+          const pct = Math.min(100, (s.used / s.goal) * 100);
+          const over = s.used > s.goal;
+          const full = s.used === s.goal;
+          const barColor = over ? '#EF4444' : full ? '#22C55E' : s.c;
+          return (
+            <div
+              key={i}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                padding: '10px 8px',
+                borderRadius: 10,
+              }}
+            >
+              <div
+                style={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: 999,
+                  background: s.c + '22',
+                  color: s.c,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 11,
+                  fontWeight: 700,
+                  flexShrink: 0,
+                }}
+              >
+                {s.initials}
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'baseline',
+                    marginBottom: 4,
+                  }}
+                >
+                  <span style={{ fontSize: 13, fontWeight: 600, color: '#0F172A' }}>{s.name}</span>
+                  <span
+                    style={{
+                      fontSize: 11,
+                      color: 'rgba(15,23,42,0.55)',
+                      fontVariantNumeric: 'tabular-nums',
+                    }}
+                  >
+                    <strong style={{ color: over ? '#EF4444' : '#0F172A' }}>{s.used}</strong>/
+                    {s.goal} min
+                  </span>
+                </div>
+                <div
+                  style={{
+                    height: 6,
+                    background: 'rgba(15,23,42,0.06)',
+                    borderRadius: 999,
+                    overflow: 'hidden',
+                  }}
+                >
+                  <div
+                    style={{ height: '100%', width: `${pct}%`, background: barColor, borderRadius: 999 }}
+                  />
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}
+
+// ── Site admin · master schedule ────────────────────────────────────
+type Activity = { name: string; c: string; bg: string };
+type MasterEvent = { d: number; t: number; h: number; col: number; k: string };
+
+function MasterMock() {
+  const ACT: Record<string, Activity> = {
+    garden: { name: 'Garden', c: '#22C55E', bg: '#DCFCE7' },
+    library: { name: 'Library', c: '#3B82F6', bg: '#DBEAFE' },
+    music: { name: 'Music', c: '#A78BFA', bg: '#EDE9FE' },
+    steam: { name: 'STEAM', c: '#F97316', bg: '#FFEDD5' },
+    recess: { name: 'Recess', c: '#F59E0B', bg: '#FEF3C7' },
+    lunch: { name: 'Lunch', c: '#94A3B8', bg: '#E2E8F0' },
+  };
+  const events: MasterEvent[] = [
+    { d: 0, t: 0, h: 6, col: 0, k: 'recess' }, { d: 0, t: 0, h: 6, col: 1, k: 'recess' }, { d: 0, t: 0, h: 6, col: 2, k: 'recess' },
+    { d: 0, t: 7, h: 12, col: 0, k: 'music' }, { d: 0, t: 7, h: 12, col: 1, k: 'library' },
+    { d: 0, t: 21, h: 14, col: 0, k: 'recess' }, { d: 0, t: 21, h: 14, col: 1, k: 'recess' }, { d: 0, t: 21, h: 14, col: 2, k: 'recess' }, { d: 0, t: 21, h: 14, col: 3, k: 'recess' },
+    { d: 0, t: 38, h: 12, col: 0, k: 'library' }, { d: 0, t: 38, h: 12, col: 1, k: 'music' },
+    { d: 0, t: 52, h: 10, col: 0, k: 'lunch' }, { d: 0, t: 52, h: 10, col: 1, k: 'lunch' },
+    { d: 0, t: 64, h: 14, col: 0, k: 'music' }, { d: 0, t: 64, h: 14, col: 1, k: 'library' },
+    { d: 1, t: 0, h: 6, col: 0, k: 'recess' }, { d: 1, t: 0, h: 6, col: 1, k: 'recess' },
+    { d: 1, t: 7, h: 12, col: 0, k: 'garden' }, { d: 1, t: 7, h: 12, col: 1, k: 'steam' },
+    { d: 1, t: 21, h: 14, col: 0, k: 'recess' }, { d: 1, t: 21, h: 14, col: 1, k: 'recess' }, { d: 1, t: 21, h: 14, col: 2, k: 'recess' },
+    { d: 1, t: 38, h: 12, col: 0, k: 'steam' }, { d: 1, t: 38, h: 12, col: 1, k: 'garden' },
+    { d: 1, t: 52, h: 10, col: 0, k: 'lunch' }, { d: 1, t: 52, h: 10, col: 1, k: 'lunch' },
+    { d: 1, t: 64, h: 14, col: 0, k: 'library' }, { d: 1, t: 64, h: 14, col: 1, k: 'music' },
+    { d: 2, t: 0, h: 6, col: 0, k: 'recess' }, { d: 2, t: 0, h: 6, col: 1, k: 'recess' },
+    { d: 2, t: 7, h: 12, col: 0, k: 'steam' }, { d: 2, t: 7, h: 12, col: 1, k: 'steam' },
+    { d: 2, t: 21, h: 14, col: 0, k: 'recess' }, { d: 2, t: 21, h: 14, col: 1, k: 'recess' }, { d: 2, t: 21, h: 14, col: 2, k: 'recess' },
+    { d: 2, t: 38, h: 12, col: 0, k: 'garden' }, { d: 2, t: 38, h: 12, col: 1, k: 'garden' },
+    { d: 2, t: 52, h: 10, col: 0, k: 'lunch' }, { d: 2, t: 52, h: 10, col: 1, k: 'lunch' },
+    { d: 2, t: 64, h: 14, col: 0, k: 'music' }, { d: 2, t: 64, h: 14, col: 1, k: 'music' },
+    { d: 3, t: 0, h: 6, col: 0, k: 'recess' }, { d: 3, t: 0, h: 6, col: 1, k: 'recess' }, { d: 3, t: 0, h: 6, col: 2, k: 'recess' },
+    { d: 3, t: 7, h: 12, col: 0, k: 'music' }, { d: 3, t: 7, h: 12, col: 1, k: 'steam' },
+    { d: 3, t: 21, h: 14, col: 0, k: 'recess' }, { d: 3, t: 21, h: 14, col: 1, k: 'recess' }, { d: 3, t: 21, h: 14, col: 2, k: 'recess' },
+    { d: 3, t: 38, h: 12, col: 0, k: 'library' }, { d: 3, t: 38, h: 12, col: 1, k: 'steam' },
+    { d: 3, t: 52, h: 10, col: 0, k: 'lunch' }, { d: 3, t: 52, h: 10, col: 1, k: 'lunch' },
+    { d: 3, t: 64, h: 14, col: 0, k: 'garden' }, { d: 3, t: 64, h: 14, col: 1, k: 'library' },
+    { d: 4, t: 0, h: 6, col: 0, k: 'recess' }, { d: 4, t: 0, h: 6, col: 1, k: 'recess' },
+    { d: 4, t: 7, h: 12, col: 0, k: 'library' }, { d: 4, t: 38, h: 12, col: 0, k: 'music' }, { d: 4, t: 38, h: 12, col: 1, k: 'library' },
+    { d: 4, t: 21, h: 14, col: 0, k: 'recess' }, { d: 4, t: 21, h: 14, col: 1, k: 'recess' },
+    { d: 4, t: 52, h: 10, col: 0, k: 'lunch' }, { d: 4, t: 52, h: 10, col: 1, k: 'lunch' },
+    { d: 4, t: 64, h: 14, col: 0, k: 'steam' }, { d: 4, t: 64, h: 14, col: 1, k: 'garden' },
+  ];
+  const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+  const zones = ['Basketball', 'Kinder Yard', 'Playstructure', 'Grass Area'];
+
+  return (
+    <Card>
+      <div style={{ padding: '14px 18px 12px', borderBottom: '1px solid rgba(15,23,42,0.06)' }}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            marginBottom: 12,
+            gap: 10,
+            flexWrap: 'wrap',
+          }}
+        >
+          <div>
+            <div style={{ fontSize: 16, fontWeight: 700, color: '#0F172A', whiteSpace: 'nowrap' }}>
+              Master Schedule
+            </div>
+            <div style={{ fontSize: 11, color: 'rgba(15,23,42,0.55)', marginTop: 2 }}>
+              School year 2025–2026
+            </div>
+          </div>
+          <div style={{ display: 'flex', gap: 4, padding: 3, background: '#F3F5F8', borderRadius: 8 }}>
+            {['All', 'Bell', 'Special', 'Yard'].map((t, i) => (
+              <span
+                key={t}
+                style={{
+                  fontSize: 10,
+                  fontWeight: 600,
+                  padding: '4px 9px',
+                  borderRadius: 6,
+                  background: i === 0 ? '#FFF' : 'transparent',
+                  color: i === 0 ? '#0F172A' : 'rgba(15,23,42,0.55)',
+                  boxShadow: i === 0 ? '0 1px 2px rgba(15,23,42,0.08)' : 'none',
+                }}
+              >
+                {t}
+              </span>
+            ))}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {Object.entries(ACT)
+            .slice(0, 4)
+            .map(([k, v]) => (
+              <span
+                key={k}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 5,
+                  padding: '3px 8px',
+                  borderRadius: 999,
+                  background: v.bg,
+                  color: v.c,
+                  fontSize: 10,
+                  fontWeight: 700,
+                }}
+              >
+                <span style={{ width: 6, height: 6, borderRadius: 999, background: v.c }} />
+                {v.name}
+              </span>
+            ))}
+        </div>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 8 }}>
+          {zones.map((z) => (
+            <span
+              key={z}
+              style={{
+                padding: '3px 8px',
+                borderRadius: 6,
+                background: '#FEF3C7',
+                color: '#92400E',
+                fontSize: 10,
+                fontWeight: 600,
+                border: '1px solid #FCD34D',
+              }}
+            >
+              {z}
+            </span>
+          ))}
+        </div>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: '40px repeat(5, 1fr)', position: 'relative' }}>
+        <div />
+        {days.map((d) => (
+          <div
+            key={'d' + d}
+            style={{
+              padding: '8px 4px',
+              fontSize: 10,
+              fontWeight: 700,
+              color: '#0F172A',
+              borderBottom: '1px solid rgba(15,23,42,0.06)',
+              textAlign: 'center',
+            }}
+          >
+            {d}
+          </div>
+        ))}
+        {['8AM', '10AM', '12PM', '2PM'].map((t, i) => (
+          <div
+            key={'t' + t}
+            style={{
+              gridColumn: '1 / 2',
+              gridRow: `${i + 2} / span 1`,
+              height: 70,
+              padding: '4px 6px',
+              fontSize: 9,
+              color: 'rgba(15,23,42,0.5)',
+              borderTop: i === 0 ? 'none' : '1px dashed rgba(15,23,42,0.06)',
+            }}
+          >
+            {t}
+          </div>
+        ))}
+        {days.map((_, di) => (
+          <div
+            key={'c' + di}
+            style={{
+              gridColumn: `${di + 2} / span 1`,
+              gridRow: '2 / span 4',
+              height: 280,
+              position: 'relative',
+              borderLeft: '1px solid rgba(15,23,42,0.06)',
+              padding: '0 2px',
+            }}
+          >
+            {events
+              .filter((e) => e.d === di)
+              .map((e, i) => {
+                const act = ACT[e.k];
+                return (
+                  <div
+                    key={i}
+                    style={{
+                      position: 'absolute',
+                      top: `${e.t}%`,
+                      height: `${e.h}%`,
+                      left: `${2 + e.col * 24}%`,
+                      width: '22%',
+                      background: act.bg,
+                      borderLeft: `2.5px solid ${act.c}`,
+                      borderRadius: 3,
+                      padding: '2px 3px',
+                      fontSize: 7,
+                      fontWeight: 700,
+                      color: act.c,
+                      lineHeight: 1,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {act.name[0]}
+                  </div>
+                );
+              })}
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+// ── District · staffing overview ────────────────────────────────────
+type Site = {
+  name: string;
+  students: number;
+  providers: [string, string][];
+  gap?: string;
+};
+
+function DistrictMock() {
+  const DISC: Record<string, string> = {
+    RSP: '#3B82F6',
+    SLP: '#A78BFA',
+    OT: '#F59E0B',
+    PT: '#22D3EE',
+    Psych: '#22C55E',
+    Couns: '#F472B6',
+  };
+  const sites: Site[] = [
+    { name: 'Lincoln Elementary', students: 142, providers: [['JR', 'RSP'], ['MK', 'RSP'], ['AT', 'SLP'], ['DB', 'OT'], ['SP', 'Psych']] },
+    { name: 'Roosevelt K-5', students: 118, providers: [['EW', 'RSP'], ['CL', 'SLP'], ['NH', 'OT'], ['TG', 'PT']] },
+    { name: 'Garfield Primary', students: 96, providers: [['BM', 'RSP'], ['KP', 'SLP'], ['RV', 'Couns']], gap: 'OT vacancy' },
+    { name: 'Madison School', students: 134, providers: [['LF', 'RSP'], ['JC', 'RSP'], ['YO', 'SLP'], ['AK', 'OT'], ['MN', 'Psych'], ['HG', 'Couns']] },
+    { name: 'Adams Elementary', students: 87, providers: [['PD', 'RSP'], ['IV', 'SLP'], ['WS', 'OT']] },
+    { name: 'Jefferson School', students: 105, providers: [['OC', 'RSP'], ['ZB', 'SLP'], ['RT', 'PT'], ['EM', 'Psych']], gap: 'RSP shared 0.5 FTE' },
+  ];
+  const total = sites.reduce((a, s) => a + s.providers.length, 0);
+
+  return (
+    <Card>
+      <div
+        style={{
+          padding: '16px 20px',
+          borderBottom: '1px solid rgba(15,23,42,0.06)',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          gap: 12,
+          flexWrap: 'wrap',
+        }}
+      >
+        <div>
+          <div style={{ fontSize: 13, color: 'rgba(15,23,42,0.55)', fontWeight: 500 }}>
+            District staffing · 2025–2026
+          </div>
+          <div style={{ fontSize: 18, color: '#0F172A', fontWeight: 700, marginTop: 2 }}>
+            {`6 sites · ${total} providers · 682 students`}
+          </div>
+        </div>
+        <div
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '4px 10px',
+            borderRadius: 999,
+            background: '#F3F5F8',
+            color: 'rgba(15,23,42,0.55)',
+            fontSize: 11,
+            fontWeight: 600,
+          }}
+        >
+          <svg
+            width="11"
+            height="11"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+            <circle cx="12" cy="12" r="3" />
+          </svg>
+          Read-only
+        </div>
+      </div>
+      <div
+        style={{
+          padding: '10px 20px',
+          borderBottom: '1px solid rgba(15,23,42,0.06)',
+          display: 'flex',
+          gap: 10,
+          flexWrap: 'wrap',
+        }}
+      >
+        {Object.entries(DISC).map(([name, c]) => (
+          <span
+            key={name}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              fontSize: 11,
+              fontWeight: 600,
+              color: 'rgba(15,23,42,0.7)',
+            }}
+          >
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: c }} />
+            {name}
+          </span>
+        ))}
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+          gap: 1,
+          background: 'rgba(15,23,42,0.06)',
+        }}
+      >
+        {sites.map((s, i) => (
+          <div key={i} style={{ background: '#FFF', padding: '14px 18px' }}>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'flex-start',
+                marginBottom: 12,
+                gap: 8,
+              }}
+            >
+              <div>
+                <div style={{ fontSize: 13, fontWeight: 700, color: '#0F172A' }}>{s.name}</div>
+                <div style={{ fontSize: 11, color: 'rgba(15,23,42,0.55)', marginTop: 2 }}>
+                  {`${s.providers.length} providers · ${s.students} students`}
+                </div>
+              </div>
+              {s.gap ? (
+                <span
+                  style={{
+                    fontSize: 10,
+                    fontWeight: 700,
+                    padding: '3px 8px',
+                    borderRadius: 999,
+                    background: '#FEF3C7',
+                    color: '#92400E',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {s.gap}
+                </span>
+              ) : null}
+            </div>
+            <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+              {s.providers.map((p, j) => (
+                <div
+                  key={j}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    padding: '4px 8px 4px 4px',
+                    background: DISC[p[1]] + '14',
+                    borderRadius: 999,
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 20,
+                      height: 20,
+                      borderRadius: 999,
+                      background: DISC[p[1]],
+                      color: '#FFF',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      fontSize: 9,
+                      fontWeight: 700,
+                    }}
+                  >
+                    {p[0]}
+                  </span>
+                  <span style={{ fontSize: 10, fontWeight: 700, color: DISC[p[1]], letterSpacing: '0.02em' }}>
+                    {p[1]}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+// ── Site admin · structural setup ───────────────────────────────────
+function StructuralMock() {
+  const rows = [
+    { label: 'TK · Morning', time: '8:00 – 11:20', tag: 'Bell', c: '#1E3A8A' },
+    { label: 'K · Half day', time: '8:00 – 12:00', tag: 'Bell', c: '#1E3A8A' },
+    { label: '1st – 5th', time: '8:00 – 2:45', tag: 'Bell', c: '#1E3A8A' },
+    { label: 'Music · 1st & 2nd', time: 'Mon · 9:30', tag: 'Special', c: '#A78BFA' },
+    { label: 'Library · 3rd–5th', time: 'Wed · 10:15', tag: 'Special', c: '#3B82F6' },
+    { label: 'Recess · upper', time: 'Daily · 10:30', tag: 'Special', c: '#F59E0B' },
+    { label: 'Lunch · all grades', time: 'Daily · 11:50', tag: 'Special', c: '#94A3B8' },
+  ];
+
+  return (
+    <Card>
+      <div style={{ padding: '16px 20px', borderBottom: '1px solid rgba(15,23,42,0.06)' }}>
+        <div style={{ fontSize: 13, color: 'rgba(15,23,42,0.55)', fontWeight: 500 }}>
+          Site setup · Lincoln Elementary
+        </div>
+        <div style={{ fontSize: 18, color: '#0F172A', fontWeight: 700, marginTop: 2 }}>
+          Bell schedule & specials
+        </div>
+      </div>
+      <div style={{ padding: '8px 0' }}>
+        {rows.map((row, i) => (
+          <div
+            key={i}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr auto auto',
+              gap: 12,
+              alignItems: 'center',
+              padding: '10px 20px',
+              borderTop: i === 0 ? 'none' : '1px solid rgba(15,23,42,0.05)',
+            }}
+          >
+            <div>
+              <div style={{ fontSize: 14, fontWeight: 600, color: '#0F172A' }}>{row.label}</div>
+              <div style={{ fontSize: 12, color: 'rgba(15,23,42,0.55)', marginTop: 2 }}>{row.time}</div>
+            </div>
+            <span
+              style={{
+                fontSize: 10,
+                fontWeight: 700,
+                padding: '3px 8px',
+                borderRadius: 6,
+                background: row.c + '18',
+                color: row.c,
+                letterSpacing: '0.04em',
+              }}
+            >
+              {row.tag.toUpperCase()}
+            </span>
+            <span
+              style={{
+                width: 22,
+                height: 22,
+                borderRadius: 999,
+                background: '#DCFCE7',
+                color: '#15803D',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="3"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            </span>
+          </div>
+        ))}
+      </div>
+      <div
+        style={{
+          background: '#F5EFE7',
+          padding: '12px 20px',
+          fontSize: 12,
+          color: '#6B5638',
+          fontWeight: 600,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+        }}
+      >
+        <span style={{ width: 7, height: 7, borderRadius: 999, background: '#8B7355' }} />
+        Reused by 8 providers across the site
+      </div>
+    </Card>
+  );
+}
+
+// ── CARE · referral queue ───────────────────────────────────────────
+function CareMock({ type }: { type: SchoolType }) {
+  const priv = type === 'private';
+  const cases = [
+    { name: 'R. Okafor · 2nd', type: 'Compliance', c: '#DC2626', bg: '#FEE2E2', due: 'Plan due Feb 3', lane: priv ? 'Learning-support review' : 'Assessment plan · 15 days' },
+    { name: 'T. Nguyen · 4th', type: 'Behavioral', c: '#F59E0B', bg: '#FEF3C7', due: 'SST Feb 11', lane: 'Action items · 2 open' },
+    { name: 'M. Silva · 1st', type: 'Academic', c: '#3B82F6', bg: '#DBEAFE', due: 'Review Feb 18', lane: 'Discussion lane' },
+    { name: 'K. Brooks · 5th', type: 'Speech', c: '#A78BFA', bg: '#EDE9FE', due: 'Follow-up Feb 24', lane: 'Active case' },
+  ];
+
+  return (
+    <Card>
+      <div
+        style={{
+          padding: '16px 20px',
+          borderBottom: '1px solid rgba(15,23,42,0.06)',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+        }}
+      >
+        <div>
+          <div style={{ fontSize: 13, color: 'rgba(15,23,42,0.55)', fontWeight: 500 }}>
+            CARE · referral queue
+          </div>
+          <div style={{ fontSize: 18, color: '#0F172A', fontWeight: 700, marginTop: 2 }}>
+            4 active cases
+          </div>
+        </div>
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            padding: '4px 10px',
+            borderRadius: 999,
+            background: '#FEE2E2',
+            color: '#DC2626',
+          }}
+        >
+          1 clock running
+        </span>
+      </div>
+      <div style={{ padding: '6px 12px' }}>
+        {cases.map((c, i) => (
+          <div
+            key={i}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              padding: '11px 8px',
+              borderTop: i === 0 ? 'none' : '1px solid rgba(15,23,42,0.05)',
+            }}
+          >
+            <span
+              style={{
+                fontSize: 10,
+                fontWeight: 700,
+                padding: '3px 8px',
+                borderRadius: 6,
+                background: c.bg,
+                color: c.c,
+                flexShrink: 0,
+                minWidth: 74,
+                textAlign: 'center',
+              }}
+            >
+              {c.type}
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: '#0F172A' }}>{c.name}</div>
+              <div style={{ fontSize: 11, color: 'rgba(15,23,42,0.55)', marginTop: 1 }}>{c.lane}</div>
+            </div>
+            <span
+              style={{
+                fontSize: 11,
+                fontWeight: 600,
+                color: 'rgba(15,23,42,0.6)',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {c.due}
+            </span>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+// ── Meetings · planning queue ───────────────────────────────────────
+function MeetingsMock({ type }: { type: SchoolType }) {
+  const priv = type === 'private';
+  const rows = [
+    { name: 'A. Chen', date: 'Feb 12 · 9:00', status: 'Confirmed', c: '#15803D', bg: '#DCFCE7' },
+    { name: 'D. Garza', date: 'Feb 12 · 10:30', status: 'Family invited', c: '#2452F5', bg: '#EFF5FF' },
+    { name: 'E. Rivera', date: 'Feb 14 · 1:15', status: 'Held', c: '#8B7355', bg: '#F5EFE7' },
+    { name: 'M. Mendez', date: 'Feb 19 · 9:45', status: 'Confirmed', c: '#15803D', bg: '#DCFCE7' },
+    { name: 'J. Wilson', date: 'unscheduled', status: 'Needs slot', c: '#DC2626', bg: '#FEE2E2' },
+  ];
+
+  return (
+    <Card>
+      <div
+        style={{
+          padding: '16px 20px',
+          borderBottom: '1px solid rgba(15,23,42,0.06)',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+        }}
+      >
+        <div>
+          <div style={{ fontSize: 13, color: 'rgba(15,23,42,0.55)', fontWeight: 500 }}>
+            {(priv ? 'Support-plan meetings' : 'IEP meetings') + ' · this term'}
+          </div>
+          <div style={{ fontSize: 18, color: '#0F172A', fontWeight: 700, marginTop: 2 }}>
+            12 due · 8 placed
+          </div>
+        </div>
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            padding: '4px 10px',
+            borderRadius: 999,
+            background: '#EFF5FF',
+            color: '#2452F5',
+          }}
+        >
+          Rolling out
+        </span>
+      </div>
+      <div style={{ padding: '6px 12px' }}>
+        {rows.map((r, i) => (
+          <div
+            key={i}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              padding: '11px 8px',
+              borderTop: i === 0 ? 'none' : '1px solid rgba(15,23,42,0.05)',
+            }}
+          >
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: '#0F172A' }}>{r.name}</div>
+              <div style={{ fontSize: 11, color: 'rgba(15,23,42,0.55)', marginTop: 1 }}>{r.date}</div>
+            </div>
+            <span
+              style={{
+                fontSize: 10,
+                fontWeight: 700,
+                padding: '4px 9px',
+                borderRadius: 999,
+                background: r.bg,
+                color: r.c,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {r.status}
+            </span>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+export function SpeddyMock({
+  kind = 'schedule',
+  type = 'public',
+}: {
+  kind?: MockKind;
+  type?: SchoolType;
+}) {
+  switch (kind) {
+    case 'minutes':
+      return <MinutesMock type={type} />;
+    case 'master':
+      return <MasterMock />;
+    case 'district':
+      return <DistrictMock />;
+    case 'structural':
+      return <StructuralMock />;
+    case 'care':
+      return <CareMock type={type} />;
+    case 'meetings':
+      return <MeetingsMock type={type} />;
+    default:
+      return <ScheduleMock type={type} />;
+  }
+}
+
+export default SpeddyMock;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next';
-import CleanLanding from './components/landing/clean-landing';
+import SpeddyLanding from './components/landing/speddy-landing';
 
 export const metadata: Metadata = {
-  title: 'Speddy — The friendly elementary SpEd platform',
+  title: 'Speddy — The friendly SpEd platform',
   description:
-    'Speddy organizes every session, every student, and every service minute so SpEd providers and school admins can focus on the work that matters.',
+    'Speddy organizes every session, every student, and every service minute so SpEd providers, site admins, and district directors can focus on the work that matters.',
 };
 
 export default function Home() {
-  return <CleanLanding />;
+  return <SpeddyLanding />;
 }


### PR DESCRIPTION
## Summary

Implements the **Speddy Landing** design ("Landing page capabilities reorganization") — a marketing landing page whose **three-axis selector drives every section**, so each visitor sees a page written for them:

- **School type** — Public · Charter · Private
- **Level** — Elementary · Middle / High
- **Role** — District · Site admin · Provider

Changing any axis re-derives the hero copy, the capability cards (with `Available now` / `Rolling out` / `In development` status pills), the product mockups, and a contextual **charter/private banner** — all from a single pure `resolve(sel)` function, so the content stays consistent and easy to reason about.

## What's new (this PR's landing work)

| File | Purpose |
| --- | --- |
| `app/components/landing/speddy-landing.tsx` | Sticky selector bar + `resolve()` logic + hero, product card, capabilities, supporting cast, CTA, footer. |
| `app/components/landing/speddy-mock.tsx` | Seven self-contained product-mockup graphics (`schedule`, `minutes`, `master`, `structural`, `district`, `care`, `meetings`), type-aware so labels read correctly for public vs. private schools. |
| `app/page.tsx` | Points `/` at the new landing; metadata broadened beyond "elementary" to match the K-12, multi-role coverage. |

Reuses the existing `SpeddyMark` (Pacifico logo) and `EmailSignup` (posts to `/api/landing-signup`) from `landing-shared.tsx`. Nav/footer link only to routes that exist on this branch — `/login`, on-page `#how`, `/privacy`, `/terms`, `/ferpa`, and a `mailto:` — consistent with self-signup having been removed earlier on the branch.

Responsive: `clamp()` for type/spacing, `flex-wrap` for rows, and a small media-query block collapses the two-column grids (and stacks the hero mockups) under 760px.

## Branch context

This is the feature branch for the capabilities reorganization, so the diff against `main` also includes the earlier groundwork commits this design builds on (IEP-meeting scheduling data model + availability engine + pages, the capabilities matrix, and the private/charter market research). The landing page is the capstone that surfaces that work.

## Verification

- `tsc --noEmit` and `next lint` both clean on the changed files.
- Drove the running app in a headless browser and screenshotted four selector combinations + a 390px mobile viewport:
  - Public / Elementary / Site admin — Master Schedule + Bell-schedule mockups, six "Available now" cards.
  - Provider / Private / Middle-High — caseload hero, pink private banner, CARE + Support-plan-meetings mockups, "In development" scheduler pill, private-specific labels/notes.
  - District / Charter / Elementary — "network" phrasing throughout, blue charter banner, single-column District staffing mockup.
  - Mobile — selector groups wrap/center, hero mockups and capability grid collapse to one column.
- Only console message was an external `ERR_TUNNEL_CONNECTION_FAILED` (HelpScout beacon / placeholder Supabase through the sandbox proxy), unrelated to the page.

## Test plan

- [ ] Load `/`, toggle each of the three selectors, confirm hero/cards/mockups/banner update coherently.
- [ ] Submit the hero and CTA email forms; confirm they post to `/api/landing-signup` and show the success state.
- [ ] Check nav "Sign in" → `/login`, "How it works" → `#how`, and footer links resolve.
- [ ] Verify layout at desktop and mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161gVUquFJTa7pV7mcSe2ik

---
_Generated by [Claude Code](https://claude.ai/code/session_0161gVUquFJTa7pV7mcSe2ik)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Speddy landing page experience to the home screen.
  * Introduced a responsive three-axis selector that customizes hero content, contextual banners, capability highlights, and signup audience targeting.
  * Added scenario-based, static product mockups with optional secondary visuals and responsive layout.
* **Updates**
  * Updated the home page title and description to better reflect SpEd platform positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->