### PR TITLE
fix(sim-district): survive live-DB drift discovered on first real seed run

### DIFF
--- a/scripts/sim-district/lib.ts
+++ b/scripts/sim-district/lib.ts
@@ -103,6 +103,10 @@ export async function assertSentinel(admin: Admin): Promise<'exists' | 'bootstra
   // half-failed prior seed must fail HERE with a clear message, not surface
   // as a duplicate-key error mid-seed.
   const problems: string[] = [];
+  const simUsers = await resolveSimAuthUsers(admin);
+  if (simUsers.size > 0) problems.push(`${simUsers.size} @${SIM_EMAIL_DOMAIN} auth user(s)`);
+  const simUserIds = [...simUsers.values()];
+
   const simSchoolIds = SCHOOLS.map(s => s.id);
   const scopedChecks: { table: string; column: string; ids: string[] }[] = [
     { table: 'schools', column: 'id', ids: simSchoolIds },
@@ -113,9 +117,15 @@ export async function assertSentinel(admin: Admin): Promise<'exists' | 'bootstra
     { table: 'special_activities', column: 'school_id', ids: simSchoolIds },
     { table: 'care_referrals', column: 'school_id', ids: simSchoolIds },
     { table: 'provider_schools', column: 'school_id', ids: simSchoolIds },
-    { table: 'user_site_schedules', column: 'school_id', ids: simSchoolIds },
     { table: 'admin_permissions', column: 'district_id', ids: [DISTRICT.id] },
   ];
+  // These two have no school_id column — reachable only via sim user ids.
+  if (simUserIds.length > 0) {
+    scopedChecks.push(
+      { table: 'schedule_sessions', column: 'provider_id', ids: simUserIds },
+      { table: 'user_site_schedules', column: 'user_id', ids: simUserIds },
+    );
+  }
   for (const check of scopedChecks) {
     const { count, error } = await admin
       .from(check.table)
@@ -125,26 +135,12 @@ export async function assertSentinel(admin: Admin): Promise<'exists' | 'bootstra
     if ((count ?? 0) > 0) problems.push(`${count} ${check.table} row(s)`);
   }
 
-  const simUsers = await resolveSimAuthUsers(admin);
-  if (simUsers.size > 0) problems.push(`${simUsers.size} @${SIM_EMAIL_DOMAIN} auth user(s)`);
-  const simUserIds = [...simUsers.values()];
-
   const { count: profileCount, error: profileErr } = await admin
     .from('profiles')
     .select('id', { count: 'exact', head: true })
     .like('email', `%@${SIM_EMAIL_DOMAIN}`);
   if (profileErr) throw new Error(`Zero-state profile check failed: ${profileErr.message}`);
   if ((profileCount ?? 0) > 0) problems.push(`${profileCount} sim profile row(s)`);
-
-  // schedule_sessions has no school_id — reachable only via sim providers.
-  if (simUserIds.length > 0) {
-    const { count, error } = await admin
-      .from('schedule_sessions')
-      .select('*', { count: 'exact', head: true })
-      .in('provider_id', simUserIds);
-    if (error) throw new Error(`Zero-state session check failed: ${error.message}`);
-    if ((count ?? 0) > 0) problems.push(`${count} schedule_sessions row(s)`);
-  }
 
   if (problems.length > 0) {
     console.error(

--- a/scripts/sim-district/seed.ts
+++ b/scripts/sim-district/seed.ts
@@ -68,6 +68,7 @@ import {
   assertSentinel,
   bulkInsert,
   createAdmin,
+  deleteWhereIn,
   minutesAfter,
   requireEnv,
   requireYesFlag,
@@ -206,6 +207,12 @@ async function main() {
       }
     });
   }
+  // handle_new_user_schools() fires on auth user creation and inserts a
+  // primary-school provider_schools row (random id) for multi-school personas.
+  // UNIQUE (provider_id, school_district, school_site) would reject our
+  // manifest-keyed rows, and user_site_schedules.site_id needs the manifest
+  // ids — so replace the trigger's rows with ours.
+  await deleteWhereIn(admin, 'provider_schools', 'provider_id', [...userIds.values()]);
   counts['provider_schools'] = await bulkInsert(admin, 'provider_schools', providerSchoolRows);
   counts['user_site_schedules'] = await bulkInsert(admin, 'user_site_schedules', siteScheduleRows);
 

