### PR TITLE
fix(parsers): harden SEIS XLSX path — header-relative data start + goal-column selection (SPE-240, PR 2)

### DIFF
--- a/__tests__/unit/lib/parsers/__snapshots__/seis-goals-xlsx.test.ts.snap
+++ b/__tests__/unit/lib/parsers/__snapshots__/seis-goals-xlsx.test.ts.snap
@@ -19,7 +19,7 @@ exports[`parseSEISReport — ~5 metadata rows above the header matches the golde
 }
 `;
 
-exports[`parseSEISReport — header on row 1 (row-skip data loss) matches the golden snapshot (including the goal-column trap) 1`] = `
+exports[`parseSEISReport — header on row 1 (row-skip fixed) matches the golden snapshot (all rows, one goal per row) 1`] = `
 {
   "errors": [],
   "metadata": {
@@ -27,13 +27,60 @@ exports[`parseSEISReport — header on row 1 (row-skip data loss) matches the go
     "sheetsProcessed": [
       "Student Goals",
     ],
-    "totalRows": 3,
+    "totalRows": 7,
   },
   "students": [
     {
+      "firstName": "Ana",
+      "goals": [
+        "By 5/1/2027, given a grade-level passage, Ana will read 90 words per minute with 95% accuracy in 3 of 4 trials.",
+      ],
+      "gradeLevel": "1",
+      "iepDate": "2026-05-01",
+      "initials": "AA",
+      "lastName": "Alvarez",
+      "rawRow": 2,
+      "schoolOfAttendance": "Mt Diablo Elementary School",
+    },
+    {
+      "firstName": "Ben",
+      "goals": [
+        "By 10/15/2026, given manipulatives, Ben will solve two-digit addition problems with 80% accuracy across 3 sessions.",
+      ],
+      "gradeLevel": "2",
+      "iepDate": "2025-10-15",
+      "initials": "BB",
+      "lastName": "Bishop",
+      "rawRow": 3,
+      "schoolOfAttendance": "St Mary School",
+    },
+    {
+      "firstName": "Cora",
+      "goals": [
+        "By 1/20/2027, Cora will produce /r/ in structured sentences with 80% accuracy in 4 of 5 trials.",
+      ],
+      "gradeLevel": "3",
+      "iepDate": "2026-01-20",
+      "initials": "CC",
+      "lastName": "Cho",
+      "rawRow": 4,
+      "schoolOfAttendance": "Mt Diablo Elementary School",
+    },
+    {
+      "firstName": "Drew",
+      "goals": [
+        "By 2/10/2027, Drew will use a coping strategy when frustrated in 4 of 5 observed opportunities.",
+      ],
+      "gradeLevel": "4",
+      "iepDate": "2026-02-10",
+      "initials": "DD",
+      "lastName": "Diaz",
+      "rawRow": 5,
+      "schoolOfAttendance": "Out of District- MOU",
+    },
+    {
       "firstName": "Ella",
       "goals": [
-        "OT (1 of 1)",
         "By 3/5/2027, Ella will copy a five-word sentence legibly within 5 minutes in 4 of 5 trials.",
       ],
       "gradeLevel": "5",
@@ -46,7 +93,6 @@ exports[`parseSEISReport — header on row 1 (row-skip data loss) matches the go
     {
       "firstName": "Finn",
       "goals": [
-        "Academic #3",
         "By 4/12/2027, Finn will form lower-case letters with correct size and spacing in 4 of 5 samples.",
       ],
       "gradeLevel": "TK",
@@ -66,6 +112,57 @@ exports[`parseSEISReport — header on row 1 (row-skip data loss) matches the go
       "initials": "GG",
       "lastName": "Gomez",
       "rawRow": 8,
+      "schoolOfAttendance": "Mt Diablo Elementary School",
+    },
+  ],
+}
+`;
+
+exports[`parseSEISReport — title rows then header on row 3 matches the golden snapshot 1`] = `
+{
+  "errors": [],
+  "metadata": {
+    "goalsFiltered": 0,
+    "sheetsProcessed": [
+      "Student Goals",
+    ],
+    "totalRows": 3,
+  },
+  "students": [
+    {
+      "firstName": "Ana",
+      "goals": [
+        "By 5/1/2027, given a grade-level passage, Ana will read 90 words per minute with 95% accuracy in 3 of 4 trials.",
+      ],
+      "gradeLevel": "1",
+      "iepDate": "2026-05-01",
+      "initials": "AA",
+      "lastName": "Alvarez",
+      "rawRow": 4,
+      "schoolOfAttendance": "Mt Diablo Elementary School",
+    },
+    {
+      "firstName": "Ben",
+      "goals": [
+        "By 10/15/2026, given manipulatives, Ben will solve two-digit addition problems with 80% accuracy across 3 sessions.",
+      ],
+      "gradeLevel": "2",
+      "iepDate": "2025-10-15",
+      "initials": "BB",
+      "lastName": "Bishop",
+      "rawRow": 5,
+      "schoolOfAttendance": "St Mary School",
+    },
+    {
+      "firstName": "Cora",
+      "goals": [
+        "By 1/20/2027, Cora will produce /r/ in structured sentences with 80% accuracy in 4 of 5 trials.",
+      ],
+      "gradeLevel": "3",
+      "iepDate": "2026-01-20",
+      "initials": "CC",
+      "lastName": "Cho",
+      "rawRow": 6,
       "schoolOfAttendance": "Mt Diablo Elementary School",
     },
   ],

--- a/__tests__/unit/lib/parsers/fixtures/builders.ts
+++ b/__tests__/unit/lib/parsers/fixtures/builders.ts
@@ -278,10 +278,11 @@ async function workbookToBuffer(workbook: ExcelJS.Workbook): Promise<Buffer> {
 }
 
 /**
- * XLSX variant with the header on row 1. Because parseSEISReport skips
- * rowNumber <= 5, the first four data rows (rows 2–5) are silently dropped —
- * this pins the SPE-240 row-skip data-loss bug. It also pins the goal-column
- * trap: the detector treats every "Goal"/"Objective" header as a goal column.
+ * XLSX variant with the header on row 1 and seven data rows (rows 2–8). Pins
+ * the SPE-240 fixes: all seven rows import (parseSEISReport starts data on the
+ * row after the detected header, not a fixed `rowNumber <= 5`), and each yields
+ * exactly one goal (goal detection prefers the exact "Goal" column instead of
+ * treating every "Goal"/"Objective" header as a goal column).
  */
 export async function buildSeisXlsxHeaderRow1(): Promise<Buffer> {
   const workbook = new ExcelJS.Workbook();
@@ -310,6 +311,25 @@ export async function buildSeisXlsxMetadataRows(): Promise<Buffer> {
   sheet.addRow(SEIS_HEADERS); // header now on row 6, outside the scan window
   for (const row of SEIS_XLSX_ROWS) {
     sheet.addRow(sparseToArray(row));
+  }
+  return workbookToBuffer(workbook);
+}
+
+/**
+ * XLSX variant with two title rows, the header on row 3, then data. Proves the
+ * row-skip fix generalizes beyond a row-1 header: detection finds the header
+ * within the 5-row window and data starts on the row AFTER it (row 4+), rather
+ * than at a fixed offset. The title rows carry no name/grade text, so they
+ * don't perturb header detection.
+ */
+export async function buildSeisXlsxTitleThenHeader(): Promise<Buffer> {
+  const workbook = new ExcelJS.Workbook();
+  const sheet = workbook.addWorksheet('Student Goals');
+  sheet.addRow(['SEIS Student Goals Report']); // row 1 title
+  sheet.addRow(['District: Example Unified']); // row 2 title
+  sheet.addRow(SEIS_HEADERS); // header on row 3
+  for (const row of SEIS_XLSX_ROWS.slice(0, 3)) {
+    sheet.addRow(sparseToArray(row)); // Alvarez, Bishop, Cho on rows 4-6
   }
   return workbookToBuffer(workbook);
 }

--- a/__tests__/unit/lib/parsers/seis-goals-xlsx.test.ts
+++ b/__tests__/unit/lib/parsers/seis-goals-xlsx.test.ts
@@ -2,37 +2,74 @@
  * Golden-fixture tests for the SEIS Student Goals Report XLSX path (SPE-239),
  * i.e. parseSEISReport via ExcelJS.
  *
- * Pins two documented data-loss bugs that SPE-240 will address:
- *  1. Row-skip: parseSEISReport skips rowNumber <= 5, so with the header on
- *     row 1 the first four data rows (rows 2-5) are silently dropped.
- *  2. Header-window: header detection only scans rows 1-5, so ~5 metadata
- *     rows above the header push it out of range and detection fails outright.
- * Also pins the goal-column trap: every "Goal"/"Objective" header is treated
- * as a goal column, so the >10-char "Annual Goal #" code leaks in as a goal.
+ * SPE-240 hardened this path; these now pin the FIXED behavior:
+ *  1. Row-skip: data starts on the row after the detected header (was a fixed
+ *     `rowNumber <= 5` skip), so a header on row 1 no longer drops rows 2-5,
+ *     and the fix generalizes to a header lower in the scan window.
+ *  2. Goal-column trap: goal detection runs on the confirmed header row only
+ *     and prefers the exact "Goal" column, so the >10-char "Annual Goal #"
+ *     code and "Objective N Met" columns no longer leak in as goals — exactly
+ *     one goal per row.
+ *
+ * Still pinned as a known limitation: header detection only scans the first 5
+ * rows, so ~5 metadata rows above the header push it out of range and detection
+ * fails outright — a loud "could not detect" error, not a silent loss.
  */
 
 import { parseSEISReport } from '@/lib/parsers/seis-parser';
 import {
   buildSeisXlsxHeaderRow1,
+  buildSeisXlsxTitleThenHeader,
   buildSeisXlsxMetadataRows,
 } from './fixtures/builders';
 
-describe('parseSEISReport — header on row 1 (row-skip data loss)', () => {
-  it('silently drops the first four data rows (rows 2-5)', async () => {
-    // psychologist has no service code, so nothing is filtered by role — any
-    // missing student is missing solely because of the row-skip bug.
+describe('parseSEISReport — header on row 1 (row-skip fixed)', () => {
+  it('imports every data row (rows 2-8), not just those past row 5', async () => {
+    // psychologist has no service code, so nothing is filtered by role — every
+    // fixture row must appear once the row-skip bug is fixed.
     const buffer = await buildSeisXlsxHeaderRow1();
     const result = await parseSEISReport(buffer, { providerRole: 'psychologist' });
 
     const lastNames = result.students.map((s) => s.lastName).sort();
-    // Fixture rows in order: Alvarez, Bishop, Cho, Diaz (rows 2-5, dropped),
-    // then Evans, Foster, Gomez (rows 6-8, kept).
-    expect(lastNames).toEqual(['Evans', 'Foster', 'Gomez']);
-    expect(result.students).toHaveLength(3);
+    // Fixture data rows in order: Alvarez, Bishop, Cho, Diaz, Evans, Foster,
+    // Gomez (rows 2-8). Previously rows 2-5 were dropped; now all import.
+    expect(lastNames).toEqual(['Alvarez', 'Bishop', 'Cho', 'Diaz', 'Evans', 'Foster', 'Gomez']);
+    expect(result.students).toHaveLength(7);
   });
 
-  it('matches the golden snapshot (including the goal-column trap)', async () => {
+  it('extracts exactly one goal per row (goal-column trap fixed)', async () => {
     const buffer = await buildSeisXlsxHeaderRow1();
+    const result = await parseSEISReport(buffer, { providerRole: 'psychologist' });
+
+    // Every student carries only their real Goal-column text — no "Annual
+    // Goal #" codes, objectives, or progress comments leaking in as goals.
+    for (const student of result.students) {
+      expect(student.goals).toHaveLength(1);
+      expect(student.goals[0]).toMatch(/^By /);
+    }
+  });
+
+  it('matches the golden snapshot (all rows, one goal per row)', async () => {
+    const buffer = await buildSeisXlsxHeaderRow1();
+    const result = await parseSEISReport(buffer, { providerRole: 'psychologist' });
+    expect(result).toMatchSnapshot();
+  });
+});
+
+describe('parseSEISReport — title rows then header on row 3', () => {
+  it('detects the header on row 3 and imports the data rows after it', async () => {
+    // The row-skip fix is header-relative, not a fixed offset: with two title
+    // rows above the header, data must still start on the row after row 3.
+    const buffer = await buildSeisXlsxTitleThenHeader();
+    const result = await parseSEISReport(buffer, { providerRole: 'psychologist' });
+
+    const lastNames = result.students.map((s) => s.lastName).sort();
+    expect(lastNames).toEqual(['Alvarez', 'Bishop', 'Cho']);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('matches the golden snapshot', async () => {
+    const buffer = await buildSeisXlsxTitleThenHeader();
     const result = await parseSEISReport(buffer, { providerRole: 'psychologist' });
     expect(result).toMatchSnapshot();
   });
@@ -40,6 +77,8 @@ describe('parseSEISReport — header on row 1 (row-skip data loss)', () => {
 
 describe('parseSEISReport — ~5 metadata rows above the header', () => {
   it('fails column detection because the header is outside the 5-row scan window', async () => {
+    // Distinct from the row-skip fix: the header itself is never found, so the
+    // sheet fails loudly with a "could not detect" error rather than importing.
     const buffer = await buildSeisXlsxMetadataRows();
     const result = await parseSEISReport(buffer, { providerRole: 'psychologist' });
 

--- a/lib/parsers/seis-parser.ts
+++ b/lib/parsers/seis-parser.ts
@@ -51,6 +51,7 @@ interface ColumnMapping {
   goalType?: number; // Annual Goal # / Service type column (Column M in SEIS)
   personResponsible?: number; // Column R in SEIS Student Goals Report
   goalColumns: number[];
+  headerRow?: number; // 1-based row the header was detected on; data starts after it
 }
 
 /**
@@ -101,10 +102,18 @@ export async function parseSEISReport(
         continue;
       }
 
+      // Data begins on the row AFTER the detected header. The old fixed
+      // `rowNumber <= 5` skip silently dropped students whenever the header sat
+      // above row 5 (header on row 1 -> rows 2-5 vanished with no error).
+      // columnMapping.headerRow is always set here: the guard above requires
+      // firstName/lastName/grade, which is exactly what detection needs to
+      // record the header row.
+      const headerRow = columnMapping.headerRow ?? 5;
+
       // Process each row
       worksheet.eachRow((row, rowNumber) => {
-        // Skip header rows (first 5 rows typically contain headers/metadata)
-        if (rowNumber <= 5) return;
+        // Skip everything up to and including the header row.
+        if (rowNumber <= headerRow) return;
 
         try {
           const firstName = getCellValue(row, columnMapping.firstName!);
@@ -301,17 +310,60 @@ function detectColumnMapping(worksheet: ExcelJS.Worksheet): ColumnMapping {
         mapping.personResponsible = colNumber;
       }
 
-      // Check for goal columns
-      if (goalPatterns.test(headerText)) {
-        if (!mapping.goalColumns.includes(colNumber)) {
-          mapping.goalColumns.push(colNumber);
-        }
-      }
+      // NOTE: goal columns are detected AFTER this loop, from the confirmed
+      // header row only — see below. Detecting them here would accumulate
+      // matches across the pre-header scan window, letting a stray
+      // "Goal"/"Objective" label above the real header pollute or hijack the
+      // selection.
     });
 
     // If we found the core columns, we're done
     if (mapping.firstName && mapping.lastName && mapping.grade) {
+      mapping.headerRow = rowNum;
       break;
+    }
+  }
+
+  // Goal-column selection, scoped to the CONFIRMED header row only. The fuzzy
+  // `goalPatterns` match sweeps in metadata columns whose header merely
+  // contains "goal"/"objective" — on the real 59-column SEIS report that's
+  // "Annual Goal #", "Purpose(s) of Goal", "Goal Met", and the "Objective N
+  // Met" columns, several of which carry >10-char values that would leak in as
+  // bogus goals. Prefer the exact "Goal" column; otherwise take the fuzzy
+  // matches minus any column already mapped to a specific metadata field.
+  if (mapping.headerRow !== undefined) {
+    const headerCells = worksheet.getRow(mapping.headerRow);
+    let exactGoalColumn: number | undefined;
+
+    headerCells.eachCell((cell, colNumber) => {
+      const headerText = getCellValue(headerCells, colNumber).toLowerCase();
+      if (!headerText) return;
+
+      if (goalPatterns.test(headerText) && !mapping.goalColumns.includes(colNumber)) {
+        mapping.goalColumns.push(colNumber);
+      }
+      // Exact "Goal" header (ignoring case and surrounding space).
+      if (exactGoalColumn === undefined && headerText.trim() === 'goal') {
+        exactGoalColumn = colNumber;
+      }
+    });
+
+    if (exactGoalColumn !== undefined) {
+      mapping.goalColumns = [exactGoalColumn];
+    } else {
+      const mappedMetaColumns = new Set(
+        [
+          mapping.firstName,
+          mapping.lastName,
+          mapping.grade,
+          mapping.schoolOfAttendance,
+          mapping.iepDate,
+          mapping.areaOfNeed,
+          mapping.goalType,
+          mapping.personResponsible,
+        ].filter((c): c is number => c !== undefined)
+      );
+      mapping.goalColumns = mapping.goalColumns.filter((c) => !mappedMetaColumns.has(c));
     }
   }
 


### PR DESCRIPTION
## What & why

Second slice of **SPE-240** (parser hardening). Fixes two coupled silent-failure bugs in the SEIS **Excel/XLSX** path (`parseSEISReport`), both pinned by the SPE-239 golden fixtures so each change is a deliberate snapshot flip.

### 1. Row-skip data loss
The data loop skipped a fixed `rowNumber <= 5`, while header detection separately scanned rows 1–5. When the header sat on **row 1**, students on rows 2–5 vanished with **no error**. Now `detectColumnMapping` records the detected header row and data starts on the row *after* it — which also generalizes to a header lower in the scan window (e.g. after title rows).

### 2. Goal-column trap
The fuzzy goal-header match swept in every column whose header merely contained `goal`/`objective` — on the real 59-column report that's `Annual Goal #`, `Purpose(s) of Goal`, `Goal Met`, and the `Objective N Met` columns, several carrying >10-char values that leaked in as bogus "goals". Goal columns are now detected **from the confirmed header row only** (so a stray label above the header can't hijack selection) and **prefer the exact `Goal` column**, otherwise excluding columns already mapped to a specific metadata field. Result: exactly one goal per row.

## Tests (SPE-239 golden fixtures)
- `buildSeisXlsxHeaderRow1` flipped from pinning the bugs to pinning the fix: all 7 rows import, one `By …` goal each, Foster's grade `18 → TK`.
- New `buildSeisXlsxTitleThenHeader` proves the fix is header-relative (title rows → header on row 3 → data from row 4).
- `buildSeisXlsxMetadataRows` unchanged: header pushed past the 5-row scan window still fails **loudly** ("could not detect"), not silently.

## Review notes
Ran the deep self-review (high effort, 3 independent finders). Key outcomes folded in:
- The headline risk — *does any caller treat a non-empty `errors` array as a hard block?* — was **refuted**: both import routes gate solely on `students.length === 0`, and this change never removes a student.
- A finder flagged that an earlier draft's `exactGoalColumn` was captured across the whole 1–5 scan window (a stray "Goal" cell above the header could hijack selection → silent data loss). Fixed by scoping goal detection to the confirmed header row.
- Dropped an earlier pre-header "skipped rows" warning: it was pushed into `errors`, which the preview modals don't render (they show `parseWarnings`), so it was inert and prone to false positives. Surfacing skipped-row/other-role signals belongs with the review-screen work (SPE-227), not an unrendered errors entry.

## Gates
`tsc --noEmit` clean · `npm test` 31 suites / 264 passed / 17 snapshots · eslint clean on changed files.

## Scope
No schema/data migrations. Import-parsing **behavior does change** (more rows imported, cleaner goals) — user-facing, so holding for explicit merge approval per our working agreement.

Remaining SPE-240 items (school-name unification, keyword substring, deliveries frequency/sub-30-min/intensive-daily, Windows-1252, generic-fallback warning, deliveries line splitter) continue in follow-up slices.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQXfDBMXjR7nD5HEw9ZKsD)_