### PR TITLE
feat(sim-district): freshness contract + schema-coverage check in verify

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,8 +13,14 @@
 - **Sim district:** permanent fake tenant in the prod DB for cross-role,
   end-to-end verification; spec + personas in `docs/SIM_DISTRICT.md`. Lifecycle:
   `npm run sim:reset -- --yes`, `npm run sim:verify`, `npm run sim:teardown -- --yes` (env vars
-  are configured in the Claude remote environment). Prefer resetting it before
-  cross-role verification runs; only ever touch sim data through these scripts.
+  are configured in the Claude remote environment). **Freshness contract:**
+  every verification run STARTS with a reset and a green `sim:verify` — seeded
+  data is date-relative to the seed date, so a stale namespace gives wrong
+  answers; a failing reset is a finding to fix, never something to work around.
+  `sim:verify` also fails on any public table the manifest doesn't classify —
+  when a feature adds tables, classifying them in
+  `scripts/sim-district/manifest.ts` (seeded / swept / declared-unseeded) is
+  part of that feature's work. Only ever touch sim data through these scripts.
 
 ## Autonomous execution for high-confidence, non-UX work
 

--- a/docs/SIM_DISTRICT.md
+++ b/docs/SIM_DISTRICT.md
@@ -313,7 +313,11 @@ territory), the generator gains those sites — and the sim is already shaped
 to test it.
 
 **Deliberately NOT seeded in v1** — features under test should create their
-own data *through the app*, so creation flows get exercised too:
+own data *through the app*, so creation flows get exercised too. The
+authoritative list is `DECLARED_UNSEEDED_TABLES` in the manifest; `sim:verify`
+fails on any public relation missing from the manifest's declared sets, so a
+table added by a new migration must be classified as part of that feature's
+work. The table below records the rationale per group:
 
 | Skipped | Why |
 |---|---|
@@ -332,9 +336,11 @@ tables join the manifest's **swept** set — cleaned by FK-equality to sim
 identities (persona user ids, student ids, `SIM-` school/district ids) — and
 `verify.ts` scans both seeded and swept sets for leftovers. A feature whose
 rows are *not* reachable by sim-identity FK must add an explicit sim marker
-as part of its verification setup, before the run happens. The manifest's two
-declared-table sets are the authoritative version of this split; this section
-summarizes intent.
+as part of its verification setup, before the run happens. The manifest's
+three declared-table sets (`SEEDED_TABLES`, `SWEPT_TABLES`,
+`DECLARED_UNSEEDED_TABLES`) are the authoritative version of this split —
+`sim:verify`'s schema-coverage check enforces that together they account for
+every exposed public relation; this section summarizes intent.
 
 ---
 
@@ -428,7 +434,11 @@ The loop this district exists for — the owner asks *"run feature X through
 the sim district"* and gets back a defensible *"everything checks out"* (or
 a precise account of what doesn't):
 
-1. **Reset:** `npm run sim:reset -- --yes` → known-good state, stable IDs.
+1. **Reset:** `npm run sim:reset -- --yes` → known-good state, stable IDs —
+   then confirm `npm run sim:verify` is green (including its schema-coverage
+   check) before walking personas. Seeded data is date-relative to the seed
+   date, so never run step 2 against a namespace that wasn't reset for THIS
+   run; a failing reset is itself a finding to fix first.
 2. **Walk the personas:** for each affected persona, drive the real UI with
    Playwright — log in with the persona's derived password, perform the
    flow, assert what they **see and can do**, and equally what they **must

