### PR TITLE
feat(sim-district): sweep coverage for IEP-meeting tables (school identity)

### DIFF
--- a/scripts/sim-district/lib.ts
+++ b/scripts/sim-district/lib.ts
@@ -11,6 +11,7 @@ import {
   SCHOOLS,
   SIM_EMAIL_DOMAIN,
   SUPABASE_PROJECT_REF,
+  SWEPT_TABLES,
 } from './manifest';
 
 config({ path: '.env.local' });
@@ -155,6 +156,22 @@ export async function assertSentinel(admin: Admin): Promise<'exists' | 'bootstra
 /** Expected sim emails, for teardown/verify sweeps. */
 export function expectedSimEmails(): string[] {
   return ALL_SIM_EMAILS.map(e => e.toLowerCase());
+}
+
+/**
+ * Resolve a swept-table identity to the sim ids it sweeps by. Exhaustive so
+ * a future identity value fails to compile instead of silently mapping to
+ * schools (shared by teardown and verify).
+ */
+export function idsForIdentity(
+  identity: (typeof SWEPT_TABLES)[number]['identity'],
+  resolved: { users: string[]; students: string[] },
+): string[] {
+  switch (identity) {
+    case 'user': return resolved.users;
+    case 'student': return resolved.students;
+    case 'school': return SCHOOLS.map(s => s.id);
+  }
 }
 
 /**

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -526,11 +526,19 @@ export const SEEDED_TABLES = [
  * surface — adding a feature's tables here is part of that feature's
  * verification setup (spec §7).
  */
