### PR TITLE
docs: preserve weekly PR quality reviews from orphaned branches

### DIFF
--- a/docs/pr-reviews/2026-06-15-weekly-pr-review.md
+++ b/docs/pr-reviews/2026-06-15-weekly-pr-review.md
@@ -1,5 +1,11 @@
 # Weekly PR Quality Review — 2026-06-15
 
+> **Archival note (2026-07-10):** preserved verbatim from the orphaned branch
+> `claude/brave-albattani-bemp5e` (never PR'd) during branch cleanup. This is a
+> point-in-time review, not living guidance; post-hoc critiques of some of its
+> recommendations are recorded in the PR #693 review threads. Findings 1 and 2
+> are tracked as SPE-215 and SPE-216.
+
 **Period covered:** 2026-06-08 → 2026-06-15  
 **PRs reviewed:** 15 merged (#644 – #658)  
 **Verdict: Generally HIGH quality, 5 targeted findings logged below.**

--- a/docs/pr-reviews/2026-06-15-weekly-pr-review.md
+++ b/docs/pr-reviews/2026-06-15-weekly-pr-review.md
@@ -1,0 +1,113 @@
+# Weekly PR Quality Review — 2026-06-15
+
+**Period covered:** 2026-06-08 → 2026-06-15  
+**PRs reviewed:** 15 merged (#644 – #658)  
+**Verdict: Generally HIGH quality, 5 targeted findings logged below.**
+
+---
+
+## Overview
+
+This was a compliance-heavy week driven by the CA-NDPA (CITE/CSPA) pre-signing sprint and a secondary-school feature launch. The security fixes are thorough and well-reasoned; the Middle/High School Module is cleanly abstracted. No shortcuts were taken on the hard problems. The findings below are real but limited in scope — none are regressions or critical bugs, but several need to be tracked before they become one.
+
+---
+
+## What Was Solid
+
+- **AI kill-switch design (#651):** `aiGated: true` on `withRoute` is the right place for this — pre-auth, centralized, per-request env read so a config change takes effect without a deploy in non-Vercel environments. Tests cover all four cases.
+- **Fail-closed rate limiting (#646):** Opt-in `failClosed` flag with sensible defaults (cheap endpoints fail open, expensive AI/upload endpoints fail closed) is exactly the right tradeoff. The IP-based rate limiter for unauthenticated worksheet uploads is also corrected.
+- **Cron repair (#645):** Caught three silent failures in one PR: wrong column name (`created_at` vs `uploaded_at`), wrong auth method (query-string token leaked to access logs), wrong HTTP status codes (200 on error masked failures from monitoring). All fixed correctly.
+- **XSS in PDF print path (#645):** `document.write` paths in `export-week-to-pdf.ts` and `worksheet-generator.ts` were injecting AI-generated + DB content unescaped. The `escapeHtml` helper + consistent application is the right fix.
+- **Provider deletion architecture (#655):** The blocker-check → null-nullable-refs → cascade-profile → delete-auth-user → remove-storage sequence is correct. Pre-flight checks prevent FK violations. CARE referrals are surfaced rather than auto-deleted due to name-based (not FK) matching — the right call for ambiguous compliance data.
+- **School-level detection (#648):** Explicit authority order (school_type > grade_span fallback > elementary default) with unit tests covering boundary cases is solid. Combined K-8/K-12 sites defaulting to elementary is a documented product decision.
+- **Sentry privacy hardening (#650 + #647):** Disabling Logs, Replay, and `meta`/`context` forwarding to Sentry breadcrumbs, plus the `deepRedact` email scrubber, is comprehensive.
+
+---
+
+## Findings
+
+### 1. `worksheet_submissions.image_url` now holds two incompatible formats (PR #644)
+
+**Severity: Medium — silent landmine**
+
+The bucket was made private and new rows now store a storage *path* (e.g. `submissions/abc.jpg`) instead of a public CDN URL. Old rows still hold `https://...public/...` URLs that now 404. The migration adds no normalization step, and the PR comment explicitly acknowledges "nothing currently renders image_url."
+
+That's accurate today, but when a read path is eventually added it will silently produce broken images for all historical submissions without any type-system signal that the field has two formats. The field name `image_url` implies a URL, making this especially easy to miss.
+
+**Recommendation:** Add a Linear item to either (a) run a one-time migration to rewrite old public URLs to paths, or (b) add a helper that detects the format and generates a signed URL either way. Don't wait until the read path is being built.
+
+---
+
+### 2. `tracesSampleRate: 1.0` survives the Sentry privacy hardening (PR #650)
+
+**Severity: Low-medium — inconsistent with stated privacy posture**
+
+All three Sentry configs (`instrumentation-client.ts`, `sentry.server.config.ts`, `sentry.edge.config.ts`) retain `tracesSampleRate: 1`. The PR correctly disabled Logs and Replay, but 100% trace sampling means every API call and page load produces a Sentry span containing the request URL path. URL paths in this app contain resource IDs (e.g. `/dashboard/teacher/my-students/[studentId]`), and at district scale this is a non-trivial data volume sent to Sentry on every interaction.
+
+This is inconsistent with the privacy-minimization theme of the week's work. Logs and Replay were cut specifically because they "can carry student context" — traces carry the same context in URL paths.
+
+**Recommendation:** Drop `tracesSampleRate` to `0.1` (10%) or lower for the district pilot. This is a one-liner change across three files.
+
+---
+
+### 3. Provider deletion leaves a dangling auth record on partial failure (PR #655)
+
+**Severity: Low — operational gap in a compliance-sensitive flow**
+
+The delete sequence is: null refs → delete profile (cascades all data) → delete auth user → remove Storage. If `profiles.delete()` succeeds but `service.auth.admin.deleteUser()` fails, the provider's data is completely gone (profile, students, worksheets) but their Supabase Auth record survives. The user cannot log in usefully (no profile), but the auth record exists in the Supabase dashboard.
+
+The PR returns `{ success: true, warning: '...' }` — which is the correct surface-level response — but there is no follow-up: no retry endpoint, no admin alert, no cleanup job. For an NDPA deletion tool where the district is relying on a paper trail that the user's data was removed, a dangling auth record is a compliance gap.
+
+**Recommendation:** Log the dangling auth user ID in a way that surfaces to Sentry (it's already logged to the console). Add a note in the Linear issue to revisit whether a cleanup API endpoint or Supabase admin-dashboard link in the warning message is needed before GA.
+
+---
+
+### 4. Blocker queries in provider deletion run sequentially (PR #655)
+
+**Severity: Low — performance**
+
+The 4 pre-delete blocker checks (care_referrals, care_meeting_notes, care_case_status_history, activated_school_years) run in a `for...of` loop with sequential `await`, adding ~4× the latency of a single query before any data changes. These are independent count queries and could be `Promise.all()`'d.
+
+```typescript
+// Current (sequential)
+for (const spec of blockerSpecs) {
+  const { count } = await service.from(spec.table)...
+}
+
+// Better
+const counts = await Promise.all(blockerSpecs.map(spec => service.from(spec.table)...));
+```
+
+Not urgent, but this runs before the destructive step in a compliance-sensitive operation.
+
+---
+
+### 5. `deepRedact` mutates Sentry event objects in-place (PR #647)
+
+**Severity: Low — style/correctness**
+
+`sentry-scrub.ts` modifies the event/log object passed to `beforeSend`/`beforeSendLog` in-place before returning it. For arrays and objects, it iterates and reassigns keys on the original reference. This works today because Sentry doesn't process the original object after the hook returns, but it violates the functional contract of a "before send" hook and could interact unexpectedly if the Sentry SDK ever adds post-hook processing.
+
+The depth cap of `8` is also unexplained — it's a reasonable ceiling but should have a comment explaining why (e.g., "Sentry events don't typically nest deeper than ~5 levels; 8 is a conservative guard against pathological/cyclic structures").
+
+**Recommendation:** Either document the mutation as intentional with a comment, or convert to a deep-clone approach (`JSON.parse(JSON.stringify(value))` before recursing, which also handles the cyclic-structure case more cleanly).
+
+---
+
+## Docs-Only PRs (no engineering concerns)
+
+- **#658** — CA-NDPA execution packet, attorney brief, IR plan (SPE-59)
+- **#657** — OpenAI + Anthropic DPAs on file, subprocessor update
+- **#654** — Data inventory exhibit grounded in live schema
+- **#653** — Subprocessor disclosure + FERPA claim accuracy
+
+All four are accurate and well-sourced against the live schema/code. No inconsistencies found.
+
+---
+
+## Items Not Flagged (intentional)
+
+- **`tracesSampleRate`** was not changed as part of the Sentry work (finding #2 above), but the overall privacy hardening direction is correct.
+- **`SELF_REGISTERABLE_ROLES` deny-by-default** (#644): New roles added in the future will be blocked by default — this is the correct posture.
+- **CARE referral name-match as a two-step flow** (#655): Surfacing for admin confirmation rather than auto-deleting is the right call when the match is by free text, not FK.
+- **Per-request env read for `AI_FEATURES_ENABLED`** (#651): Intentional and documented. The comment correctly explains the tradeoff.

--- a/docs/pr-reviews/2026-06-27-weekly-pr-review.md
+++ b/docs/pr-reviews/2026-06-27-weekly-pr-review.md
@@ -1,5 +1,12 @@
 # Weekly PR Quality Review — 2026-06-27
 
+> **Archival note (2026-07-10):** preserved verbatim from the orphaned branch
+> `claude/brave-albattani-7Wtyz` (never PR'd) during branch cleanup. The date in
+> the filename/title is the review's run date; it covers an earlier backlog
+> period (May 22 – June 1). This is a point-in-time review, not living
+> guidance; post-hoc critiques of some of its process recommendations are
+> recorded in the PR #693 review threads.
+
 **Period covered:** May 22 – June 1, 2026  
 **PRs reviewed:** #624–#643 (20 PRs)
 

--- a/docs/pr-reviews/2026-06-27-weekly-pr-review.md
+++ b/docs/pr-reviews/2026-06-27-weekly-pr-review.md
@@ -1,0 +1,115 @@
+# Weekly PR Quality Review — 2026-06-27
+
+**Period covered:** May 22 – June 1, 2026  
+**PRs reviewed:** #624–#643 (20 PRs)
+
+---
+
+## Overall Assessment
+
+The period covers two distinct work streams: a large mechanical refactor batch (SPE-75 withRoute migration, PRs #624–#634) and a focused security hardening sprint (PRs #636–#643). Quality is uneven across these streams.
+
+The security work is generally well-researched — migrations are guarded and idempotent, and the post-mortem on the regression is candid. However, it produced the most damaging incident in the period: a production security fix that broke unauthenticated reads and required a hotfix because verification checked the wrong thing. The withRoute batch shows the clearest evidence of process breakdown under velocity pressure: 11 PRs in a single day, all with unchecked test plan items, none with meaningful smoke testing.
+
+---
+
+## Concerns (Ranked by Severity)
+
+### CRITICAL — Production regression from incomplete verification (PR #640 / #643)
+
+SPE-10 revoked `anon` EXECUTE on SECURITY DEFINER functions but verified only at the grant/advisor level — not by querying as the `anon` role. The actual failure: policies declared `TO public` calling functions anon can no longer execute produced `permission denied` errors instead of `0 rows`.
+
+A single `SELECT` query run as the `anon` role before merging would have caught this. The root cause per the post-mortem: *"I checked which functions were used in RLS but not the policies' roles, and I verified at the grant/advisor level rather than by querying as anon."*
+
+**Process gap:** No documented verification checklist for database permission changes. Security migrations should require explicit role-scoped query verification before merge.
+
+---
+
+### HIGH — 11 PRs merged same day, all with unchecked CI/smoke-test items (PRs #624–#634)
+
+Each PR was created and merged in under 20 minutes. All 11 had unchecked test plan checkboxes (`CI green`, `Smoke-check`) at merge time. This is not a documentation gap — it means the review process did not happen.
+
+The withRoute abstraction is sound, and the individual changes are mostly mechanical. But 11 PRs merged in one day across 59+ route files with no manual verification creates latent bugs that CI won't catch (no integration tests for these routes). Notable edge case: `submit-worksheet` (#628) was wrapped with `auth: false` but still manually calls `supabase.auth.getUser()` inside the handler, making the withRoute wrapper cosmetic for this route — a misleading contract.
+
+---
+
+### HIGH — Production migration applied before code was merged/deployed (PR #637)
+
+The PR description states: *"The migration has already been applied to the production database. Merging/deploying this branch promptly closes the window where the currently-deployed code still references the dropped columns."*
+
+The correct sequence is: merge code → deploy → apply migration. What happened created a window where deployed production code referenced schema columns that no longer existed. The urgency framing treats this backward sequence as valid rather than as a process failure that needs correction.
+
+---
+
+### MEDIUM — Same verification gap exists in SPE-114 (PR #642)
+
+PR #642 revoked `authenticated` EXECUTE on 8 functions classified as unused. The audit used grep-based code search — the same approach that missed the policy `TO public` binding in PR #640. If any of these functions are called indirectly, the failure mode is identical.
+
+Additionally: the 8 unused functions were revoked but not dropped. If they are genuinely unused dead code, they should be deleted. Revoking access while leaving them in the schema is a half-measure — the complexity remains and the revocation has to be maintained indefinitely.
+
+---
+
+### MEDIUM — SPE-92 XSS fix was narrowly scoped; similar `document.write` patterns remain
+
+PR #636 fixed `document.write` in `manual-lesson-view-modal.tsx` with DOMPurify. At least two other sites remain unaddressed:
+
+- `worksheet-button.tsx:62` — writes `printableHtml` directly  
+- `lesson-preview-modal.tsx:479` — writes server-fetched HTML from `/api/lessons/[id]/render` directly; that endpoint has a `TODO: revisit whether this should require auth + explicit ownership check` comment that has been unresolved since the #628 batch
+
+Security remediations that fix one instance while leaving similar patterns open are incomplete.
+
+---
+
+### MEDIUM — SPE-91 PII logging fix was narrowly scoped; 26+ console statements remain in calendar-week-view alone
+
+PR #636 removed 6 `console.log` calls from two files. The codebase has 586 console statement calls total. `calendar-week-view.tsx` has 26 including `[DEBUG]`-tagged statements logging user IDs and school context objects. `lessons/generate/route.ts` has a conditional `[DEBUG] Full metadata capture is ENABLED` path with PII capture.
+
+A proper remediation would inventory all console output, gate debug logs behind an environment check, and route necessary server-side logging through the structured logger at `lib/monitoring/logger.ts`. That work was not done.
+
+---
+
+### MEDIUM — 12 auth tests skipped under SPE-111, with no SPE-111 work since (PR #638)
+
+CI gating was added (genuine improvement), but achieving green required skipping 12 tests covering login flow, session maintenance, and error handling. The `it.skip` annotations with SPE-111 pointers are better than silent skips, but these have now been sitting skipped for 4+ weeks with no SPE-111 activity in the log.
+
+---
+
+### LOW — Dead code not removed when identified
+
+- 8 functions in PR #642 confirmed as unused were revoked but not dropped
+- Commented-out code block in `app/api/auth/login/route.ts` (lines 202–232) was left as a draft artifact in a security-sensitive file
+- `(supabase.rpc as any)(...)` casts in `useOtherProviderSessions.ts` and `student-details.ts` were identified in PR #642's audit but not fixed (root fix: regenerate or extend Supabase TypeScript types)
+
+---
+
+### LOW — withRoute migration is incomplete with no completion plan
+
+After 11 PRs, ~15 routes remain on the old pattern including `auth/signup`, `auth/login`, `auth/forgot-password`, `email-webhook`, `extension/compare`, and `extension/import`. The codebase is in a permanent mixed state with no documented plan for the remaining routes or a rationale for excluding them.
+
+---
+
+## Positive Patterns Worth Calling Out
+
+- **withRoute abstraction quality** — The wrapper itself is clean, typed correctly, Zod validation at the boundary layer, rate limiting integrated, consistent error shape. Good design.
+- **Migration quality and idempotency** — All security migrations use `to_regprocedure()` / `IF EXISTS` guards, include reversibility instructions, and have clear explanatory headers. Professional.
+- **SPE-643 post-mortem** — Honest, accurate description of what went wrong and why. This is the right culture.
+- **SPE-9 (pg_graphql)** — Correctly verified: checked for GraphQL imports in codebase, then dropped the extension. Complete and clean.
+- **Rate limiting on AI routes** — All 4 AI generation endpoints have per-user rate limits through withRoute. Real security value, not just structural cleanup.
+
+---
+
+## Recommended Process Improvements
+
+1. **Require role-scoped query verification for all DB permission changes.** Before merging any migration touching RLS policies or EXECUTE grants, run a representative query as each affected role and record the output in the PR.
+
+2. **No production migrations before code is deployed.** Apply migrations only after deploying the code that handles the new schema, or document a compatibility window explicitly.
+
+3. **Set a hard daily limit on batch refactor merges.** 11 PRs in one day is indistinguishable from having no review process. Spread batch merges or group into larger reviewable units with CI verification between batches.
+
+4. **Treat `it.skip` as time-bounded deferral.** Any `it.skip` without its ticket resolved within 30 days should be deleted, not maintained. Tests for removed behavior should be deleted, not skipped.
+
+5. **Security remediations require full pattern audits, not point fixes.** Each security ticket should include an explicit "are there other instances of this pattern?" step before closing.
+
+6. **Drop confirmed dead code — don't just revoke it.** If a function is safe to stop executing, it is safe to drop from the schema.
+
+7. **Complete or explicitly descope the withRoute migration.** Document which routes are intentionally excluded and why; don't leave the codebase in permanent mixed state.


### PR DESCRIPTION
## Summary

Branch-cleanup salvage. The 2026-06-15 and 2026-06-27 weekly PR quality review reports existed **only** as commits on two stray, never-PR'd branches (`claude/brave-albattani-bemp5e` and `claude/brave-albattani-7Wtyz`) that are about to be deleted. This moves both reports into `docs/pr-reviews/` so nothing is lost:

- `docs/pr-reviews/2026-06-15-weekly-pr-review.md` — covers PRs #644–658; five findings incl. the `worksheet_submissions.image_url` dual-format landmine and `tracesSampleRate: 1.0` privacy inconsistency.
- `docs/pr-reviews/2026-06-27-weekly-pr-review.md` — covers PRs #624–643; CRITICAL finding on the SPE-10 anon-revoke regression's verification gap plus process recommendations.

Docs-only; no code changes. The two untracked code findings from the 06-15 review are being filed as Linear issues alongside this PR. The trivial `.claude/settings.local.json` tweak on the 06-27 branch was intentionally not salvaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCkoy5NKwbydGevxJfKSLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCkoy5NKwbydGevxJfKSLS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added weekly pull request quality reviews for June 15 and June 27, 2026.
  * Summarized review coverage, overall quality assessments, notable findings, positive patterns, and recommended process improvements.
  * Documented security, testing, migration, privacy, and code-quality observations, along with items intentionally not flagged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->