### PR TITLE
docs: point CLAUDE.md at the sim district reference and lifecycle commands

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,6 +10,11 @@
   to get up to speed fast; it's cross-referenced to the relevant Linear tickets
   and to the "Speddy" Miro board. When you change one of those areas, update the
   matching section (each ends with a "Source of truth" file list).
+- **Sim district:** permanent fake tenant in the prod DB for cross-role,
+  end-to-end verification; spec + personas in `docs/SIM_DISTRICT.md`. Lifecycle:
+  `npm run sim:reset -- --yes`, `sim:verify`, `sim:teardown -- --yes` (env vars
+  are configured in the Claude remote environment). Prefer resetting it before
+  cross-role verification runs; only ever touch sim data through these scripts.
 
 ## Autonomous execution for high-confidence, non-UX work
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,7 +12,7 @@
   matching section (each ends with a "Source of truth" file list).
 - **Sim district:** permanent fake tenant in the prod DB for cross-role,
   end-to-end verification; spec + personas in `docs/SIM_DISTRICT.md`. Lifecycle:
-  `npm run sim:reset -- --yes`, `sim:verify`, `sim:teardown -- --yes` (env vars
+  `npm run sim:reset -- --yes`, `npm run sim:verify`, `npm run sim:teardown -- --yes` (env vars
   are configured in the Claude remote environment). Prefer resetting it before
   cross-role verification runs; only ever touch sim data through these scripts.
 


### PR DESCRIPTION
## Summary

Adds a two-line index entry to `.claude/CLAUDE.md` pointing at `docs/SIM_DISTRICT.md` and the `sim:reset` / `sim:verify` / `sim:teardown` commands, so future Claude sessions know the sim district exists without being told — the fixture only gets used routinely if sessions discover it unprompted. Mirrors the existing `ARCHITECTURE.md` pointer pattern; deliberately a pointer, not inline documentation (the spec stays the single source of truth).

Follow-up to #690 (harness) and #689 (spec).

## Verification

- Docs-only change to `.claude/CLAUDE.md`; no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nHWELLA85Xny831f5NpvP

---
_Generated by [Claude Code](https://claude.ai/code/session_019nHWELLA85Xny831f5NpvP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Sim district” guideline for cross-role end-to-end verification using a permanent fake tenant in the production database.
  * Linked to the simulation specs/personas documentation and clarified how the simulated data should be managed.
  * Documented the recommended lifecycle commands: `npm run sim:reset -- --yes`, `npm run sim:verify`, and `npm run sim:teardown -- --yes`.
  * Noted that required environment variables are preconfigured in the remote Claude environment, and sim data should be modified only via these scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->