-export const SWEPT_TABLES: { table: string; column: string; identity: 'user' | 'student' }[] = [
+export const SWEPT_TABLES: { table: string; column: string; identity: 'user' | 'student' | 'school' }[] = [
   { table: 'sign_in_logs', column: 'user_id', identity: 'user' },
   { table: 'todos', column: 'user_id', identity: 'user' },
   { table: 'lessons', column: 'provider_id', identity: 'user' },
   { table: 'worksheets', column: 'student_id', identity: 'student' },
+  // IEP meetings (SPE-203/206/208): verification runs create these through
+  // the app. Deleting iep_meetings cascades attendees + confirmation tokens;
+  // site_meeting_rules has NO cascade path from schools, so its sweep is what
+  // lets teardown's school delete succeed.
+  { table: 'iep_meetings', column: 'student_id', identity: 'student' },
+  { table: 'student_parent_contacts', column: 'student_id', identity: 'student' },
+  { table: 'teacher_availability_prefs', column: 'profile_id', identity: 'user' },
+  { table: 'site_meeting_rules', column: 'school_id', identity: 'school' },
 ];
 
 /**
@@ -544,9 +552,10 @@ export const SWEPT_TABLES: { table: string; column: string; identity: 'user' | '
 export const DECLARED_UNSEEDED_TABLES: string[] = [
   // Feature-under-test surfaces — verification runs create these live, via the app:
   'conversations', 'conversation_participants', 'conversation_read_state', 'messages',
-  'iep_meetings', 'iep_meeting_attendees', 'student_parent_contacts',
-  'parent_confirmation_tokens', 'provider_availability', 'teacher_availability_prefs',
-  'site_meeting_rules',
+  'provider_availability',
+  // Children of swept IEP tables — cleaned by ON DELETE CASCADE from
+  // iep_meetings / student_parent_contacts, so no direct sweep key needed:
+  'iep_meeting_attendees', 'parent_confirmation_tokens',
   // AI-generated content (AI gated off; generation costs real tokens):
   'exit_tickets', 'exit_ticket_results', 'progress_checks', 'progress_check_results',
   'saved_worksheets', 'worksheet_submissions', 'lesson_adjustment_queue',

--- a/scripts/sim-district/teardown.ts
+++ b/scripts/sim-district/teardown.ts
@@ -45,7 +45,10 @@ export async function teardown(admin: Admin): Promise<Record<string, number>> {
 
   // 2. Swept tables — rows the app created during verification runs (invariant 4).
   for (const sweep of SWEPT_TABLES) {
-    const ids = sweep.identity === 'user' ? simUserIds : simStudentIds;
+    const ids =
+      sweep.identity === 'user' ? simUserIds :
+      sweep.identity === 'student' ? simStudentIds :
+      SIM_SCHOOL_IDS;
     deleted[`${sweep.table} (swept)`] = await deleteWhereIn(admin, sweep.table, sweep.column, ids);
   }
 

--- a/scripts/sim-district/teardown.ts
+++ b/scripts/sim-district/teardown.ts
@@ -14,6 +14,7 @@ import {
   assertProjectRef,
   createAdmin,
   deleteWhereIn,
+  idsForIdentity,
   requireYesFlag,
   resolveSimAuthUsers,
 } from './lib';
@@ -45,10 +46,7 @@ export async function teardown(admin: Admin): Promise<Record<string, number>> {
 
   // 2. Swept tables — rows the app created during verification runs (invariant 4).
   for (const sweep of SWEPT_TABLES) {
-    const ids =
-      sweep.identity === 'user' ? simUserIds :
-      sweep.identity === 'student' ? simStudentIds :
-      SIM_SCHOOL_IDS;
+    const ids = idsForIdentity(sweep.identity, { users: simUserIds, students: simStudentIds });
     deleted[`${sweep.table} (swept)`] = await deleteWhereIn(admin, sweep.table, sweep.column, ids);
   }
 

--- a/scripts/sim-district/verify.ts
+++ b/scripts/sim-district/verify.ts
@@ -82,7 +82,10 @@ async function collectCounts(admin: Admin) {
     care_case_status_history: await countWhereIn(admin, 'care_case_status_history', 'case_id', careCaseIds),
   };
   for (const sweep of SWEPT_TABLES) {
-    const ids = sweep.identity === 'user' ? simUserIds : simStudentIds;
+    const ids =
+      sweep.identity === 'user' ? simUserIds :
+      sweep.identity === 'student' ? simStudentIds :
+      SIM_SCHOOL_IDS;
     counts[`${sweep.table} (swept)`] = ids.length > 0 ? await countWhereIn(admin, sweep.table, sweep.column, ids) : 0;
   }
 

--- a/scripts/sim-district/verify.ts
+++ b/scripts/sim-district/verify.ts
@@ -28,6 +28,7 @@ import {
   assertProjectRef,
   countWhereIn,
   createAdmin,
+  idsForIdentity,
   listPublicRelations,
   resolveSimAuthUsers,
 } from './lib';
@@ -82,10 +83,7 @@ async function collectCounts(admin: Admin) {
     care_case_status_history: await countWhereIn(admin, 'care_case_status_history', 'case_id', careCaseIds),
   };
   for (const sweep of SWEPT_TABLES) {
-    const ids =
-      sweep.identity === 'user' ? simUserIds :
-      sweep.identity === 'student' ? simStudentIds :
-      SIM_SCHOOL_IDS;
+    const ids = idsForIdentity(sweep.identity, { users: simUserIds, students: simStudentIds });
     counts[`${sweep.table} (swept)`] = ids.length > 0 ? await countWhereIn(admin, sweep.table, sweep.column, ids) : 0;
   }
 


### PR DESCRIPTION
## Summary

Setup work for the first cross-role verification run (IEP meetings — the spec §9 first candidate). Per the teardown contract, a feature's tables must join the manifest's swept set before a run creates rows through the app:

- `SWEPT_TABLES` gains a **`school` identity** (SIM school ids) alongside `user`/`student`; `teardown.ts` and `verify.ts` resolve it.
- **`iep_meetings`** (by `student_id`), **`student_parent_contacts`** (by `student_id`), **`teacher_availability_prefs`** (by `profile_id`), and **`site_meeting_rules`** (by `school_id`) move from declared-unseeded to swept.
- `site_meeting_rules` has **no cascade path from `schools`** — without this sweep, teardown's school delete fails on FK. This was the load-bearing piece.
- `iep_meeting_attendees` + `parent_confirmation_tokens` stay declared-unseeded with a comment: they're cleaned by `ON DELETE CASCADE` from their swept parents.

## Verification

Exercised live with **real app-created rows** from the IEP-meetings verification run: teardown swept 12 meetings (cascading attendees/tokens), 1 site-rules row — while leaving a pre-existing non-sim school's rules row untouched (sweep scoping proof) — and 1 teacher pref; `sim:verify --expect-empty` all-zero; reseed + `sim:verify` green (22 checks incl. schema coverage). `tsc --noEmit` clean.

The run itself surfaced a real product bug in `reserveMeetings()` (attendee bulk insert always fails on the NOT NULL `rsvp_status` — PostgREST pads heterogeneous batch rows with explicit NULLs); that's tracked separately in Linear, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCkoy5NKwbydGevxJfKSLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCkoy5NKwbydGevxJfKSLS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simulated district teardown to correctly remove records linked to schools (not just users/students).
  * Expanded cleanup coverage for IEP meetings, student-parent contacts, teacher availability preferences, and site meeting rules.
  * Updated verification so swept-table counts are derived consistently for user, student, and school identities, while preserving remaining required unseeded data.
* **Refactor**
  * Centralized identity-to-ID resolution for swept-table teardown and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->