### PR TITLE
fix(import): roster-specific error for an incomplete roster template (SPE-250)

### DIFF
--- a/__tests__/unit/lib/parsers/speddy-template-csv.test.ts
+++ b/__tests__/unit/lib/parsers/speddy-template-csv.test.ts
@@ -33,6 +33,51 @@ describe('detectSpeddyTemplateFormat', () => {
   });
 });
 
+describe('parseCSVReport — incomplete roster template (SPE-250)', () => {
+  it('gives a roster-specific error when Initials is present but a required column is missing/misnamed', async () => {
+    // "Teacher" mistyped as "Teacher Name" — fails template detection and would
+    // otherwise fall through to the SEIS/generic name-column error.
+    const csv = Buffer.from('Initials,Grade,Teacher Name\nJD,3,Smith', 'utf-8');
+    const result = await parseCSVReport(csv, {});
+
+    expect(result.students).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toMatch(/roster template/i);
+    expect(result.errors[0].message).toMatch(/Teacher/);
+    // Names the roster requirement, not the SEIS/generic name-column guidance.
+    expect(result.errors[0].message).not.toMatch(/First Name, Last Name/);
+  });
+
+  it('names every missing required roster column', async () => {
+    // Only Initials present (Grade + Teacher missing).
+    const csv = Buffer.from('Initials,Room\nJD,12', 'utf-8');
+    const result = await parseCSVReport(csv, {});
+
+    expect(result.errors[0].message).toMatch(/Grade/);
+    expect(result.errors[0].message).toMatch(/Teacher/);
+  });
+
+  it('does not hijack a genuine SEIS/generic file (no Initials column)', async () => {
+    // Missing a grade column but clearly not a roster — keeps the name/grade guidance.
+    const csv = Buffer.from('First Name,Last Name,Age\nJane,Doe,8', 'utf-8');
+    const result = await parseCSVReport(csv, {});
+
+    expect(result.errors[0].message).toMatch(/First Name, Last Name/);
+    expect(result.errors[0].message).not.toMatch(/roster template/i);
+  });
+
+  it('does not claim a roster when a name-based file also carries an Initials column', async () => {
+    // A genuine name-based file with an extra Initials column (First Name at
+    // index 0 trips detectColumnMapping's falsy-index quirk into the error
+    // branch) must keep the name guidance, not be mislabeled a roster.
+    const csv = Buffer.from('First Name,Last Name,Initials,Age\nJane,Doe,JD,8', 'utf-8');
+    const result = await parseCSVReport(csv, {});
+
+    expect(result.errors[0].message).not.toMatch(/roster template/i);
+    expect(result.errors[0].message).toMatch(/First Name, Last Name/);
+  });
+});
+
 describe('parseCSVReport — Speddy roster template', () => {
   it('parses the template fixture into goal-less students with inline teacher + schedule', async () => {
     const result = await parseCSVReport(readFixture('roster-template.csv'), {});

--- a/app/api/import-students/route.ts
+++ b/app/api/import-students/route.ts
@@ -844,9 +844,21 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
     if (parseResult.students.length === 0) {
       log.warn(`No students found in ${fileType} file`, { userId, fileName: file.name });
 
+      // Surface the specific column-detection reason (the roster-template hint
+      // from SPE-250, or the name/goal-column message) as the top-level `error`
+      // the client shows — it drops the `parseErrors` array. Scoped to CSV and
+      // to row-0 detection errors on purpose: SEIS .xlsx per-sheet errors and
+      // per-row parse exceptions (`row > 0`) can carry internal or misattributed
+      // text that shouldn't headline. Falls back to the generic message when no
+      // detection error was recorded (e.g. all rows filtered out by role).
+      const detectionError = isCSV
+        ? parseResult.errors.find((e) => e.row === 0)?.message
+        : undefined;
       return NextResponse.json(
         {
-          error: 'No students with IEP goals found in the file. Please check that the file contains columns for student names, grades, and IEP goals.',
+          error:
+            detectionError ||
+            'No students with IEP goals found in the file. Please check that the file contains columns for student names, grades, and IEP goals.',
           parseErrors: parseResult.errors,
           parseWarnings: 'warnings' in parseResult ? parseResult.warnings || [] : []
         },

--- a/lib/parsers/csv-parser.ts
+++ b/lib/parsers/csv-parser.ts
@@ -132,9 +132,22 @@ export async function parseCSVReport(buffer: Buffer, options: ParseOptions = {})
     const formatDetected = isSEISFormat ? 'seis-student-goals' : 'generic' as const;
 
     if (!columnMapping.firstName || !columnMapping.lastName || !columnMapping.grade) {
+      // A file carrying the roster template's signature `Initials` column and NO
+      // name columns is a roster attempt with a missing/misnamed required column
+      // — give the roster requirement rather than the SEIS/generic name-column
+      // guidance (SPE-250). Guard on the name columns being absent so a genuine
+      // name-based file that merely also carries an Initials column (or whose
+      // First/Last/Grade column sits at index 0 — a pre-existing falsy-index
+      // quirk in detectColumnMapping's `!mapping.x` checks) still gets the name
+      // guidance rather than a misleading "looks like the roster template".
+      const looksLikeRoster =
+        columnMapping.firstName === undefined && columnMapping.lastName === undefined;
+      const rosterHint = looksLikeRoster ? describeIncompleteRosterTemplate(records) : null;
       errors.push({
         row: 0,
-        message: isSEISFormat
+        message: rosterHint
+          ? rosterHint
+          : isSEISFormat
           ? 'SEIS Student Goals Report detected but could not find expected columns (Last Name, First Name, Grade)'
           : 'Could not detect student name or grade columns. Looking for columns like: First Name, Last Name, Grade, Student Name.'
       });
@@ -526,6 +539,31 @@ export function detectSpeddyTemplateFormat(records: string[][]): boolean {
   // goal-less template parser.
   const hasGoalColumn = headers.some((h) => /goal|iep\s*goal|objective|target|present\s*level/.test(h));
   return !hasGoalColumn;
+}
+
+/**
+ * If a CSV carries the roster template's signature `Initials` column but did not
+ * pass `detectSpeddyTemplateFormat`, it's a roster attempt with a missing or
+ * misnamed required column (e.g. `Teacher` typed as `Teacher Name`). Return a
+ * roster-specific message naming what's required so the user isn't shown the
+ * SEIS/generic name-column guidance (SPE-250). Returns null for genuine
+ * SEIS/generic files (no `Initials` column) and for roster+goal hybrids that
+ * already carry all three required columns.
+ */
+function describeIncompleteRosterTemplate(records: string[][]): string | null {
+  const headers = (records[0] || []).map(normalizeTemplateHeader);
+  // `Initials` is the roster template's signature — SEIS/generic student files
+  // use First/Last Name, never Initials — so its presence marks a roster attempt.
+  if (!headers.includes('initials')) return null;
+  const missing = ([
+    ['initials', 'Initials'],
+    ['grade', 'Grade'],
+    ['teacher', 'Teacher'],
+  ] as const)
+    .filter(([key]) => !headers.includes(key))
+    .map(([, label]) => label);
+  if (missing.length === 0) return null;
+  return `This looks like the roster template, but it's missing a required column: ${missing.join(', ')}. Roster imports need Initials, Grade, and Teacher.`;
 }
 
 /**


### PR DESCRIPTION
## What & why

A roster CSV with a **missing or misnamed required header** (e.g. `Teacher` typed as `Teacher Name`, or the Teacher column omitted) failed roster-template detection, fell through to SEIS/generic detection, and surfaced a confusing SEIS-oriented error:

> "Could not detect student name or grade columns. Looking for columns like: First Name, Last Name, Grade, Student Name."

The file was correctly rejected, but a roster user got no useful guidance. This is **SPE-250** (surfaced during the SPE-233 self-review).

## The change

- **`lib/parsers/csv-parser.ts`** — when a CSV carries the roster template's signature `Initials` column **and no name columns**, emit a roster-specific error naming the missing required column(s): *"This looks like the roster template, but it's missing a required column: Teacher. Roster imports need Initials, Grade, and Teacher."*
- **`app/api/import-students/route.ts`** — surface the specific **row-0 detection reason** as the top-level `error` the client displays (the modal shows `error` and ignores the `parseErrors` array). Scoped to CSV and to row-0 errors so SEIS `.xlsx` per-sheet errors and per-row parse exceptions can never headline; falls back to the generic message otherwise.

## Guards (from self-review)

Two adversarial review angles shaped the final scope:

- The roster hint only fires when **no name columns are detected**, so a genuine name-based file that merely also carries an `Initials` column isn't mislabeled a roster.
- Surfacing is limited to **row-0 CSV detection errors**, so internal per-row exception text (`Error parsing row: …`) and multi-sheet SEIS `.xlsx` errors can't become the user-facing headline.

## Verification

- Typecheck, lint, full import/parser suite green — **47 tests**, including 4 new ones: the roster hint, the multi-missing-column case, and both no-hijack guards (no `Initials` column; name-file-with-`Initials`).

## Separately logged — SPE-252 (not fixed here)

The review surfaced a **pre-existing** falsy-index bug: `parseCSVReport`'s `!columnMapping.firstName` check treats a column at **index 0** as missing (`!0 === true`), so a CSV whose first column is `First Name`/`Last Name`/`Grade` fails to import. This PR **guards against amplifying** it (the roster hint stands down when names are present) but does **not** change that behavior — the root fix (`=== undefined` checks) is its own small PR since it changes import behavior. Filed as **SPE-252**.

## Scope

Backend messaging only — no change to what imports succeed/fail. Holding for your merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGbXfFBzrWzL5NHGN3umyC)_