### PR TITLE
fix(iep): create attendee rows on meeting reserve (SPE-217)

### DIFF
--- a/lib/supabase/queries/iep-meetings.ts
+++ b/lib/supabase/queries/iep-meetings.ts
@@ -341,6 +341,9 @@ export async function reserveMeetings(
     throw error;
   }
 
+  // Every row must carry rsvp_status explicitly: PostgREST multi-row inserts
+  // unify all rows' keys and send missing ones as NULL, which overrides the
+  // column DEFAULT and violates NOT NULL — the whole batch fails (SPE-217).
   const attendeeRows = (inserted ?? []).flatMap(meeting => {
     const draft = drafts.find(d => d.student.id === meeting.student_id);
     const rows: Database['public']['Tables']['iep_meeting_attendees']['Insert'][] =
@@ -358,6 +361,7 @@ export async function reserveMeetings(
         meeting_id: meeting.id,
         profile_id: leaRep.admin_id,
         attendee_role: 'lea_rep',
+        rsvp_status: 'pending',
       });
     }
     if (draft?.student.teacherProfileId) {
@@ -365,12 +369,14 @@ export async function reserveMeetings(
         meeting_id: meeting.id,
         profile_id: draft.student.teacherProfileId,
         attendee_role: 'teacher',
+        rsvp_status: 'pending',
       });
     } else if (draft?.student.teacherName) {
       rows.push({
         meeting_id: meeting.id,
         display_name: draft.student.teacherName,
         attendee_role: 'teacher',
+        rsvp_status: 'pending',
       });
     }
     return rows;


### PR DESCRIPTION
## Summary

Fixes [SPE-217](https://linear.app/speddy/issue/SPE-217): reserving IEP meetings created the meetings but **zero attendee rows**, every time. The attendee batch mixed row shapes — the case-manager row carried `rsvp_status: 'accepted'` while the `lea_rep`/`teacher` rows omitted the key. PostgREST multi-row inserts unify all rows' columns and send missing keys as **explicit NULL**, which overrides the column's `DEFAULT 'pending'` and violates NOT NULL — the whole batch failed and the UI degraded it to a dismissible warning.

The fix: every attendee row now sets `rsvp_status` explicitly (`'pending'` for LEA rep and teacher rows), with a comment documenting the PostgREST behavior so the next mixed-shape batch doesn't reintroduce it. Audited the rest of the codebase for the same hazard — all other bulk inserts are single-row or uniform-shape.

## Verification

Found and root-caused by the sim district's first cross-role verification run; fix verified the same way, through the real UI against a freshly reset sim district:

- Rachel (case manager persona) planned + reserved her 12 due students via `/dashboard/meetings` — success banner, **no** "attendees could not be added" warning.
- DB layer: 12 reserved meetings → **36 attendee rows, exactly 3 per meeting** — case_manager (organizer, accepted, source `speddy`) ×12, lea_rep (site admin, pending) ×12, teacher ×12 (3 by profile for the linked teacher, 9 by display name), `meetings_without_full_team = 0`.
- `npm run typecheck` clean; sim namespace reset after the run (teardown swept all verification rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCkoy5NKwbydGevxJfKSLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCkoy5NKwbydGevxJfKSLS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed meeting reservations failing when creating multiple attendee records.
  * New attendee records now consistently start with a pending RSVP status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->