### PR TITLE
fix(parsers): schedule sub-30-minute services at their real length, not a rounded 30 (SPE-240, PR 3)

### DIFF
--- a/__tests__/unit/lib/parsers/__snapshots__/deliveries-parser.test.ts.snap
+++ b/__tests__/unit/lib/parsers/__snapshots__/deliveries-parser.test.ts.snap
@@ -42,7 +42,7 @@ exports[`parseDeliveriesCSV matches the golden snapshot for the resource role (3
     {
       "endDate": "2026-06-10",
       "key": "gomez_gia",
-      "minutesPerSession": 30,
+      "minutesPerSession": 9,
       "name": "Gomez, Gia",
       "seisId": "2000007",
       "service": "330 - Specialized Academic Instruction",
@@ -54,7 +54,7 @@ exports[`parseDeliveriesCSV matches the golden snapshot for the resource role (3
     {
       "endDate": "2026-06-10",
       "key": "hunt_hana",
-      "minutesPerSession": 30,
+      "minutesPerSession": 8,
       "name": "Hunt, Hana",
       "seisId": "2000008",
       "service": "330 - Specialized Academic Instruction",
@@ -158,7 +158,7 @@ exports[`parseDeliveriesCSV psychologist role (no service code) keeps all servic
     {
       "endDate": "2026-06-10",
       "key": "evans_ella",
-      "minutesPerSession": 30,
+      "minutesPerSession": 15,
       "name": "Evans, Ella",
       "seisId": "2000005",
       "service": "450 - Occupational Therapy",
@@ -182,7 +182,7 @@ exports[`parseDeliveriesCSV psychologist role (no service code) keeps all servic
     {
       "endDate": "2026-06-10",
       "key": "gomez_gia",
-      "minutesPerSession": 30,
+      "minutesPerSession": 9,
       "name": "Gomez, Gia",
       "seisId": "2000007",
       "service": "330 - Specialized Academic Instruction",
@@ -194,7 +194,7 @@ exports[`parseDeliveriesCSV psychologist role (no service code) keeps all servic
     {
       "endDate": "2026-06-10",
       "key": "hunt_hana",
-      "minutesPerSession": 30,
+      "minutesPerSession": 8,
       "name": "Hunt, Hana",
       "seisId": "2000008",
       "service": "330 - Specialized Academic Instruction",

--- a/__tests__/unit/lib/parsers/deliveries-parser.test.ts
+++ b/__tests__/unit/lib/parsers/deliveries-parser.test.ts
@@ -74,8 +74,15 @@ describe('calculateSessions', () => {
     expect(calculateSessions(45)).toEqual({ sessionsPerWeek: 1, minutesPerSession: 45 });
   });
 
-  it('otherwise breaks weekly minutes into ceil(n/30) 30-minute sessions', () => {
-    expect(calculateSessions(15)).toEqual({ sessionsPerWeek: 1, minutesPerSession: 30 });
+  it('schedules a sub-30-minute mandate as one session of exactly that length (no doubling)', () => {
+    // Previously these rounded up to 1x30, booking more time than mandated.
+    expect(calculateSessions(15)).toEqual({ sessionsPerWeek: 1, minutesPerSession: 15 });
+    expect(calculateSessions(20)).toEqual({ sessionsPerWeek: 1, minutesPerSession: 20 });
+    expect(calculateSessions(29)).toEqual({ sessionsPerWeek: 1, minutesPerSession: 29 });
+  });
+
+  it('breaks 30+ weekly minutes into ceil(n/30) 30-minute sessions', () => {
+    expect(calculateSessions(30)).toEqual({ sessionsPerWeek: 1, minutesPerSession: 30 });
     expect(calculateSessions(150)).toEqual({ sessionsPerWeek: 5, minutesPerSession: 30 });
     expect(calculateSessions(600)).toEqual({ sessionsPerWeek: 20, minutesPerSession: 30 });
     expect(calculateSessions(720)).toEqual({ sessionsPerWeek: 24, minutesPerSession: 30 });

--- a/lib/parsers/deliveries-parser.ts
+++ b/lib/parsers/deliveries-parser.ts
@@ -103,6 +103,14 @@ export function calculateSessions(weeklyMinutes: number): { sessionsPerWeek: num
     return { sessionsPerWeek: 1, minutesPerSession: 45 };
   }
 
+  // Sub-30-minute mandates are a single session of exactly that length. The
+  // default `ceil(n / 30)` path would round these up to a full 30-minute
+  // session (e.g. a 15 min/week mandate scheduled as 30 min/week), booking
+  // more service time than the IEP requires.
+  if (weeklyMinutes < 30) {
+    return { sessionsPerWeek: 1, minutesPerSession: weeklyMinutes };
+  }
+
   // Default: 30-minute sessions
   const sessionsPerWeek = Math.ceil(weeklyMinutes / 30);
   return { sessionsPerWeek, minutesPerSession: 30 };


### PR DESCRIPTION
## What & why

Third slice of **SPE-240** (parser hardening). Fixes a service-minutes bug in the delivery-schedule import.

`calculateSessions(weeklyMinutes)` turns a student's weekly service minutes into scheduled sessions. Any **sub-30-minute** mandate was rounded up to a full 30-minute session:

```
15 min/week  →  ceil(15/30) = 1 session × 30 min  →  30 min/week scheduled
```

That's **double the mandated time** — a compliance problem for IEP service minutes. Now weekly minutes `< 30` map to a single session of exactly that length (`1 × 15`). `30` and above are unchanged.

## Tests (SPE-239 golden fixtures)
- `calculateSessions` unit tests split into a sub-30 case (15/20/29 → exact) and a 30+ case, pinning the `29`/`30` boundary.
- Deliveries golden snapshots flip for the five sub-30 rows: Evans `15 min Weekly` → 15; Gomez `300 min Yearly` (→9/wk) → 9; Hunt `270 min Yearly` (→8/wk) → 8. `sessionsPerWeek` stays 1; `weeklyMinutes` unchanged.

## Review
Independent review pass (correctness-focused, given the small surface): boundaries, branch ordering (the `<= 0` and `=== 45` guards correctly precede the new branch), integer-safety of `weeklyMinutes`, and a full caller trace — `use-schedule-operations`, `drag-session`, `schedule/page`, the import-preview modal, and the `import-students` reconstruction site all use the value directly or as a null-guard; none assume a fixed 30/45. No defects found.

## Scope
No schema/data migrations. This **changes scheduled session minutes** for sub-30 services — user-facing, so holding for your explicit merge approval.

Out of scope (pre-existing, untouched): non-45 mandates that aren't multiples of 30 still round up to 30-min blocks (e.g. 50 → 2×30); that's a separate scheduling-granularity question. Remaining SPE-240 items (deliveries Monthly/frequency gaps, Windows-1252, school-name unification, keyword substring, etc.) continue in follow-up slices.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQXfDBMXjR7nD5HEw9ZKsD)_