### PR TITLE
fix(import-preview): Select All ignores disabled "no changes" rows (SPE-221)

### DIFF
--- a/__tests__/unit/components/StudentImportPreviewModal.test.tsx
+++ b/__tests__/unit/components/StudentImportPreviewModal.test.tsx
@@ -73,4 +73,33 @@ describe('StudentImportPreviewModal — Select All excludes disabled skip rows (
     expect(checkboxes[1]).toBeChecked();
     expect(checkboxes[2]).not.toBeChecked(); // skip stays out of the selection
   });
+
+  // Legacy shape: a row with no `action`, only `matchStatus: 'duplicate'`. The
+  // effective-action fallback maps it to "skip", so the checkbox must be
+  // disabled AND the row must be excluded from Select All — the two now share
+  // one eligibility rule (getEffectiveAction) so they can't drift apart.
+  it('treats a legacy no-action "duplicate" row as a disabled skip, excluded from Select All', async () => {
+    const user = userEvent.setup();
+    const legacyData: ModalData = {
+      students: [
+        { firstName: 'Dave', lastName: 'Delta', initials: 'DD', gradeLevel: '2', action: 'insert' },
+        { firstName: 'Erin', lastName: 'Echo', initials: 'EE', gradeLevel: '3', matchStatus: 'duplicate' },
+      ],
+      summary: { total: 2, new: 1, duplicates: 1 },
+    };
+    render(<StudentImportPreviewModal isOpen data={legacyData} onClose={() => {}} />);
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes[0]).toBeChecked(); // insert — selectable
+    expect(checkboxes[1]).toBeDisabled(); // duplicate — checkbox disabled, not just unchecked
+    expect(checkboxes[1]).not.toBeChecked();
+    expect(screen.getByRole('button', { name: /Confirm 1 Student\b/i })).toBeInTheDocument();
+
+    // Select All must not pull the disabled duplicate into the selection.
+    await user.click(screen.getByRole('button', { name: 'Deselect All' }));
+    await user.click(screen.getByRole('button', { name: 'Select All' }));
+    expect(screen.getByRole('button', { name: /Confirm 1 Student\b/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('checkbox')[1]).not.toBeChecked();
+  });
 });

