### PR TITLE
fix(import): normalize grade in confirm-route dedup keys (legacy 18/0) (SPE-245)

### DIFF
--- a/__tests__/unit/lib/utils/student-dedup-key.test.ts
+++ b/__tests__/unit/lib/utils/student-dedup-key.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for the import confirm-route duplicate-detection key (SPE-245).
+ *
+ * The key must let a stored legacy SEIS grade (`grade_level` '18'/'0') dedup
+ * against an incoming normalized 'TK'/'K', while keeping genuinely distinct
+ * students distinct. All values here are fictional.
+ */
+
+import {
+  buildStudentDedupKey,
+  normalizeInitialsForKey,
+} from '@/lib/utils/student-dedup-key';
+
+describe('buildStudentDedupKey', () => {
+  it('collapses legacy SEIS grades so 18/TK and 0/K dedup to the same key', () => {
+    // The whole point: a DB row stored as '18' and an import row as 'TK' match.
+    expect(buildStudentDedupKey('JS', '18')).toBe(buildStudentDedupKey('JS', 'TK'));
+    expect(buildStudentDedupKey('AB', '0')).toBe(buildStudentDedupKey('AB', 'K'));
+  });
+
+  it('produces canonical grades (18 -> TK, 0 -> K, ordinary grades unchanged)', () => {
+    expect(buildStudentDedupKey('JS', '18')).toBe('JS-TK');
+    expect(buildStudentDedupKey('JS', '0')).toBe('JS-K');
+    expect(buildStudentDedupKey('JS', '5')).toBe('JS-5');
+    expect(buildStudentDedupKey('JS', 'TK')).toBe('JS-TK');
+  });
+
+  it('normalizes initials (case and punctuation) on both sides of the key', () => {
+    // A raw DB initials value matches the import side's normalized initials.
+    expect(buildStudentDedupKey('j.s.', '3')).toBe(buildStudentDedupKey('JS', '3'));
+    expect(buildStudentDedupKey(' js ', '3')).toBe('JS-3');
+  });
+
+  it('keeps genuinely distinct students distinct', () => {
+    expect(buildStudentDedupKey('JS', '3')).not.toBe(buildStudentDedupKey('JS', '4'));
+    expect(buildStudentDedupKey('JS', 'TK')).not.toBe(buildStudentDedupKey('AB', 'TK'));
+  });
+
+  it('handles null/undefined initials and grade without throwing', () => {
+    expect(buildStudentDedupKey(null, null)).toBe('-');
+    expect(buildStudentDedupKey(undefined, '3')).toBe('-3');
+    expect(buildStudentDedupKey('JS', undefined)).toBe('JS-');
+  });
+});
+
+describe('normalizeInitialsForKey', () => {
+  it('uppercases and strips non-letters', () => {
+    expect(normalizeInitialsForKey('j.s.')).toBe('JS');
+    expect(normalizeInitialsForKey(' a-b ')).toBe('AB');
+    expect(normalizeInitialsForKey(null)).toBe('');
+  });
+});

--- a/app/api/import-students/confirm/route.ts
+++ b/app/api/import-students/confirm/route.ts
@@ -10,6 +10,7 @@ import { log } from '@/lib/monitoring/logger';
 import { track } from '@/lib/monitoring/analytics';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
 import { updateExistingSessionsForStudent } from '@/lib/scheduling/session-requirement-sync';
+import { buildStudentDedupKey } from '@/lib/utils/student-dedup-key';
 
 export const runtime = 'nodejs';
 
@@ -82,10 +83,12 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
       supabase.rpc('user_accessible_school_ids')
     ]);
 
-    // Build lookup map for O(1) duplicate detection: key = "INITIALS-GRADE"
+    // Build lookup map for O(1) duplicate detection: key = "INITIALS-GRADE".
+    // The key normalizes both components so a stored legacy SEIS grade
+    // (grade_level '18'/'0') still matches an incoming normalized 'TK'/'K'.
     const existingStudentMap = new Map<string, boolean>();
     for (const student of existingStudents || []) {
-      const key = `${student.initials}-${student.grade_level}`;
+      const key = buildStudentDedupKey(student.initials, student.grade_level);
       existingStudentMap.set(key, true);
     }
 
