### PR TITLE
docs(claude): PR follow-through is autonomous; merging is the pause point

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -84,6 +84,17 @@ branch, and keep capturing deferred items in Linear. Report a brief summary
 when a batch merges or when escalating — keep me informed without making me a
 bottleneck.
 
+**PR follow-through is yours; merging is the pause point.** You never need my
+permission to set up PR follow-through — subscribe to / watch a PR's activity
+and schedule your own `send_later` check-ins to follow a PR on your own, and
+run the whole pre-merge loop (open the PR, watch CI, run reviews, address valid
+feedback, push fixes) without asking. **The one action to pause on is merging:**
+hold a finished, green PR for me and tell me it's ready rather than merging it
+yourself — unless I've given you the go-ahead to merge, for that PR or as a
+standing rule for the work at hand (then merge on green without checking back).
+The purely-internal, non-UX, all-gates-green case above is the standing
+exception where that go-ahead is already granted.
+
 ## Standing rule: deep self-review before any substantive PR
 
 Before marking any substantive PR ready for review (features, bug fixes,


### PR DESCRIPTION
## What & why

Clarifies the working agreement in `.claude/CLAUDE.md` so every future session inherits it — no need to re-state it per session.

Two things made explicit:

1. **PR follow-through is autonomous — never ask permission for it.** Subscribing to / watching a PR's activity, scheduling `send_later` check-ins to follow a PR, and running the whole pre-merge loop (open the PR, watch CI, run reviews, address valid feedback, push fixes) all happen without asking.
2. **Merging is the single pause point.** A finished, green PR is held for the owner's merge unless they've given the go-ahead — per-PR or as a standing rule (in which case it merges on green without checking back). The existing purely-internal, non-UX, all-gates-green auto-merge case remains the standing pre-granted exception.

## Scope

Docs-only — one paragraph added to the "Autonomous execution" section of `.claude/CLAUDE.md`. No code, no behavior change. Holding for your merge (per the very rule this documents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGbXfFBzrWzL5NHGN3umyC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified PR follow-through responsibilities and monitoring expectations.
  * Documented the approval and merge handoff point for completed, passing PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->