### PR TITLE
docs: allowlist packet accuracy fixes from Codex review (SPE-204)

### DIFF
--- a/docs/google-workspace-allowlist-email.md
+++ b/docs/google-workspace-allowlist-email.md
@@ -17,9 +17,11 @@ special-education provider in the district and also Speddy's developer, so
 happy to answer anything directly.]
 
 Speddy is a FERPA-positioned special-education service management platform
-(scheduling, IEP compliance). Its newest feature — rolling out now — helps
-case managers schedule IEP meetings by checking staff **free/busy
-availability** and sending meetings as normal Google Calendar invites. Per the district's
+(scheduling, IEP compliance). Its newest feature is rolling out in phases:
+staff first connect their Google Calendar (live today), and the meeting
+scheduler will then use those connections to check staff **free/busy
+availability** and send meetings as normal Google Calendar invites. We're
+requesting approval once, ahead of that rollout. Per the district's
 recent policy on unverified third-party connections, staff who try to
 connect their district Google account currently see Google's
 "Access blocked: admin_policy_enforced" screen.

--- a/docs/google-workspace-allowlist-email.md
+++ b/docs/google-workspace-allowlist-email.md
@@ -17,9 +17,9 @@ special-education provider in the district and also Speddy's developer, so
 happy to answer anything directly.]
 
 Speddy is a FERPA-positioned special-education service management platform
-(scheduling, IEP compliance). Its newest feature helps case managers
-schedule IEP meetings by checking staff **free/busy availability** and
-sending meetings as normal Google Calendar invites. Per the district's
+(scheduling, IEP compliance). Its newest feature — rolling out now — helps
+case managers schedule IEP meetings by checking staff **free/busy
+availability** and sending meetings as normal Google Calendar invites. Per the district's
 recent policy on unverified third-party connections, staff who try to
 connect their district Google account currently see Google's
 "Access blocked: admin_policy_enforced" screen.
@@ -34,9 +34,10 @@ Key points, detailed in the attached one-page packet:
 
 - **Per-user consent only** — no service account, no domain-wide delegation;
   trusting the app just lets individual staff choose to connect.
-- **Minimal scopes** — free/busy availability plus events on the user's own
-  calendar; no Gmail, Drive, or Contacts, and free/busy shows times only,
-  not event contents.
+- **Minimal scopes** — free/busy availability plus managing events on the
+  user's **own** calendar (Google's wording: see, create, change, delete);
+  no Gmail, Drive, or Contacts, and free/busy shows times only, not event
+  contents.
 - **Staff accounts only** — no student Google accounts are involved.
 - Tokens are encrypted at the application layer, never logged, and
   revocable by the user, by Speddy, or domain-wide by you at any time.

--- a/docs/google-workspace-allowlist-email.md
+++ b/docs/google-workspace-allowlist-email.md
@@ -36,10 +36,11 @@ Key points, detailed in the attached one-page packet:
 
 - **Per-user consent only** — no service account, no domain-wide delegation;
   trusting the app just lets individual staff choose to connect.
