### PR TITLE
fix(privacy): stop logging student PII in server logs and browser console (SPE-220)

### DIFF
--- a/app/(dashboard)/dashboard/students/page.tsx
+++ b/app/(dashboard)/dashboard/students/page.tsx
@@ -108,13 +108,8 @@ export default function StudentsPage() {
   }, [currentSchool]);
 
   const fetchStudents = useCallback(async () => {
-    console.log('fetchStudents called');
-    console.log('currentSchool:', currentSchool);
-    console.log('userRole:', userRole);
-
     try {
       if (!currentSchool) {
-        console.log('No currentSchool, returning early');
         setStudents([]);
         setLoading(false);
         return;
@@ -136,43 +131,33 @@ export default function StudentsPage() {
         currentRole = role; // Use the fresh role immediately
       }
 
-      console.log('Fetching students for school:', currentSchool.display_name || currentSchool.school_site);
-      console.log('Using role:', currentRole);
-
       // Use role-aware query for SEAs, standard query for others
       if (currentRole === 'sea') {
-        console.log('Loading students for SEA user:', user.id);
         const { data, error } = await loadStudentsForUser(user.id, currentRole, {
           currentSchool
         });
 
-        console.log('loadStudentsForUser response:', { data, error, hasData: !!data, hasError: !!error });
-
         if (error) {
           console.error('Error fetching SEA students:', {
-            error,
             errorMessage: error?.message,
             errorCode: error?.code,
             errorDetails: error?.details,
-            errorHint: error?.hint,
-            fullError: JSON.stringify(error, null, 2)
+            errorHint: error?.hint
           });
           setStudents([]);
         } else if (!Array.isArray(data)) {
-          console.error('Data fetched is not an array!', data);
+          console.error('SEA students data is not an array');
           setStudents([]);
         } else {
-          console.log('SEA students data received:', data);
           setStudents(data as Student[]);
         }
       } else {
         const data = await getStudents(currentSchool);
 
         if (!Array.isArray(data)) {
-          console.error('Data fetched is not an array!', data);
+          console.error('Students data is not an array');
           setStudents([]);
         } else {
-          console.log('Students data received:', data);
           setStudents(data);
         }
       }
@@ -186,9 +171,6 @@ export default function StudentsPage() {
 
   // Fetch students
   useEffect(() => {
-    console.log('Students page useEffect triggered');
-    console.log('currentSchool in useEffect:', currentSchool);
-    
     fetchStudents();
     checkUnscheduledSessions();
   }, [currentSchool, fetchStudents, checkUnscheduledSessions]);

--- a/app/api/import-iep-goals/route.ts
+++ b/app/api/import-iep-goals/route.ts
@@ -194,10 +194,12 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
         lastName: targetDetails?.last_name || undefined
       };
 
+      // Log only non-PII identifiers — never the student's first/last name.
       log.info('Target student details fetched', {
         userId,
         targetStudentId,
-        targetStudent
+        initials: targetStudent.initials,
+        gradeLevel: targetStudent.gradeLevel
       });
     }
 

--- a/app/components/students/csv-import.tsx
+++ b/app/components/students/csv-import.tsx
@@ -51,11 +51,6 @@ GH,4,Garcia,3,30`;
       );
     });
 
-    if (missing.length > 0) {
-      console.log('Missing columns:', missing);
-      console.log('Found headers:', headers);
-    }
-
     return missing.length === 0;
   };
 


### PR DESCRIPTION
## Summary

The app's privacy posture is **initials-only display + PII-scrubbed goals**, but the logs undercut it: the IEP import route wrote the target student's first/last name into server logs, and the Students page shipped ~20 `console.log` calls to production including **full student-row dumps** in the browser console. This removes the names and row dumps while keeping counts, IDs, initials, and grade for debuggability.

Phase 0 hygiene (SPE-220), **no behavior change**. `security` / `quick-win`.

## Changes

- **`app/api/import-iep-goals/route.ts`** — the `"Target student details fetched"` log passed the whole `targetStudent` object (first/last name included). Now logs only `userId`, `targetStudentId`, `initials`, and `gradeLevel`.
- **`app/(dashboard)/dashboard/students/page.tsx`** — removed the ~12 `console.log` calls in `fetchStudents`/`useEffect`, including the `"SEA students data received:"` / `"Students data received:"` **full student-row dumps**. Real `console.error` failures are kept, but the raw `data` payloads are dropped from the two "not an array" logs, and the raw error object + stringified dump from the SEA-error log.
- **`app/components/students/csv-import.tsx`** — dropped the two stray `console.log` calls (column names) in `validateColumns`.

## Verification

- `tsc --noEmit`: clean. `next lint` on touched files: clean. `npm test`: 29 suites, 247 passed.
- **Repo-wide sweep** for `first_name`/`last_name`/`firstName`/`lastName` inside any `log.*`/`console.*` payload across `app` + `lib` returns **no student-name log sites** (the only hit is a *teacher*-name example inside a JSDoc comment). The import routes' other logs already use counts + IDs + initials.
- Monitoring/analytics events untouched (they already carry counts + IDs only). Remaining `file.name` logs are the upload **filename**, not student data.

## Acceptance

- ✅ No student first/last names in server-log payloads from the import routes.
- ✅ No student-row dumps in the browser console on the Students page.
- ✅ Monitoring/analytics events unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQXfDBMXjR7nD5HEw9ZKsD)_