### PR TITLE
fix(students): correct Edit/File-Upload tooltip copy + friendly CSV duplicate error (SPE-223)

### DIFF
--- a/app/(dashboard)/dashboard/students/page.tsx
+++ b/app/(dashboard)/dashboard/students/page.tsx
@@ -306,7 +306,7 @@ export default function StudentsPage() {
                   Import CSV
                 </Button>
               </LongHoverTooltip>
-              <LongHoverTooltip content="Upload student data files using the guided import wizard. Supports various file formats.">
+              <LongHoverTooltip content="Upload student data from multiple source files (SEIS goals, deliveries, and an Aeries class list).">
                 <Button
                   variant="secondary"
                   onClick={() => setShowFileUploadModal(true)}
@@ -689,7 +689,7 @@ export default function StudentsPage() {
                             </>
                           ) : (
                             <>
-                              <LongHoverTooltip content="Edit this student's information including name, grade, teacher assignment, and service details.">
+                              <LongHoverTooltip content="Edit this student's service minutes — sessions per week and minutes per session.">
                                 <Button
                                   variant="secondary"
                                   size="sm"

--- a/app/components/students/csv-import.tsx
+++ b/app/components/students/csv-import.tsx
@@ -158,7 +158,20 @@ GH,4,Garcia,3,30`;
             }
           } catch (err: any) {
             console.error('Import error:', err);
-            setError(err.message);
+            // Map Postgres unique-violation errors to a friendly message rather
+            // than surfacing the raw "duplicate key value violates unique
+            // constraint …" text (mirrors app/api/import-students/confirm/route.ts).
+            const rawText = `${err?.message || ''} ${err?.details || ''}`;
+            const isDuplicate =
+              err?.code === '23505' ||
+              rawText.includes('duplicate key') ||
+              rawText.includes('unique constraint') ||
+              rawText.includes('ux_students_provider_grade_initials');
+            setError(
+              isDuplicate
+                ? 'This file contains a student whose initials and grade match another student — either a duplicate row in the file or one already in your caseload. Remove the duplicate and upload again.'
+                : (err?.message || 'Failed to import students. Please try again.')
+            );
           } finally {
             setImporting(false);
           }


### PR DESCRIPTION
## Summary

Three Phase-0 copy/UX corrections on the Students page: two tooltips that describe things the UI doesn't do, and a CSV path that surfaces raw Postgres error text. `quick-win` / `chore`, part of the [Student Upload Consolidation](https://linear.app/speddy/project/student-upload-consolidation-d3ee5ca039cb) runbook.

## Changes

- **Edit tooltip** (`students/page.tsx`) — claimed inline edit covers *"name, grade, teacher assignment, and service details"*, but `handleUpdate` only writes `sessions_per_week` + `minutes_per_session`. Reworded to *"Edit this student's service minutes — sessions per week and minutes per session."*
- **"File Upload" tooltip** (`students/page.tsx`) — described a *"guided import wizard"* supporting *"various file formats"*. The modal it opens (`SeisUploadWizardModal`) is a **single-screen** modal titled **"File Upload"** that accepts three specific sources. Aligned the tooltip to the modal: *"Upload student data from multiple source files (SEIS goals, deliveries, and an Aeries class list)."* (The modal's own title/subtitle were already accurate, so left as-is.)
- **Friendly CSV duplicate error** (`csv-import.tsx`) — the batch insert surfaced raw `duplicate key value violates unique constraint …` text. Now maps unique-violation errors (Postgres code `23505` / duplicate-key / constraint-name markers) to a friendly message, mirroring the pattern in `app/api/import-students/confirm/route.ts:413–429`. The copy covers **both** an existing-caseload match and a duplicate row within the same file; non-duplicate errors still show their original message.

## Scope note

The ticket's scope note says the `csv-import.tsx` mapping should be done **only if Phase 1 hasn't started** (Phase 1 deletes that component). Phase 1 has not started, so it's included; the two tooltip fixes are worthwhile regardless.

## Verification

- `tsc --noEmit`, `next lint` (touched files): clean. Full suite: **30 suites, 255 passed** (no regressions).
- Deep self-review (`/code-review` high effort): verified the copy against actual behavior (inline-edit form edits only sessions/minutes; the modal is single-screen "File Upload"), and that the duplicate detection mirrors the confirm route — the thrown `PostgrestError`'s `code`/`message`/`details` survive throw+catch, `23505` is the correct `unique_violation` code, and non-duplicate error paths (`'No valid students found in CSV'`, parse errors) fall through to their original message. The review's one finding — that the original copy wrongly implied "already in your caseload" for an intra-file duplicate — is fixed.

## Acceptance

- ✅ Tooltips describe actual behavior.
- ✅ Re-uploading a CSV containing an existing (or duplicated) student shows the friendly duplicate message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQXfDBMXjR7nD5HEw9ZKsD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Clarified tooltips for file uploads and editing student service minutes.
  - Improved student import errors by identifying likely duplicate records or existing caseload conflicts.
  - Preserved a general error message for other import failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->