### PR TITLE
feat(iep): Google free/busy in the planner + calendar hold events (SPE-218)

### DIFF
--- a/__tests__/unit/lib/calendar/google-busy.test.ts
+++ b/__tests__/unit/lib/calendar/google-busy.test.ts
@@ -75,12 +75,11 @@ describe('isoIntervalsToBusyBlocks', () => {
   });
 
   it('labels blocks for the availability engine', () => {
-    const [block] = isoIntervalsToBusyBlocks(
-      [{ start: localIso(2026, 9, 15, 9, 0), end: localIso(2026, 9, 15, 9, 30) }],
-      'Shared calendar'
-    );
+    const [block] = isoIntervalsToBusyBlocks([
+      { start: localIso(2026, 9, 15, 9, 0), end: localIso(2026, 9, 15, 9, 30) },
+    ]);
     expect(block.source).toBe('google');
-    expect(block.label).toBe('Shared calendar');
+    expect(block.label).toBe('Google Calendar');
   });
 });
 

--- a/__tests__/unit/lib/calendar/google-busy.test.ts
+++ b/__tests__/unit/lib/calendar/google-busy.test.ts
@@ -1,0 +1,102 @@
+import {
+  isoIntervalsToBusyBlocks,
+  localDateToIso,
+} from '@/lib/calendar/google-busy';
+
+/** ISO instant built from LOCAL wall-clock parts — keeps tests TZ-agnostic. */
+function localIso(
+  y: number,
+  m: number,
+  d: number,
+  h: number,
+  min: number
+): string {
+  return new Date(y, m - 1, d, h, min).toISOString();
+}
+
+describe('isoIntervalsToBusyBlocks', () => {
+  it('converts a same-day interval to local date + minutes', () => {
+    const blocks = isoIntervalsToBusyBlocks([
+      { start: localIso(2026, 9, 15, 9, 0), end: localIso(2026, 9, 15, 10, 30) },
+    ]);
+    expect(blocks).toEqual([
+      {
+        date: '2026-09-15',
+        start_minutes: 9 * 60,
+        end_minutes: 10 * 60 + 30,
+        source: 'google',
+        label: 'Google Calendar',
+      },
+    ]);
+  });
+
+  it('splits midnight-crossing intervals into one block per date', () => {
+    const blocks = isoIntervalsToBusyBlocks([
+      { start: localIso(2026, 9, 15, 23, 0), end: localIso(2026, 9, 16, 1, 0) },
+    ]);
+    expect(blocks).toEqual([
+      expect.objectContaining({
+        date: '2026-09-15',
+        start_minutes: 23 * 60,
+        end_minutes: 24 * 60,
+      }),
+      expect.objectContaining({
+        date: '2026-09-16',
+        start_minutes: 0,
+        end_minutes: 60,
+      }),
+    ]);
+  });
+
+  it('covers full intermediate days on multi-day spans', () => {
+    const blocks = isoIntervalsToBusyBlocks([
+      { start: localIso(2026, 9, 15, 22, 0), end: localIso(2026, 9, 17, 2, 0) },
+    ]);
+    expect(blocks).toHaveLength(3);
+    expect(blocks[1]).toEqual(
+      expect.objectContaining({
+        date: '2026-09-16',
+        start_minutes: 0,
+        end_minutes: 24 * 60,
+      })
+    );
+  });
+
+  it('drops malformed and zero-length intervals', () => {
+    expect(
+      isoIntervalsToBusyBlocks([
+        { start: 'garbage', end: localIso(2026, 9, 15, 10, 0) },
+        {
+          start: localIso(2026, 9, 15, 10, 0),
+          end: localIso(2026, 9, 15, 10, 0),
+        },
+      ])
+    ).toEqual([]);
+  });
+
+  it('labels blocks for the availability engine', () => {
+    const [block] = isoIntervalsToBusyBlocks(
+      [{ start: localIso(2026, 9, 15, 9, 0), end: localIso(2026, 9, 15, 9, 30) }],
+      'Shared calendar'
+    );
+    expect(block.source).toBe('google');
+    expect(block.label).toBe('Shared calendar');
+  });
+});
+
+describe('localDateToIso', () => {
+  it('round-trips to local midnight', () => {
+    const iso = localDateToIso('2026-09-15');
+    const d = new Date(iso);
+    expect([d.getFullYear(), d.getMonth() + 1, d.getDate()]).toEqual([
+      2026, 9, 15,
+    ]);
+    expect(d.getHours()).toBe(0);
+    expect(d.getMinutes()).toBe(0);
+  });
+
+  it('supports day offsets for exclusive range ends', () => {
+    const d = new Date(localDateToIso('2026-09-30', 1));
+    expect([d.getMonth() + 1, d.getDate()]).toEqual([10, 1]);
+  });
+});

--- a/__tests__/unit/lib/calendar/google-calendar-api.test.ts
+++ b/__tests__/unit/lib/calendar/google-calendar-api.test.ts
@@ -88,8 +88,9 @@ describe('freeBusyQuery', () => {
     });
 
     expect(global.fetch).toHaveBeenCalledTimes(2);
-    expect(result.primary).toHaveLength(2);
-    expect(result['blocked@district.org']).toEqual([]);
+    expect(result.busyByCalendar.primary).toHaveLength(2);
+    expect(result.busyByCalendar['blocked@district.org']).toEqual([]);
+    expect(result.incomplete).toBe(false);
   });
 
   it('batches large calendar lists so nothing is silently dropped', async () => {
@@ -129,11 +130,13 @@ describe('freeBusyQuery', () => {
       expect(sent.items.length).toBeLessThanOrEqual(20);
     }
     // Every calendar got data — including those beyond the first batch.
-    expect(result['t24@d.org']).toHaveLength(1);
-    expect(Object.keys(result)).toHaveLength(26);
+    expect(result.busyByCalendar['t24@d.org']).toHaveLength(1);
+    expect(Object.keys(result.busyByCalendar)).toHaveLength(26);
+    expect(result.incomplete).toBe(false);
   });
 
-  it('throws a GoogleOAuthError shape on API failure without token material', async () => {
+  it('flags API failures as incomplete instead of throwing, without token material', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
       status: 403,
@@ -142,26 +145,60 @@ describe('freeBusyQuery', () => {
       }),
     }) as unknown as typeof fetch;
 
-    await expect(
-      freeBusyQuery({
-        accessToken: 'super-secret-access-token',
-        timeMin: '2026-09-01T00:00:00Z',
-        timeMax: '2026-09-02T00:00:00Z',
-        calendarIds: ['primary'],
-      })
-    ).rejects.toMatchObject({
-      name: 'GoogleOAuthError',
-      code: 'PERMISSION_DENIED',
-      status: 403,
+    const result = await freeBusyQuery({
+      accessToken: 'super-secret-access-token',
+      timeMin: '2026-09-01T00:00:00Z',
+      timeMax: '2026-09-02T00:00:00Z',
+      calendarIds: ['primary'],
     });
-    await expect(
-      freeBusyQuery({
-        accessToken: 'super-secret-access-token',
-        timeMin: '2026-09-01T00:00:00Z',
-        timeMax: '2026-09-02T00:00:00Z',
-        calendarIds: ['primary'],
-      }).catch(e => e.message)
-    ).resolves.not.toContain('super-secret');
+
+    expect(result.incomplete).toBe(true);
+    expect(result.busyByCalendar.primary).toEqual([]);
+    expect(errorSpy).toHaveBeenCalled();
+    const logged = errorSpy.mock.calls.flat().map(String).join(' ');
+    expect(logged).not.toContain('super-secret');
+    errorSpy.mockRestore();
+  });
+
+  it('keeps data from healthy slices when another slice fails', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const start = '2026-09-01T00:00:00Z';
+    const end = new Date(Date.parse(start) + 60 * DAY_MS).toISOString(); // 2 chunks
+    let call = 0;
+    global.fetch = jest.fn().mockImplementation(async () => {
+      call += 1;
+      if (call === 1) {
+        return {
+          ok: false,
+          status: 429,
+          json: async () => ({ error: { status: 'RESOURCE_EXHAUSTED' } }),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          calendars: {
+            primary: {
+              busy: [
+                { start: '2026-10-05T09:00:00Z', end: '2026-10-05T10:00:00Z' },
+              ],
+            },
+          },
+        }),
+      };
+    }) as unknown as typeof fetch;
+
+    const result = await freeBusyQuery({
+      accessToken: 'token',
+      timeMin: start,
+      timeMax: end,
+      calendarIds: ['primary'],
+    });
+
+    expect(result.incomplete).toBe(true);
+    expect(result.busyByCalendar.primary).toHaveLength(1);
+    errorSpy.mockRestore();
   });
 });
 

--- a/__tests__/unit/lib/calendar/google-calendar-api.test.ts
+++ b/__tests__/unit/lib/calendar/google-calendar-api.test.ts
@@ -27,7 +27,7 @@ describe('chunkTimeRange', () => {
   it('splits long ranges into contiguous chunks ending at timeMax', () => {
     const start = '2026-09-01T00:00:00Z';
     const end = new Date(Date.parse(start) + 100 * DAY_MS).toISOString();
-    const chunks = chunkTimeRange(start, end, 42);
+    const chunks = chunkTimeRange(start, end);
     expect(chunks).toHaveLength(3);
     for (let i = 1; i < chunks.length; i++) {
       expect(chunks[i].timeMin).toBe(chunks[i - 1].timeMax);
@@ -45,7 +45,7 @@ describe('chunkTimeRange', () => {
   it('caps runaway ranges at the total-day limit', () => {
     const start = '2026-01-01T00:00:00Z';
     const end = new Date(Date.parse(start) + 3000 * DAY_MS).toISOString();
-    const chunks = chunkTimeRange(start, end, 42);
+    const chunks = chunkTimeRange(start, end);
     const totalMs =
       Date.parse(chunks[chunks.length - 1].timeMax) - Date.parse(start);
     expect(totalMs).toBeLessThanOrEqual(370 * DAY_MS);
@@ -90,6 +90,47 @@ describe('freeBusyQuery', () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
     expect(result.primary).toHaveLength(2);
     expect(result['blocked@district.org']).toEqual([]);
+  });
+
+  it('batches large calendar lists so nothing is silently dropped', async () => {
+    const ids = ['primary', ...Array.from({ length: 25 }, (_, i) => `t${i}@d.org`)];
+    const fetchMock = jest.fn().mockImplementation(async (_url, init) => {
+      const sent = JSON.parse((init as RequestInit).body as string);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          calendars: Object.fromEntries(
+            sent.items.map((item: { id: string }) => [
+              item.id,
+              {
+                busy: [
+                  { start: '2026-09-01T09:00:00Z', end: '2026-09-01T10:00:00Z' },
+                ],
+              },
+            ])
+          ),
+        }),
+      };
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await freeBusyQuery({
+      accessToken: 'token',
+      timeMin: '2026-09-01T00:00:00Z',
+      timeMax: '2026-09-08T00:00:00Z', // single time chunk
+      calendarIds: ids,
+    });
+
+    // 26 calendars → two batches (20 + 6) within the one time chunk.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const call of fetchMock.mock.calls) {
+      const sent = JSON.parse((call[1] as RequestInit).body as string);
+      expect(sent.items.length).toBeLessThanOrEqual(20);
+    }
+    // Every calendar got data — including those beyond the first batch.
+    expect(result['t24@d.org']).toHaveLength(1);
+    expect(Object.keys(result)).toHaveLength(26);
   });
 
   it('throws a GoogleOAuthError shape on API failure without token material', async () => {

--- a/__tests__/unit/lib/calendar/google-calendar-api.test.ts
+++ b/__tests__/unit/lib/calendar/google-calendar-api.test.ts
@@ -1,0 +1,191 @@
+import {
+  chunkTimeRange,
+  deleteCalendarEvent,
+  freeBusyQuery,
+  insertCalendarEvent,
+} from '@/lib/calendar/google-calendar-api';
+
+const realFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = realFetch;
+});
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('chunkTimeRange', () => {
+  it('returns a single chunk for short ranges', () => {
+    const chunks = chunkTimeRange(
+      '2026-09-01T00:00:00Z',
+      '2026-09-10T00:00:00Z'
+    );
+    expect(chunks).toEqual([
+      { timeMin: '2026-09-01T00:00:00.000Z', timeMax: '2026-09-10T00:00:00.000Z' },
+    ]);
+  });
+
+  it('splits long ranges into contiguous chunks ending at timeMax', () => {
+    const start = '2026-09-01T00:00:00Z';
+    const end = new Date(Date.parse(start) + 100 * DAY_MS).toISOString();
+    const chunks = chunkTimeRange(start, end, 42);
+    expect(chunks).toHaveLength(3);
+    for (let i = 1; i < chunks.length; i++) {
+      expect(chunks[i].timeMin).toBe(chunks[i - 1].timeMax);
+    }
+    expect(chunks[chunks.length - 1].timeMax).toBe(end);
+  });
+
+  it('returns nothing for invalid or inverted ranges', () => {
+    expect(chunkTimeRange('nope', '2026-09-01T00:00:00Z')).toEqual([]);
+    expect(
+      chunkTimeRange('2026-09-02T00:00:00Z', '2026-09-01T00:00:00Z')
+    ).toEqual([]);
+  });
+
+  it('caps runaway ranges at the total-day limit', () => {
+    const start = '2026-01-01T00:00:00Z';
+    const end = new Date(Date.parse(start) + 3000 * DAY_MS).toISOString();
+    const chunks = chunkTimeRange(start, end, 42);
+    const totalMs =
+      Date.parse(chunks[chunks.length - 1].timeMax) - Date.parse(start);
+    expect(totalMs).toBeLessThanOrEqual(370 * DAY_MS);
+  });
+});
+
+describe('freeBusyQuery', () => {
+  it('merges busy intervals across chunks and skips errored calendars', async () => {
+    const start = '2026-09-01T00:00:00Z';
+    const end = new Date(Date.parse(start) + 60 * DAY_MS).toISOString(); // 2 chunks
+    let call = 0;
+    global.fetch = jest.fn().mockImplementation(async () => {
+      call += 1;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          calendars: {
+            primary: {
+              busy: [
+                {
+                  start: `2026-09-0${call}T09:00:00Z`,
+                  end: `2026-09-0${call}T10:00:00Z`,
+                },
+              ],
+            },
+            'blocked@district.org': {
+              errors: [{ reason: 'notFound' }],
+            },
+          },
+        }),
+      };
+    }) as unknown as typeof fetch;
+
+    const result = await freeBusyQuery({
+      accessToken: 'token',
+      timeMin: start,
+      timeMax: end,
+      calendarIds: ['primary', 'blocked@district.org'],
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(result.primary).toHaveLength(2);
+    expect(result['blocked@district.org']).toEqual([]);
+  });
+
+  it('throws a GoogleOAuthError shape on API failure without token material', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({
+        error: { status: 'PERMISSION_DENIED', message: 'forbidden' },
+      }),
+    }) as unknown as typeof fetch;
+
+    await expect(
+      freeBusyQuery({
+        accessToken: 'super-secret-access-token',
+        timeMin: '2026-09-01T00:00:00Z',
+        timeMax: '2026-09-02T00:00:00Z',
+        calendarIds: ['primary'],
+      })
+    ).rejects.toMatchObject({
+      name: 'GoogleOAuthError',
+      code: 'PERMISSION_DENIED',
+      status: 403,
+    });
+    await expect(
+      freeBusyQuery({
+        accessToken: 'super-secret-access-token',
+        timeMin: '2026-09-01T00:00:00Z',
+        timeMax: '2026-09-02T00:00:00Z',
+        calendarIds: ['primary'],
+      }).catch(e => e.message)
+    ).resolves.not.toContain('super-secret');
+  });
+});
+
+describe('insertCalendarEvent', () => {
+  it('creates the event on the primary calendar and returns its id', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'evt_123' }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const id = await insertCalendarEvent({
+      accessToken: 'token',
+      summary: 'IEP — J.D. (hold)',
+      startIso: '2026-09-15T16:00:00.000Z',
+      endIso: '2026-09-15T17:00:00.000Z',
+    });
+
+    expect(id).toBe('evt_123');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/calendars/primary/events');
+    const sent = JSON.parse(init.body as string);
+    expect(sent.summary).toBe('IEP — J.D. (hold)');
+    expect(sent.attendees).toBeUndefined(); // internal hold: nobody invited
+  });
+
+  it('rejects when Google returns no event id', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    }) as unknown as typeof fetch;
+
+    await expect(
+      insertCalendarEvent({
+        accessToken: 'token',
+        summary: 'x',
+        startIso: '2026-09-15T16:00:00.000Z',
+        endIso: '2026-09-15T17:00:00.000Z',
+      })
+    ).rejects.toMatchObject({ code: 'calendar_api_error' });
+  });
+});
+
+describe('deleteCalendarEvent', () => {
+  it.each([204, 404, 410])('treats HTTP %i as success', async status => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: status < 400,
+      status,
+      json: async () => ({}),
+    }) as unknown as typeof fetch;
+    await expect(
+      deleteCalendarEvent({ accessToken: 'token', eventId: 'evt' })
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws on other failures', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: { status: 'PERMISSION_DENIED' } }),
+    }) as unknown as typeof fetch;
+    await expect(
+      deleteCalendarEvent({ accessToken: 'token', eventId: 'evt' })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+});

