### PR TITLE
chore(session-timeout): remove orphaned 'ai-upload' keep-alive activity (SPE-242)

### DIFF
--- a/__tests__/unit/lib/hooks/use-activity-tracker.test.ts
+++ b/__tests__/unit/lib/hooks/use-activity-tracker.test.ts
@@ -122,9 +122,9 @@ describe('useActivityTracker', () => {
     
     // Call keepAlive multiple times rapidly
     act(() => {
-      result.current.keepAlive('ai-upload');
-      result.current.keepAlive('ai-upload');
-      result.current.keepAlive('ai-upload');
+      result.current.keepAlive('file-upload');
+      result.current.keepAlive('file-upload');
+      result.current.keepAlive('file-upload');
     });
     
     // Should call onActivity for each keepAlive call

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -343,7 +343,7 @@ flowchart TD
 - **Idle timeout** (`lib/config/session-timeout.ts`): default **45 min**
   (`NEXT_PUBLIC_SESSION_TIMEOUT`, `2_700_000` ms), **2-min** warning,
   **30 s** activity throttle, with `KEEP_ALIVE_ACTIVITIES`
-  (`ai-upload`, `lesson-generation`, `file-upload`, `worksheet-generation`) and
+  (`lesson-generation`, `file-upload`, `worksheet-generation`) and
   `EXEMPT_ROUTES`. Wired by `useActivityTracker` + `auth-provider.tsx`;
   cross-tab via storage event + `BroadcastChannel`; #661 enforces the window
   across tab/browser close.

--- a/lib/config/session-timeout.ts
+++ b/lib/config/session-timeout.ts
@@ -14,7 +14,6 @@ export const SESSION_CONFIG = {
   
   // Activities that should extend the session without user interaction
   KEEP_ALIVE_ACTIVITIES: [
-    'ai-upload',
     'lesson-generation',
     'file-upload',
     'worksheet-generation',


### PR DESCRIPTION
## What & why

Dead-code cleanup, follow-up to **SPE-219** (AI-upload removal). SPE-219 deleted the AI Upload modal/button — the only thing that ever called `keepAlive('ai-upload')` — so the `'ai-upload'` entry in `SESSION_CONFIG.KEEP_ALIVE_ACTIVITIES` is now orphaned. It was deliberately left out of SPE-219 to keep that PR a clean minimal deletion (this touches shared session-timeout infra, not AI-upload code).

## Change
- Remove `'ai-upload'` from `KEEP_ALIVE_ACTIVITIES` (`lib/config/session-timeout.ts`). The `KeepAliveActivity` union narrows accordingly.
- Point the `use-activity-tracker` test sample at a live activity (`'file-upload'`) — it was calling `keepAlive('ai-upload')`.
- Drop `ai-upload` from the `KEEP_ALIVE_ACTIVITIES` example in `docs/ARCHITECTURE.md`.

Confirmed nothing else references the literal `'ai-upload'` (no `shouldKeepAlive('ai-upload')` caller), so the type narrowing is safe.

## Gates
`tsc --noEmit` clean · `npm test` 32 suites / 276 passed · eslint clean. **No behavior change.**

## Scope
Internal dead-code removal only. Holding for your merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQXfDBMXjR7nD5HEw9ZKsD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated session timeout behavior so AI uploads no longer extend the session automatically.
  - Confirmed that file uploads and other supported activities continue to maintain session activity as expected.

- **Documentation**
  - Updated session lifecycle documentation to reflect the revised keep-alive activity rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->