### PR TITLE
docs: district Google Workspace allowlist packet + cover email (SPE-204)

### DIFF
--- a/docs/google-workspace-allowlist-email.md
+++ b/docs/google-workspace-allowlist-email.md
@@ -1,0 +1,53 @@
+# Draft: allowlist request email to district IT
+
+Cover email for `google-workspace-allowlist-packet.md`. Fill the two
+placeholders (client ID, attachment/link), adjust the optional line about
+your role, and send from whichever address you prefer.
+
+---
+
+**To:** [District IT / Google Workspace administrator]
+**Subject:** App access request: Speddy (special-education scheduling) — one OAuth client to trust
+
+Hi [name],
+
+I'm writing to request that Speddy be marked as a trusted app in the
+district's Google Workspace admin console. [Optional: I'm a
+special-education provider in the district and also Speddy's developer, so
+happy to answer anything directly.]
+
+Speddy is a FERPA-positioned special-education service management platform
+(scheduling, IEP compliance). Its newest feature helps case managers
+schedule IEP meetings by checking staff **free/busy availability** and
+sending meetings as normal Google Calendar invites. Per the district's
+recent policy on unverified third-party connections, staff who try to
+connect their district Google account currently see Google's
+"Access blocked: admin_policy_enforced" screen.
+
+The specific action:
+
+> **Admin console → Security → Access and data control → API controls →
+> App access control → Configure new app** → search for client ID
+> `<CALENDAR_OAUTH_CLIENT_ID>.apps.googleusercontent.com` → mark **Trusted**.
+
+Key points, detailed in the attached one-page packet:
+
+- **Per-user consent only** — no service account, no domain-wide delegation;
+  trusting the app just lets individual staff choose to connect.
+- **Minimal scopes** — free/busy availability plus events on the user's own
+  calendar; no Gmail, Drive, or Contacts, and free/busy shows times only,
+  not event contents.
+- **Staff accounts only** — no student Google accounts are involved.
+- Tokens are encrypted at the application layer, never logged, and
+  revocable by the user, by Speddy, or domain-wide by you at any time.
+- Speddy is offered to California LEAs under the CA-NDPA Standard v1.5
+  (CITE/CSPA); the technical security overview, data inventory, and
+  subprocessor list are available on request.
+
+Attached: [Google Workspace App Access Request packet]. I'd welcome a quick
+call if that's easier — and if the district would like the NDPA executed as
+part of this review, we're ready to do that too.
+
+Thanks,
+Blair Stewart
+Orchestrate LLC (Speddy) · help@speddy.xyz