--- a/__tests__/unit/lib/supabase/queries/iep-meetings-plan.test.ts
+++ b/__tests__/unit/lib/supabase/queries/iep-meetings-plan.test.ts
@@ -1,0 +1,131 @@
+import {
+  buildPlanRequests,
+  type CaseloadStudent,
+  type PlanningData,
+} from '@/lib/supabase/queries/iep-meetings';
+import type { BusyBlock } from '@/lib/iep-meetings/availability';
+
+function student(overrides: Partial<CaseloadStudent>): CaseloadStudent {
+  return {
+    id: 's1',
+    initials: 'A.B.',
+    grade_level: '3',
+    teacher_id: null,
+    teacherName: null,
+    teacherProfileId: null,
+    teacherEmail: null,
+    dueDate: '2026-10-01',
+    meetingType: 'annual',
+    hasUpcomingMeeting: false,
+    ...overrides,
+  };
+}
+
+function planningData(overrides: Partial<PlanningData> = {}): PlanningData {
+  return {
+    caseload: [],
+    site: { windows: [], blackouts: [], maxMeetingsPerDay: null },
+    hasSiteRules: false,
+    organizerBusy: [
+      { day_of_week: 1, start_minutes: 540, end_minutes: 570, source: 'session' },
+    ],
+    teacherConstraints: new Map(),
+    existingMeetings: [],
+    leaRep: null,
+    ...overrides,
+  };
+}
+
+const googleBlock = (label: string): BusyBlock => ({
+  date: '2026-09-20',
+  start_minutes: 600,
+  end_minutes: 660,
+  source: 'google',
+  label,
+});
+
+describe('buildPlanRequests', () => {
+  it('merges Google primary busy into the organizer constraint', () => {
+    const googleBusy = new Map<string, BusyBlock[]>([
+      ['primary', [googleBlock('mine')]],
+    ]);
+    const [request] = buildPlanRequests(
+      [student({})],
+      planningData(),
+      googleBusy
+    );
+    const organizer = request.attendees[0];
+    expect(organizer.key).toBe('organizer');
+    expect(organizer.busy).toHaveLength(2);
+    expect(organizer.busy.map(b => b.source).sort()).toEqual([
+      'google',
+      'session',
+    ]);
+  });
+
+  it('keys teacher constraints by profile id, merging prefs and Google busy', () => {
+    const planning = planningData({
+      teacherConstraints: new Map([
+        [
+          't-profile',
+          {
+            key: 't-profile',
+            busy: [],
+            availableWindows: [{ start_minutes: 720, end_minutes: 780 }],
+          },
+        ],
+      ]),
+    });
+    const googleBusy = new Map<string, BusyBlock[]>([
+      ['teacher@d.org', [googleBlock('teacher')]],
+    ]);
+    const [request] = buildPlanRequests(
+      [student({ teacherProfileId: 't-profile', teacherEmail: 'teacher@d.org' })],
+      planning,
+      googleBusy
+    );
+    expect(request.attendees).toHaveLength(2);
+    const teacher = request.attendees[1];
+    expect(teacher.key).toBe('t-profile');
+    expect(teacher.busy).toHaveLength(1);
+    expect(teacher.availableWindows).toEqual([
+      { start_minutes: 720, end_minutes: 780 },
+    ]);
+  });
+
+  it('falls back to an email key for teachers without accounts', () => {
+    const googleBusy = new Map<string, BusyBlock[]>([
+      ['noacct@d.org', [googleBlock('teacher')]],
+    ]);
+    const [request] = buildPlanRequests(
+      [student({ teacherEmail: 'noacct@d.org' })],
+      planningData(),
+      googleBusy
+    );
+    expect(request.attendees[1].key).toBe('email:noacct@d.org');
+  });
+
+  it('reuses one merged constraint object for students sharing a teacher', () => {
+    const googleBusy = new Map<string, BusyBlock[]>([
+      ['teacher@d.org', [googleBlock('teacher')]],
+    ]);
+    const requests = buildPlanRequests(
+      [
+        student({ id: 's1', teacherEmail: 'teacher@d.org' }),
+        student({ id: 's2', teacherEmail: 'teacher@d.org' }),
+      ],
+      planningData(),
+      googleBusy
+    );
+    expect(requests[0].attendees[1]).toBe(requests[1].attendees[1]);
+  });
+
+  it('omits the teacher constraint when there is nothing to constrain', () => {
+    const [request] = buildPlanRequests(
+      [student({ teacherEmail: 'quiet@d.org' })],
+      planningData(),
+      null
+    );
+    expect(request.attendees).toHaveLength(1);
+  });
+});

--- a/app/(dashboard)/dashboard/meetings/page.tsx
+++ b/app/(dashboard)/dashboard/meetings/page.tsx
@@ -177,6 +177,10 @@ export default function MeetingsPage() {
           });
           if (google.connected) {
             googleBusy = google.busyByCalendar;
+            if (google.incomplete) {
+              note =
+                'Some Google Calendar availability could not be fetched — these drafts may not reflect every conflict.';
+            }
           } else {
             note =
               'Google Calendar is not connected — these drafts use internal schedules only.';

--- a/app/(dashboard)/dashboard/meetings/page.tsx
+++ b/app/(dashboard)/dashboard/meetings/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Card } from '@/app/components/ui/card';
 import { Button } from '@/app/components/ui/button';
 import { CalendarConnectionCard } from '@/app/components/calendar/calendar-connection-card';