--- a/scripts/sim-district/seed.ts
+++ b/scripts/sim-district/seed.ts
@@ -212,7 +212,8 @@ async function main() {
   // UNIQUE (provider_id, school_district, school_site) would reject our
   // manifest-keyed rows, and user_site_schedules.site_id needs the manifest
   // ids — so replace the trigger's rows with ours.
-  await deleteWhereIn(admin, 'provider_schools', 'provider_id', [...userIds.values()]);
+  counts['provider_schools (trigger rows removed)'] =
+    await deleteWhereIn(admin, 'provider_schools', 'provider_id', [...userIds.values()]);
   counts['provider_schools'] = await bulkInsert(admin, 'provider_schools', providerSchoolRows);
   counts['user_site_schedules'] = await bulkInsert(admin, 'user_site_schedules', siteScheduleRows);
 

--- a/scripts/sim-district/teardown.ts
+++ b/scripts/sim-district/teardown.ts
@@ -49,6 +49,20 @@ export async function teardown(admin: Admin): Promise<Record<string, number>> {
     deleted[`${sweep.table} (swept)`] = await deleteWhereIn(admin, sweep.table, sweep.column, ids);
   }
 
+  // debug_signup_log: the auth signup triggers log every sim user creation,
+  // and a user's first row has NULL metadata. Metadata-tagged rows recover
+  // user ids orphaned by earlier teardowns; everything sweeps by user_id.
+  {
+    const debugIds = new Set(simUserIds);
+    const { data, error } = await admin
+      .from('debug_signup_log')
+      .select('user_id')
+      .eq('metadata->>school_district', DISTRICT.name);
+    if (error) throw new Error(`debug_signup_log scan failed: ${error.message}`);
+    for (const row of data ?? []) if (row.user_id) debugIds.add(row.user_id);
+    deleted['debug_signup_log (swept)'] = await deleteWhereIn(admin, 'debug_signup_log', 'user_id', [...debugIds]);
+  }
+
   // 3. School-scoped schedule scaffolding (school_id match catches all seeded
   //    rows; provider_id match catches any strays created by sim providers).
   for (const table of ['special_activities', 'bell_schedules', 'school_hours'] as const) {

--- a/scripts/sim-district/verify.ts
+++ b/scripts/sim-district/verify.ts
@@ -138,6 +138,9 @@ async function main() {
     expect('care_case_status_history', n => n === expectedHistory, String(expectedHistory));
     expect('provider_schools', n => n > 0, '> 0');
     expect('user_site_schedules', n => n > 0, '> 0');
+    // Signup triggers tag their log rows with the sim district name via
+    // metadata; a zero here would mean the real-path trigger never fired.
+    expect('debug_signup_log (sim-tagged)', n => n > 0, '> 0');
   }
 
   console.log(expectEmpty ? 'Orphan scan (expect zero everywhere):\n' : 'Post-seed verification:\n');

--- a/scripts/sim-district/verify.ts
+++ b/scripts/sim-district/verify.ts
@@ -82,6 +82,18 @@ async function collectCounts(admin: Admin) {
     const ids = sweep.identity === 'user' ? simUserIds : simStudentIds;
     counts[`${sweep.table} (swept)`] = ids.length > 0 ? await countWhereIn(admin, sweep.table, sweep.column, ids) : 0;
   }
+
+  // debug_signup_log rows from the signup triggers, tagged to the sim district
+  // via metadata (NULL-metadata rows are swept by user_id in teardown but are
+  // not attributable here once the users are gone).
+  {
+    const { count, error } = await admin
+      .from('debug_signup_log')
+      .select('*', { count: 'exact', head: true })
+      .eq('metadata->>school_district', DISTRICT.name);
+    if (error) throw new Error(`debug_signup_log scan failed: ${error.message}`);
+    counts['debug_signup_log (sim-tagged)'] = count ?? 0;
+  }
   return counts;
 }
 

--- a/supabase/migrations/20260710_remove_dead_migration_log_insert_from_profile_creation.sql
+++ b/supabase/migrations/20260710_remove_dead_migration_log_insert_from_profile_creation.sql
@@ -1,0 +1,107 @@
+-- Remove the dead school_migration_log INSERT from create_profile_for_new_user.
+--
+-- The SEA-only logging branch (added in 20250826_update_profile_creation_with_ids)
+-- inserts into school_migration_log, but that table does not exist in the live
+-- database (the 20250807 migration that created it is not in the recorded
+-- history, and no schema contains it). The branch therefore throws
+-- `relation "school_migration_log" does not exist` on EVERY SEA profile
+-- creation, breaking SEA account creation through all admin routes that call
+-- this RPC (providers/teachers/site-admin/create-admin-account). Surfaced by
+-- the sim district's first live seed on its SEA persona.
+--
+-- This redefinition is byte-identical to the live function except the dead
+-- INSERT block is removed. CREATE OR REPLACE preserves ownership and the
+-- existing grants (service-role-only: anon revoked in 20260529201326,
+-- authenticated revoked in 20260531012347).
+
+CREATE OR REPLACE FUNCTION public.create_profile_for_new_user(user_id uuid, user_email text, user_metadata jsonb)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_state_name TEXT;
+  v_district_name TEXT;
+  v_school_name TEXT;
+  v_state_id VARCHAR(2);
+  v_district_id VARCHAR(20);
+  v_school_id VARCHAR(20);
+  v_confidence FLOAT;
+BEGIN
+  -- Extract names from metadata
+  v_state_name := COALESCE(user_metadata->>'state', '');
+  v_district_name := COALESCE(user_metadata->>'school_district', '');
+  v_school_name := COALESCE(user_metadata->>'school_site', '');
+
+  -- Try to find matching IDs
+  IF v_state_name != '' OR v_district_name != '' OR v_school_name != '' THEN
+    SELECT
+      matched_state_id,
+      matched_district_id,
+      matched_school_id,
+      confidence_score
+    INTO
+      v_state_id,
+      v_district_id,
+      v_school_id,
+      v_confidence
+    FROM public.find_school_ids_by_names(
+      v_school_name,
+      v_district_name,
+      v_state_name
+    );
+  END IF;
+
+  -- Insert or update the profile with the found IDs
+  INSERT INTO public.profiles (
+    id,
+    email,
+    full_name,
+    role,
+    school_district,
+    school_site,
+    state_id,
+    district_id,
+    school_id,
+    works_at_multiple_schools,
+    district_domain,
+    created_at,
+    updated_at
+  )
+  VALUES (
+    user_id,
+    user_email,
+    COALESCE(user_metadata->>'full_name', ''),
+    COALESCE(user_metadata->>'role', 'resource'),
+    v_district_name,
+    v_school_name,
+    v_state_id,
+    v_district_id,
+    v_school_id,
+    COALESCE((user_metadata->>'works_at_multiple_schools')::boolean, false),
+    SPLIT_PART(user_email, '@', 2),
+    NOW(),
+    NOW()
+  )
+  ON CONFLICT (id) DO UPDATE
+  SET
+    email = EXCLUDED.email,
+    full_name = COALESCE(EXCLUDED.full_name, profiles.full_name),
+    role = COALESCE(EXCLUDED.role, profiles.role),
+    school_district = COALESCE(EXCLUDED.school_district, profiles.school_district),
+    school_site = COALESCE(EXCLUDED.school_site, profiles.school_site),
+    state_id = COALESCE(EXCLUDED.state_id, profiles.state_id),
+    district_id = COALESCE(EXCLUDED.district_id, profiles.district_id),
+    school_id = COALESCE(EXCLUDED.school_id, profiles.school_id),
+    works_at_multiple_schools = COALESCE(EXCLUDED.works_at_multiple_schools, profiles.works_at_multiple_schools),
+    district_domain = EXCLUDED.district_domain,
+    updated_at = NOW();
+
+  -- If this was an SEA profile and we couldn't match schools, log a warning
+  IF COALESCE(user_metadata->>'role', 'resource') = 'sea' AND v_school_id IS NULL THEN
+    RAISE WARNING 'SEA profile created without school IDs for user %: state=%, district=%, school=%',
+      user_id, v_state_name, v_district_name, v_school_name;
+  END IF;
+END;
+$function$;


### PR DESCRIPTION
## Summary

First live run of `npm run sim:reset -- --yes` surfaced three mismatches between the sim-district scripts and the production database, plus one pre-existing prod bug in `create_profile_for_new_user`. This PR fixes all four; after the fixes the full seed + verify cycle runs green end to end (output in the comments/session report).

### 1. Zero-state check queried a non-existent column (`lib.ts`)

The bootstrap zero-state check counted `user_site_schedules` by `school_id`, but the table has no such column — it's keyed by `user_id` and `site_id → provider_schools`. Because the check is a PostgREST HEAD request, the error body was swallowed and the seed died with an empty message. The check now keys by `user_id` alongside `schedule_sessions`, matching how teardown and verify already treat the table.

### 2. Signup-trigger side effect collides with manifest-keyed inserts (`seed.ts`)

The live `handle_new_user_schools()` trigger fires on auth user creation and inserts a primary-school `provider_schools` row (random UUID) for personas with `works_at_multiple_schools`. The seed's step-4 insert of manifest-keyed rows then violates `UNIQUE (provider_id, school_district, school_site)` — and `user_site_schedules.site_id` needs the deterministic manifest ids. The seed now deletes the trigger-created rows for sim users (sim-keyed only) before inserting its own.

### 3. `debug_signup_log` rows leaked past teardown (`teardown.ts`, `verify.ts`)

Both signup triggers log every auth user creation to `debug_signup_log`, including one row per user with NULL metadata. Teardown never swept the table, and rows orphan permanently once their users are deleted (69 rows had accumulated from the failed runs). Teardown now recovers orphaned user ids from metadata-tagged rows (`metadata->>school_district` = the manifest district name) and sweeps by `user_id`; `verify --expect-empty` now also counts sim-tagged rows.

### 4. Prod bug: dead `school_migration_log` insert broke SEA account creation (migration)

Seed step 3 failed on the SEA persona because `create_profile_for_new_user` has an SEA-only branch inserting into `school_migration_log` — a table that doesn't exist in prod (the repo migration `20250807_add_school_ids_to_profiles.sql` that created it isn't in the recorded migration history; the RPC update `20250826_update_profile_creation_with_ids` is). **Creating any SEA account through the admin routes failed in production** (`app/api/admin/district/providers/route.ts` etc.).

