### PR TITLE
fix(parsers): word-boundary goal-to-provider matching + surface blank-metadata goals (SPE-247)

### DIFF
--- a/__tests__/unit/lib/parsers/__snapshots__/seis-goals-csv.test.ts.snap
+++ b/__tests__/unit/lib/parsers/__snapshots__/seis-goals-csv.test.ts.snap
@@ -412,8 +412,8 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) parses the full fixt
 exports[`parseCSVReport — SEIS Student Goals Report (CSV) per-role goal filtering snapshots kept-student and filtered-goal counts per role 1`] = `
 {
   "counseling": {
-    "goalsFiltered": 10,
-    "students": 1,
+    "goalsFiltered": 9,
+    "students": 2,
   },
   "ot": {
     "goalsFiltered": 8,
@@ -424,12 +424,12 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) per-role goal filter
     "students": 10,
   },
   "resource": {
-    "goalsFiltered": 5,
-    "students": 5,
+    "goalsFiltered": 4,
+    "students": 6,
   },
   "speech": {
-    "goalsFiltered": 10,
-    "students": 1,
+    "goalsFiltered": 9,
+    "students": 2,
   },
 }
 `;

--- a/__tests__/unit/lib/parsers/seis-goals-csv.test.ts
+++ b/__tests__/unit/lib/parsers/seis-goals-csv.test.ts
@@ -5,9 +5,12 @@
  * Pins: BOM handling (SPE-241, already landed), the full parsed result over a
  * 59-column fictional fixture, duplicate-student goal merging, the 5-of-6
  * detection boundary at the file level (column-shifted -> generic fallback),
- * and per-role goal filtering including the documented keyword
- * cross-contamination ("Handwriting" -> resource) and typo losses
- * ("Receptive Languge" -> not speech).
+ * and per-role goal filtering with word-boundary keyword matching (SPE-247):
+ * "Handwriting" routes to OT (not resource via "writing"), "Social/Emotional"
+ * no longer leaks to OT via "emOTional", and a blank-metadata row surfaces for
+ * review instead of vanishing. A "Receptive Languge" typo row (unrecognized but
+ * non-blank) is still filtered — surfacing that is deferred to the review
+ * screen (SPE-227).
  */
 
 import { parseCSVReport } from '@/lib/parsers/csv-parser';
@@ -62,27 +65,40 @@ describe('parseCSVReport — SEIS Student Goals Report (CSV)', () => {
       expect(counts).toMatchSnapshot();
     });
 