@@ -9,12 +9,12 @@ import {
   DEFAULT_MEETING_WINDOWS,
   minutesToTime,
   planMeetings,
-  type AttendeeConstraints,
   type BusyBlock,
   type PlanResult,
 } from '@/lib/iep-meetings/availability';
 import { fetchGoogleBusyBlocks } from '@/lib/calendar/google-busy';
 import {
+  buildPlanRequests,
   cancelMeeting,
   getMyMeetings,
   getPlanningData,
@@ -84,6 +84,10 @@ export default function MeetingsPage() {
   const [drafting, setDrafting] = useState(false);
   const [googleNote, setGoogleNote] = useState<string | null>(null);
   const [holdsCreated, setHoldsCreated] = useState<number>(0);
+  // Staleness guards: an async draft run or hold-sync response that isn't
+  // the latest must never write state computed for an earlier world.
+  const plannerRunRef = useRef(0);
+  const reserveTokenRef = useRef(0);
 
   const load = useCallback(async () => {
     if (!schoolId) return;
@@ -135,6 +139,7 @@ export default function MeetingsPage() {
 
   const runPlanner = useCallback(async () => {
     if (!planning) return;
+    const runId = ++plannerRunRef.current;
     setDrafting(true);
     setGoogleNote(null);
     try {
@@ -145,55 +150,50 @@ export default function MeetingsPage() {
       // Google free/busy as one more busy source (spec §5): the organizer's
       // own calendar plus teacher calendars already visible to them through
       // Google's sharing. Absent/broken connection or a failed lookup
-      // degrades to internal sources — never blocks planning.
+      // degrades to internal sources — never blocks planning. Skipped
+      // entirely when there is nothing to plan (also covers past or cleared
+      // horizon values, which would otherwise produce a bogus request).
       let googleBusy: Map<string, BusyBlock[]> | null = null;
-      try {
-        const emails = Array.from(
-          new Set(
-            inHorizon
-              .map(s => s.teacherEmail)
-              .filter((e): e is string => !!e)
-          )
-        );
-        const google = await fetchGoogleBusyBlocks({
-          from: todayStr(),
-          to: horizon,
-          emails,
-        });
-        if (google.connected) googleBusy = google.busyByCalendar;
-      } catch (err) {
-        console.error('Google availability lookup failed:', err);
-        setGoogleNote(
-          'Google Calendar availability was unavailable — these drafts use internal schedules only.'
-        );
+      let note: string | null = null;
+      if (inHorizon.length > 0) {
+        try {
+          // The engine never searches past a meeting's due date, so fetch
+          // busy data only through the latest in-horizon due date.
+          const fetchTo = inHorizon.reduce(
+            (max, s) => (s.dueDate! > max ? s.dueDate! : max),
+            todayStr()
+          );
+          const emails = Array.from(
+            new Set(
+              inHorizon
+                .map(s => s.teacherEmail)
+                .filter((e): e is string => !!e)
+            )
+          );
+          const google = await fetchGoogleBusyBlocks({
+            from: todayStr(),
+            to: fetchTo,
+            emails,
+          });
+          if (google.connected) {
+            googleBusy = google.busyByCalendar;
+          } else {
+            note =
+              'Google Calendar is not connected — these drafts use internal schedules only.';
+          }
+        } catch (err) {
+          console.error('Google availability lookup failed:', err);
+          note =
+            'Google Calendar availability was unavailable — these drafts use internal schedules only.';
+        }
       }
 
-      const requests = inHorizon.map(student => {
-        const attendees: AttendeeConstraints[] = [
-          {
-            key: 'organizer',
-            busy: [
-              ...planning.organizerBusy,
-              ...(googleBusy?.get('primary') ?? []),
-            ],
-          },
-        ];
-        const teacherPrefs = student.teacherProfileId
-          ? planning.teacherConstraints.get(student.teacherProfileId)
-          : undefined;
-        const teacherGoogleBusy = student.teacherEmail
-          ? (googleBusy?.get(student.teacherEmail) ?? [])
-          : [];
-        if (teacherPrefs || teacherGoogleBusy.length > 0) {
-          attendees.push({
-            key:
-              student.teacherProfileId ?? `email:${student.teacherEmail}`,
-            busy: [...(teacherPrefs?.busy ?? []), ...teacherGoogleBusy],
-            availableWindows: teacherPrefs?.availableWindows ?? null,
-          });
-        }
-        return { key: student.id, dueDate: student.dueDate, attendees };
-      });
+      // A newer run (or a reserve) started while we awaited Google: these
+      // results describe a stale world — discard them.
+      if (runId !== plannerRunRef.current) return;
+      setGoogleNote(note);
+
+      const requests = buildPlanRequests(inHorizon, planning, googleBusy);
       // No admin-configured windows yet? Case managers aren't blocked —
       // fall back to general school-day hours and say so in the UI.
       const site = planning.hasSiteRules
@@ -210,12 +210,14 @@ export default function MeetingsPage() {
       setSelected(new Set(planned.filter(r => r.slot).map(r => r.key)));
       setReservedCount(null);
     } finally {
-      setDrafting(false);
+      if (runId === plannerRunRef.current) setDrafting(false);
     }
   }, [planning, unscheduled, horizon]);
 
   const handleReserve = async () => {
-    if (!planning || !results || !schoolId) return;
+    // No reserving off a draft that is being recomputed — the visible
+    // results may describe a stale world.
+    if (!planning || !results || !schoolId || drafting || reserving) return;
     const drafts: MeetingDraft[] = results
       .filter(r => r.slot && selected.has(r.key))
       .map(r => ({
@@ -226,34 +228,25 @@ export default function MeetingsPage() {
     setReserving(true);
     setError(null);
     try {
-      const { reserved, attendeesFailed, meetingIds } = await reserveMeetings(
+      const { reserved, attendeesFailed, holdSync } = await reserveMeetings(
         schoolId,
         drafts,
         planning.leaRep
       );
+      // Invalidate any in-flight draft run: its results predate these
+      // reservations and must not repopulate the planner.
+      plannerRunRef.current += 1;
+      const reserveToken = ++reserveTokenRef.current;
       setReservedCount(reserved);
-      // Best-effort hold events on the organizer's Google Calendar
-      // (spec §2.1) — reservations stand regardless of Google, so this is
-      // fire-and-forget: many sequential event inserts on a slow Google day
-      // must never pin the reserve UX. The banner picks up the count
-      // whenever the sync lands.
       setHoldsCreated(0);
-      if (meetingIds.length > 0) {
-        void fetch('/api/calendar/google/meeting-events', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ action: 'create', meetingIds }),
-        })
-          .then(res => (res.ok ? res.json().catch(() => null) : null))
-          .then(sync => {
-            if (sync?.connected && sync.created > 0) {
-              setHoldsCreated(sync.created);
-            }
-          })
-          .catch(syncErr =>
-            console.error('Calendar hold sync failed:', syncErr)
-          );
-      }
+      // Hold creation runs inside reserveMeetings (fire-and-forget); the
+      // banner picks up the count when it lands — unless a newer reserve
+      // has since taken over the banner.
+      void holdSync.then(count => {
+        if (reserveToken === reserveTokenRef.current && count > 0) {
+          setHoldsCreated(count);
+        }
+      });
       if (attendeesFailed) {
         setError(
           'Meetings were reserved, but some attendees could not be added — check each meeting and re-add missing team members.'
@@ -278,14 +271,8 @@ export default function MeetingsPage() {
     )
       return;
     try {
+      // Google-hold removal happens inside cancelMeeting.
       await cancelMeeting(meeting.id);
-      // Remove the Google Calendar hold if one exists — best-effort; the
-      // cancellation stands either way.
-      fetch('/api/calendar/google/meeting-events', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'cancel', meetingId: meeting.id }),
-      }).catch(syncErr => console.error('Hold removal failed:', syncErr));
       await load();
     } catch {
       setError('Failed to cancel meeting');
@@ -322,8 +309,13 @@ export default function MeetingsPage() {
         <h1 className="text-2xl font-bold text-gray-900">Meetings</h1>
         <Button
           onClick={() => {
+            // Toggling resets ALL planner output state, including any
+            // in-flight draft run and a stale availability note.
+            plannerRunRef.current += 1;
             setPlannerOpen(o => !o);
             setResults(null);
+            setGoogleNote(null);
+            setDrafting(false);
           }}
         >
           {plannerOpen ? 'Close planner' : 'Plan meetings'}
@@ -342,7 +334,7 @@ export default function MeetingsPage() {
         <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-green-700 mb-6">
           Reserved {reservedCount} meeting{reservedCount === 1 ? '' : 's'}.
           {holdsCreated > 0
-            ? ` ${holdsCreated === reservedCount ? 'Holds' : `${holdsCreated} hold${holdsCreated === 1 ? '' : 's'}`} added to your Google Calendar.`
+            ? ` ${holdsCreated} hold${holdsCreated === 1 ? '' : 's'} added to your Google Calendar.`
             : ''}{' '}
           Family confirmations come later — these are internal holds.
         </div>
@@ -527,7 +519,7 @@ export default function MeetingsPage() {
                     <Button
                       onClick={handleReserve}
                       isLoading={reserving}
-                      disabled={selected.size === 0}
+                      disabled={selected.size === 0 || drafting}
                     >
                       Reserve {selected.size} meeting
                       {selected.size === 1 ? '' : 's'}

--- a/app/(dashboard)/dashboard/meetings/page.tsx
+++ b/app/(dashboard)/dashboard/meetings/page.tsx
@@ -233,22 +233,26 @@ export default function MeetingsPage() {
       );
       setReservedCount(reserved);
       // Best-effort hold events on the organizer's Google Calendar
-      // (spec §2.1) — reservations stand regardless of Google.
+      // (spec §2.1) — reservations stand regardless of Google, so this is
+      // fire-and-forget: many sequential event inserts on a slow Google day
+      // must never pin the reserve UX. The banner picks up the count
+      // whenever the sync lands.
       setHoldsCreated(0);
       if (meetingIds.length > 0) {
-        try {
-          const res = await fetch('/api/calendar/google/meeting-events', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ action: 'create', meetingIds }),
-          });
-          const sync = res.ok ? await res.json().catch(() => null) : null;
-          if (sync?.connected && sync.created > 0) {
-            setHoldsCreated(sync.created);
-          }
-        } catch (syncErr) {
-          console.error('Calendar hold sync failed:', syncErr);
-        }
+        void fetch('/api/calendar/google/meeting-events', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'create', meetingIds }),
+        })
+          .then(res => (res.ok ? res.json().catch(() => null) : null))
+          .then(sync => {
+            if (sync?.connected && sync.created > 0) {
+              setHoldsCreated(sync.created);
+            }
+          })
+          .catch(syncErr =>
+            console.error('Calendar hold sync failed:', syncErr)
+          );
       }
       if (attendeesFailed) {
         setError(

--- a/app/(dashboard)/dashboard/meetings/page.tsx
+++ b/app/(dashboard)/dashboard/meetings/page.tsx
@@ -10,8 +10,10 @@ import {
   minutesToTime,
   planMeetings,
   type AttendeeConstraints,
+  type BusyBlock,
   type PlanResult,
 } from '@/lib/iep-meetings/availability';
+import { fetchGoogleBusyBlocks } from '@/lib/calendar/google-busy';
 import {
   cancelMeeting,
   getMyMeetings,
@@ -79,6 +81,9 @@ export default function MeetingsPage() {
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [reserving, setReserving] = useState(false);
   const [reservedCount, setReservedCount] = useState<number | null>(null);
+  const [drafting, setDrafting] = useState(false);
+  const [googleNote, setGoogleNote] = useState<string | null>(null);
+  const [holdsCreated, setHoldsCreated] = useState<number>(0);
 
   const load = useCallback(async () => {
     if (!schoolId) return;
@@ -128,36 +133,85 @@ export default function MeetingsPage() {
     return unscheduled.filter(s => s.dueDate! <= cutoffStr).length;
   }, [unscheduled]);
 
-  const runPlanner = useCallback(() => {
+  const runPlanner = useCallback(async () => {
     if (!planning) return;
-    // The horizon filters by DUE DATE (spec §2.1): "plan meetings due
-    // through [date]" — students due later wait for the next planning pass.
-    const inHorizon = unscheduled.filter(s => s.dueDate! <= horizon);
-    const requests = inHorizon.map(student => {
-      const attendees: AttendeeConstraints[] = [
-        { key: 'organizer', busy: planning.organizerBusy },
-      ];
-      if (student.teacherProfileId) {
-        const teacher = planning.teacherConstraints.get(student.teacherProfileId);
-        if (teacher) attendees.push(teacher);
+    setDrafting(true);
+    setGoogleNote(null);
+    try {
+      // The horizon filters by DUE DATE (spec §2.1): "plan meetings due
+      // through [date]" — students due later wait for the next planning pass.
+      const inHorizon = unscheduled.filter(s => s.dueDate! <= horizon);
+
+      // Google free/busy as one more busy source (spec §5): the organizer's
+      // own calendar plus teacher calendars already visible to them through
+      // Google's sharing. Absent/broken connection or a failed lookup
+      // degrades to internal sources — never blocks planning.
+      let googleBusy: Map<string, BusyBlock[]> | null = null;
+      try {
+        const emails = Array.from(
+          new Set(
+            inHorizon
+              .map(s => s.teacherEmail)
+              .filter((e): e is string => !!e)
+          )
+        );
+        const google = await fetchGoogleBusyBlocks({
+          from: todayStr(),
+          to: horizon,
+          emails,
+        });
+        if (google.connected) googleBusy = google.busyByCalendar;
+      } catch (err) {
+        console.error('Google availability lookup failed:', err);
+        setGoogleNote(
+          'Google Calendar availability was unavailable — these drafts use internal schedules only.'
+        );
       }
-      return { key: student.id, dueDate: student.dueDate, attendees };
-    });
-    // No admin-configured windows yet? Case managers aren't blocked —
-    // fall back to general school-day hours and say so in the UI.
-    const site = planning.hasSiteRules
-      ? planning.site
-      : { ...planning.site, windows: DEFAULT_MEETING_WINDOWS };
-    const planned = planMeetings(requests, {
-      from: todayStr(),
-      to: horizon,
-      durationMinutes: 60,
-      site,
-      existingMeetings: planning.existingMeetings,
-    });
-    setResults(planned);
-    setSelected(new Set(planned.filter(r => r.slot).map(r => r.key)));
-    setReservedCount(null);
+
+      const requests = inHorizon.map(student => {
+        const attendees: AttendeeConstraints[] = [
+          {
+            key: 'organizer',
+            busy: [
+              ...planning.organizerBusy,
+              ...(googleBusy?.get('primary') ?? []),
+            ],
+          },
+        ];
+        const teacherPrefs = student.teacherProfileId
+          ? planning.teacherConstraints.get(student.teacherProfileId)
+          : undefined;
+        const teacherGoogleBusy = student.teacherEmail
+          ? (googleBusy?.get(student.teacherEmail) ?? [])
+          : [];
+        if (teacherPrefs || teacherGoogleBusy.length > 0) {
+          attendees.push({
+            key:
+              student.teacherProfileId ?? `email:${student.teacherEmail}`,
+            busy: [...(teacherPrefs?.busy ?? []), ...teacherGoogleBusy],
+            availableWindows: teacherPrefs?.availableWindows ?? null,
+          });
+        }
+        return { key: student.id, dueDate: student.dueDate, attendees };
+      });
+      // No admin-configured windows yet? Case managers aren't blocked —
+      // fall back to general school-day hours and say so in the UI.
+      const site = planning.hasSiteRules
+        ? planning.site
+        : { ...planning.site, windows: DEFAULT_MEETING_WINDOWS };
+      const planned = planMeetings(requests, {
+        from: todayStr(),
+        to: horizon,
+        durationMinutes: 60,
+        site,
+        existingMeetings: planning.existingMeetings,
+      });
+      setResults(planned);
+      setSelected(new Set(planned.filter(r => r.slot).map(r => r.key)));
+      setReservedCount(null);
+    } finally {
+      setDrafting(false);
+    }
   }, [planning, unscheduled, horizon]);
 
   const handleReserve = async () => {
@@ -172,12 +226,30 @@ export default function MeetingsPage() {
     setReserving(true);
     setError(null);
     try {
-      const { reserved, attendeesFailed } = await reserveMeetings(
+      const { reserved, attendeesFailed, meetingIds } = await reserveMeetings(
         schoolId,
         drafts,
         planning.leaRep
       );
       setReservedCount(reserved);
+      // Best-effort hold events on the organizer's Google Calendar
+      // (spec §2.1) — reservations stand regardless of Google.
+      setHoldsCreated(0);
+      if (meetingIds.length > 0) {
+        try {
+          const res = await fetch('/api/calendar/google/meeting-events', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ action: 'create', meetingIds }),
+          });
+          const sync = res.ok ? await res.json().catch(() => null) : null;
+          if (sync?.connected && sync.created > 0) {
+            setHoldsCreated(sync.created);
+          }
+        } catch (syncErr) {
+          console.error('Calendar hold sync failed:', syncErr);
+        }
+      }
       if (attendeesFailed) {
         setError(
           'Meetings were reserved, but some attendees could not be added — check each meeting and re-add missing team members.'
@@ -203,6 +275,13 @@ export default function MeetingsPage() {
       return;
     try {
       await cancelMeeting(meeting.id);
+      // Remove the Google Calendar hold if one exists — best-effort; the
+      // cancellation stands either way.
+      fetch('/api/calendar/google/meeting-events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'cancel', meetingId: meeting.id }),
+      }).catch(syncErr => console.error('Hold removal failed:', syncErr));
       await load();
     } catch {
       setError('Failed to cancel meeting');
@@ -258,6 +337,9 @@ export default function MeetingsPage() {
       {reservedCount !== null && (
         <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-green-700 mb-6">
           Reserved {reservedCount} meeting{reservedCount === 1 ? '' : 's'}.
+          {holdsCreated > 0
+            ? ` ${holdsCreated === reservedCount ? 'Holds' : `${holdsCreated} hold${holdsCreated === 1 ? '' : 's'}`} added to your Google Calendar.`
+            : ''}{' '}
           Family confirmations come later — these are internal holds.
         </div>
       )}
@@ -349,10 +431,19 @@ export default function MeetingsPage() {
                     className="border border-gray-300 rounded-md px-3 py-2 text-sm"
                   />
                 </div>
-                <Button variant="secondary" onClick={runPlanner}>
+                <Button
+                  variant="secondary"
+                  onClick={runPlanner}
+                  isLoading={drafting}
+                >
                   Draft placements
                 </Button>
               </div>
+              {googleNote && (
+                <div className="bg-gray-50 border border-gray-200 rounded-lg p-3 text-gray-600 text-sm mb-4">
+                  {googleNote}
+                </div>
+              )}
 
               {results && (
                 <>

--- a/app/api/calendar/google/freebusy/route.ts
+++ b/app/api/calendar/google/freebusy/route.ts
@@ -1,0 +1,91 @@
+/**
+ * Google free/busy for the planner (SPE-218): queries with the SIGNED-IN
+ * user's token — their own calendar plus colleague calendars already visible
+ * to them under Google's sharing rules (spec §5, organizer-centric).
+ *
+ * "Not connected" is a normal response ({connected:false}), not an error:
+ * the planner degrades to internal sources.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import {
+  CalendarReconnectRequiredError,
+  getValidGoogleAccessToken,
+} from '@/lib/calendar/connections';
+import { freeBusyQuery } from '@/lib/calendar/google-calendar-api';
+
+export const dynamic = 'force-dynamic';
+
+const MAX_EMAILS = 25;
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  let body: { timeMin?: string; timeMax?: string; emails?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const timeMin = typeof body.timeMin === 'string' ? body.timeMin : '';
+  const timeMax = typeof body.timeMax === 'string' ? body.timeMax : '';
+  if (
+    !Number.isFinite(Date.parse(timeMin)) ||
+    !Number.isFinite(Date.parse(timeMax)) ||
+    Date.parse(timeMax) <= Date.parse(timeMin)
+  ) {
+    return NextResponse.json(
+      { error: 'timeMin/timeMax must be a valid, ordered ISO range' },
+      { status: 400 }
+    );
+  }
+
+  const emails = Array.isArray(body.emails)
+    ? body.emails
+        .filter((e): e is string => typeof e === 'string' && e.includes('@'))
+        .slice(0, MAX_EMAILS)
+    : [];
+
+  let accessToken: string;
+  try {
+    accessToken = await getValidGoogleAccessToken(supabase, user.id);
+  } catch (err) {
+    if (err instanceof CalendarReconnectRequiredError) {
+      return NextResponse.json({ connected: false });
+    }
+    console.error(
+      'Free/busy token lookup failed:',
+      err instanceof Error ? err.message : 'unknown error'
+    );
+    return NextResponse.json(
+      { error: 'Calendar availability unavailable' },
+      { status: 502 }
+    );
+  }
+
+  try {
+    const calendars = await freeBusyQuery({
+      accessToken,
+      timeMin,
+      timeMax,
+      calendarIds: ['primary', ...emails],
+    });
+    return NextResponse.json({ connected: true, calendars });
+  } catch (err) {
+    console.error(
+      'Free/busy query failed:',
+      err instanceof Error ? err.message : 'unknown error'
+    );
+    return NextResponse.json(
+      { error: 'Calendar availability unavailable' },
+      { status: 502 }
+    );
+  }
+}

--- a/app/api/calendar/google/freebusy/route.ts
+++ b/app/api/calendar/google/freebusy/route.ts
@@ -70,13 +70,13 @@ export async function POST(request: NextRequest) {
   if (token.response) return token.response;
 
   try {
-    const calendars = await freeBusyQuery({
+    const { busyByCalendar, incomplete } = await freeBusyQuery({
       accessToken: token.accessToken,
       timeMin,
       timeMax,
       calendarIds: ['primary', ...emails],
     });
-    return NextResponse.json({ connected: true, calendars });
+    return NextResponse.json({ connected: true, calendars: busyByCalendar, incomplete });
   } catch (err) {
     console.error(
       'Free/busy query failed:',

--- a/app/api/calendar/google/freebusy/route.ts
+++ b/app/api/calendar/google/freebusy/route.ts
@@ -4,19 +4,23 @@
  * to them under Google's sharing rules (spec §5, organizer-centric).
  *
  * "Not connected" is a normal response ({connected:false}), not an error:
- * the planner degrades to internal sources.
+ * the planner degrades to internal sources. Google's per-request caps (time
+ * span, calendars per request) are handled inside freeBusyQuery — nothing
+ * is silently truncated here.
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import {
-  CalendarReconnectRequiredError,
-  getValidGoogleAccessToken,
-} from '@/lib/calendar/connections';
 import { freeBusyQuery } from '@/lib/calendar/google-calendar-api';
+import {
+  getCalendarAccessTokenOrResponse,
+  parseJsonObjectBody,
+} from '@/lib/calendar/route-helpers';
 
 export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
 
-const MAX_EMAILS = 25;
+/** Request-size guard only — real Google caps are batched in freeBusyQuery. */
+const MAX_EMAILS = 100;
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient();
@@ -27,10 +31,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
   }
 
-  let body: { timeMin?: string; timeMax?: string; emails?: unknown };
-  try {
-    body = await request.json();
-  } catch {
+  const body = await parseJsonObjectBody(request);
+  if (!body) {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
@@ -48,31 +50,28 @@ export async function POST(request: NextRequest) {
   }
 
   const emails = Array.isArray(body.emails)
-    ? body.emails
-        .filter((e): e is string => typeof e === 'string' && e.includes('@'))
-        .slice(0, MAX_EMAILS)
+    ? body.emails.filter(
+        (e): e is string => typeof e === 'string' && e.includes('@')
+      )
     : [];
-
-  let accessToken: string;
-  try {
-    accessToken = await getValidGoogleAccessToken(supabase, user.id);
-  } catch (err) {
-    if (err instanceof CalendarReconnectRequiredError) {
-      return NextResponse.json({ connected: false });
-    }
-    console.error(
-      'Free/busy token lookup failed:',
-      err instanceof Error ? err.message : 'unknown error'
-    );
+  if (emails.length > MAX_EMAILS) {
+    // Explicit failure beats silently planning without someone's calendar.
     return NextResponse.json(
-      { error: 'Calendar availability unavailable' },
-      { status: 502 }
+      { error: `Too many calendars requested (max ${MAX_EMAILS})` },
+      { status: 400 }
     );
   }
 
+  const token = await getCalendarAccessTokenOrResponse(
+    supabase,
+    user.id,
+    'Calendar availability unavailable'
+  );
+  if (token.response) return token.response;
+
   try {
     const calendars = await freeBusyQuery({
-      accessToken,
+      accessToken: token.accessToken,
       timeMin,
       timeMax,
       calendarIds: ['primary', ...emails],

--- a/app/api/calendar/google/meeting-events/route.ts
+++ b/app/api/calendar/google/meeting-events/route.ts
@@ -1,0 +1,178 @@
+/**
+ * Hold events on the organizer's Google Calendar (SPE-218, spec §2.1).
+ *
+ * Reserved IEP meetings are internal holds: an event on the ORGANIZER's own
+ * calendar only, initials-only title, no attendees — team/family invitations
+ * belong to the confirmation pass (SPE-209/210). Everything here is
+ * best-effort: reserving and cancelling meetings in Speddy never depends on
+ * Google succeeding.
+ *
+ * POST { action: 'create', meetingIds: string[] }
+ *   → creates events for the caller's reserved meetings that lack one,
+ *     storing iep_meetings.google_event_id.
+ * POST { action: 'cancel', meetingId: string }
+ *   → deletes the hold event (already-gone counts as success) and clears
+ *     google_event_id.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import {
+  CalendarReconnectRequiredError,
+  getValidGoogleAccessToken,
+} from '@/lib/calendar/connections';
+import {
+  deleteCalendarEvent,
+  insertCalendarEvent,
+} from '@/lib/calendar/google-calendar-api';
+
+export const dynamic = 'force-dynamic';
+
+const MAX_MEETINGS_PER_CALL = 50;
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  let body: { action?: string; meetingIds?: unknown; meetingId?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  let accessToken: string;
+  try {
+    accessToken = await getValidGoogleAccessToken(supabase, user.id);
+  } catch (err) {
+    if (err instanceof CalendarReconnectRequiredError) {
+      // No connection is a normal state — nothing to sync.
+      return NextResponse.json({ connected: false });
+    }
+    console.error(
+      'Meeting-event token lookup failed:',
+      err instanceof Error ? err.message : 'unknown error'
+    );
+    return NextResponse.json(
+      { error: 'Calendar sync unavailable' },
+      { status: 502 }
+    );
+  }
+
+  if (body.action === 'create') {
+    const meetingIds = Array.isArray(body.meetingIds)
+      ? body.meetingIds
+          .filter((id): id is string => typeof id === 'string')
+          .slice(0, MAX_MEETINGS_PER_CALL)
+      : [];
+    if (meetingIds.length === 0) {
+      return NextResponse.json({ connected: true, created: 0, failed: 0 });
+    }
+
+    // Organizer-scoped on top of RLS; only reserved meetings without an
+    // event yet, so the call is idempotent across retries.
+    const { data: meetings, error } = await supabase
+      .from('iep_meetings')
+      .select(
+        'id, scheduled_start, scheduled_end, location, students(initials)'
+      )
+      .in('id', meetingIds)
+      .eq('organizer_id', user.id)
+      .eq('status', 'reserved')
+      .is('google_event_id', null)
+      .is('deleted_at', null);
+    if (error) {
+      console.error('Meeting-event fetch failed:', error);
+      return NextResponse.json(
+        { error: 'Failed to load meetings' },
+        { status: 500 }
+      );
+    }
+
+    let created = 0;
+    let failed = 0;
+    for (const meeting of meetings ?? []) {
+      if (!meeting.scheduled_start || !meeting.scheduled_end) continue;
+      const studentsRel = meeting.students as unknown as
+        | { initials: string }
+        | { initials: string }[]
+        | null;
+      const student = Array.isArray(studentsRel) ? studentsRel[0] : studentsRel;
+      try {
+        const eventId = await insertCalendarEvent({
+          accessToken,
+          summary: `IEP — ${student?.initials ?? 'student'} (hold)`,
+          description:
+            'Reserved via Speddy — internal hold; team and family confirmation to follow.',
+          location: meeting.location ?? undefined,
+          startIso: meeting.scheduled_start,
+          endIso: meeting.scheduled_end,
+        });
+        const { error: updateError } = await supabase
+          .from('iep_meetings')
+          .update({ google_event_id: eventId })
+          .eq('id', meeting.id);
+        if (updateError) {
+          // Event exists but the link failed — delete the orphan so a retry
+          // doesn't double-book the hold.
+          await deleteCalendarEvent({ accessToken, eventId }).catch(() => {});
+          throw updateError;
+        }
+        created += 1;
+      } catch (err) {
+        failed += 1;
+        console.error(
+          `Hold event for meeting ${meeting.id} failed:`,
+          err instanceof Error ? err.message : 'unknown error'
+        );
+      }
+    }
+    return NextResponse.json({ connected: true, created, failed });
+  }
+
+  if (body.action === 'cancel') {
+    const meetingId = typeof body.meetingId === 'string' ? body.meetingId : '';
+    if (!meetingId) {
+      return NextResponse.json({ error: 'meetingId required' }, { status: 400 });
+    }
+    const { data: meeting, error } = await supabase
+      .from('iep_meetings')
+      .select('id, google_event_id')
+      .eq('id', meetingId)
+      .eq('organizer_id', user.id)
+      .maybeSingle();
+    if (error) {
+      console.error('Meeting lookup for event removal failed:', error);
+      return NextResponse.json(
+        { error: 'Failed to load meeting' },
+        { status: 500 }
+      );
+    }
+    if (!meeting?.google_event_id) {
+      return NextResponse.json({ connected: true, removed: false });
+    }
+    try {
+      await deleteCalendarEvent({
+        accessToken,
+        eventId: meeting.google_event_id,
+      });
+      await supabase
+        .from('iep_meetings')
+        .update({ google_event_id: null })
+        .eq('id', meeting.id);
+      return NextResponse.json({ connected: true, removed: true });
+    } catch (err) {
+      console.error(
+        `Hold event removal for meeting ${meeting.id} failed:`,
+        err instanceof Error ? err.message : 'unknown error'
+      );
+      return NextResponse.json({ connected: true, removed: false });
+    }
+  }
+
+  return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
+}

--- a/app/api/calendar/google/meeting-events/route.ts
+++ b/app/api/calendar/google/meeting-events/route.ts
@@ -112,15 +112,21 @@ export async function POST(request: NextRequest) {
           startIso: meeting.scheduled_start,
           endIso: meeting.scheduled_end,
         });
-        const { error: updateError } = await supabase
+        // Claim the row atomically: only if it is STILL reserved and
+        // unclaimed. A cancellation or a concurrent create since the read
+        // above means the hold is unwanted — delete the fresh event rather
+        // than orphaning it or stamping a row that moved on.
+        const { data: claimed, error: updateError } = await supabase
           .from('iep_meetings')
           .update({ google_event_id: eventId })
-          .eq('id', meeting.id);
-        if (updateError) {
-          // Event exists but the link failed — delete the orphan so a retry
-          // doesn't double-book the hold.
+          .eq('id', meeting.id)
+          .eq('status', 'reserved')
+          .is('google_event_id', null)
+          .select('id');
+        if (updateError || !claimed?.length) {
           await deleteCalendarEvent({ accessToken, eventId }).catch(() => {});
-          throw updateError;
+          if (updateError) throw updateError;
+          continue; // row no longer needs a hold — neither created nor failed
         }
         created += 1;
       } catch (err) {

--- a/app/api/calendar/google/meeting-events/route.ts
+++ b/app/api/calendar/google/meeting-events/route.ts
@@ -7,7 +7,8 @@
  * best-effort: reserving and cancelling meetings in Speddy never depends on
  * Google succeeding.
  *
- * POST { action: 'create', meetingIds: string[] }
+ * POST { action: 'create', meetingIds: string[] }   (≤ MAX_MEETINGS_PER_CALL;
+ *   the client chunks larger batches)
  *   → creates events for the caller's reserved meetings that lack one,
  *     storing iep_meetings.google_event_id.
  * POST { action: 'cancel', meetingId: string }
@@ -17,17 +18,23 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import {
-  CalendarReconnectRequiredError,
-  getValidGoogleAccessToken,
-} from '@/lib/calendar/connections';
-import {
   deleteCalendarEvent,
   insertCalendarEvent,
 } from '@/lib/calendar/google-calendar-api';
+import {
+  getCalendarAccessTokenOrResponse,
+  parseJsonObjectBody,
+} from '@/lib/calendar/route-helpers';
+import { MAX_MEETINGS_PER_CALL } from '@/lib/calendar/hold-events-client';
 
 export const dynamic = 'force-dynamic';
+// Up to 50 Google inserts per call: without this, the platform's default
+// function duration can kill the loop mid-batch on a slow Google day.
+export const maxDuration = 60;
+/** Modest write concurrency: fast batches without hammering one calendar. */
+const INSERT_CONCURRENCY = 4;
 
-const MAX_MEETINGS_PER_CALL = 50;
+type HoldOutcome = 'created' | 'failed' | 'skipped';
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient();
@@ -38,39 +45,24 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
   }
 
-  let body: { action?: string; meetingIds?: unknown; meetingId?: unknown };
-  try {
-    body = await request.json();
-  } catch {
+  const body = await parseJsonObjectBody(request);
+  if (!body) {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
-  }
-
-  let accessToken: string;
-  try {
-    accessToken = await getValidGoogleAccessToken(supabase, user.id);
-  } catch (err) {
-    if (err instanceof CalendarReconnectRequiredError) {
-      // No connection is a normal state — nothing to sync.
-      return NextResponse.json({ connected: false });
-    }
-    console.error(
-      'Meeting-event token lookup failed:',
-      err instanceof Error ? err.message : 'unknown error'
-    );
-    return NextResponse.json(
-      { error: 'Calendar sync unavailable' },
-      { status: 502 }
-    );
   }
 
   if (body.action === 'create') {
     const meetingIds = Array.isArray(body.meetingIds)
-      ? body.meetingIds
-          .filter((id): id is string => typeof id === 'string')
-          .slice(0, MAX_MEETINGS_PER_CALL)
+      ? body.meetingIds.filter((id): id is string => typeof id === 'string')
       : [];
     if (meetingIds.length === 0) {
       return NextResponse.json({ connected: true, created: 0, failed: 0 });
+    }
+    if (meetingIds.length > MAX_MEETINGS_PER_CALL) {
+      // Explicit failure beats silently dropping the tail of a batch.
+      return NextResponse.json(
+        { error: `Too many meetings per call (max ${MAX_MEETINGS_PER_CALL})` },
+        { status: 400 }
+      );
     }
 
     // Organizer-scoped on top of RLS; only reserved meetings without an
@@ -92,18 +84,31 @@ export async function POST(request: NextRequest) {
         { status: 500 }
       );
     }
+    if (!meetings || meetings.length === 0) {
+      return NextResponse.json({ connected: true, created: 0, failed: 0 });
+    }
 
-    let created = 0;
-    let failed = 0;
-    for (const meeting of meetings ?? []) {
-      if (!meeting.scheduled_start || !meeting.scheduled_end) continue;
+    const token = await getCalendarAccessTokenOrResponse(
+      supabase,
+      user.id,
+      'Calendar sync unavailable'
+    );
+    if (token.response) return token.response;
+    const accessToken = token.accessToken;
+
+    const processMeeting = async (
+      meeting: (typeof meetings)[number]
+    ): Promise<HoldOutcome> => {
+      if (!meeting.scheduled_start || !meeting.scheduled_end) return 'skipped';
       const studentsRel = meeting.students as unknown as
         | { initials: string }
         | { initials: string }[]
         | null;
       const student = Array.isArray(studentsRel) ? studentsRel[0] : studentsRel;
+
+      let eventId: string;
       try {
-        const eventId = await insertCalendarEvent({
+        eventId = await insertCalendarEvent({
           accessToken,
           summary: `IEP — ${student?.initials ?? 'student'} (hold)`,
           description:
@@ -112,29 +117,58 @@ export async function POST(request: NextRequest) {
           startIso: meeting.scheduled_start,
           endIso: meeting.scheduled_end,
         });
-        // Claim the row atomically: only if it is STILL reserved and
-        // unclaimed. A cancellation or a concurrent create since the read
-        // above means the hold is unwanted — delete the fresh event rather
-        // than orphaning it or stamping a row that moved on.
-        const { data: claimed, error: updateError } = await supabase
-          .from('iep_meetings')
-          .update({ google_event_id: eventId })
-          .eq('id', meeting.id)
-          .eq('status', 'reserved')
-          .is('google_event_id', null)
-          .select('id');
-        if (updateError || !claimed?.length) {
-          await deleteCalendarEvent({ accessToken, eventId }).catch(() => {});
-          if (updateError) throw updateError;
-          continue; // row no longer needs a hold — neither created nor failed
-        }
-        created += 1;
       } catch (err) {
-        failed += 1;
         console.error(
           `Hold event for meeting ${meeting.id} failed:`,
           err instanceof Error ? err.message : 'unknown error'
         );
+        return 'failed';
+      }
+
+      // Claim the row atomically: only if it is STILL reserved, unclaimed,
+      // and not soft-deleted. A cancellation or a concurrent create since
+      // the read above means the hold is unwanted — delete the fresh event
+      // rather than orphaning it or stamping a row that moved on.
+      const { data: claimed, error: updateError } = await supabase
+        .from('iep_meetings')
+        .update({ google_event_id: eventId })
+        .eq('id', meeting.id)
+        .eq('status', 'reserved')
+        .is('google_event_id', null)
+        .is('deleted_at', null)
+        .select('id');
+      if (updateError || !claimed?.length) {
+        try {
+          await deleteCalendarEvent({ accessToken, eventId });
+        } catch (cleanupErr) {
+          // The unwanted event survived — surface it, don't pretend clean.
+          console.error(
+            `Orphan hold cleanup for meeting ${meeting.id} failed (event ${eventId}):`,
+            cleanupErr instanceof Error ? cleanupErr.message : 'unknown error'
+          );
+          return 'failed';
+        }
+        if (updateError) {
+          console.error(
+            `Hold claim for meeting ${meeting.id} failed:`,
+            updateError
+          );
+          return 'failed';
+        }
+        return 'skipped'; // row no longer needs a hold; event cleaned up
+      }
+      return 'created';
+    };
+
+    let created = 0;
+    let failed = 0;
+    for (let i = 0; i < meetings.length; i += INSERT_CONCURRENCY) {
+      const outcomes = await Promise.all(
+        meetings.slice(i, i + INSERT_CONCURRENCY).map(processMeeting)
+      );
+      for (const outcome of outcomes) {
+        if (outcome === 'created') created += 1;
+        else if (outcome === 'failed') failed += 1;
       }
     }
     return NextResponse.json({ connected: true, created, failed });
@@ -145,6 +179,9 @@ export async function POST(request: NextRequest) {
     if (!meetingId) {
       return NextResponse.json({ error: 'meetingId required' }, { status: 400 });
     }
+    // Look the meeting up BEFORE acquiring a token: cancels for meetings
+    // without a hold (pre-feature meetings, failed inserts, double-cancels)
+    // are no-ops that shouldn't pay the token/refresh pipeline.
     const { data: meeting, error } = await supabase
       .from('iep_meetings')
       .select('id, google_event_id')
@@ -159,17 +196,28 @@ export async function POST(request: NextRequest) {
       );
     }
     if (!meeting?.google_event_id) {
-      return NextResponse.json({ connected: true, removed: false });
+      return NextResponse.json({ removed: false });
     }
+
+    const token = await getCalendarAccessTokenOrResponse(
+      supabase,
+      user.id,
+      'Calendar sync unavailable'
+    );
+    if (token.response) return token.response;
+
     try {
       await deleteCalendarEvent({
-        accessToken,
+        accessToken: token.accessToken,
         eventId: meeting.google_event_id,
       });
-      await supabase
+      const { error: clearError } = await supabase
         .from('iep_meetings')
         .update({ google_event_id: null })
         .eq('id', meeting.id);
+      // A stale google_event_id misreports state — only claim removal once
+      // the link is actually cleared.
+      if (clearError) throw clearError;
       return NextResponse.json({ connected: true, removed: true });
     } catch (err) {
       console.error(

--- a/docs/google-workspace-allowlist-email.md
+++ b/docs/google-workspace-allowlist-email.md
@@ -17,9 +17,11 @@ special-education provider in the district and also Speddy's developer, so
 happy to answer anything directly.]
 
 Speddy is a FERPA-positioned special-education service management platform
-(scheduling, IEP compliance). Its newest feature — rolling out now — helps
-case managers schedule IEP meetings by checking staff **free/busy
-availability** and sending meetings as normal Google Calendar invites. Per the district's
+(scheduling, IEP compliance). Its newest feature is rolling out in phases:
+staff first connect their Google Calendar (live today), and the meeting
+scheduler will then use those connections to check staff **free/busy
+availability** and send meetings as normal Google Calendar invites. We're
+requesting approval once, ahead of that rollout. Per the district's
 recent policy on unverified third-party connections, staff who try to
 connect their district Google account currently see Google's
 "Access blocked: admin_policy_enforced" screen.

--- a/docs/google-workspace-allowlist-email.md
+++ b/docs/google-workspace-allowlist-email.md
@@ -17,11 +17,13 @@ special-education provider in the district and also Speddy's developer, so
 happy to answer anything directly.]
 
 Speddy is a FERPA-positioned special-education service management platform
-(scheduling, IEP compliance). Its newest feature is rolling out in phases:
-staff first connect their Google Calendar (live today), and the meeting
-scheduler will then use those connections to check staff **free/busy
-availability** and send meetings as normal Google Calendar invites. We're
-requesting approval once, ahead of that rollout. Per the district's
+(scheduling, IEP compliance). Its newest feature is rolling out in phases.
+Live today: staff connect their Google Calendar, the meeting scheduler
+checks staff **free/busy availability**, and reserved meetings appear as
+initials-only holds on the organizer's own calendar (no attendees are
+invited). In a later confirmation phase, confirmed meetings go out as
+normal Google Calendar invites. We're requesting approval once, covering
+both phases. Per the district's
 recent policy on unverified third-party connections, staff who try to
 connect their district Google account currently see Google's
 "Access blocked: admin_policy_enforced" screen.
@@ -38,9 +40,10 @@ Key points, detailed in the attached one-page packet:
   trusting the app just lets individual staff choose to connect.
 - **Minimal scopes** — free/busy availability (times only, not event
   contents) plus reading and managing events on the user's **own** calendar
-  (Google's wording: see, create, change, delete) for conflict detection,
-  meeting invitations, and RSVP tracking. Speddy modifies or deletes only
-  events it created; no Gmail, Drive, or Contacts access.
+  (Google's wording: see, create, change, delete) for conflict detection
+  and meeting holds today, and invitations/RSVP tracking in the later
+  confirmation phase. Speddy modifies or deletes only events it created;
+  no Gmail, Drive, or Contacts access.
 - **Staff accounts only** — no student Google accounts are involved.
 - Tokens are encrypted at the application layer, never logged, and
   revocable by the user, by Speddy, or domain-wide by you at any time.

--- a/docs/google-workspace-allowlist-email.md
+++ b/docs/google-workspace-allowlist-email.md
@@ -17,9 +17,9 @@ special-education provider in the district and also Speddy's developer, so
 happy to answer anything directly.]
 
 Speddy is a FERPA-positioned special-education service management platform
-(scheduling, IEP compliance). Its newest feature helps case managers
-schedule IEP meetings by checking staff **free/busy availability** and
-sending meetings as normal Google Calendar invites. Per the district's
+(scheduling, IEP compliance). Its newest feature — rolling out now — helps
+case managers schedule IEP meetings by checking staff **free/busy
+availability** and sending meetings as normal Google Calendar invites. Per the district's
 recent policy on unverified third-party connections, staff who try to
 connect their district Google account currently see Google's
 "Access blocked: admin_policy_enforced" screen.
@@ -34,9 +34,10 @@ Key points, detailed in the attached one-page packet:
 
 - **Per-user consent only** — no service account, no domain-wide delegation;
   trusting the app just lets individual staff choose to connect.
-- **Minimal scopes** — free/busy availability plus events on the user's own
-  calendar; no Gmail, Drive, or Contacts, and free/busy shows times only,
-  not event contents.
+- **Minimal scopes** — free/busy availability plus managing events on the
+  user's **own** calendar (Google's wording: see, create, change, delete);
+  no Gmail, Drive, or Contacts, and free/busy shows times only, not event
+  contents.
 - **Staff accounts only** — no student Google accounts are involved.
 - Tokens are encrypted at the application layer, never logged, and
   revocable by the user, by Speddy, or domain-wide by you at any time.

--- a/docs/google-workspace-allowlist-email.md
+++ b/docs/google-workspace-allowlist-email.md
@@ -36,10 +36,11 @@ Key points, detailed in the attached one-page packet:
 
 - **Per-user consent only** — no service account, no domain-wide delegation;
   trusting the app just lets individual staff choose to connect.
-- **Minimal scopes** — free/busy availability plus managing events on the
-  user's **own** calendar (Google's wording: see, create, change, delete);
-  no Gmail, Drive, or Contacts, and free/busy shows times only, not event
-  contents.
+- **Minimal scopes** — free/busy availability (times only, not event
+  contents) plus reading and managing events on the user's **own** calendar
+  (Google's wording: see, create, change, delete) for conflict detection,
+  meeting invitations, and RSVP tracking. Speddy modifies or deletes only
+  events it created; no Gmail, Drive, or Contacts access.
 - **Staff accounts only** — no student Google accounts are involved.
 - Tokens are encrypted at the application layer, never logged, and
   revocable by the user, by Speddy, or domain-wide by you at any time.

--- a/docs/google-workspace-allowlist-packet.md
+++ b/docs/google-workspace-allowlist-packet.md
@@ -51,13 +51,15 @@ available on request.
 Scheduling an IEP meeting means finding a time that works for the site
 administrator, the case manager, the general-education teacher, service
 providers, and the family. Speddy's calendar integration is rolling out in
-phases. **Staff calendar connections are live today.** In the next phase,
-the meeting scheduler will use those connections to read **availability**
-(free/busy) and deliver confirmed meetings as **ordinary Google Calendar
-invitations** sent from the organizer's own calendar; reminders, RSVPs, and
+phases. **Live today:** staff connect their calendars, the meeting
+scheduler reads **availability** (free/busy) to propose conflict-free
+times, and reserved meetings appear as **initials-only hold events on the
+organizer's own calendar** — no attendees are invited. **In a later
+confirmation phase**, confirmed meetings become ordinary Google Calendar
+invitations sent from the organizer's calendar; reminders, RSVPs, and
 reschedules then behave the way staff already expect from Google Calendar.
 The scopes below are what a staff member consents to when connecting;
-district approval is requested once, ahead of that rollout.
+district approval is requested once and covers both phases.
 
 ## 4. Exactly what access is requested, and why
 
@@ -66,7 +68,7 @@ Speddy requests the **minimum** Google OAuth scopes for the feature:
 | Scope | What it allows | Why Speddy needs it |
 |---|---|---|
 | `https://www.googleapis.com/auth/calendar.freebusy` | Busy/free times only — no event titles, descriptions, or attendees — for the connecting user's calendars and calendars already visible to them under Google's own sharing rules | Find meeting times that avoid existing commitments without exposing what those commitments are |
-| `https://www.googleapis.com/auth/calendar.events.owned` | Google's wording: "See, create, change, and **delete** events" on calendars the user **owns** (not calendars merely shared with them) | Read event information on the user's own calendar to detect scheduling conflicts (e.g., all-day absences); create the IEP meeting invitation from the organizer's calendar, update or delete it on reschedule/cancellation, and read RSVP responses. By design, Speddy modifies or deletes only events it created |
+| `https://www.googleapis.com/auth/calendar.events.owned` | Google's wording: "See, create, change, and **delete** events" on calendars the user **owns** (not calendars merely shared with them) | **Current use:** read event information on the user's own calendar to detect scheduling conflicts (e.g., all-day absences), and create/remove initials-only hold events for reserved meetings on the organizer's calendar. **Later confirmation phase:** send the meeting as an ordinary invitation, update or delete it on reschedule/cancellation, and read RSVP responses. By design, Speddy modifies or deletes only events it created |
 | `openid`, `email` (non-sensitive) | The connected account's email address | Show "Connected as name@district.org" and detect wrong-account connections |
 
 Deliberately **not** requested: `calendar` (full read/write of all calendars),

--- a/docs/google-workspace-allowlist-packet.md
+++ b/docs/google-workspace-allowlist-packet.md
@@ -50,10 +50,14 @@ available on request.
 
 Scheduling an IEP meeting means finding a time that works for the site
 administrator, the case manager, the general-education teacher, service
-providers, and the family. Speddy's meeting scheduler does this by reading
-**availability** (free/busy) and delivering confirmed meetings as **ordinary
-Google Calendar invitations** sent from the organizer's own calendar — so
-reminders, RSVPs, and reschedules work the way staff already expect.
+providers, and the family. Speddy's calendar integration is rolling out in
+phases: **staff calendar connections are live today**, and the meeting
+scheduler then uses those connections to read **availability** (free/busy)
+and deliver confirmed meetings as **ordinary Google Calendar invitations**
+sent from the organizer's own calendar — so reminders, RSVPs, and
+reschedules work the way staff already expect. The scopes below are exactly
+what a staff member consents to when connecting; district approval is
+requested once, ahead of that rollout.
 
 ## 4. Exactly what access is requested, and why
 
@@ -62,7 +66,7 @@ Speddy requests the **minimum** Google OAuth scopes for the feature:
 | Scope | What it allows | Why Speddy needs it |
 |---|---|---|
 | `https://www.googleapis.com/auth/calendar.freebusy` | Busy/free times only — no event titles, descriptions, or attendees — for the connecting user's calendars and calendars already visible to them under Google's own sharing rules | Find meeting times that avoid existing commitments without exposing what those commitments are |
-| `https://www.googleapis.com/auth/calendar.events.owned` | Read/create/update events on calendars the user **owns** (not calendars merely shared with them) | Create the IEP meeting invitation from the organizer's calendar, keep it updated on reschedule/cancel, and read RSVP responses for meetings Speddy created |
+| `https://www.googleapis.com/auth/calendar.events.owned` | Google's wording: "See, create, change, and **delete** events" on calendars the user **owns** (not calendars merely shared with them) | Create the IEP meeting invitation from the organizer's calendar, update or delete it on reschedule/cancellation, and read RSVP responses. By design, Speddy modifies or deletes only events it created |
 | `openid`, `email` (non-sensitive) | The connected account's email address | Show "Connected as name@district.org" and detect wrong-account connections |
 
 Deliberately **not** requested: `calendar` (full read/write of all calendars),

--- a/docs/google-workspace-allowlist-packet.md
+++ b/docs/google-workspace-allowlist-packet.md
@@ -51,13 +51,13 @@ available on request.
 Scheduling an IEP meeting means finding a time that works for the site
 administrator, the case manager, the general-education teacher, service
 providers, and the family. Speddy's calendar integration is rolling out in
-phases: **staff calendar connections are live today**, and the meeting
-scheduler then uses those connections to read **availability** (free/busy)
-and deliver confirmed meetings as **ordinary Google Calendar invitations**
-sent from the organizer's own calendar — so reminders, RSVPs, and
-reschedules work the way staff already expect. The scopes below are exactly
-what a staff member consents to when connecting; district approval is
-requested once, ahead of that rollout.
+phases. **Staff calendar connections are live today.** In the next phase,
+the meeting scheduler will use those connections to read **availability**
+(free/busy) and deliver confirmed meetings as **ordinary Google Calendar
+invitations** sent from the organizer's own calendar; reminders, RSVPs, and
+reschedules then behave the way staff already expect from Google Calendar.
+The scopes below are what a staff member consents to when connecting;
+district approval is requested once, ahead of that rollout.
 
 ## 4. Exactly what access is requested, and why
 
@@ -66,7 +66,7 @@ Speddy requests the **minimum** Google OAuth scopes for the feature:
 | Scope | What it allows | Why Speddy needs it |
 |---|---|---|
 | `https://www.googleapis.com/auth/calendar.freebusy` | Busy/free times only — no event titles, descriptions, or attendees — for the connecting user's calendars and calendars already visible to them under Google's own sharing rules | Find meeting times that avoid existing commitments without exposing what those commitments are |
-| `https://www.googleapis.com/auth/calendar.events.owned` | Google's wording: "See, create, change, and **delete** events" on calendars the user **owns** (not calendars merely shared with them) | Create the IEP meeting invitation from the organizer's calendar, update or delete it on reschedule/cancellation, and read RSVP responses. By design, Speddy modifies or deletes only events it created |
+| `https://www.googleapis.com/auth/calendar.events.owned` | Google's wording: "See, create, change, and **delete** events" on calendars the user **owns** (not calendars merely shared with them) | Read event information on the user's own calendar to detect scheduling conflicts (e.g., all-day absences); create the IEP meeting invitation from the organizer's calendar, update or delete it on reschedule/cancellation, and read RSVP responses. By design, Speddy modifies or deletes only events it created |
 | `openid`, `email` (non-sensitive) | The connected account's email address | Show "Connected as name@district.org" and detect wrong-account connections |
 
 Deliberately **not** requested: `calendar` (full read/write of all calendars),

--- a/lib/calendar/google-busy.ts
+++ b/lib/calendar/google-busy.ts
@@ -82,6 +82,12 @@ export interface GoogleBusyResult {
   connected: boolean;
   /** Key 'primary' = the connected user; other keys = requested emails. */
   busyByCalendar: Map<string, BusyBlock[]>;
+  /**
+   * True when part of the Google range couldn't be fetched — the blocks are
+   * usable but not exhaustive, and callers should say so rather than present
+   * drafts as conflict-free.
+   */
+  incomplete: boolean;
 }
 
 /**
@@ -120,7 +126,7 @@ export async function fetchGoogleBusyBlocks(params: {
   }
   const body = await res.json();
   if (!body?.connected) {
-    return { connected: false, busyByCalendar: new Map() };
+    return { connected: false, busyByCalendar: new Map(), incomplete: false };
   }
   const busyByCalendar = new Map<string, BusyBlock[]>();
   for (const [id, intervals] of Object.entries(body.calendars ?? {})) {
@@ -129,5 +135,5 @@ export async function fetchGoogleBusyBlocks(params: {
       isoIntervalsToBusyBlocks(intervals as IsoInterval[])
     );
   }
-  return { connected: true, busyByCalendar };
+  return { connected: true, busyByCalendar, incomplete: Boolean(body.incomplete) };
 }

--- a/lib/calendar/google-busy.ts
+++ b/lib/calendar/google-busy.ts
@@ -9,15 +9,18 @@
  * server route does the Google call and returns raw ISO intervals.
  */
 import type { BusyBlock } from '@/lib/iep-meetings/availability';
+import { formatDateLocal } from '@/lib/utils/date-helpers';
+import type { IsoInterval } from './google-calendar-api';
 
-export interface IsoInterval {
-  start: string;
-  end: string;
-}
+// Single wire-contract type shared with the server-side API client
+// (type-only import — erased at build, no server code in the bundle).
+export type { IsoInterval } from './google-calendar-api';
 
-function localDateStr(d: Date): string {
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-}
+const GOOGLE_BUSY_LABEL = 'Google Calendar';
+/** Client-side ceiling; the server's own per-request timeouts sit below it. */
+const FETCH_TIMEOUT_MS = 30_000;
+
+const LOCAL_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 function minutesIntoDay(d: Date): number {
   return d.getHours() * 60 + d.getMinutes();
@@ -28,10 +31,7 @@ function minutesIntoDay(d: Date): number {
  * splitting intervals that cross midnight into one block per calendar date.
  * Zero-length results are dropped.
  */
-export function isoIntervalsToBusyBlocks(
-  intervals: IsoInterval[],
-  label = 'Google Calendar'
-): BusyBlock[] {
+export function isoIntervalsToBusyBlocks(intervals: IsoInterval[]): BusyBlock[] {
   const blocks: BusyBlock[] = [];
   for (const interval of intervals) {
     const startMs = Date.parse(interval.start);
@@ -59,11 +59,11 @@ export function isoIntervalsToBusyBlocks(
           : minutesIntoDay(segmentEnd);
       if (endMinutes > startMinutes) {
         blocks.push({
-          date: localDateStr(cursor),
+          date: formatDateLocal(cursor),
           start_minutes: startMinutes,
           end_minutes: endMinutes,
           source: 'google',
-          label,
+          label: GOOGLE_BUSY_LABEL,
         });
       }
       cursor = dayEnd;
@@ -95,6 +95,15 @@ export async function fetchGoogleBusyBlocks(params: {
   to: string; // 'YYYY-MM-DD' inclusive
   emails?: string[];
 }): Promise<GoogleBusyResult> {
+  // Guard before date math: an empty or malformed date would otherwise
+  // become an Invalid Date whose toISOString() throws a RangeError.
+  if (
+    !LOCAL_DATE_RE.test(params.from) ||
+    !LOCAL_DATE_RE.test(params.to) ||
+    params.to < params.from
+  ) {
+    throw new Error('fetchGoogleBusyBlocks: invalid local date range');
+  }
   const res = await fetch('/api/calendar/google/freebusy', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -103,6 +112,8 @@ export async function fetchGoogleBusyBlocks(params: {
       timeMax: localDateToIso(params.to, 1),
       emails: params.emails ?? [],
     }),
+    // A hung request must not pin the planner's drafting spinner forever.
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
   if (!res.ok) {
     throw new Error(`Google availability request failed (${res.status})`);

--- a/lib/calendar/google-busy.ts
+++ b/lib/calendar/google-busy.ts
@@ -1,0 +1,122 @@
+/**
+ * Browser-side helpers turning Google free/busy intervals into the
+ * availability engine's BusyBlock shape (SPE-218).
+ *
+ * The engine works in local calendar dates + minutes-from-midnight
+ * (lib/iep-meetings/availability.ts); the rest of the app treats the
+ * browser's local time as the school's time, so conversion happens here,
+ * client-side, with plain Date math. Tokens never reach the browser — the
+ * server route does the Google call and returns raw ISO intervals.
+ */
+import type { BusyBlock } from '@/lib/iep-meetings/availability';
+
+export interface IsoInterval {
+  start: string;
+  end: string;
+}
+
+function localDateStr(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function minutesIntoDay(d: Date): number {
+  return d.getHours() * 60 + d.getMinutes();
+}
+
+/**
+ * Convert ISO busy intervals to date-specific BusyBlocks in local time,
+ * splitting intervals that cross midnight into one block per calendar date.
+ * Zero-length results are dropped.
+ */
+export function isoIntervalsToBusyBlocks(
+  intervals: IsoInterval[],
+  label = 'Google Calendar'
+): BusyBlock[] {
+  const blocks: BusyBlock[] = [];
+  for (const interval of intervals) {
+    const startMs = Date.parse(interval.start);
+    const endMs = Date.parse(interval.end);
+    if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) {
+      continue;
+    }
+    let cursor = new Date(startMs);
+    const end = new Date(endMs);
+    while (cursor < end) {
+      const dayEnd = new Date(
+        cursor.getFullYear(),
+        cursor.getMonth(),
+        cursor.getDate() + 1,
+        0,
+        0,
+        0,
+        0
+      );
+      const segmentEnd = end < dayEnd ? end : dayEnd;
+      const startMinutes = minutesIntoDay(cursor);
+      const endMinutes =
+        segmentEnd.getTime() === dayEnd.getTime()
+          ? 24 * 60
+          : minutesIntoDay(segmentEnd);
+      if (endMinutes > startMinutes) {
+        blocks.push({
+          date: localDateStr(cursor),
+          start_minutes: startMinutes,
+          end_minutes: endMinutes,
+          source: 'google',
+          label,
+        });
+      }
+      cursor = dayEnd;
+    }
+  }
+  return blocks;
+}
+
+/** Local midnight of a 'YYYY-MM-DD' date as an ISO instant. */
+export function localDateToIso(date: string, plusDays = 0): string {
+  const [y, m, d] = date.split('-').map(Number);
+  return new Date(y, m - 1, d + plusDays, 0, 0, 0, 0).toISOString();
+}
+
+export interface GoogleBusyResult {
+  connected: boolean;
+  /** Key 'primary' = the connected user; other keys = requested emails. */
+  busyByCalendar: Map<string, BusyBlock[]>;
+}
+
+/**
+ * Fetch Google busy blocks for the signed-in user's calendar plus optional
+ * colleague emails over an inclusive local-date range. Never throws for
+ * "no/broken connection" — that's a normal planner state ({connected:false});
+ * network/server failures do throw so callers can distinguish degraded runs.
+ */
+export async function fetchGoogleBusyBlocks(params: {
+  from: string; // 'YYYY-MM-DD' inclusive
+  to: string; // 'YYYY-MM-DD' inclusive
+  emails?: string[];
+}): Promise<GoogleBusyResult> {
+  const res = await fetch('/api/calendar/google/freebusy', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      timeMin: localDateToIso(params.from),
+      timeMax: localDateToIso(params.to, 1),
+      emails: params.emails ?? [],
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Google availability request failed (${res.status})`);
+  }
+  const body = await res.json();
+  if (!body?.connected) {
+    return { connected: false, busyByCalendar: new Map() };
+  }
+  const busyByCalendar = new Map<string, BusyBlock[]>();
+  for (const [id, intervals] of Object.entries(body.calendars ?? {})) {
+    busyByCalendar.set(
+      id,
+      isoIntervalsToBusyBlocks(intervals as IsoInterval[])
+    );
+  }
+  return { connected: true, busyByCalendar };
+}

--- a/lib/calendar/google-calendar-api.ts
+++ b/lib/calendar/google-calendar-api.ts
@@ -1,0 +1,179 @@
+/**
+ * Google Calendar REST calls for the IEP scheduler (SPE-218). Server-only:
+ * callers obtain an access token via getValidGoogleAccessToken().
+ *
+ * Same posture as google-oauth.ts: plain fetch (no googleapis dependency),
+ * short timeouts, GoogleOAuthError shapes, and never any token material in
+ * errors or logs.
+ */
+import { GoogleOAuthError } from './google-oauth';
+
+const CALENDAR_API = 'https://www.googleapis.com/calendar/v3';
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/** Google caps freeBusy query spans; stay comfortably under it per request. */
+const FREEBUSY_MAX_DAYS_PER_REQUEST = 42;
+/** Planning horizons are within a school year; hard-cap runaway ranges. */
+const FREEBUSY_MAX_TOTAL_DAYS = 370;
+
+async function calendarRequest(
+  accessToken: string,
+  path: string,
+  init: { method: string; body?: unknown }
+): Promise<Response> {
+  try {
+    return await fetch(`${CALENDAR_API}${path}`, {
+      method: init.method,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: init.body === undefined ? undefined : JSON.stringify(init.body),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch {
+    throw new GoogleOAuthError(
+      'Google Calendar API unreachable or timed out',
+      'network_error'
+    );
+  }
+}
+
+async function raiseForStatus(res: Response, what: string): Promise<void> {
+  if (res.ok) return;
+  let code = 'calendar_api_error';
+  let message = `Google Calendar ${what} failed`;
+  try {
+    const body = await res.json();
+    if (body?.error?.status) code = String(body.error.status);
+    if (body?.error?.message) message = String(body.error.message);
+  } catch {
+    // keep generic message
+  }
+  throw new GoogleOAuthError(message, code, res.status);
+}
+
+export interface IsoInterval {
+  start: string; // RFC3339
+  end: string; // RFC3339
+}
+
+/**
+ * Split [timeMin, timeMax) into consecutive sub-ranges no longer than
+ * maxDays, for APIs that cap the queryable span. Exported for tests.
+ */
+export function chunkTimeRange(
+  timeMin: string,
+  timeMax: string,
+  maxDays: number = FREEBUSY_MAX_DAYS_PER_REQUEST
+): { timeMin: string; timeMax: string }[] {
+  const startMs = Date.parse(timeMin);
+  const endMs = Date.parse(timeMax);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) {
+    return [];
+  }
+  const cappedEndMs = Math.min(
+    endMs,
+    startMs + FREEBUSY_MAX_TOTAL_DAYS * 24 * 60 * 60 * 1000
+  );
+  const stepMs = maxDays * 24 * 60 * 60 * 1000;
+  const chunks: { timeMin: string; timeMax: string }[] = [];
+  for (let cursor = startMs; cursor < cappedEndMs; cursor += stepMs) {
+    chunks.push({
+      timeMin: new Date(cursor).toISOString(),
+      timeMax: new Date(Math.min(cursor + stepMs, cappedEndMs)).toISOString(),
+    });
+  }
+  return chunks;
+}
+
+/**
+ * freebusy.query over an arbitrary range (chunked), for the user's own
+ * calendar ('primary') plus any other calendar ids (colleague emails).
+ * Calendars the token can't see come back with per-calendar errors from
+ * Google — those are skipped, contributing no busy data, by design
+ * (spec §5: sources are additive, never required).
+ */
+export async function freeBusyQuery(params: {
+  accessToken: string;
+  timeMin: string;
+  timeMax: string;
+  calendarIds: string[];
+}): Promise<Record<string, IsoInterval[]>> {
+  const busyByCalendar: Record<string, IsoInterval[]> = {};
+  for (const id of params.calendarIds) busyByCalendar[id] = [];
+
+  for (const chunk of chunkTimeRange(params.timeMin, params.timeMax)) {
+    const res = await calendarRequest(params.accessToken, '/freeBusy', {
+      method: 'POST',
+      body: {
+        timeMin: chunk.timeMin,
+        timeMax: chunk.timeMax,
+        items: params.calendarIds.map(id => ({ id })),
+      },
+    });
+    await raiseForStatus(res, 'free/busy query');
+    const body = await res.json();
+    const calendars = body?.calendars ?? {};
+    for (const id of params.calendarIds) {
+      const entry = calendars[id];
+      if (!entry || Array.isArray(entry.errors)) continue; // not visible — skip
+      for (const interval of entry.busy ?? []) {
+        if (interval?.start && interval?.end) {
+          busyByCalendar[id].push({ start: interval.start, end: interval.end });
+        }
+      }
+    }
+  }
+  return busyByCalendar;
+}
+
+/** Create an event on the user's primary calendar; returns the event id. */
+export async function insertCalendarEvent(params: {
+  accessToken: string;
+  summary: string;
+  description?: string;
+  location?: string;
+  startIso: string;
+  endIso: string;
+}): Promise<string> {
+  const res = await calendarRequest(params.accessToken, '/calendars/primary/events', {
+    method: 'POST',
+    body: {
+      summary: params.summary,
+      description: params.description,
+      location: params.location,
+      start: { dateTime: params.startIso },
+      end: { dateTime: params.endIso },
+      // Internal hold: no attendees yet — the confirmation pass (SPE-209/210)
+      // owns invitations.
+      reminders: { useDefault: true },
+    },
+  });
+  await raiseForStatus(res, 'event creation');
+  const body = await res.json();
+  if (!body?.id) {
+    throw new GoogleOAuthError(
+      'Google Calendar event creation returned no id',
+      'calendar_api_error'
+    );
+  }
+  return body.id as string;
+}
+
+/**
+ * Delete an event from the user's primary calendar. Already-gone events
+ * (404/410) count as success — the goal state is "no event".
+ */
+export async function deleteCalendarEvent(params: {
+  accessToken: string;
+  eventId: string;
+}): Promise<void> {
+  const res = await calendarRequest(
+    params.accessToken,
+    `/calendars/primary/events/${encodeURIComponent(params.eventId)}`,
+    { method: 'DELETE' }
+  );
+  if (res.status === 404 || res.status === 410) return;
+  await raiseForStatus(res, 'event deletion');
+}

--- a/lib/calendar/google-calendar-api.ts
+++ b/lib/calendar/google-calendar-api.ts
@@ -21,6 +21,8 @@ const FREEBUSY_MAX_DAYS_PER_REQUEST = 42;
 const FREEBUSY_MAX_TOTAL_DAYS = 370;
 /** Google limits calendars per freeBusy request; batch and merge. */
 const FREEBUSY_MAX_CALENDARS_PER_REQUEST = 20;
+/** Long horizons × big caseloads fan out; keep concurrency polite. */
+const FREEBUSY_CONCURRENCY = 6;
 
 async function calendarRequest(
   accessToken: string,
@@ -100,22 +102,34 @@ function chunkList<T>(items: T[], size: number): T[][] {
   return batches;
 }
 
+export interface FreeBusyResult {
+  busyByCalendar: Record<string, IsoInterval[]>;
+  /**
+   * True when any slice (time chunk × calendar batch) failed: coverage has
+   * gaps. Callers must surface this — partial data presented as complete is
+   * how meetings get planned over real conflicts.
+   */
+  incomplete: boolean;
+}
+
 /**
  * freebusy.query over an arbitrary range and calendar count, for the user's
  * own calendar ('primary') plus any other calendar ids (colleague emails).
  * Both Google caps are handled here — the time span (chunked windows) and
  * the calendars-per-request limit (batched ids) — so callers never silently
- * lose coverage. Independent read-only requests run in parallel. Calendars
- * the token can't see come back with per-calendar errors from Google —
- * those are skipped, contributing no busy data, by design (spec §5:
- * sources are additive, never required).
+ * lose coverage. Independent read-only requests run with bounded
+ * concurrency, and one failed slice (429, timeout) only gaps that slice —
+ * flagged via `incomplete`, never thrown away silently. Calendars the token
+ * can't see come back with per-calendar errors from Google — those are
+ * skipped, contributing no busy data, by design (spec §5: sources are
+ * additive, never required).
  */
 export async function freeBusyQuery(params: {
   accessToken: string;
   timeMin: string;
   timeMax: string;
   calendarIds: string[];
-}): Promise<Record<string, IsoInterval[]>> {
+}): Promise<FreeBusyResult> {
   const busyByCalendar: Record<string, IsoInterval[]> = {};
   for (const id of params.calendarIds) busyByCalendar[id] = [];
 
@@ -131,8 +145,12 @@ export async function freeBusyQuery(params: {
     }
   }
 
-  await Promise.all(
-    requests.map(async ({ chunk, ids }) => {
+  let incomplete = false;
+  const fetchSlice = async ({
+    chunk,
+    ids,
+  }: (typeof requests)[number]): Promise<void> => {
+    try {
       const res = await calendarRequest(params.accessToken, '/freeBusy', {
         method: 'POST',
         body: {
@@ -156,9 +174,19 @@ export async function freeBusyQuery(params: {
           }
         }
       }
-    })
-  );
-  return busyByCalendar;
+    } catch (err) {
+      incomplete = true;
+      console.error(
+        `Free/busy slice failed (${chunk.timeMin}..${chunk.timeMax}, ${ids.length} calendars):`,
+        err instanceof Error ? err.message : 'unknown error'
+      );
+    }
+  };
+
+  for (let i = 0; i < requests.length; i += FREEBUSY_CONCURRENCY) {
+    await Promise.all(requests.slice(i, i + FREEBUSY_CONCURRENCY).map(fetchSlice));
+  }
+  return { busyByCalendar, incomplete };
 }
 
 /** Create an event on the user's primary calendar; returns the event id. */

--- a/lib/calendar/google-calendar-api.ts
+++ b/lib/calendar/google-calendar-api.ts
@@ -13,8 +13,14 @@ const REQUEST_TIMEOUT_MS = 10_000;
 
 /** Google caps freeBusy query spans; stay comfortably under it per request. */
 const FREEBUSY_MAX_DAYS_PER_REQUEST = 42;
-/** Planning horizons are within a school year; hard-cap runaway ranges. */
+/**
+ * Planning horizons are within a school year; hard-cap runaway ranges.
+ * Callers bound their range to what the planner actually consults (latest
+ * due date), so this cap is a backstop, not an expected path.
+ */
 const FREEBUSY_MAX_TOTAL_DAYS = 370;
+/** Google limits calendars per freeBusy request; batch and merge. */
+const FREEBUSY_MAX_CALENDARS_PER_REQUEST = 20;
 
 async function calendarRequest(
   accessToken: string,
@@ -60,12 +66,11 @@ export interface IsoInterval {
 
 /**
  * Split [timeMin, timeMax) into consecutive sub-ranges no longer than
- * maxDays, for APIs that cap the queryable span. Exported for tests.
+ * Google's per-request span limit. Exported for tests.
  */
 export function chunkTimeRange(
   timeMin: string,
-  timeMax: string,
-  maxDays: number = FREEBUSY_MAX_DAYS_PER_REQUEST
+  timeMax: string
 ): { timeMin: string; timeMax: string }[] {
   const startMs = Date.parse(timeMin);
   const endMs = Date.parse(timeMax);
@@ -76,7 +81,7 @@ export function chunkTimeRange(
     endMs,
     startMs + FREEBUSY_MAX_TOTAL_DAYS * 24 * 60 * 60 * 1000
   );
-  const stepMs = maxDays * 24 * 60 * 60 * 1000;
+  const stepMs = FREEBUSY_MAX_DAYS_PER_REQUEST * 24 * 60 * 60 * 1000;
   const chunks: { timeMin: string; timeMax: string }[] = [];
   for (let cursor = startMs; cursor < cappedEndMs; cursor += stepMs) {
     chunks.push({
@@ -87,12 +92,23 @@ export function chunkTimeRange(
   return chunks;
 }
 
+function chunkList<T>(items: T[], size: number): T[][] {
+  const batches: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    batches.push(items.slice(i, i + size));
+  }
+  return batches;
+}
+
 /**
- * freebusy.query over an arbitrary range (chunked), for the user's own
- * calendar ('primary') plus any other calendar ids (colleague emails).
- * Calendars the token can't see come back with per-calendar errors from
- * Google — those are skipped, contributing no busy data, by design
- * (spec §5: sources are additive, never required).
+ * freebusy.query over an arbitrary range and calendar count, for the user's
+ * own calendar ('primary') plus any other calendar ids (colleague emails).
+ * Both Google caps are handled here — the time span (chunked windows) and
+ * the calendars-per-request limit (batched ids) — so callers never silently
+ * lose coverage. Independent read-only requests run in parallel. Calendars
+ * the token can't see come back with per-calendar errors from Google —
+ * those are skipped, contributing no busy data, by design (spec §5:
+ * sources are additive, never required).
  */
 export async function freeBusyQuery(params: {
   accessToken: string;
@@ -103,28 +119,45 @@ export async function freeBusyQuery(params: {
   const busyByCalendar: Record<string, IsoInterval[]> = {};
   for (const id of params.calendarIds) busyByCalendar[id] = [];
 
+  const idBatches = chunkList(
+    params.calendarIds,
+    FREEBUSY_MAX_CALENDARS_PER_REQUEST
+  );
+  const requests: { chunk: { timeMin: string; timeMax: string }; ids: string[] }[] =
+    [];
   for (const chunk of chunkTimeRange(params.timeMin, params.timeMax)) {
-    const res = await calendarRequest(params.accessToken, '/freeBusy', {
-      method: 'POST',
-      body: {
-        timeMin: chunk.timeMin,
-        timeMax: chunk.timeMax,
-        items: params.calendarIds.map(id => ({ id })),
-      },
-    });
-    await raiseForStatus(res, 'free/busy query');
-    const body = await res.json();
-    const calendars = body?.calendars ?? {};
-    for (const id of params.calendarIds) {
-      const entry = calendars[id];
-      if (!entry || Array.isArray(entry.errors)) continue; // not visible — skip
-      for (const interval of entry.busy ?? []) {
-        if (interval?.start && interval?.end) {
-          busyByCalendar[id].push({ start: interval.start, end: interval.end });
-        }
-      }
+    for (const ids of idBatches) {
+      requests.push({ chunk, ids });
     }
   }
+
+  await Promise.all(
+    requests.map(async ({ chunk, ids }) => {
+      const res = await calendarRequest(params.accessToken, '/freeBusy', {
+        method: 'POST',
+        body: {
+          timeMin: chunk.timeMin,
+          timeMax: chunk.timeMax,
+          items: ids.map(id => ({ id })),
+        },
+      });
+      await raiseForStatus(res, 'free/busy query');
+      const body = await res.json();
+      const calendars = body?.calendars ?? {};
+      for (const id of ids) {
+        const entry = calendars[id];
+        if (!entry || Array.isArray(entry.errors)) continue; // not visible — skip
+        for (const interval of entry.busy ?? []) {
+          if (interval?.start && interval?.end) {
+            busyByCalendar[id].push({
+              start: interval.start,
+              end: interval.end,
+            });
+          }
+        }
+      }
+    })
+  );
   return busyByCalendar;
 }
 

--- a/lib/calendar/hold-events-client.ts
+++ b/lib/calendar/hold-events-client.ts
@@ -26,7 +26,11 @@ export async function syncHoldEvents(meetingIds: string[]): Promise<number> {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'create', meetingIds: batch }),
       });
-      const sync = res.ok ? await res.json().catch(() => null) : null;
+      if (!res.ok) {
+        console.error(`Calendar hold sync failed: HTTP ${res.status}`);
+        continue;
+      }
+      const sync = await res.json().catch(() => null);
       if (sync?.connected && typeof sync.created === 'number') {
         created += sync.created;
       }
@@ -43,5 +47,14 @@ export function removeHoldEvent(meetingId: string): void {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ action: 'cancel', meetingId }),
-  }).catch(err => console.error('Hold removal failed:', err));
+  })
+    .then(async res => {
+      const body = res.ok ? await res.json().catch(() => null) : null;
+      // {removed:false} WITHOUT connected is the legitimate no-hold no-op;
+      // connected:true + removed:false means a hold event may survive.
+      if (!res.ok || (body?.connected && body.removed === false)) {
+        console.error(`Hold removal did not complete for meeting ${meetingId}`);
+      }
+    })
+    .catch(err => console.error('Hold removal failed:', err));
 }

--- a/lib/calendar/hold-events-client.ts
+++ b/lib/calendar/hold-events-client.ts
@@ -1,0 +1,47 @@
+/**
+ * Browser-side sync calls for Google Calendar hold events (SPE-218).
+ *
+ * These are invoked from inside the reserve/cancel query operations — not by
+ * pages — so no future caller can forget them: a forgotten cancel-sync
+ * leaves a phantom hold that flows back through the free/busy source and
+ * silently poisons every later planning run. Both calls are best-effort and
+ * must never block the primary flow.
+ */
+
+/** Server-enforced per-call cap; larger batches are chunked here. */
+export const MAX_MEETINGS_PER_CALL = 50;
+
+/**
+ * Create hold events for freshly reserved meetings. Resolves to the number
+ * of holds created; resolves (never rejects) with a partial count when a
+ * batch fails — callers only use it for the success banner.
+ */
+export async function syncHoldEvents(meetingIds: string[]): Promise<number> {
+  let created = 0;
+  for (let i = 0; i < meetingIds.length; i += MAX_MEETINGS_PER_CALL) {
+    const batch = meetingIds.slice(i, i + MAX_MEETINGS_PER_CALL);
+    try {
+      const res = await fetch('/api/calendar/google/meeting-events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'create', meetingIds: batch }),
+      });
+      const sync = res.ok ? await res.json().catch(() => null) : null;
+      if (sync?.connected && typeof sync.created === 'number') {
+        created += sync.created;
+      }
+    } catch (err) {
+      console.error('Calendar hold sync failed:', err);
+    }
+  }
+  return created;
+}
+
+/** Fire-and-forget removal of a cancelled meeting's hold event. */
+export function removeHoldEvent(meetingId: string): void {
+  void fetch('/api/calendar/google/meeting-events', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action: 'cancel', meetingId }),
+  }).catch(err => console.error('Hold removal failed:', err));
+}

--- a/lib/calendar/route-helpers.ts
+++ b/lib/calendar/route-helpers.ts
@@ -1,9 +1,13 @@
 /**
- * Shared helpers for the calendar OAuth route handlers (SPE-205).
+ * Shared helpers for the calendar route handlers (SPE-205/SPE-218).
  */
-import type { NextRequest } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@/src/types/database';
+import {
+  CalendarReconnectRequiredError,
+  getValidGoogleAccessToken,
+} from './connections';
 
 /** CSRF state cookie, scoped to the OAuth routes only. */
 export const STATE_COOKIE = 'gcal_oauth_state';
@@ -38,4 +42,56 @@ export async function meetingsPathForUser(
   return data?.role === 'site_admin' || data?.role === 'district_admin'
     ? '/dashboard/admin/meetings'
     : '/dashboard/meetings';
+}
+
+/**
+ * Parsed JSON object body, or null for missing/malformed/non-object
+ * payloads (request.json() happily returns null or primitives — callers
+ * must not dereference those).
+ */
+export async function parseJsonObjectBody(
+  request: NextRequest
+): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed: unknown = await request.json();
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The one token step every calendar data route shares, so the degraded-mode
+ * contract can't drift between routes: a reconnect-required connection is
+ * the NORMAL {connected:false} response (planner falls back to internal
+ * sources); anything else maps to a single 502 shape.
+ */
+export async function getCalendarAccessTokenOrResponse(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  unavailableMessage: string
+): Promise<
+  | { accessToken: string; response?: undefined }
+  | { accessToken?: undefined; response: NextResponse }
+> {
+  try {
+    return { accessToken: await getValidGoogleAccessToken(supabase, userId) };
+  } catch (err) {
+    if (err instanceof CalendarReconnectRequiredError) {
+      return { response: NextResponse.json({ connected: false }) };
+    }
+    console.error(
+      `${unavailableMessage}:`,
+      err instanceof Error ? err.message : 'unknown error'
+    );
+    return {
+      response: NextResponse.json(
+        { error: unavailableMessage },
+        { status: 502 }
+      ),
+    };
+  }
 }

--- a/lib/supabase/queries/iep-meetings.ts
+++ b/lib/supabase/queries/iep-meetings.ts
@@ -7,9 +7,14 @@ import {
   type BusyBlock,
   type DayWindow,
   type DateRange,
+  type PlanRequest,
   type ProposedSlot,
   type SiteConstraints,
 } from '@/lib/iep-meetings/availability';
+import {
+  removeHoldEvent,
+  syncHoldEvents,
+} from '@/lib/calendar/hold-events-client';
 import type { SiteMeetingRules } from '@/src/types';
 
 export interface MeetingListItem extends IepMeeting {
@@ -282,6 +287,56 @@ export async function getPlanningData(schoolId: string): Promise<PlanningData> {
   };
 }
 
+/**
+ * Assemble the engine's PlanRequests from planning data plus optional
+ * Google busy blocks (spec §5: availability is the union of whatever
+ * sources exist). Lives in the query layer so every planning surface —
+ * the bulk planner today, the SPE-210 reschedule flow later — shares one
+ * merge, per the engine header's contract ("sources are assembled by the
+ * query layer").
+ */
+export function buildPlanRequests(
+  students: CaseloadStudent[],
+  planning: PlanningData,
+  googleBusy: Map<string, BusyBlock[]> | null
+): PlanRequest[] {
+  const organizer: AttendeeConstraints = {
+    key: 'organizer',
+    busy: [...planning.organizerBusy, ...(googleBusy?.get('primary') ?? [])],
+  };
+  // Several students share a teacher — merge each teacher's constraints once.
+  const teacherCache = new Map<string, AttendeeConstraints | null>();
+  return students.map(student => {
+    const attendees: AttendeeConstraints[] = [organizer];
+    const teacherKey =
+      student.teacherProfileId ??
+      (student.teacherEmail ? `email:${student.teacherEmail}` : null);
+    if (teacherKey) {
+      if (!teacherCache.has(teacherKey)) {
+        const prefs = student.teacherProfileId
+          ? planning.teacherConstraints.get(student.teacherProfileId)
+          : undefined;
+        const googleTeacherBusy = student.teacherEmail
+          ? (googleBusy?.get(student.teacherEmail) ?? [])
+          : [];
+        teacherCache.set(
+          teacherKey,
+          prefs || googleTeacherBusy.length > 0
+            ? {
+                key: teacherKey,
+                busy: [...(prefs?.busy ?? []), ...googleTeacherBusy],
+                availableWindows: prefs?.availableWindows ?? null,
+              }
+            : null
+        );
+      }
+      const teacher = teacherCache.get(teacherKey);
+      if (teacher) attendees.push(teacher);
+    }
+    return { key: student.id, dueDate: student.dueDate, attendees };
+  });
+}
+
 export interface MeetingDraft {
   student: CaseloadStudent;
   slot: ProposedSlot;
@@ -318,6 +373,8 @@ export async function reserveMeetings(
   reserved: number;
   attendeesFailed: boolean;
   meetingIds: string[];
+  /** Best-effort Google hold creation; resolves to the created count. */
+  holdSync: Promise<number>;
 }> {
   const supabase = createClient<Database>();
   const {
@@ -402,10 +459,18 @@ export async function reserveMeetings(
     }
   }
 
+  const meetingIds = (inserted ?? []).map(m => m.id);
+  // Hold events belong to the reserve operation itself (spec §2.1) so no
+  // caller can forget them; fire-and-forget keeps Google latency out of the
+  // reserve UX. Callers may await holdSync for feedback, never for success.
+  const holdSync =
+    meetingIds.length > 0 ? syncHoldEvents(meetingIds) : Promise.resolve(0);
+
   return {
     reserved: inserted?.length ?? 0,
     attendeesFailed,
-    meetingIds: (inserted ?? []).map(m => m.id),
+    meetingIds,
+    holdSync,
   };
 }
 
@@ -427,4 +492,7 @@ export async function cancelMeeting(meetingId: string): Promise<void> {
     console.error('Error cancelling meeting:', error);
     throw error;
   }
+  // Remove the Google hold as part of the cancel operation — a forgotten
+  // sync would leave a phantom busy block feeding future planning runs.
+  removeHoldEvent(meetingId);
 }

--- a/lib/supabase/queries/iep-meetings.ts
+++ b/lib/supabase/queries/iep-meetings.ts
@@ -30,6 +30,8 @@ export interface CaseloadStudent {
   teacher_id: string | null;
   teacherName: string | null;
   teacherProfileId: string | null;
+  /** For Google free/busy lookups via calendars shared with the organizer. */
+  teacherEmail: string | null;
   dueDate: string | null; // earlier of upcoming IEP / triennial
   meetingType: 'annual' | 'triennial';
   hasUpcomingMeeting: boolean;
@@ -105,7 +107,7 @@ export async function getPlanningData(schoolId: string): Promise<PlanningData> {
       supabase
         .from('students')
         .select(
-          'id, initials, grade_level, teacher_id, teachers(id, account_id, first_name, last_name), student_details(upcoming_iep_date, upcoming_triennial_date)'
+          'id, initials, grade_level, teacher_id, teachers(id, account_id, first_name, last_name, email), student_details(upcoming_iep_date, upcoming_triennial_date)'
         )
         .eq('provider_id', user.id)
         .eq('school_id', schoolId),
@@ -187,6 +189,7 @@ export async function getPlanningData(schoolId: string): Promise<PlanningData> {
       account_id: string | null;
       first_name: string | null;
       last_name: string | null;
+      email: string | null;
     } | null;
     student_details: {
       upcoming_iep_date: string | null;
@@ -218,6 +221,7 @@ export async function getPlanningData(schoolId: string): Promise<PlanningData> {
         ? [teacher.first_name, teacher.last_name].filter(Boolean).join(' ') || null
         : null,
       teacherProfileId: teacher?.account_id ?? null,
+      teacherEmail: teacher?.email ?? null,
       dueDate,
       meetingType,
       hasUpcomingMeeting: studentsWithMeetings.has(s.id),
@@ -310,7 +314,11 @@ export async function reserveMeetings(
   schoolId: string,
   drafts: MeetingDraft[],
   leaRep: { admin_id: string; full_name: string } | null
-): Promise<{ reserved: number; attendeesFailed: boolean }> {
+): Promise<{
+  reserved: number;
+  attendeesFailed: boolean;
+  meetingIds: string[];
+}> {
   const supabase = createClient<Database>();
   const {
     data: { user },
@@ -394,7 +402,11 @@ export async function reserveMeetings(
     }
   }
 
-  return { reserved: inserted?.length ?? 0, attendeesFailed };
+  return {
+    reserved: inserted?.length ?? 0,
+    attendeesFailed,
+    meetingIds: (inserted ?? []).map(m => m.id),
+  };
 }
 
 export async function cancelMeeting(meetingId: string): Promise<void> {


### PR DESCRIPTION
## Summary

Implements [SPE-218](https://linear.app/speddy/issue/SPE-218): the planner now **consumes** Google Calendar data, and reservations become **visible holds** on the organizer's calendar — the bridge between SPE-205 (connections, shipped) and SPE-210 (reschedule + RSVP watch). This also makes the allowlist packet's "next phase" real.

Everything degrades gracefully: no connection, a revoked grant, or a Google outage leaves the planner running exactly as today on internal sources (sessions, site rules, teacher prefs), with a visible note when a lookup fails mid-planning.

## How it works

**Free/busy into the planner (spec §5)**
- "Draft placements" now fetches Google availability for the planning horizon before planning: the organizer's own calendar plus teacher emails on the in-horizon caseload, queried **with the organizer's token** via `POST /api/calendar/google/freebusy` — so colleague data comes only from calendars already visible to the organizer under Google's own sharing rules (organizer-centric, per spec). Calendars the token can't see return per-calendar errors from Google and simply contribute nothing.
- Long horizons are chunked (42-day requests, 370-day hard cap) in `lib/calendar/google-calendar-api.ts`.
- The browser converts ISO intervals to the engine's local-date + minutes `BusyBlock` shape (`lib/calendar/google-busy.ts`, midnight-splitting) and merges them into organizer + teacher constraints. **The availability engine itself is unchanged** — Google is just one more `BusyBlock` producer, exactly as its header comment promised.

**Hold events on reserve (spec §2.1)**
- After reserving, the page calls `POST /api/calendar/google/meeting-events` which creates an event on the organizer's **own** calendar per meeting — initials-only title ("IEP — J.D. (hold)"), **no attendees** (team/family invitations belong to SPE-209/210) — and stores `iep_meetings.google_event_id`. If the DB link fails after the event exists, the orphan event is deleted so retries can't double-book.
- Cancelling a meeting best-effort deletes its hold (404/410 count as success). Reserving/cancelling in Speddy never blocks on Google.
- The success banner reports "Holds added to your Google Calendar" when they were.

**Supporting changes**
- `reserveMeetings` returns the inserted meeting ids; caseload rows carry `teacherEmail` (for the free/busy items list).
- Tokens never reach the browser; the new API client follows the SPE-205 posture (10s timeouts, `GoogleOAuthError` shapes, no token material in errors — test-guarded).

## Verification

- 21 new unit tests (interval→BusyBlock conversion incl. midnight/multi-day splits, TZ-agnostic by construction; chunking; freebusy chunk-merging + errored-calendar skip; event insert/delete semantics incl. 404/410-as-success; token-leak guard) — full suite 180 passed / 12 pre-existing skips
- `npm run typecheck:fast` clean; `next lint` clean on all touched files
- No schema changes (uses `google_event_id` from SPE-203)
- End-to-end validation needs a live connection — currently only the Gmail test user can connect (district accounts are policy-blocked pending the allowlist request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JNyyXpouXU9j5e8AQtQR1

---
_Generated by [Claude Code](https://claude.ai/code/session_016JNyyXpouXU9j5e8AQtQR1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meeting planning now uses Google Calendar free/busy to find availability, with user-facing messaging when Google lookup fails.
  * Reserved meetings sync as Google Calendar “hold” events; holds are created best-effort and are removed when meetings are canceled.
  * Improved handling for multi-day intervals, timezone-agnostic conversions, and chunked/batched Google Calendar API operations.
* **Documentation**
  * Updated Google Workspace allowlist materials to describe the phased rollout and scoped permissions.
* **Tests**
  * Added unit tests covering free/busy conversion, time chunking, free/busy querying, event hold create/cancel behavior, and key edge cases/error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->