--- a/__tests__/unit/components/StudentImportPreviewModal.test.tsx
+++ b/__tests__/unit/components/StudentImportPreviewModal.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen, userEvent } from '../../../test-utils';
+import { StudentImportPreviewModal } from '@/app/components/students/student-import-preview-modal';
+
+// SPE-221: "No changes" (action: 'skip') rows render with disabled checkboxes,
+// so "Select All" must never pull them into the selection. The confirm count
+// and the Select/Deselect-All label must reflect the *selectable* rows only
+// (insert + update), not the total row count.
+
+type ModalData = React.ComponentProps<typeof StudentImportPreviewModal>['data'];
+
+// Preview with one of each action: 2 selectable (insert + update) + 1 skip.
+const makeData = (): ModalData => ({
+  students: [
+    { firstName: 'Aaron', lastName: 'Alpha', initials: 'AA', gradeLevel: '3', action: 'insert' },
+    { firstName: 'Bella', lastName: 'Bravo', initials: 'BB', gradeLevel: '4', action: 'update' },
+    { firstName: 'Cora', lastName: 'Charlie', initials: 'CC', gradeLevel: '5', action: 'skip' },
+  ],
+  summary: { total: 3, new: 1, duplicates: 2, inserts: 1, updates: 1, skips: 1 },
+});
+
+const renderModal = () =>
+  render(<StudentImportPreviewModal isOpen data={makeData()} onClose={() => {}} />);
+
+describe('StudentImportPreviewModal — Select All excludes disabled skip rows (SPE-221)', () => {
+  it('defaults to selecting only the insert/update rows; the skip checkbox is disabled and unchecked', () => {
+    renderModal();
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(3); // goals sections are collapsed by default
+
+    expect(checkboxes[0]).toBeChecked(); // insert
+    expect(checkboxes[1]).toBeChecked(); // update
+    expect(checkboxes[2]).toBeDisabled(); // skip — user cannot toggle it
+    expect(checkboxes[2]).not.toBeChecked(); // skip — never in the selection
+
+    // Confirm count reflects the 2 selectable rows, not all 3.
+    expect(screen.getByRole('button', { name: /Confirm 2 Students/i })).toBeInTheDocument();
+    // Every selectable row is selected, so the toggle offers "Deselect All".
+    expect(screen.getByRole('button', { name: 'Deselect All' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Select All' })).not.toBeInTheDocument();
+  });
+
+  it('Deselect All clears the selection to zero and disables Confirm; the label flips to Select All', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole('button', { name: 'Deselect All' }));
+
+    expect(screen.getByRole('button', { name: /Confirm 0 Students/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Select All' })).toBeInTheDocument();
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes[0]).not.toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+    expect(checkboxes[2]).not.toBeChecked();
+  });
+
+  it('Select All re-selects only the 2 selectable rows, never the disabled skip row', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    // Empty the selection, then Select All.
+    await user.click(screen.getByRole('button', { name: 'Deselect All' }));
+    await user.click(screen.getByRole('button', { name: 'Select All' }));
+
+    // Back to exactly the 2 selectable rows — the confirm count does not inflate to 3.
+    expect(screen.getByRole('button', { name: /Confirm 2 Students/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Deselect All' })).toBeInTheDocument();
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).toBeChecked();
+    expect(checkboxes[2]).not.toBeChecked(); // skip stays out of the selection
+  });
+});

--- a/app/components/students/student-import-preview-modal.tsx
+++ b/app/components/students/student-import-preview-modal.tsx
@@ -171,13 +171,25 @@ export function StudentImportPreviewModal({
     });
   };
 
+  // A row is selectable unless it's a "no changes" skip. Mirror the action
+  // fallback used for the initial selection above until Phase 3 makes `action`
+  // always present on preview rows.
+  const selectableIndices = data.students.reduce<number[]>((acc, student, idx) => {
+    const action = student.action || (student.matchStatus === 'new' ? 'insert' : 'skip');
+    if (action !== 'skip') acc.push(idx);
+    return acc;
+  }, []);
+  const allSelectableSelected =
+    selectableIndices.length > 0 && selectedStudents.size === selectableIndices.length;
+
   const toggleSelectAll = () => {
-    if (selectedStudents.size === data.students.length) {
+    if (allSelectableSelected) {
       // Deselect all
       setSelectedStudents(new Set());
     } else {
-      // Select all
-      setSelectedStudents(new Set(data.students.map((_, idx) => idx)));
+      // Select only selectable (insert/update) rows — never the disabled "no
+      // changes" skips, which the user otherwise can't individually clear.
+      setSelectedStudents(new Set(selectableIndices));
     }
   };
 
@@ -477,7 +489,7 @@ export function StudentImportPreviewModal({
                   size="sm"
                   onClick={toggleSelectAll}
                 >
-                  {selectedStudents.size === data.students.length ? 'Deselect All' : 'Select All'}
+                  {allSelectableSelected ? 'Deselect All' : 'Select All'}
                 </Button>
               </div>
 

--- a/app/components/students/student-import-preview-modal.tsx
+++ b/app/components/students/student-import-preview-modal.tsx
@@ -103,6 +103,17 @@ interface StudentImportPreviewModalProps {
   currentSchool?: any; // Current school context for assignment
 }
 
+// Effective UPSERT action for a preview row. Falls back to the legacy
+// matchStatus when `action` is absent (the fallback goes away in Phase 3 once
+// `action` is always present). A row is selectable iff its effective action is
+// not 'skip' — the single source of truth for both Select All and the per-row
+// checkbox's disabled state, so the two can't drift out of sync.
+function getEffectiveAction(
+  student: StudentPreview
+): 'insert' | 'update' | 'skip' {
+  return student.action || (student.matchStatus === 'new' ? 'insert' : 'skip');
+}
+
 export function StudentImportPreviewModal({
   isOpen,
   onClose,
@@ -119,7 +130,7 @@ export function StudentImportPreviewModal({
     const selected = new Set<number>();
     data.students.forEach((student, idx) => {
       // Use action field if available, otherwise fall back to matchStatus
-      const action = student.action || (student.matchStatus === 'new' ? 'insert' : 'skip');
+      const action = getEffectiveAction(student);
       if (action === 'insert' || action === 'update') {
         selected.add(idx);
       }
@@ -175,7 +186,7 @@ export function StudentImportPreviewModal({
   // fallback used for the initial selection above until Phase 3 makes `action`
   // always present on preview rows.
   const selectableIndices = data.students.reduce<number[]>((acc, student, idx) => {
-    const action = student.action || (student.matchStatus === 'new' ? 'insert' : 'skip');
+    const action = getEffectiveAction(student);
     if (action !== 'skip') acc.push(idx);
     return acc;
   }, []);
@@ -244,7 +255,7 @@ export function StudentImportPreviewModal({
         // Determine action based on student.action or matchStatus
         // - 'new' students default to insert
         // - matched/duplicate students default to skip (not insert, to avoid duplicates)
-        const action = student.action || (student.matchStatus === 'new' ? 'insert' : 'skip');
+        const action = getEffectiveAction(student);
 
         return {
           firstName: student.firstName,
@@ -498,12 +509,15 @@ export function StudentImportPreviewModal({
                   const isSelected = selectedStudents.has(idx);
                   const isExpanded = expandedStudent === idx;
                   const currentInitials = getInitials(idx);
+                  // A "no changes" skip row: not selectable, so its checkbox is
+                  // disabled — same eligibility rule as selectableIndices.
+                  const isSkipRow = getEffectiveAction(student) === 'skip';
 
                   return (
                     <div
                       key={idx}
                       className={`border rounded-md overflow-hidden ${
-                        student.action === 'skip'
+                        isSkipRow
                           ? 'border-gray-200 bg-gray-50 opacity-60'
                           : isSelected
                           ? 'border-blue-300 bg-blue-50'
@@ -517,9 +531,9 @@ export function StudentImportPreviewModal({
                             type="checkbox"
                             checked={isSelected}
                             onChange={() => toggleStudentSelection(idx)}
-                            disabled={student.action === 'skip'}
+                            disabled={isSkipRow}
                             className={`mt-1 h-4 w-4 rounded border-gray-300 ${
-                              student.action === 'skip' ? 'opacity-50 cursor-not-allowed' : 'text-blue-600'
+                              isSkipRow ? 'opacity-50 cursor-not-allowed' : 'text-blue-600'
                             }`}
                           />
 


### PR DESCRIPTION
## Summary

"No changes" (`action: 'skip'`) rows render with **disabled** checkboxes, but **Select All** added *every* row to the selection — including the skips the user then couldn't individually deselect — inflating the `Confirm N Students` count at exactly the moment the user is deciding whether to trust the import. Harmless server-side (the confirm route treats skips as no-ops) but confusing.

Phase 0 UX bug fix (SPE-221), part of the [Student Upload Consolidation](https://linear.app/speddy/project/student-upload-consolidation-d3ee5ca039cb) runbook. `quick-win` / `Bug`.

## Changes

`app/components/students/student-import-preview-modal.tsx`:
- **`getEffectiveAction(student)`** — one helper is the single source of truth for row selectability (`action`, falling back to the legacy `matchStatus` until Phase 3 removes it). Used by the initial selection, `selectableIndices`, the import mapping, **and** the row checkbox's `disabled` state + styling, so "toggleable" and "selectable" can't drift apart.
- **`selectableIndices`** derives the non-skip rows; **`toggleSelectAll`** selects `new Set(selectableIndices)` (never skips) and deselects to empty; **`allSelectableSelected`** drives the Select-All/Deselect-All label (compares against the *selectable* count, not `data.students.length`).
- Footer counts and the `Confirm N Students` label already derive from `selectedStudents`, so with skips kept out they now reflect selectable rows only — no more inflated count. Also corrects the initial label, which previously read "Select All" even when every selectable row was already selected.
- The action badge keeps its own `matchStatus`-aware branch, so a duplicate still reads "Possible Duplicate".

## Tests

New `__tests__/unit/components/StudentImportPreviewModal.test.tsx`:
- insert + update + skip fixture: default selects only insert/update; the skip checkbox stays **disabled + unchecked**; **Select All** never grabs the skip; **Deselect All** clears to zero and disables Confirm; the confirm count / label track the **selectable** count.
- legacy `matchStatus: 'duplicate'` (no `action`) fixture: the row's checkbox is **disabled** and excluded from Select All (locks in the `getEffectiveAction` unification).

## Verification

- `tsc --noEmit`, `next lint` (touched files): clean. Full suite: **30 suites, 251 passed** (29→30, +4 new).
- **Regression guard proven**: the core test **fails** against the pre-fix modal (pre-fix Select All selected all rows and the initial label was "Select All") and **passes** with the fix.
- Deep self-review (`/code-review` high effort): selection-logic finder proved the `selectedStudents ⊆ selectableIndices` invariant holds for all reachable data; the second finder flagged the checkbox-vs-`selectableIndices` divergence for a legacy no-`action` row.

## Review follow-up — addressed in-PR (was SPE-244)

That divergence — the checkbox `disabled` used the direct `student.action === 'skip'` while selectability used the fallback — was **also flagged by CodeRabbit**. Rather than defer it (it's unreachable today: every preview row from both API routes sets `action`), I resolved it here by unifying everything on `getEffectiveAction`, with **zero behavior change on the modern path** and a test covering the legacy shape. Tracked as **SPE-244**, which closes with this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the student import preview “Select All” behavior to exclude “No Changes”/non-importable rows (disabled skip equivalents).
  * Improved selection labels and confirmation counts so they reflect only eligible insert/update students.
  * “Deselect All” now reliably clears selections and keeps the Confirm action disabled until eligible rows are selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->