-    it('keeps the "Handwriting" area for resource (writing-keyword cross-contamination)', async () => {
-      const result = await parseCSVReport(SEIS_GOALS_CSV_BOM(), { providerRole: 'resource' });
-      expect(result.students.some((s) => s.lastName === 'Foster')).toBe(true);
+    it('routes the "Handwriting" student to OT (SPE-247)', async () => {
+      // Foster's Area of Need is "Handwriting". With word-boundary matching it no
+      // longer cross-contaminates the resource "writing" keyword; "handwriting"
+      // is now an OT keyword, and Person Responsible is an OT too.
+      const ot = await parseCSVReport(SEIS_GOALS_CSV_BOM(), { providerRole: 'ot' });
+      expect(ot.students.some((s) => s.lastName === 'Foster')).toBe(true);
     });
 
-    it('drops the "Receptive Languge" typo row for speech', async () => {
+    it('still keeps the Foster row for resource via its "Academic #3" goal, not the area', async () => {
+      // The Handwriting area no longer matches resource, but the Annual Goal #
+      // "Academic #3" legitimately does — so Foster still imports for resource.
+      const resource = await parseCSVReport(SEIS_GOALS_CSV_BOM(), { providerRole: 'resource' });
+      expect(resource.students.some((s) => s.lastName === 'Foster')).toBe(true);
+    });
+
+    it('still filters the "Receptive Languge" typo row for speech (deferred to SPE-227)', async () => {
+      // Unrecognized-but-nonblank metadata is not surfaced yet; only truly blank
+      // rows are. This pins that the typo row stays filtered for now.
       const result = await parseCSVReport(SEIS_GOALS_CSV_BOM(), { providerRole: 'speech' });
       expect(result.students.some((s) => s.lastName === 'Hunt')).toBe(false);
     });
 
-    it('drops the blank Area-of-Need / Annual-Goal# row for resource', async () => {
+    it('surfaces the blank Area-of-Need / Annual-Goal# row for review instead of dropping it (SPE-247)', async () => {
       const result = await parseCSVReport(SEIS_GOALS_CSV_BOM(), { providerRole: 'resource' });
-      expect(result.students.some((s) => s.lastName === 'Gomez')).toBe(false);
+      expect(result.students.some((s) => s.lastName === 'Gomez')).toBe(true);
     });
 
-    it('wrongly matches the Social/Emotional student to OT ("ot" is a substring of "emotional")', async () => {
-      // Cross-contamination bug: the 2-letter OT keyword matches "emOTional",
-      // so Diaz (a counseling student) is pulled into an OT import. SPE-240 is
-      // expected to change this; the snapshot counts above will shift with it.
+    it('no longer matches the Social/Emotional student to OT (word boundary fixes "emOTional")', async () => {
+      // Diaz is a counseling student; the old 2-letter "ot" substring wrongly
+      // pulled "emOTional" into OT. Word boundaries fix it.
       const ot = await parseCSVReport(SEIS_GOALS_CSV_BOM(), { providerRole: 'ot' });
-      expect(ot.students.some((s) => s.lastName === 'Diaz')).toBe(true);
+      expect(ot.students.some((s) => s.lastName === 'Diaz')).toBe(false);
+      const counseling = await parseCSVReport(SEIS_GOALS_CSV_BOM(), { providerRole: 'counseling' });
+      expect(counseling.students.some((s) => s.lastName === 'Diaz')).toBe(true);
     });
   });
 });

--- a/__tests__/unit/lib/parsers/service-type-mapping.test.ts
+++ b/__tests__/unit/lib/parsers/service-type-mapping.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for role-based goal matching (SPE-247).
+ *
+ * Pins word-boundary keyword matching (no substring cross-contamination),
+ * the Handwriting -> OT coverage fix, and blank-metadata detection. All values
+ * fictional.
+ */
+
+import {
+  doesTextMatchProvider,
+  isBlankGoalMetadata,
+  isGoalForProviderByKeywords,
+} from '@/lib/parsers/service-type-mapping';
+
+describe('doesTextMatchProvider — word-boundary keyword matching', () => {
+  it('does not let the resource "writing" keyword match "Handwriting"', () => {
+    expect(doesTextMatchProvider('Handwriting', 'resource')).toBe(false);
+    expect(doesTextMatchProvider('Fine Motor / Handwriting', 'resource')).toBe(false);
+  });
+
+  it('routes handwriting areas to OT', () => {
+    expect(doesTextMatchProvider('Handwriting', 'ot')).toBe(true);
+    expect(doesTextMatchProvider('Handwriting (spacing and pencil control)', 'ot')).toBe(true);
+    expect(doesTextMatchProvider('Fine Motor / Handwriting', 'ot')).toBe(true);
+  });
+
+  it('does not let the 2-letter "ot" keyword match "emotional"', () => {
+    expect(doesTextMatchProvider('Social/Emotional', 'ot')).toBe(false);
+    expect(doesTextMatchProvider('Social/Emotional', 'counseling')).toBe(true);
+  });
+
+  it('still matches legitimate whole-word keywords', () => {
+    expect(doesTextMatchProvider('Occupational Therapy', 'ot')).toBe(true);
+    expect(doesTextMatchProvider('OT', 'ot')).toBe(true);
+    expect(doesTextMatchProvider('Reading comprehension', 'resource')).toBe(true);
+    expect(doesTextMatchProvider('Written Expression', 'resource')).toBe(true);
+    expect(doesTextMatchProvider('Speech/Language', 'speech')).toBe(true);
+    expect(doesTextMatchProvider('Math', 'resource')).toBe(true);
+  });
+
+  it('does not match an unrelated word that merely contains a keyword', () => {
+    // "another" contains "ot"; "robot" contains "ot"; neither is OT.
+    expect(doesTextMatchProvider('another goal', 'ot')).toBe(false);
+    expect(doesTextMatchProvider('robotics club', 'ot')).toBe(false);
+  });
+
+  it('never filters roles that have no keyword set (e.g. psychologist)', () => {
+    expect(doesTextMatchProvider('anything at all', 'psychologist')).toBe(true);
+  });
+});
+
+describe('isBlankGoalMetadata', () => {
+  it('is true only when every provider-signal column is blank', () => {
+    expect(isBlankGoalMetadata('', '', '')).toBe(true);
+    expect(isBlankGoalMetadata(undefined, undefined, undefined)).toBe(true);
+    expect(isBlankGoalMetadata('   ', '', undefined)).toBe(true);
+  });
+
+  it('is false when any column carries text — even unrecognized text', () => {
+    expect(isBlankGoalMetadata('Receptive Languge', '', '')).toBe(false);
+    expect(isBlankGoalMetadata('', 'Comm (1 of 1)', '')).toBe(false);
+    expect(isBlankGoalMetadata('', '', 'Case Manager')).toBe(false);
+  });
+});
+
+describe('isGoalForProviderByKeywords — multi-column attribution', () => {
+  it('keeps a mixed-signal Handwriting/Academic row for both resource and OT', () => {
+    // Foster-like row: Handwriting area, "Academic #3" goal, OT person.
+    const area = 'Handwriting';
+    const goal = 'Academic #3';
+    const person = 'Occupational Therapist';
+    expect(isGoalForProviderByKeywords(area, goal, person, 'resource')).toBe(true); // via "Academic"
+    expect(isGoalForProviderByKeywords(area, goal, person, 'ot')).toBe(true); // via "Handwriting"/"Occupational"
+  });
+
+  it('excludes a pure Handwriting goal from resource but keeps it for OT', () => {
+    expect(isGoalForProviderByKeywords('Handwriting', 'Goal 1', 'Therapist', 'resource')).toBe(false);
+    expect(isGoalForProviderByKeywords('Handwriting', 'Goal 1', 'Therapist', 'ot')).toBe(true);
+  });
+});

--- a/lib/parsers/csv-parser.ts
+++ b/lib/parsers/csv-parser.ts
@@ -6,7 +6,7 @@
 import { parse } from 'csv-parse/sync';
 import { TextDecoder } from 'util';
 import { normalizeSchoolName } from '../school-helpers';
-import { getServiceTypeCode, getServiceTypeNameForRole, isGoalForProviderByKeywords } from './service-type-mapping';
+import { getServiceTypeCode, getServiceTypeNameForRole, isGoalForProviderByKeywords, isBlankGoalMetadata } from './service-type-mapping';
 import { normalizeGradeLevel } from '../utils/grade-parser';
 
 export interface ParsedStudent {
@@ -265,11 +265,17 @@ export async function parseCSVReport(buffer: Buffer, options: ParseOptions = {})
         for (const goalColIndex of columnMapping.goalColumns) {
           const goalText = row[goalColIndex] || '';
 
-          // For SEIS format, filter by provider role using multiple columns
+          // For SEIS format, filter by provider role using multiple columns.
+          // Goals with no provider signal at all (blank Area of Need, Annual
+          // Goal #, and Person Responsible) fall through and are surfaced for
+          // review rather than silently dropped (SPE-247).
           if (isSEISFormat && options.providerRole) {
-            if (!isGoalForProvider(areaOfNeed, goalType, personResponsible, options.providerRole)) {
+            if (
+              !isGoalForProvider(areaOfNeed, goalType, personResponsible, options.providerRole) &&
+              !isBlankGoalMetadata(areaOfNeed, goalType, personResponsible)
+            ) {
               goalsFiltered++;
-              continue; // Skip goals that don't match provider's type
+              continue; // Skip goals that clearly belong to a different provider
             }
           }
 

--- a/lib/parsers/seis-parser.ts
+++ b/lib/parsers/seis-parser.ts
@@ -4,7 +4,7 @@
  */
 
 import * as ExcelJS from 'exceljs';
-import { getServiceTypeCode, isGoalForProviderByKeywords } from './service-type-mapping';
+import { getServiceTypeCode, isGoalForProviderByKeywords, isBlankGoalMetadata } from './service-type-mapping';
 import { normalizeGradeLevel } from '../utils/grade-parser';
 
 // ExcelJS cell value types for rich text and formula results
@@ -161,9 +161,11 @@ export async function parseSEISReport(
                   providerRole
                 );
 
-                if (!matchesProvider) {
+                // Goals with no provider signal at all (all metadata columns
+                // blank) are surfaced for review rather than dropped (SPE-247).
+                if (!matchesProvider && !isBlankGoalMetadata(areaOfNeed, goalType, personResponsible)) {
                   goalsFiltered++;
-                  continue; // Skip goals that don't match provider's type
+                  continue; // Skip goals that clearly belong to a different provider
                 }
               }
             }

--- a/lib/parsers/service-type-mapping.ts
+++ b/lib/parsers/service-type-mapping.ts
@@ -97,6 +97,7 @@ export const PROVIDER_KEYWORDS: Record<string, string[]> = {
     'gross motor',
     'occupational',
     'ot',
+    'handwriting',
   ],
   counseling: [
     'social',
@@ -110,27 +111,65 @@ export const PROVIDER_KEYWORDS: Record<string, string[]> = {
   ],
 };
 
+/** Escape a string for literal use inside a RegExp. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Precompiled word-boundary matchers, one per role, built from PROVIDER_KEYWORDS.
+ *
+ * Word boundaries (\b) are what make this correct: plain substring matching
+ * cross-contaminated roles — "writing" matched "Handwriting" (an OT goal), and
+ * the two-letter "ot" matched "emOTional" (a counseling goal). Requiring a word
+ * boundary on both sides of the keyword fixes both without hand-maintaining a
+ * stop-list. Multi-word keywords ("fine motor", "speech/language") still match
+ * because \b is only anchored at the two ends of the phrase.
+ */
+const PROVIDER_KEYWORD_MATCHERS: Record<string, RegExp> = Object.fromEntries(
+  Object.entries(PROVIDER_KEYWORDS).map(([role, keywords]) => [
+    role,
+    new RegExp(`\\b(?:${keywords.map(escapeRegExp).join('|')})\\b`, 'i'),
+  ]),
+);
+
 /**
  * Check if goal text matches a provider's keywords
  * Used for filtering SEIS Student Goals Report by provider type
  *
  * @param text - Text from Area of Need, Annual Goal #, or Person Responsible columns
  * @param providerRole - The provider's role (resource, speech, ot, counseling)
- * @returns true if the text contains keywords matching the provider's role
+ * @returns true if the text contains a whole-word keyword for the provider's role
  */
 export function doesTextMatchProvider(text: string, providerRole: string): boolean {
   if (!text) return false;
 
   const normalizedRole = providerRole.toLowerCase().trim();
-  const keywords = PROVIDER_KEYWORDS[normalizedRole];
+  const matcher = PROVIDER_KEYWORD_MATCHERS[normalizedRole];
 
   // If no keywords defined for this role (e.g., psychologist), don't filter
-  if (!keywords) return true;
+  if (!matcher) return true;
 
-  const lowerText = text.toLowerCase();
+  return matcher.test(text);
+}
 
-  // Check if any keyword is found in the text
-  return keywords.some(keyword => lowerText.includes(keyword));
+/**
+ * True when a goal row carries no provider signal at all — blank Area of Need,
+ * Annual Goal #, and Person Responsible. Such rows can't be attributed to any
+ * provider, so callers surface them for review instead of silently dropping
+ * them (SPE-247). Unrecognized-but-nonblank metadata (e.g. a "Receptive Languge"
+ * typo) is intentionally out of scope here — surfacing that belongs with the
+ * review screen (SPE-227), which can flag it as "needs review" rather than
+ * quietly mixing it into every role's import.
+ */
+export function isBlankGoalMetadata(
+  areaOfNeed: string | undefined,
+  goalNumber: string | undefined,
+  personResponsible: string | undefined,
+): boolean {
+  return [areaOfNeed, goalNumber, personResponsible].every(
+    (col) => !col || col.trim().length === 0,
+  );
 }
 
 /**


### PR DESCRIPTION
## What & why

Role-based SEIS goal filtering matched provider keywords by **substring**, which cross-contaminated providers:

- `"writing"` is a substring of **"Handwriting"** → a **resource** provider imported the OT's handwriting goals, while **OT** could lose them (no OT keyword in "Handwriting").
- the two-letter `"ot"` is a substring of **"em**OT**ional"** → **counseling** goals leaked into **OT** imports.

Both send a student's goals to the wrong specialist — the kind of silent misrouting that matters for IEP compliance. This is the product-signed-off fix (Blair, July 14).

## Changes

- **Word-boundary keyword matching.** `doesTextMatchProvider` now tests a precompiled per-role regex (`\b(?:kw1|kw2|…)\b`) instead of substring `includes`. Fixes both cross-contaminations at the root, with no hand-maintained stop-list. Multi-word keywords ("fine motor", "speech/language") still match because `\b` only anchors the two ends of the phrase.
- **Add `handwriting` to the OT keyword set**, so handwriting areas route to OT.
- **Surface blank-metadata goals for review.** A goal row with *no* provider signal at all — blank Area of Need **and** Annual Goal # **and** Person Responsible — is now surfaced instead of silently dropped, on both the CSV (`parseCSVReport`) and XLSX (`parseSEISReport`) SEIS paths.

Deliveries parsing (numeric service codes, `isServiceCodeForRole`) is untouched.

## Scope decision

Unrecognized-but-**nonblank** metadata (e.g. a `"Receptive Languge"` typo) is intentionally **still filtered** for now. Surfacing that as "needs review" belongs with the review-screen work (**SPE-227**), which can flag it visually — surfacing it here would quietly mix uncertain goals into every role's import with no indicator. Blank rows are rare and unambiguous, so they're safe to surface immediately.

## Behavior / test changes

New `service-type-mapping.test.ts` pins the matcher in isolation (Handwriting→OT-not-resource, `emOTional`≠OT, whole-word keywords still match, blank detection). The SEIS-goals golden fixture flips the assertions that documented the old bug, and its per-role **count snapshot** shifts accordingly:

| role | students | filtered | why |
|---|---|---|---|
| resource | 5 → **6** | 5 → 4 | blank row (Gomez) now surfaces |
| speech | 1 → **2** | 10 → 9 | blank row surfaces |
| counseling | 1 → **2** | 10 → 9 | blank row surfaces |
| ot | 3 → 3 | 8 → 8 | Diaz leaves (emOTional fixed), Gomez surfaces |
| psychologist | 10 | 0 | unchanged (no keyword filtering) |

No role *lost* a student to the stricter matching in the fixture.

## Known tradeoff

Word-boundary matching is stricter, so an inflected area name could miss where substring caught it (e.g. `"Mathematics"` vs `\bmath\b`). Evidence it's low-risk: the golden fixture is built to mirror the real SEIS export, and this change produced **zero** unintended drops in it — real SEIS "Area of Need" values use canonical short forms ("Math", "Reading", "Written Expression"). The stricter matching can only ever match *less*, never introduce new false-positives. Follow-up captured for consolidating the duplicated `escapeRegExp` helper across the codebase.

## Gates

`tsc --noEmit` clean · eslint clean · full jest green (34 suites / 293 passed, incl. 11 new). High-effort `/code-review` on the diff found no correctness issues.

Internal parser-accuracy fix; holding for your merge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQXfDBMXjR7nD5HEw9ZKsD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQXfDBMXjR7nD5HEw9ZKsD)_