### PR TITLE
docs(claude): standing rule — high-effort self-review before substantive PRs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,3 +58,14 @@ protection, never bypass hooks or commit signing, stay on the designated
 branch, and keep capturing deferred items in Linear. Report a brief summary
 when a batch merges or when escalating — keep me informed without making me a
 bottleneck.
+
+## Standing rule: deep self-review before any substantive PR
+
+Before marking any substantive PR ready for review (features, bug fixes,
+refactors — anything beyond trivial or docs-only diffs), run the `/code-review`
+skill at **high** effort on the branch diff, then fix its confirmed findings
+or state why one is deferred. Run it proactively — never treat external review
+bots (CodeRabbit/Codex) as the review layer: they rate-limit and can post
+"review finished" no-ops (seen on PR #704, where the deep self-review caught
+staleness races the gates missed). Bot findings remain a complementary layer —
+still read and address them when they arrive.


### PR DESCRIPTION
## What

Adds a standing rule to `.claude/CLAUDE.md`: before marking any substantive PR ready for review (features, bug fixes, refactors — anything beyond trivial or docs-only diffs), run the `/code-review` skill at **high** effort on the branch diff and fix or explicitly defer its confirmed findings.

## Why

Agreed during the PR #704 review cycle:

- The 8-angle deep self-review caught confirmed bugs the standard gates (typecheck/tests/lint) and both review bots missed — including a planner staleness race that could produce duplicate reservations.
- CodeRabbit's rate-limited "review finished" no-ops on #704 showed that external bots can silently fail to review, so they can't be the *only* review layer.

The rule makes the deep pass the default for substantive work instead of an escalation, with bot findings kept as a complementary layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JNyyXpouXU9j5e8AQtQR1

---
_Generated by [Claude Code](https://claude.ai/code/session_016JNyyXpouXU9j5e8AQtQR1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a documented review process requiring high-effort code review for substantive changes before they are marked ready.
  * Clarified that external review tools complement, but do not replace, this review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->