-- **Minimal scopes** — free/busy availability plus managing events on the
-  user's **own** calendar (Google's wording: see, create, change, delete);
-  no Gmail, Drive, or Contacts, and free/busy shows times only, not event
-  contents.
+- **Minimal scopes** — free/busy availability (times only, not event
+  contents) plus reading and managing events on the user's **own** calendar
+  (Google's wording: see, create, change, delete) for conflict detection,
+  meeting invitations, and RSVP tracking. Speddy modifies or deletes only
+  events it created; no Gmail, Drive, or Contacts access.
 - **Staff accounts only** — no student Google accounts are involved.
 - Tokens are encrypted at the application layer, never logged, and
   revocable by the user, by Speddy, or domain-wide by you at any time.

--- a/docs/google-workspace-allowlist-packet.md
+++ b/docs/google-workspace-allowlist-packet.md
@@ -50,10 +50,14 @@ available on request.
 
 Scheduling an IEP meeting means finding a time that works for the site
 administrator, the case manager, the general-education teacher, service
-providers, and the family. Speddy's meeting scheduler does this by reading
-**availability** (free/busy) and delivering confirmed meetings as **ordinary
-Google Calendar invitations** sent from the organizer's own calendar — so
-reminders, RSVPs, and reschedules work the way staff already expect.
+providers, and the family. Speddy's calendar integration is rolling out in
+phases: **staff calendar connections are live today**, and the meeting
+scheduler then uses those connections to read **availability** (free/busy)
+and deliver confirmed meetings as **ordinary Google Calendar invitations**
+sent from the organizer's own calendar — so reminders, RSVPs, and
+reschedules work the way staff already expect. The scopes below are exactly
+what a staff member consents to when connecting; district approval is
+requested once, ahead of that rollout.
 
 ## 4. Exactly what access is requested, and why
 
@@ -62,7 +66,7 @@ Speddy requests the **minimum** Google OAuth scopes for the feature:
 | Scope | What it allows | Why Speddy needs it |
 |---|---|---|
 | `https://www.googleapis.com/auth/calendar.freebusy` | Busy/free times only — no event titles, descriptions, or attendees — for the connecting user's calendars and calendars already visible to them under Google's own sharing rules | Find meeting times that avoid existing commitments without exposing what those commitments are |
-| `https://www.googleapis.com/auth/calendar.events.owned` | Read/create/update events on calendars the user **owns** (not calendars merely shared with them) | Create the IEP meeting invitation from the organizer's calendar, keep it updated on reschedule/cancel, and read RSVP responses for meetings Speddy created |
+| `https://www.googleapis.com/auth/calendar.events.owned` | Google's wording: "See, create, change, and **delete** events" on calendars the user **owns** (not calendars merely shared with them) | Create the IEP meeting invitation from the organizer's calendar, update or delete it on reschedule/cancellation, and read RSVP responses. By design, Speddy modifies or deletes only events it created |
 | `openid`, `email` (non-sensitive) | The connected account's email address | Show "Connected as name@district.org" and detect wrong-account connections |
 
 Deliberately **not** requested: `calendar` (full read/write of all calendars),

--- a/docs/google-workspace-allowlist-packet.md
+++ b/docs/google-workspace-allowlist-packet.md
@@ -51,13 +51,13 @@ available on request.
 Scheduling an IEP meeting means finding a time that works for the site
 administrator, the case manager, the general-education teacher, service
 providers, and the family. Speddy's calendar integration is rolling out in
-phases: **staff calendar connections are live today**, and the meeting
-scheduler then uses those connections to read **availability** (free/busy)
-and deliver confirmed meetings as **ordinary Google Calendar invitations**
-sent from the organizer's own calendar — so reminders, RSVPs, and
-reschedules work the way staff already expect. The scopes below are exactly
-what a staff member consents to when connecting; district approval is
-requested once, ahead of that rollout.
+phases. **Staff calendar connections are live today.** In the next phase,
+the meeting scheduler will use those connections to read **availability**
+(free/busy) and deliver confirmed meetings as **ordinary Google Calendar
+invitations** sent from the organizer's own calendar; reminders, RSVPs, and
+reschedules then behave the way staff already expect from Google Calendar.
+The scopes below are what a staff member consents to when connecting;
+district approval is requested once, ahead of that rollout.
 
 ## 4. Exactly what access is requested, and why
 
@@ -66,7 +66,7 @@ Speddy requests the **minimum** Google OAuth scopes for the feature:
 | Scope | What it allows | Why Speddy needs it |
 |---|---|---|
 | `https://www.googleapis.com/auth/calendar.freebusy` | Busy/free times only — no event titles, descriptions, or attendees — for the connecting user's calendars and calendars already visible to them under Google's own sharing rules | Find meeting times that avoid existing commitments without exposing what those commitments are |
-| `https://www.googleapis.com/auth/calendar.events.owned` | Google's wording: "See, create, change, and **delete** events" on calendars the user **owns** (not calendars merely shared with them) | Create the IEP meeting invitation from the organizer's calendar, update or delete it on reschedule/cancellation, and read RSVP responses. By design, Speddy modifies or deletes only events it created |
+| `https://www.googleapis.com/auth/calendar.events.owned` | Google's wording: "See, create, change, and **delete** events" on calendars the user **owns** (not calendars merely shared with them) | Read event information on the user's own calendar to detect scheduling conflicts (e.g., all-day absences); create the IEP meeting invitation from the organizer's calendar, update or delete it on reschedule/cancellation, and read RSVP responses. By design, Speddy modifies or deletes only events it created |
 | `openid`, `email` (non-sensitive) | The connected account's email address | Show "Connected as name@district.org" and detect wrong-account connections |
 
 Deliberately **not** requested: `calendar` (full read/write of all calendars),


### PR DESCRIPTION
## Summary

Codex posted two valid P2 findings on #702 right as it merged — both matter because the packet's whole job is standing up to district IT scrutiny ([SPE-204](https://linear.app/speddy/issue/SPE-204)):

1. **Understated scope capability**: Google's consent screen describes `calendar.events.owned` as "See, create, change, and **delete** events." The packet said "read/create/update" — an admin comparing the packet against the real consent screen would see a mismatch, which is exactly what undermines an allowlist request. Now quotes Google's full wording and scopes the intended use ("Speddy modifies or deletes only events it created").
2. **Described undeployed behavior as current**: the packet/email said Speddy reads free/busy and sends calendar invites, but the planner doesn't consume Google data yet (that wiring follows SPE-205). Reworded as a phased rollout — connections live today, scheduler consumption following — so the district approves exactly what's deployed.

Same two files as #702; wording only. **Merge before filling in client IDs and sending the packet to MDUSD.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JNyyXpouXU9j5e8AQtQR1

---
_Generated by [Claude Code](https://claude.ai/code/session_016JNyyXpouXU9j5e8AQtQR1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the phased rollout of calendar integration and meeting scheduling.
  * Documented that availability checks use free/busy information only, without exposing event details.
  * Clarified that invitations are sent as standard calendar events from the organizer’s calendar.
  * Updated permission descriptions to explain that the app can update or delete only events it created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->