### PR TITLE
fix(import): write teacher_name on insert so imported students show their teacher (SPE-251 Part A)

### DIFF
--- a/app/api/import-students/confirm/route.ts
+++ b/app/api/import-students/confirm/route.ts
@@ -318,9 +318,12 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
           }
           batchPayload.push(updatePayload);
         } else {
-          // Insert. `teacherName` is intentionally omitted to match the previous
-          // import_student_atomic behavior, which never wrote the deprecated
-          // teacher_name column on insert (teacher_id is the real link).
+          // Insert. Set `teacher_name` alongside `teacher_id` when a teacher
+          // resolved. The Students list (and teacher-name-based checks) still
+          // read the deprecated `teacher_name` column for display, so a matched
+          // teacher that set only `teacher_id` would otherwise render as "Not
+          // assigned" (SPE-251). Left null when no teacher matched — the student
+          // is then genuinely unassigned. Mirrors the update branch above.
           batchPayload.push({
             action: 'insert',
             initials: initialsNormalized,
@@ -332,6 +335,7 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
             sessionsPerWeek: student.sessionsPerWeek ?? null,
             minutesPerSession: student.minutesPerSession ?? null,
             teacherId: student.teacherId || null,
+            teacherName: student.teacherId ? (student.teacherName ?? null) : null,
             firstName: student.firstName,
             lastName: student.lastName,
             goals: student.goals


### PR DESCRIPTION
## What & why

The consolidated import pipeline's **insert** path set `teacher_id` but left `teacher_name` null, while the Students list (and several other views) still **display** the deprecated `teacher_name` column. So a brand-new student imported via the unified modal rendered as **"Not assigned"** even when their roster/class-list teacher matched and `teacher_id` resolved.

Surfaced by Codex during the SPE-233 review (PR #726) and verified against code + the live database. This is **SPE-251 Part A**.

## The change

One line in `app/api/import-students/confirm/route.ts` — the insert branch now mirrors the already-correct update branch:

```
teacherName: student.teacherId ? (student.teacherName ?? null) : null,
```

- Sets `teacher_name` to the resolved teacher's name **only when a teacher matched** (`teacher_id` present). Left null when unmatched — the student is then genuinely unassigned.
- **No migration needed** — `upsert_students_atomic` already inserts `teacher_name` from the payload; the API was simply always sending null.

## Why this is safe (and a net fix)

Deep self-review (two independent adversarial angles, both clean):

- **Correctness:** when `teacher_id` is set, `teacherName` is always the matched teacher's full name (never empty, never a raw unmatched string) across both insert paths (roster + SEIS). Verified the value survives the client round-trip, and that the RPC writes it (checked against the live deployed function — no drift).
- **No regressions:** dedup keys on initials+grade (not `teacher_name`); the admin "unmatched students" view stays correct because the guard sets `teacher_name` only in lockstep with `teacher_id`; the old "intentionally omitted" comment guarded nothing real (a one-time backfill already populated `teacher_name` for every student with a `teacher_id`, and all 307 existing students carry it).
- **Bonus:** this also closes a *latent* bug — imported students with a matched teacher were being silently skipped by teacher-name-based special-activity conflict checks, so they could be scheduled during their class's special activity. They now behave like every other student.

## Verification

- Typecheck + full import/parser suite green (128 tests).
- No dedicated confirm-route unit test exists (API route over the RPC); end-to-end import verification is tracked separately in SPE-235.

## Not included — SPE-251 Part B (`school_district`)

The other half of SPE-251 — legacy (null `school_id`) schools need `school_district` set on insert or those students can be invisible — requires a small **database migration** and has **zero impact today** (0 students affected; only 5 legacy provider profiles). Holding that for a separate change so this low-risk, no-migration fix can land on its own.

## Scope

Backend one-liner restoring expected display behavior. Holding for your merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGbXfFBzrWzL5NHGN3umyC)_