--- a/docs/google-workspace-allowlist-packet.md
+++ b/docs/google-workspace-allowlist-packet.md
@@ -1,0 +1,129 @@
+# Speddy — Google Workspace App Access Request (District IT Packet)
+
+**For the district's Google Workspace administrator.** This packet explains
+what Speddy is, exactly what Google account access it requests and why, how
+that data is protected, and the one console action needed to allow staff to
+use it. Companion documents (available on request or in this repository):
+`speddy-technical-security-overview.md`, `data-inventory.md`,
+`subprocessors.md`, `incident-response-plan.md`, `offboarding-runbook.md`.
+
+_Prepared 2026-07-11 · Tracked in SPE-204 · Contact: help@speddy.xyz_
+
+---
+
+## 1. The request
+
+Mark Speddy's OAuth application as **Trusted** (or "Allowed") in the
+district's Google Workspace admin console so that staff who choose to can
+connect their district Google Calendar to Speddy:
+
+**Admin console → Security → Access and data control → API controls →
+App access control → Configure new app** → search by the OAuth client ID
+below → select **Trusted**.
+
+| App | OAuth client ID | Needed for |
+|---|---|---|
+| Speddy — Google Calendar integration | `<CALENDAR_OAUTH_CLIENT_ID>.apps.googleusercontent.com` | Staff connecting their calendar for IEP meeting scheduling (this request) |
+| Speddy — Sign in with Google | `<SIGN_IN_OAUTH_CLIENT_ID>` *(optional, same app)* | Staff signing in to Speddy with their district Google account instead of a password |
+
+Two important properties of this request:
+
+- **Trusting the app grants no data access by itself.** Speddy uses per-user
+  OAuth consent — each staff member individually chooses to connect and sees
+  Google's consent screen listing exactly what is shared. There is **no
+  service account and no domain-wide delegation**; the district is unblocking
+  individual consent, not granting blanket access.
+- **Only staff accounts are involved.** Students do not have Speddy accounts
+  and no student Google account is ever touched.
+
+## 2. What Speddy is
+
+Speddy (Orchestrate LLC, Sacramento, CA) is a special-education service
+management platform for school districts: provider scheduling, IEP compliance
+tracking, and team coordination. It is FERPA-positioned, US-hosted
+(database and storage in Supabase's us-west-1 / Northern California region),
+and offered to California LEAs with the **CA-NDPA Standard v1.5** (CITE /
+California Student Privacy Alliance) — execution packet prepared and
+available on request.
+
+## 3. What the calendar integration does
+
+Scheduling an IEP meeting means finding a time that works for the site
+administrator, the case manager, the general-education teacher, service
+providers, and the family. Speddy's meeting scheduler does this by reading
+**availability** (free/busy) and delivering confirmed meetings as **ordinary
+Google Calendar invitations** sent from the organizer's own calendar — so
+reminders, RSVPs, and reschedules work the way staff already expect.
+
+## 4. Exactly what access is requested, and why
+
+Speddy requests the **minimum** Google OAuth scopes for the feature:
+
+| Scope | What it allows | Why Speddy needs it |
+|---|---|---|
+| `https://www.googleapis.com/auth/calendar.freebusy` | Busy/free times only — no event titles, descriptions, or attendees — for the connecting user's calendars and calendars already visible to them under Google's own sharing rules | Find meeting times that avoid existing commitments without exposing what those commitments are |
+| `https://www.googleapis.com/auth/calendar.events.owned` | Read/create/update events on calendars the user **owns** (not calendars merely shared with them) | Create the IEP meeting invitation from the organizer's calendar, keep it updated on reschedule/cancel, and read RSVP responses for meetings Speddy created |
+| `openid`, `email` (non-sensitive) | The connected account's email address | Show "Connected as name@district.org" and detect wrong-account connections |
+
+Deliberately **not** requested: `calendar` (full read/write of all calendars),
+`calendar.events` (events on all visible calendars), Gmail, Drive, Contacts,
+or any other Google service. The scope set is pinned by an automated test in
+Speddy's codebase so it cannot drift silently.
+
+## 5. What Speddy will never do with Google data
+
+Speddy's use of Google user data adheres to the **Google API Services User
+Data Policy, including the Limited Use requirements**, disclosed publicly in
+the privacy policy (https://www.speddy.xyz/privacy, §5):
+
+- No advertising use of any kind
+- No sale of Google user data; no transfers except to operate the feature
+  (encrypted storage/hosting with Supabase and Vercel), for security, or as
+  required by law — no other third parties receive it
+- No human access except with explicit permission, for security/abuse
+  investigation, legal compliance, or in aggregated anonymized form
+- No use of Google user data to train AI/ML models
+- Free/busy data is processed **transiently** to compute open meeting times —
+  Speddy does not retain a copy of anyone's calendar
+
+## 6. How the credentials are protected
+
+- **OAuth tokens are encrypted at the application layer** (AES-256-GCM) with
+  a key held only in server environment configuration — the database stores
+  ciphertext only, on top of Supabase's disk-level AES-256 encryption
+- Database rows are protected by **owner-only row-level security**: no other
+  user, including district administrators within Speddy, can read a staff
+  member's connection
+- Tokens are **never written to logs**; token requests to Google carry
+  short timeouts and sanitized error handling
+- Connect and disconnect events are **audit-logged**
+- **Disconnect is self-serve**: one click in Speddy deletes the stored tokens
+  and makes a best-effort revocation of the grant at Google; staff can also
+  revoke at any time from their Google Account permissions page, and the
+  district can revoke domain-wide by removing the app's trusted status
+- Platform posture (TLS 1.2+, RLS on every table, NIST CSF 1.1
+  self-assessment, 72-hour breach notification commitment, written incident
+  response plan, deletion/offboarding runbook) is detailed in the
+  companion **Technical & Security Overview**
+
+## 7. Google verification status
+
+Speddy's OAuth application is currently in Google's **Testing** mode while
+formal app verification is completed with Google's Trust & Safety team
+(domain ownership verified; privacy policy updated with the required
+disclosures; verification submission in progress). In Testing mode, only
+individually registered test users can connect at all — combined with
+per-user consent, district exposure during evaluation is limited to the
+specific staff members who opt in.
+
+## 8. Offboarding
+
+If the district stops using Speddy: remove the app's trusted status (blocks
+all new and existing grants at the Google layer), and Speddy deletes stored
+connections on request per the deletion runbook — alongside the standard
+NDPA data-destruction obligations.
+
+---
+
+**Questions / requests for any companion document:** help@speddy.xyz
+(Blair Stewart, Orchestrate LLC).


### PR DESCRIPTION
## Summary

The first live calendar-connect attempt from an @mdusd.org account was blocked by the district's Workspace policy (`Error 400: admin_policy_enforced`) — confirming spec §13.4's assumption and making district allowlisting a **pilot prerequisite**, not a launch item. This adds the two documents that make that IT conversation short ([SPE-204](https://linear.app/speddy/issue/SPE-204)'s last no-code checklist item).

## Contents

**`docs/google-workspace-allowlist-packet.md`** — the packet for district IT:
- The exact one-action request: Admin console → Security → API controls → App access control → mark the client ID **Trusted** (client-ID placeholders to fill from the Google console)
- The two trust properties that matter to an admin: **per-user consent only** (no service account, no domain-wide delegation) and **staff accounts only** (no student Google accounts)
- Per-scope justification table (`calendar.freebusy`, `calendar.events.owned`, `openid email`) — **doubles as the draft for SPE-204's Google-verification scope justifications**
- Limited Use commitments (mirrors privacy policy §5), token-security posture (AES-256-GCM app-layer encryption, owner-only RLS, no tokens in logs, audit events), Google verification status, offboarding path

**`docs/google-workspace-allowlist-email.md`** — fill-in cover email requesting the allowlist action, with the console path inline and an optional line about the dual provider/developer role.

## Notes for review

- All claims are grounded in the existing compliance docs (`speddy-technical-security-overview.md`, `data-inventory.md`, `subprocessors.md`, NDPA execution packet) and the shipped SPE-205 implementation — nothing aspirational.
- Outward-facing material: please review wording before merge; the email's optional role line and the client-ID placeholders are yours to fill before sending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JNyyXpouXU9j5e8AQtQR1

---
_Generated by [Claude Code](https://claude.ai/code/session_016JNyyXpouXU9j5e8AQtQR1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an administrator guide for marking the app as trusted in Google Workspace.
  * Documented Google Calendar integration, requested permissions, data protection practices, OAuth verification status, and offboarding steps.
  * Added a ready-to-send email template for requesting administrator approval, including setup instructions and security details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->