Per discussion, `supabase/migrations/20260710_remove_dead_migration_log_insert_from_profile_creation.sql` redefines the RPC identically minus the dead INSERT block. Applied to prod via MCP as version `20260710190424` (note: the commit message says `20260710191211` — that's a typo for the recorded version; the correct one is `20260710190424`). Verified post-apply: no log reference, still SECURITY DEFINER with pinned `search_path=public`, ACL unchanged (`postgres` + `service_role` only).

Related, not addressed here: the `admin/migrate-schools` page also references the missing `school_migration_log` table and is broken in prod regardless of this fix — left for a follow-up since it's stale Aug-2025 one-time tooling.

## Verification

- Offline check: all generator outputs validated unique against the live unique constraints (`students` 202 rows, `schedule_sessions` instances 1032, `user_site_schedules` 15, `school_hours` 240).
- Live: `npm run sim:teardown -- --yes` (swept the 69 leaked debug rows) → `npm run sim:verify -- --expect-empty` — all 25 checks green.
- Live: `npm run sim:reset -- --yes` → all 9 steps complete (18 personas incl. SEA, 202 students, 1,277 sessions) → `npm run sim:verify` — **all 20 post-seed checks green**.
- `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCkoy5NKwbydGevxJfKSLS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SIM district empty-state validation to reliably detect leftover auth, profile, permission, scheduling, and user data.
  * Ensured seeded SIM provider school rows aren’t overridden by trigger-generated records.
  * Fixed profile creation by removing a dead migration-log insert that could block admin-driven account creation.
  * Expanded district teardown to fully remove orphaned, district-tagged signup log entries.
* **Tests**
  * Added verification in empty-state mode that district-tagged signup logs are removed (count must be zero).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->