@@ -154,7 +157,7 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
         // For inserts, check for duplicates
         if (action === 'insert') {
           // Check for duplicate using Map - O(1) instead of database query
-          const duplicateKey = `${initialsNormalized}-${student.gradeLevel}`;
+          const duplicateKey = buildStudentDedupKey(initialsNormalized, student.gradeLevel);
           if (existingStudentMap.has(duplicateKey)) {
             results.push({
               success: false,
@@ -368,7 +371,7 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
         } else {
           // INSERT: Create student and student_details atomically using RPC function
           // This prevents orphaned student records if student_details insert fails
-          const duplicateKey = `${initialsNormalized}-${student.gradeLevel}`;
+          const duplicateKey = buildStudentDedupKey(initialsNormalized, student.gradeLevel);
 
           const { data: importResult, error: importError } = await supabase
             .rpc('import_student_atomic', {

--- a/lib/utils/student-dedup-key.ts
+++ b/lib/utils/student-dedup-key.ts
@@ -1,0 +1,29 @@
+import { normalizeGradeLevel } from './grade-parser';
+
+/**
+ * Normalize initials for a duplicate-detection key: uppercase, letters only.
+ * Mirrors the confirm route's `initialsNormalized` derivation so keys built
+ * from stored DB rows and from an incoming import compare equal.
+ */
+export function normalizeInitialsForKey(initials: string | null | undefined): string {
+  return String(initials ?? '').toUpperCase().replace(/[^A-Z]/g, '');
+}
+
+/**
+ * Build the `INITIALS-GRADE` duplicate-detection key used by the import confirm
+ * route. Both components are normalized so a key built from a stored DB row and
+ * one built from an incoming import compare equal even when a legacy record
+ * carries a raw SEIS grade — `students.grade_level` was `'18'` (TK) / `'0'` (K)
+ * for students imported before SPE-240 normalized those to `'TK'` / `'K'`.
+ *
+ * Without this, a stored `'JS-18'` and an incoming `'JS-TK'` are treated as
+ * different students, so a re-import can create a duplicate (the DB unique index
+ * `ux_students_provider_grade_initials`, keyed on the raw `grade_level`, can't
+ * catch `'TK'` vs `'18'` either).
+ */
+export function buildStudentDedupKey(
+  initials: string | null | undefined,
+  gradeLevel: string | null | undefined,
+): string {
+  return `${normalizeInitialsForKey(initials)}-${normalizeGradeLevel(String(gradeLevel ?? ''))}`;
+}


### PR DESCRIPTION
## What & why

Defense-in-depth follow-up from **SPE-240 PR1** review. The import confirm route detects duplicate students with an `INITIALS-GRADE` key, but built the two sides inconsistently:
- **DB side** (map of existing students): raw `students.grade_level`
- **Import side** (incoming rows): the parser's already-normalized `gradeLevel`

After SPE-240 the parser emits `TK` for legacy SEIS grade `18` and `K` for `0`. So a student stored as `JS-18` and a re-import of the same student as `JS-TK` **didn't match** — and the DB unique index (`ux_students_provider_grade_initials`, keyed on the raw grade) can't catch `TK` vs `18` either, so a re-import could create a **duplicate**.

(The common re-import path was already fixed in PR1 via the matcher; this closes the narrower fast-path gap where the matcher is dropped for a non-grade reason, e.g. a changed name.)

## Change
- New `lib/utils/student-dedup-key.ts` → `buildStudentDedupKey(initials, grade)`, which normalizes **both** the initials (uppercase, letters only) and the grade (via the canonical `normalizeGradeLevel`), so keys from a stored DB row and an incoming import compare equal.
- Used at all three key sites in `app/api/import-students/confirm/route.ts` (DB-map build, insert pre-check, insert-execution) — also unifies the pre-existing raw-vs-normalized *initials* inconsistency in the same pass.
- Unit-tested (`18↔TK`, `0↔K`, initials case/punctuation, distinct students stay distinct, null/undefined handling).

## Not included
The optional one-off `grade_level` data migration (`'18'→'TK'` at the source) — that's a schema/data change and a **separate stop-and-discuss**, noted in SPE-245 to ride with the SPE-229/SPE-230 confirm-route work.

## Correctness
The common case (clean initials + canonical grade) is byte-identical to before, so existing dedup behavior is unchanged; only the alternate encodings of the *same* app grade (`18/0`) now collapse — no genuinely-distinct students merge. Verified by an independent review pass (all key sites consistent, no remaining old-format keys, `grade_level`/`initials` are `TEXT` so null-only, `??` preserves a literal `"0"`).

## Gates
`tsc --noEmit` clean · `npm test` 32 suites / 276 passed / 17 snapshots · eslint clean.

## Scope
Internal correctness only (no schema/data change, no UX change). Holding for your merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQXfDBMXjR7nD5HEw9ZKsD)_