### PR TITLE
Add communication-style guidance to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,6 +22,31 @@
   `scripts/sim-district/manifest.ts` (seeded / swept / declared-unseeded) is
   part of that feature's work. Only ever touch sim data through these scripts.
 
+## How to communicate with me
+
+I'm a non-technical founder acting as product manager and CEO. Claude Code is
+the engineer. Match every update to that — the goal is that I stay genuinely
+informed without spending brainpower decoding jargon or skimming past things
+that matter.
+
+- **Lead with the takeaway, not the process.** Start with what changed and what
+  it means for the product, the user, or the business. Engineering detail stays
+  out unless I ask for it.
+- **Plain language by default.** No jargon. If a technical point genuinely
+  affects a decision I need to make, translate it into one plain sentence
+  ("this makes pages load faster," not "this memoizes the render tree").
+- **Keep routine updates to a short paragraph** — 3–5 lines. What I did, why it
+  mattered, what's next. I should absorb it in a few seconds without skimming.
+- **Make decisions impossible to miss.** When you need my input, put it under a
+  clear **"⚠️ Your call:"** heading, kept separate from the status update. Lay
+  out the options in plain terms, name the tradeoff, and tell me which one you'd
+  pick and why. I approve or redirect. (The "Stop and discuss with me first"
+  list below defines *when* a decision is mine — this defines *how* you bring it
+  to me.)
+- **Offer depth, don't force it.** When there's more technical detail available,
+  end with a short offer ("want the technical details?") and let me pull it if I
+  want it.
+
 ## Autonomous execution for high-confidence, non-UX work
 
 For work that is purely technical and internal, proceed end-to-end without


### PR DESCRIPTION
## What this does

Adds a **"How to communicate with me"** section to `.claude/CLAUDE.md` that captures the intended working relationship: Claude Code acts as the engineer, the founder acts as a non-technical product manager / CEO.

## Why

Updates had been too verbose and jargon-heavy, causing important information and decision points to get skimmed past. This section fixes *how* updates are delivered, without touching the existing rules that define *when* a decision belongs to the founder.

## The guidance added

- Lead with the takeaway (product/user/business impact), not the engineering process.
- Plain language by default; translate technical points into one plain sentence only when they affect a decision.
- Routine updates kept to a short paragraph (3–5 lines).
- Decisions flagged clearly under a **"⚠️ Your call:"** heading, separate from status, with options and a recommendation.
- Depth offered on request rather than forced.

The change is documentation-only and complements the existing "Autonomous execution" and "Stop and discuss with me first" sections rather than modifying them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cx2hQ41cHbHHP47w1jKJif)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added communication guidelines emphasizing clear takeaways, plain language, concise updates, and clearly identified decisions.
  * Added guidance for offering optional technical details without overwhelming readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->