### PR TITLE
fix(import): detect name/grade columns at index 0 (falsy-index bug) (SPE-252)

### DIFF
--- a/__tests__/unit/lib/parsers/generic-csv.test.ts
+++ b/__tests__/unit/lib/parsers/generic-csv.test.ts
@@ -18,11 +18,12 @@
 import { parseCSVReport } from '@/lib/parsers/csv-parser';
 import { readFixture, WINDOWS_1252_CSV, UTF8_WITH_REPLACEMENT_CHAR_CSV } from './fixtures/builders';
 
-describe('parseCSVReport — index-0 name column bug', () => {
-  it('rejects a generic CSV whose First Name column is at index 0', async () => {
-    // `if (!columnMapping.firstName ...)` treats a detected index of 0 as
-    // "not found" (0 is falsy), so a file with First Name in the first column
-    // yields zero students. SPE-240 should switch these to `=== undefined`.
+describe('parseCSVReport — index-0 name column (SPE-252)', () => {
+  it('imports a generic CSV whose First Name column is at index 0', async () => {
+    // `columnMapping.firstName` is a column *index*. The old `!columnMapping.x`
+    // check treated a detected index of 0 as "not found" (0 is falsy) and
+    // rejected the file. Now compared with `=== undefined`, so a First Name /
+    // Last Name / Grade column in the leftmost position works (SPE-252).
     const csv = Buffer.from(
       [
         'First Name,Last Name,Grade,Goal',
@@ -31,9 +32,32 @@ describe('parseCSVReport — index-0 name column bug', () => {
       'utf-8',
     );
     const result = await parseCSVReport(csv, {});
-    expect(result.students).toHaveLength(0);
-    expect(result.errors.length).toBeGreaterThan(0);
-    expect(result.errors[0].message).toMatch(/could not detect/i);
+    expect(result.errors).toHaveLength(0);
+    expect(result.students).toHaveLength(1);
+    expect(result.students[0]).toMatchObject({
+      firstName: 'Ada',
+      lastName: 'Ames',
+      gradeLevel: '3',
+      initials: 'AA',
+    });
+    expect(result.students[0].goals[0]).toMatch(/read 60 words/);
+  });
+
+  it('lets a real Grade column override an index-0 "grade" substring false positive', async () => {
+    // "Gradebook ID" matches the loose gradePatterns and sits at index 0; the
+    // real Grade column appears later. The first-detection guard keeps its
+    // falsy-override form on purpose, so the real Grade must win — not the
+    // gradebook id (SPE-252 review guard).
+    const csv = Buffer.from(
+      [
+        'Gradebook ID,First Name,Last Name,Grade,Goal',
+        'GB-1,Ada,Ames,3,"The student will read 60 words per minute with 90% accuracy."',
+      ].join('\r\n'),
+      'utf-8',
+    );
+    const result = await parseCSVReport(csv, {});
+    expect(result.students).toHaveLength(1);
+    expect(result.students[0].gradeLevel).toBe('3');
   });
 });
 

--- a/__tests__/unit/lib/parsers/speddy-template-csv.test.ts
+++ b/__tests__/unit/lib/parsers/speddy-template-csv.test.ts
@@ -67,9 +67,10 @@ describe('parseCSVReport — incomplete roster template (SPE-250)', () => {
   });
 
   it('does not claim a roster when a name-based file also carries an Initials column', async () => {
-    // A genuine name-based file with an extra Initials column (First Name at
-    // index 0 trips detectColumnMapping's falsy-index quirk into the error
-    // branch) must keep the name guidance, not be mislabeled a roster.
+    // A genuine name-based file with an extra Initials column but no Grade
+    // column (Age ≠ grade) reaches the error branch; it must keep the name
+    // guidance, not be mislabeled a roster — the looksLikeRoster guard stands
+    // down because the name columns are present.
     const csv = Buffer.from('First Name,Last Name,Initials,Age\nJane,Doe,JD,8', 'utf-8');
     const result = await parseCSVReport(csv, {});
 

--- a/lib/parsers/csv-parser.ts
+++ b/lib/parsers/csv-parser.ts
@@ -131,15 +131,22 @@ export async function parseCSVReport(buffer: Buffer, options: ParseOptions = {})
     const isSEISFormat = detectSEISStudentGoalsFormat(records);
     const formatDetected = isSEISFormat ? 'seis-student-goals' : 'generic' as const;
 
-    if (!columnMapping.firstName || !columnMapping.lastName || !columnMapping.grade) {
+    if (
+      columnMapping.firstName === undefined ||
+      columnMapping.lastName === undefined ||
+      columnMapping.grade === undefined
+    ) {
+      // `firstName`/`lastName`/`grade` are column *indices*; a required column
+      // in the leftmost position has index 0, so the falsy `!columnMapping.x`
+      // form treated a detected index-0 column as missing and wrongly rejected
+      // the file. Compare against undefined explicitly (SPE-252).
       // A file carrying the roster template's signature `Initials` column and NO
       // name columns is a roster attempt with a missing/misnamed required column
       // — give the roster requirement rather than the SEIS/generic name-column
       // guidance (SPE-250). Guard on the name columns being absent so a genuine
-      // name-based file that merely also carries an Initials column (or whose
-      // First/Last/Grade column sits at index 0 — a pre-existing falsy-index
-      // quirk in detectColumnMapping's `!mapping.x` checks) still gets the name
-      // guidance rather than a misleading "looks like the roster template".
+      // name-based file that also carries an Initials column (e.g. one missing
+      // only its Grade column) still gets the name guidance rather than a
+      // misleading "looks like the roster template".
       const looksLikeRoster =
         columnMapping.firstName === undefined && columnMapping.lastName === undefined;
       const rosterHint = looksLikeRoster ? describeIncompleteRosterTemplate(records) : null;
@@ -457,7 +464,12 @@ function detectColumnMapping(records: string[][]): ColumnMapping {
       mapping.lastName = index;
     }
 
-    // Check for grade
+    // Check for grade. Intentionally the falsy `!mapping.grade` (not
+    // `=== undefined`): gradePatterns matches any "grade" substring, so an early
+    // false positive like "Gradebook ID" at index 0 must stay overridable by a
+    // later real "Grade" column. The index-0 fix (SPE-252) lives at the
+    // required-column gate in parseCSVReport, which needs `=== undefined`; this
+    // first-detection guard deliberately keeps its override behavior.
     if (!mapping.grade && gradePatterns.test(headerText)) {
       mapping.grade = index;
     }


### PR DESCRIPTION
## What & why

`parseCSVReport` decided a file's columns were undetectable with:

```ts
if (!columnMapping.firstName || !columnMapping.lastName || !columnMapping.grade) { … reject … }
```

But those fields hold a **column index** (`number | undefined`). A required column in the **leftmost position** has index `0`, and `!0 === true` — so a *detected* index-0 column was treated as missing. A generic CSV whose first column is `First Name` (or `Last Name`, or `Grade`) failed to import entirely, even though the column was right there.

This is **SPE-252**, surfaced during the SPE-250 self-review. (The existing `generic-csv.test.ts` even pinned the buggy behavior with a comment anticipating this exact `=== undefined` fix.)

## The change

- **`parseCSVReport`** — the required-column **gate** now compares the detected indices against `undefined` explicitly, so an index-0 column counts as detected.
- **`detectColumnMapping` guards are intentionally left as `!mapping.x`** (falsy). `gradePatterns` matches any `"grade"` substring, so an early false positive like `Gradebook ID` at index 0 must stay **overridable** by a later real `Grade` column. Only the gate needed the fix — flipping the first-detection guards to `=== undefined` would have regressed that override (raised in review by Codex).
- Tests: flipped the `generic-csv.test.ts` case that pinned the old zero-student behavior to assert the file now imports; added a test that a real `Grade` column overrides an index-0 `"grade"` substring false positive; refreshed two comments the fix made stale.

## Why it's safe (self-reviewed, two adversarial angles + Codex)

- **Complete & scoped:** every index-valued `ColumnMapping` field was checked; only the gate needed the change. The SEIS branch uses fixed non-zero indices; `seis-parser.ts`'s `!mapping.x` is safe because ExcelJS column numbers are **1-based** (index 0 never occurs).
- **No regressions:** a roster template (Initials/Grade, no names) is still rejected and is detected earlier anyway; the SPE-250 roster-hint branch reaches the same set of files; the loose-`grade`-substring override is preserved (Codex P2); both generic snapshots use `Student ID` at index 0 (names at 1+) so they're untouched.
- **No new surface:** import-students returns a preview the user confirms before any DB write; goals are PII-scrubbed.

## Verification

- Typecheck, lint, and the **full unit suite green** (271 passed, 16 snapshots), including the flipped index-0 test and the new false-positive-override test.

## Scope

Small correctness fix to CSV column detection. It **does** change behavior (previously-rejected first-column-name files now import — the intended outcome), so holding for your merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)