--- a/scripts/sim-district/lib.ts
+++ b/scripts/sim-district/lib.ts
@@ -161,19 +161,29 @@ export function expectedSimEmails(): string[] {
  * Every relation PostgREST exposes in the public schema (tables AND views),
  * from the OpenAPI schema root. Feeds verify's coverage check: each name must
  * be classified in the manifest (SEEDED / SWEPT / DECLARED_UNSEEDED).
+ * Caveat: PostgREST serves this from its schema cache, which can lag briefly
+ * after a migration — a coverage run immediately post-migration may
+ * transiently miss brand-new relations.
  */
 export async function listPublicRelations(): Promise<string[]> {
   const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
   const key = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
-  const res = await fetch(`${url}/rest/v1/`, {
-    headers: { apikey: key, Authorization: `Bearer ${key}` },
-  });
-  if (!res.ok) throw new Error(`schema root fetch failed: HTTP ${res.status}`);
-  const spec = (await res.json()) as { definitions?: Record<string, unknown> };
-  if (!spec.definitions) {
-    throw new Error('schema root returned no definitions — cannot run the coverage check');
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const res = await fetch(`${url}/rest/v1/`, {
+      headers: { apikey: key, Authorization: `Bearer ${key}` },
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`schema root fetch failed: HTTP ${res.status}`);
+    const spec = (await res.json()) as { definitions?: Record<string, unknown> };
+    if (!spec.definitions) {
+      throw new Error('schema root returned no definitions — cannot run the coverage check');
+    }
+    return Object.keys(spec.definitions);
+  } finally {
+    clearTimeout(timer);
   }
-  return Object.keys(spec.definitions);
 }
 
 /** Chunk an array (Supabase .in() lists and bulk inserts stay bounded). */

--- a/scripts/sim-district/lib.ts
+++ b/scripts/sim-district/lib.ts
@@ -157,6 +157,25 @@ export function expectedSimEmails(): string[] {
   return ALL_SIM_EMAILS.map(e => e.toLowerCase());
 }
 
+/**
+ * Every relation PostgREST exposes in the public schema (tables AND views),
+ * from the OpenAPI schema root. Feeds verify's coverage check: each name must
+ * be classified in the manifest (SEEDED / SWEPT / DECLARED_UNSEEDED).
+ */
+export async function listPublicRelations(): Promise<string[]> {
+  const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+  const key = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
+  const res = await fetch(`${url}/rest/v1/`, {
+    headers: { apikey: key, Authorization: `Bearer ${key}` },
+  });
+  if (!res.ok) throw new Error(`schema root fetch failed: HTTP ${res.status}`);
+  const spec = (await res.json()) as { definitions?: Record<string, unknown> };
+  if (!spec.definitions) {
+    throw new Error('schema root returned no definitions — cannot run the coverage check');
+  }
+  return Object.keys(spec.definitions);
+}
+
 /** Chunk an array (Supabase .in() lists and bulk inserts stay bounded). */
 export function chunk<T>(items: T[], size: number): T[][] {
   const out: T[][] = [];

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -532,3 +532,43 @@ export const SWEPT_TABLES: { table: string; column: string; identity: 'user' | '
   { table: 'lessons', column: 'provider_id', identity: 'user' },
   { table: 'worksheets', column: 'student_id', identity: 'student' },
 ];
+
+/**
+ * Every OTHER public relation, declared so verify's coverage check can prove
+ * the manifest accounts for the entire exposed schema (spec §7). Features
+ * under test create their own rows through the app (and their tables join
+ * SWEPT_TABLES before the run); global/infra tables are never sim-owned.
+ * A table added by a new migration MUST be classified here (or in
+ * SEEDED/SWEPT) as part of that feature's work — sim:verify fails until it is.
+ */
+export const DECLARED_UNSEEDED_TABLES: string[] = [
+  // Feature-under-test surfaces — verification runs create these live, via the app:
+  'conversations', 'conversation_participants', 'conversation_read_state', 'messages',
+  'iep_meetings', 'iep_meeting_attendees', 'student_parent_contacts',
+  'parent_confirmation_tokens', 'provider_availability', 'teacher_availability_prefs',
+  'site_meeting_rules',
+  // AI-generated content (AI gated off; generation costs real tokens):
+  'exit_tickets', 'exit_ticket_results', 'progress_checks', 'progress_check_results',
+  'saved_worksheets', 'worksheet_submissions', 'lesson_adjustment_queue',
+  'lesson_performance_history',
+  // Progress/assessment surfaces:
+  'iep_goal_progress', 'manual_goal_progress', 'student_assessments',
+  'student_performance_metrics', 'assessment_types', 'progress_notifications',
+  // Staffing / master-schedule (site-admin surface; seed when a feature needs it):
+  'staff', 'staff_hours', 'staff_teacher_assignments', 'instruction_schedules',
+  'yard_duty_assignments', 'yard_duty_zones', 'rotation_groups',
+  'rotation_group_members', 'rotation_activity_pairs', 'rotation_week_assignments',
+  'activity_type_availability', 'activated_school_years', 'school_year_config',
+  'holidays',
+  // Personal / auxiliary:
+  'documents', 'curriculum_tracking', 'calendar_connections', 'calendar_events',
+  'api_keys', 'teams', 'team_members', 'material_constraints',
+  // Global / infra — never sim-owned:
+  'states', 'landing_signups', 'analytics_events', 'audit_logs',
+  'api_rate_limits', 'upload_rate_limits',
+  // Signup-trigger debug log — swept bespoke in teardown (metadata-tagged):
+  'debug_signup_log',
+  // Read-only views (PostgREST exposes them alongside base tables):
+  'cross_provider_visibility', 'shared_students', 'unmatched_student_teachers',
+  'upload_analytics_summary',
+];

--- a/scripts/sim-district/verify.ts
+++ b/scripts/sim-district/verify.ts
@@ -154,13 +154,20 @@ async function main() {
     ...SWEPT_TABLES.map(s => s.table),
     ...DECLARED_UNSEEDED_TABLES,
   ]);
-  const unaccounted = (await listPublicRelations()).filter(t => !declared.has(t)).sort();
-  results.push({
-    what: 'schema coverage (manifest)',
-    actual: unaccounted.length,
-    expected: '0 unclassified',
-    ok: unaccounted.length === 0,
-  });
+  let unaccounted: string[] = [];
+  try {
+    unaccounted = (await listPublicRelations()).filter(t => !declared.has(t)).sort();
+    results.push({
+      what: 'schema coverage (manifest)',
+      actual: unaccounted.length,
+      expected: '0 unclassified',
+      ok: unaccounted.length === 0,
+    });
+  } catch (err) {
+    // A failed schema fetch must not discard the count report above it.
+    results.push({ what: 'schema coverage (manifest)', actual: -1, expected: '0 unclassified', ok: false });
+    console.error(`Schema coverage check failed to run: ${(err as Error).message}`);
+  }
 
   console.log(expectEmpty ? 'Orphan scan (expect zero everywhere):\n' : 'Post-seed verification:\n');
   let failed = 0;

--- a/scripts/sim-district/verify.ts
+++ b/scripts/sim-district/verify.ts
@@ -13,10 +13,12 @@
 import {
   ALL_SIM_EMAILS,
   CARE_REFERRALS,
+  DECLARED_UNSEEDED_TABLES,
   DISTRICT,
   PERSONAS,
   RECORD_TEACHERS,
   SCHOOLS,
+  SEEDED_TABLES,
   SWEPT_TABLES,
   TOTAL_STUDENTS,
   careCaseId,
@@ -26,6 +28,7 @@ import {
   assertProjectRef,
   countWhereIn,
   createAdmin,
+  listPublicRelations,
   resolveSimAuthUsers,
 } from './lib';
 
@@ -143,12 +146,34 @@ async function main() {
     expect('debug_signup_log (sim-tagged)', n => n > 0, '> 0');
   }
 
+  // Coverage: every public relation must be classified in the manifest
+  // (seeded, swept, or declared-unseeded) so schema drift surfaces at every
+  // reset instead of mid-verification-run (spec §7). Runs in both modes.
+  const declared = new Set<string>([
+    ...SEEDED_TABLES,
+    ...SWEPT_TABLES.map(s => s.table),
+    ...DECLARED_UNSEEDED_TABLES,
+  ]);
+  const unaccounted = (await listPublicRelations()).filter(t => !declared.has(t)).sort();
+  results.push({
+    what: 'schema coverage (manifest)',
+    actual: unaccounted.length,
+    expected: '0 unclassified',
+    ok: unaccounted.length === 0,
+  });
+
   console.log(expectEmpty ? 'Orphan scan (expect zero everywhere):\n' : 'Post-seed verification:\n');
   let failed = 0;
   for (const r of results) {
     const mark = r.ok ? 'ok  ' : 'FAIL';
     if (!r.ok) failed++;
     console.log(`  [${mark}] ${r.what.padEnd(32)} actual=${String(r.actual).padEnd(6)} expected=${r.expected}`);
+  }
+  if (unaccounted.length > 0) {
+    console.error(
+      `\nUnclassified public relations — add each to SEEDED_TABLES, SWEPT_TABLES, or ` +
+        `DECLARED_UNSEEDED_TABLES in scripts/sim-district/manifest.ts (spec §7):\n  ${unaccounted.join(', ')}`,
+    );
   }
 
   if (failed > 0) {


### PR DESCRIPTION
## Summary

Closes the two gaps that could let the sim district silently go stale and feed bad data to verification runs (discussed and approved in session).

### 1. Freshness contract (docs)

Seeded data is **date-relative to the seed date** (session instances ±14 days, attendance "past week", IEP dates), so the fixture is stale by design unless reset. `CLAUDE.md` and the spec (§7, §9) now make it a hard rule instead of a preference:

- Every verification run **starts** with `sim:reset` and a green `sim:verify`; never test against a namespace that wasn't reset for *this* run.
- A failing reset is a finding to fix first, never something to work around.
- When a feature adds tables, classifying them in the sim manifest is part of that feature's work.

### 2. Schema-coverage check (mechanism)

The §7 "deliberately NOT seeded" prose list is now code: `DECLARED_UNSEEDED_TABLES` in `manifest.ts` (grouped with rationale; includes the 4 public views and `debug_signup_log`). `sim:verify` now lists every relation PostgREST exposes in `public` (via the OpenAPI schema root, `lib.listPublicRelations()`) and **fails** if anything is missing from `SEEDED ∪ SWEPT ∪ DECLARED_UNSEEDED`, printing exactly which names need classifying.

Net effect: a migration that adds a table makes the next `sim:verify` fail with a one-line fix, so coverage drift surfaces at every reset instead of mid-test.

## Verification

- Live run against the currently-seeded district: **all 22 checks green**, `schema coverage (manifest) actual=0 expected=0 unclassified` (77 tables + 4 views all accounted for). The passing check also validates the schema-root fetch itself — wrong or missing names would have appeared as unclassified.
- `tsc --noEmit` clean on the sim scripts.
- Docs-only elsewhere; no schema changes, no behavior changes outside the sim tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCkoy5NKwbydGevxJfKSLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCkoy5NKwbydGevxJfKSLS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Tightened the sim-district verification workflow, emphasizing fresh resets, date-relative seeded data, and treating reset/verification failures as actionable findings.
  * Clarified schema-coverage expectations and how newly added tables must be classified for verification to pass.

* **Verification Improvements**
  * Added a schema-coverage check that compares all exposed public relations against the manifest’s declared coverage.
  * Verification now reports unclassified relations (or marks the check failed if it can’t be performed) to make missing manifest classifications easier to diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->