### PR TITLE
fix(import-preview): keep the modal open on partial import failure (SPE-222)

### DIFF
--- a/__tests__/unit/components/StudentImportPreviewModal.test.tsx
+++ b/__tests__/unit/components/StudentImportPreviewModal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, userEvent } from '../../../test-utils';
+import { render, screen, userEvent, waitFor, fireEvent, act, mockFetch } from '../../../test-utils';
 import { StudentImportPreviewModal } from '@/app/components/students/student-import-preview-modal';
 
 // SPE-221: "No changes" (action: 'skip') rows render with disabled checkboxes,
@@ -101,5 +101,166 @@ describe('StudentImportPreviewModal — Select All excludes disabled skip rows (
     await user.click(screen.getByRole('button', { name: 'Select All' }));
     expect(screen.getByRole('button', { name: /Confirm 1 Student\b/i })).toBeInTheDocument();
     expect(screen.getAllByRole('checkbox')[1]).not.toBeChecked();
+  });
+});
+
+// SPE-222: a partial-failure import used to auto-close the modal after 3s,
+// dismissing the failure list the user most needs to read. The modal must now
+// stay open on partial failure (Done button), and refresh the caseload behind
+// it without unmounting. Full success still closes immediately.
+describe('StudentImportPreviewModal — partial-failure keeps the modal open (SPE-222)', () => {
+  const importData = (): ModalData => ({
+    students: [
+      { firstName: 'Aaron', lastName: 'Alpha', initials: 'AA', gradeLevel: '3', action: 'insert' },
+      { firstName: 'Bella', lastName: 'Bravo', initials: 'BB', gradeLevel: '4', action: 'update' },
+    ],
+    summary: { total: 2, new: 1, duplicates: 1, inserts: 1, updates: 1 },
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('on partial failure: refreshes the caseload, keeps the modal open with the error list + a Done button, and does not auto-close', async () => {
+    const user = userEvent.setup();
+    mockFetch({
+      data: {
+        results: [
+          { initials: 'AA', success: true },
+          { initials: 'BB', success: false, error: 'duplicate key' },
+        ],
+        summary: { succeeded: 1, failed: 1 },
+      },
+    });
+    const onClose = jest.fn();
+    const onImportComplete = jest.fn();
+    render(
+      <StudentImportPreviewModal
+        isOpen
+        data={importData()}
+        onClose={onClose}
+        onImportComplete={onImportComplete}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Confirm 2 Students/i }));
+
+    // The failure list is shown and the footer collapses to a single Done button.
+    expect(await screen.findByRole('button', { name: 'Done' })).toBeInTheDocument();
+    expect(screen.getByText(/Some students failed to import: BB: duplicate key/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Confirm/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+    // The failure is announced to assistive tech, and focus moves to Done so a
+    // keyboard user isn't dropped onto <body> when Confirm unmounts.
+    expect(screen.getByRole('alert')).toHaveTextContent('Some students failed to import: BB: duplicate key');
+    expect(screen.getByRole('button', { name: 'Done' })).toHaveFocus();
+
+    // Caseload refreshed behind the modal (onImportComplete), but the modal
+    // stayed open (onClose not called) — i.e. no timer-based auto-close.
+    expect(onImportComplete).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+
+    // The user dismisses the modal explicitly.
+    await user.click(screen.getByRole('button', { name: 'Done' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('on full success: refreshes the caseload and closes the modal immediately', async () => {
+    const user = userEvent.setup();
+    mockFetch({
+      data: {
+        results: [
+          { initials: 'AA', success: true },
+          { initials: 'BB', success: true },
+        ],
+        summary: { succeeded: 2, failed: 0 },
+      },
+    });
+    const onClose = jest.fn();
+    const onImportComplete = jest.fn();
+    render(
+      <StudentImportPreviewModal
+        isOpen
+        data={importData()}
+        onClose={onClose}
+        onImportComplete={onImportComplete}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Confirm 2 Students/i }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(onImportComplete).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/Some students failed/)).not.toBeInTheDocument();
+  });
+
+  it('on total failure (nothing succeeded): no refresh, no Done — keeps Cancel + Confirm for retry', async () => {
+    const user = userEvent.setup();
+    mockFetch({
+      data: {
+        results: [
+          { initials: 'AA', success: false, error: 'server error' },
+          { initials: 'BB', success: false, error: 'server error' },
+        ],
+        summary: { succeeded: 0, failed: 2 },
+      },
+    });
+    const onClose = jest.fn();
+    const onImportComplete = jest.fn();
+    render(
+      <StudentImportPreviewModal
+        isOpen
+        data={importData()}
+        onClose={onClose}
+        onImportComplete={onImportComplete}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Confirm 2 Students/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Some students failed to import/);
+    // Nothing imported → no caseload refresh, and the modal keeps the retry
+    // affordance (Cancel + Confirm) rather than collapsing to Done.
+    expect(onImportComplete).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Confirm 2 Students/i })).toBeInTheDocument();
+  });
+
+  it('schedules no deferred (3s) auto-close timer on partial failure', async () => {
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    mockFetch({
+      data: {
+        results: [
+          { initials: 'AA', success: true },
+          { initials: 'BB', success: false, error: 'x' },
+        ],
+        summary: { succeeded: 1, failed: 1 },
+      },
+    });
+    const onClose = jest.fn();
+    render(
+      <StudentImportPreviewModal
+        isOpen
+        data={importData()}
+        onClose={onClose}
+        onImportComplete={jest.fn()}
+      />
+    );
+
+    // fireEvent + act (no RTL async helpers) so the setTimeout spy doesn't trip
+    // RTL's fake-timer detection; flush the mocked fetch's microtask chain.
+    fireEvent.click(screen.getByRole('button', { name: /Confirm 2 Students/i }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Reached the finished state, and the removed 3-second auto-close is not back.
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), 3000);
   });
 });

--- a/app/(dashboard)/dashboard/students/page.tsx
+++ b/app/(dashboard)/dashboard/students/page.tsx
@@ -365,8 +365,10 @@ export default function StudentsPage() {
             data={bulkImportPreviewData}
             currentSchool={currentSchool}
             onImportComplete={() => {
+              // Refresh the caseload behind the modal without unmounting it, so
+              // a partial-failure modal stays open on its error list. The modal
+              // unmounts only on explicit close (onClose).
               fetchStudents();
-              setBulkImportPreviewData(null);
             }}
           />
         )}

--- a/app/components/students/student-import-preview-modal.tsx
+++ b/app/components/students/student-import-preview-modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { Button } from '../ui/button';
 
@@ -159,6 +159,19 @@ export function StudentImportPreviewModal({
 
   const [importing, setImporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // After an import that partially failed, the modal stays open on its failure
+  // list and the footer collapses to a single "Done" button (no auto-close).
+  const [importFinished, setImportFinished] = useState(false);
+  const doneButtonRef = useRef<HTMLButtonElement>(null);
+
+  // When the modal switches to the post-import "finished" state, move focus to
+  // the Done button — the Confirm button the user activated has unmounted, so
+  // without this keyboard focus falls to <body>.
+  useEffect(() => {
+    if (importFinished) {
+      doneButtonRef.current?.focus();
+    }
+  }, [importFinished]);
 
   const getInitials = (index: number) => {
     return editedInitials[index] || data.students[index].initials;
@@ -299,14 +312,14 @@ export function StudentImportPreviewModal({
         const errorMessages = failed.map((r: any) => `${r.initials}: ${r.error}`).join(', ');
         setError(`Some students failed to import: ${errorMessages}`);
 
-        // Still close if some succeeded
+        // Some succeeded: refresh the caseload behind the modal, but keep the
+        // modal open so the user can read the failure list. They dismiss it
+        // with the Done button — no timer-based auto-close.
         if (result.data.summary.succeeded > 0) {
-          setTimeout(() => {
-            if (onImportComplete) {
-              onImportComplete();
-            }
-            onClose();
-          }, 3000);
+          if (onImportComplete) {
+            onImportComplete();
+          }
+          setImportFinished(true);
         }
       } else {
         // All succeeded
@@ -448,7 +461,7 @@ export function StudentImportPreviewModal({
 
             {/* Errors/Warnings */}
             {error && (
-              <div className="bg-red-50 border border-red-200 rounded-md p-4">
+              <div role="alert" className="bg-red-50 border border-red-200 rounded-md p-4">
                 <p className="text-sm text-red-800">{error}</p>
               </div>
             )}
@@ -760,6 +773,9 @@ export function StudentImportPreviewModal({
           <div className="flex justify-between items-center gap-3 px-6 py-4 border-t bg-gray-50">
             <div className="text-sm text-gray-600">
               {(() => {
+                // Once the import has run (partial failure), the pending-selection
+                // summary is no longer meaningful — the error list explains what happened.
+                if (importFinished) return null;
                 // Calculate counts for selected students by action
                 const selectedInserts = Array.from(selectedStudents).filter(idx => {
                   const s = data.students[idx];
@@ -779,16 +795,24 @@ export function StudentImportPreviewModal({
               })()}
             </div>
             <div className="flex gap-3">
-              <Button variant="secondary" onClick={onClose} disabled={importing}>
-                Cancel
-              </Button>
-              <Button
-                variant="primary"
-                onClick={handleImport}
-                disabled={importing || selectedCount === 0}
-              >
-                {importing ? 'Processing...' : `Confirm ${selectedCount} Student${selectedCount !== 1 ? 's' : ''}`}
-              </Button>
+              {importFinished ? (
+                <Button ref={doneButtonRef} variant="primary" onClick={onClose}>
+                  Done
+                </Button>
+              ) : (
+                <>
+                  <Button variant="secondary" onClick={onClose} disabled={importing}>
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="primary"
+                    onClick={handleImport}
+                    disabled={importing || selectedCount === 0}
+                  >
+                    {importing ? 'Processing...' : `Confirm ${selectedCount} Student${selectedCount !== 1 ? 's' : ''}`}
+                  </Button>
+                </>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

When some students import and others fail, the preview modal rendered the per-student error list and then a `setTimeout(3000)` closed the modal — dismissing the one screen that most needs the user's attention while they're still reading it.

Phase 0 UX bug fix (SPE-222), part of the [Student Upload Consolidation](https://linear.app/speddy/project/student-upload-consolidation-d3ee5ca039cb) runbook. `quick-win` / `Bug`.

## Changes

**`app/components/students/student-import-preview-modal.tsx`**
- Removed the 3-second auto-close timer. On **partial failure** (some succeeded, some failed): call `onImportComplete()` to refresh the caseload behind the modal, set a new `importFinished` state, and keep the modal open. The footer collapses to a single **Done** button and hides the now-stale pending-selection summary.
- **Full success** still closes immediately (unchanged). **Total failure** (nothing succeeded) keeps the Cancel + Confirm retry affordance (unchanged).
- **Accessibility**: the failure banner is now `role="alert"` (announced to screen readers), and focus moves to the Done button when the modal enters the finished state — otherwise the activated Confirm button unmounts and focus falls to `<body>`.

**`app/(dashboard)/dashboard/students/page.tsx`**
- Split the wiring: `onImportComplete` now only calls `fetchStudents()` (refresh) and no longer clears `bulkImportPreviewData`, so the refresh doesn't unmount the modal. The modal unmounts only on explicit `onClose`. Safe because `fetchStudents` never sets `loading = true`, so the page's `if (loading) return <spinner>` guard can't unmount the modal subtree during the refresh.

## Tests

`__tests__/unit/components/StudentImportPreviewModal.test.tsx` (4 new cases):
- **Partial failure**: modal stays open with the failure list + Done; caseload refreshed (`onImportComplete`) but not closed (`onClose` not called until Done); the alert is announced and Done receives focus.
- **Full success**: refreshes and closes immediately.
- **Total failure**: no refresh, no Done — keeps Cancel + Confirm for retry.
- **Regression guard**: asserts no `setTimeout(_, 3000)` auto-close is scheduled.

## Verification

- `tsc --noEmit`, `next lint` (touched files): clean. Full suite: **30 suites, 255 passed**.
- Deep self-review (`/code-review` high effort, 2 finders): the state-machine/wiring finder confirmed full-success still closes, `importFinished` resets on reopen, and the refresh can't unmount the modal (`fetchStudents` never raises `loading`); the edge-case/test finder's three findings — a timer regression-guard gap, a missing all-failed test, and the a11y gap (announce + focus) — are all addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQXfDBMXjR7nD5HEw9ZKsD)_