### PR TITLE
feat(sim-district): sim-run skill + shared walk plumbing for verification runs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -21,6 +21,10 @@
   when a feature adds tables, classifying them in
   `scripts/sim-district/manifest.ts` (seeded / swept / declared-unseeded) is
   part of that feature's work. Only ever touch sim data through these scripts.
+  **To run a feature verification through the sim district, use the `sim-run`
+  skill** (`.claude/skills/sim-run/SKILL.md`) — it carries the spec §9 loop
+  plus this environment's Playwright/network mechanics and the shared helpers
+  in `scripts/sim-district/walk.ts`; don't re-derive any of it.
 
 ## How to communicate with me
 

--- a/.claude/skills/sim-run/SKILL.md
+++ b/.claude/skills/sim-run/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: sim-run
+description: Run a feature verification through the Sim District — reset the fixture, walk personas through the real UI with Playwright, assert DB state underneath, and deliver a Sim Run Report. Use whenever asked to test/verify a feature "through the sim district", run cross-role or end-to-end verification, or smoke-test the fixture itself.
+---
+
+# Sim District verification run
+
+`docs/SIM_DISTRICT.md` §9 defines *what* a run is and why. This skill is the
+*how* for this environment — follow it start to finish and you will not need
+to rediscover any of its mechanics. Working precedents: PR #695/#698 (the IEP
+meetings run that caught SPE-217) and the fixture smoke walk.
+
+## Non-negotiables (in order)
+
+1. **Freshness contract.** Every run STARTS with
+   `npm run sim:reset -- --yes` and a green `npm run sim:verify`. Seeded data
+   is date-relative to the seed date; a stale namespace gives wrong answers.
+   A failing reset is a finding to fix, never something to work around.
+2. **Sweep contract before the run creates rows.** If the feature's tables
+   aren't yet classified in `scripts/sim-district/manifest.ts`
+   (SEEDED / SWEPT / DECLARED_UNSEEDED), classifying them is part of THIS
+   run's setup — `sim:verify` fails on unclassified tables. When adding a
+   SWEPT entry, pick the identity (`user` | `student` | `school`) whose sim
+   ids reach the rows, and check delete paths: a table with **no cascade from
+   students/profiles/schools** (e.g. `site_meeting_rules`) MUST be swept or
+   teardown's parent deletes will hit FK violations. Children cleaned by
+   `ON DELETE CASCADE` from a swept parent stay DECLARED_UNSEEDED with a
+   comment.
+3. **Only touch sim data through the scripts.** Read-only SQL for assertions
+   is fine (Supabase MCP `execute_sql`); never hand-write or hand-delete sim
+   rows.
+4. **Credentials.** `derivePassword(SIM_DISTRICT_PASSWORD, email)` +
+   `simEmail(local)` from the manifest, computed inside scripts. Never print,
+   log, or hardcode a password. `walk.ts#loginAs` does this for you.
+
+## Environment mechanics (Claude remote sandbox)
+
+- **Target the app locally.** The gateway usually blocks `www.speddy.xyz`
+  (403 CONNECT). Run current `main` against the prod DB — spec-sanctioned:
+  ensure `.env.local` has `NEXT_PUBLIC_SUPABASE_URL` and
+  `NEXT_PUBLIC_SUPABASE_ANON_KEY` (fetch the anon key with Supabase MCP
+  `get_publishable_keys`; the file is gitignored), start `npm run dev` in the
+  background, and wait for `curl --noproxy localhost http://localhost:3000/login`
+  to return 200.
+- **The browser cannot reach Supabase; Node can.** This is the trap that
+  wastes hours: pages render but every client-side fetch dies silently —
+  empty dashboards, no role nav, no redirects. Never launch Chromium with
+  proxy settings; instead create contexts with `walk.ts#newWalkContext`,
+  which wires `relaySupabase()` (route interception → Node fetch).
+- **Use `scripts/sim-district/walk.ts`.** It carries launch fallbacks,
+  the relay, `loginAs`, content-based waits (`bodyHas` — never fixed sleeps;
+  dev mode compiles routes on first hit), nav helpers, and check recording.
+  A run script should be persona "acts" plus assertions, nothing else.
+- **Script location.** Put run scripts in the session scratchpad and import
+  repo modules by absolute path (`/home/user/speddy/scripts/sim-district/walk`);
+  scratchpad files can't resolve `node_modules` bare specifiers. Run with
+  `npx tsx <script>`.
+- **Role landings** (middleware + client redirects): admins →
+  `/dashboard/admin`, SEA → `/dashboard/sea`, teacher → `/dashboard/teacher`,
+  providers stay on `/dashboard`. Non-admins hitting `/dashboard/admin`
+  bounce — a free negative assertion.
+
+## Persona quick reference
+
+`PERSONAS` in `scripts/sim-district/manifest.ts` is authoritative — these are
+the usual walk leads (email-local → who):
+
+| email-local | persona |
+|---|---|
+| `district.admin` | Dana — district admin (no Chat, no site-rules editor) |
+| `siteadmin.willow` | Priya — site admin, Willow |
+| `rsp.willow` | Rachel — resource specialist, Willow (28 students; 12 with due dates; students 0–2 taught by Nora) |
+| `rsp.maple` | Alicia — resource specialist, Maple (cross-school negative space) |
+| `rsp.itinerant` | Tomás — multi-site provider (Willow/Juniper/Cedar) |
+| `slp.itinerant` / `ot.itinerant` | Maria (speech) / Jun (OT) |
+| `sea.willow` | Leah — SEA (excluded from Chat/CARE/Schedule/Meetings nav; delegated sessions) |
+| `teacher.willow.1` | Nora — login teacher, Willow (availability prompt) |
+| `teacher.willow.2` | David — login teacher with ZERO students (empty state) |
+| `teacher.cedar` | Fatima — login teacher, Cedar (secondary) |
+
+Cedar/Redwood are secondary sites: scheduling surfaces hidden, no session
+instances seeded — useful negative space.
+
+## The run, step by step
+
+1. **Read the feature first** — its pages, query layer, RLS policies, and
+   which personas it touches. Test what actually shipped, not the spec.
+2. Classify new tables in the manifest (non-negotiable #2); typecheck
+   (`npx tsc --noEmit --skipLibCheck --esModuleInterop --module commonjs --target es2020 --moduleResolution node scripts/sim-district/*.ts`).
+3. Reset + verify green; start the local app.
+4. Write the walk script as acts in dependency order (e.g. admin configures →
+   teacher responds → provider consumes), one `newWalkContext` per persona.
+5. Assert **positive AND negative space** per persona — cross-school
+   isolation, role exclusions, middleware bounces. Negative assertions are
+   mandatory (§9): most multi-role bugs are leaks, and happy-path-only runs
+   prove nothing. Screenshot each act.
+6. **DB layer** via Supabase MCP `execute_sql` (read-only): row counts,
+   scoping columns (`school_id`/`district_id`/organizer), constraint-chain
+   properties (times inside configured windows, nothing past due dates,
+   nothing at other schools). The DB is the tiebreaker when a UI check races.
+7. **Lifecycle close:** `sim:teardown -- --yes` →
+   `sim:verify -- --expect-empty` (all zeros proves the sweeps caught the
+   run's rows) → `sim:reset -- --yes` + green verify, leaving the district
+   standing. Kill the dev server.
+8. **Deliver the Sim Run Report** (below) and send screenshots with
+   SendUserFile.
+
+## When the run finds a product bug
+
+Reproduce it minimally outside the UI — a signed-in `@supabase/supabase-js`
+probe from Node mirrors the app's exact client path and yields the real
+PostgREST error (UI layers often swallow them into warnings). File a Linear
+issue with root cause + evidence. Then STOP for owner approval before
+changing product code (CLAUDE.md stop-list); sim-script fixes are autonomous.
+Suspect your own harness first: a relay abort or a racing selector looks
+identical to an app bug until the DB or a probe settles it.
+
+## Sim Run Report format
+
+- **Verdict first** — pass/fail and the headline finding.
+- **Scope:** what was walked, and an explicit **not covered** list (never
+  silently imply coverage).
+- **Per persona:** positive and negative assertions, with screenshots.
+- **DB layer:** what was verified underneath the UI.
+- **Findings:** each with reproduction, root cause if known, Linear link.
+  Anything ambiguous is flagged for a human call, never rounded up to a pass.
+
+## Minimal act example
+
+```ts
+// scratchpad/my-run.ts — npx tsx scratchpad/my-run.ts
+import {
+  BASE_URL, bodyHas, launchBrowser, loginAs, newWalkContext, record, summarize,
+} from '/home/user/speddy/scripts/sim-district/walk';
+
+const browser = await launchBrowser();
+const ctx = await newWalkContext(browser);
+const page = await loginAs(ctx, 'rsp.willow');
+await page.goto(`${BASE_URL}/dashboard/meetings`, { waitUntil: 'domcontentloaded' });
+record('Rachel (resource, Willow)', 'positive', 'meetings page loads caseload stats',
+  await bodyHas(page, 'Unscheduled with due dates'));
+await ctx.close();
+await browser.close();
+process.exit(summarize() > 0 ? 1 : 0);
+```

--- a/.claude/skills/sim-run/SKILL.md
+++ b/.claude/skills/sim-run/SKILL.md
@@ -36,7 +36,9 @@ meetings run that caught SPE-217) and the fixture smoke walk.
 ## Environment mechanics (Claude remote sandbox)
 
 - **Target the app locally.** The gateway usually blocks `www.speddy.xyz`
-  (403 CONNECT). Run current `main` against the prod DB — spec-sanctioned:
+  (403 CONNECT). Run the **checked-out worktree** against the prod DB — the
+  code under test (pre-merge that is the feature branch; post-merge, main) —
+  spec-sanctioned:
   ensure `.env.local` has `NEXT_PUBLIC_SUPABASE_URL` and
   `NEXT_PUBLIC_SUPABASE_ANON_KEY` (fetch the anon key with Supabase MCP
   `get_publishable_keys`; the file is gitignored), start `npm run dev` in the
@@ -71,8 +73,9 @@ the usual walk leads (email-local → who):
 | `siteadmin.willow` | Priya — site admin, Willow |
 | `rsp.willow` | Rachel — resource specialist, Willow (28 students; 12 with due dates; students 0–2 taught by Nora) |
 | `rsp.maple` | Alicia — resource specialist, Maple (cross-school negative space) |
-| `rsp.itinerant` | Tomás — multi-site provider (Willow/Juniper/Cedar) |
-| `slp.itinerant` / `ot.itinerant` | Maria (speech) / Jun (OT) |
+| `rsp.itinerant` | Maria — itinerant resource (Maple + Juniper) |
+| `slp.itinerant` | Tomás — itinerant speech (Willow/Juniper/Cedar) |
+| `ot.itinerant` | Jun — itinerant OT (Maple + Redwood) |
 | `sea.willow` | Leah — SEA (excluded from Chat/CARE/Schedule/Meetings nav; delegated sessions) |
 | `teacher.willow.1` | Nora — login teacher, Willow (availability prompt) |
 | `teacher.willow.2` | David — login teacher with ZERO students (empty state) |

--- a/docs/SIM_DISTRICT.md
+++ b/docs/SIM_DISTRICT.md
@@ -432,7 +432,11 @@ nothing else.
 
 The loop this district exists for — the owner asks *"run feature X through
 the sim district"* and gets back a defensible *"everything checks out"* (or
-a precise account of what doesn't):
+a precise account of what doesn't). This section defines the loop; the
+**operational playbook** — environment mechanics, Playwright plumbing
+(`scripts/sim-district/walk.ts`), persona quick-reference, report template —
+is the `sim-run` skill at `.claude/skills/sim-run/SKILL.md`. Runs should
+start there:
 
 1. **Reset:** `npm run sim:reset -- --yes` → known-good state, stable IDs —
    then confirm `npm run sim:verify` is green (including its schema-coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "node-cron": "^4.2.1",
         "nodemailer": "^7.0.5",
         "npm-run-all": "^4.1.5",
+        "playwright": "1.56.1",
         "postcss": "^8.5.4",
         "prettier": "^3.6.2",
         "supabase": "^2.34.3",
@@ -14171,9 +14172,8 @@
       "version": "1.56.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
       "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.56.1"
       },
@@ -14191,9 +14191,8 @@
       "version": "1.56.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
       "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -14205,13 +14204,13 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "node-cron": "^4.2.1",
     "nodemailer": "^7.0.5",
     "npm-run-all": "^4.1.5",
+    "playwright": "1.56.1",
     "postcss": "^8.5.4",
     "prettier": "^3.6.2",
     "supabase": "^2.34.3",

--- a/scripts/sim-district/walk.ts
+++ b/scripts/sim-district/walk.ts
@@ -1,0 +1,171 @@
+/**
+ * Shared Playwright plumbing for sim-district verification runs (spec §9).
+ * The full playbook lives in the sim-run skill (.claude/skills/sim-run/SKILL.md);
+ * this module carries the environment mechanics so run scripts stay tiny.
+ *
+ * The critical quirk this encodes: in the Claude remote sandbox the BROWSER
+ * cannot reach Supabase directly while Node can — every context must be wired
+ * with relaySupabase() (newWalkContext does it) or all client-side data
+ * fetches fail silently: empty dashboards, no role nav, no redirects.
+ */
+import { chromium, type Browser, type BrowserContext, type Page } from 'playwright';
+import { derivePassword, simEmail } from './manifest';
+import { requireEnv } from './lib';
+
+/** The app under test. Local dev server against the prod DB by default. */
+export const BASE_URL = process.env.SIM_RUN_BASE_URL ?? 'http://localhost:3000';
+
+// ---------------------------------------------------------------------------
+// Check recording — every run reports positives AND negatives (spec §9)
+// ---------------------------------------------------------------------------
+
+export interface Check {
+  persona: string;
+  kind: 'positive' | 'negative';
+  what: string;
+  ok: boolean;
+  detail?: string;
+}
+
+export const checks: Check[] = [];
+
+export function record(
+  persona: string,
+  kind: Check['kind'],
+  what: string,
+  ok: boolean,
+  detail?: string,
+): void {
+  checks.push({ persona, kind, what, ok, detail });
+  const mark = ok ? 'ok  ' : 'FAIL';
+  const tag = kind === 'negative' ? 'NEG ' : 'POS ';
+  console.log(`  [${mark}] ${tag} (${persona}) ${what}${detail ? ` — ${detail}` : ''}`);
+}
+
+/** Print the tally; returns the number of failed checks (use as exit code). */
+export function summarize(): number {
+  const failed = checks.filter(c => !c.ok).length;
+  console.log(`\n${checks.length} checks, ${failed} failed.`);
+  return failed;
+}
+
+// ---------------------------------------------------------------------------
+// Browser + network plumbing
+// ---------------------------------------------------------------------------
+
+/** Chromium is preinstalled; fall back to the pinned sandbox paths if the
+ *  playwright package's expected revision is missing. Never pass proxy
+ *  settings — localhost must stay direct and supabase rides the relay. */
+export async function launchBrowser(): Promise<Browser> {
+  try {
+    return await chromium.launch();
+  } catch {
+    for (const p of ['/opt/pw-browsers/chromium', '/opt/pw-browsers/chromium-1194/chrome-linux/chrome']) {
+      try {
+        return await chromium.launch({ executablePath: p });
+      } catch {
+        /* try next */
+      }
+    }
+    throw new Error('no launchable chromium found (see PLAYWRIGHT_BROWSERS_PATH)');
+  }
+}
+
+/**
+ * Route the browser's Supabase traffic through Node fetch. The sandbox blocks
+ * direct browser egress to supabase.co but allows it from Node, so route
+ * interception relays request/response byte-for-byte (minus hop-by-hop and
+ * encoding headers — Node fetch already decompressed the body).
+ */
+export async function relaySupabase(ctx: BrowserContext): Promise<void> {
+  const supaHost = new URL(requireEnv('NEXT_PUBLIC_SUPABASE_URL')).host;
+  await ctx.route(`**://${supaHost}/**`, async route => {
+    const req = route.request();
+    try {
+      const headers = { ...req.headers() };
+      delete headers['accept-encoding'];
+      const resp = await fetch(req.url(), {
+        method: req.method(),
+        headers,
+        body: ['GET', 'HEAD'].includes(req.method()) ? undefined : (req.postDataBuffer() ?? undefined),
+      });
+      const body = Buffer.from(await resp.arrayBuffer());
+      const respHeaders: Record<string, string> = {};
+      resp.headers.forEach((v, k) => {
+        if (!['content-encoding', 'content-length', 'transfer-encoding'].includes(k.toLowerCase())) {
+          respHeaders[k] = v;
+        }
+      });
+      await route.fulfill({ status: resp.status, headers: respHeaders, body });
+    } catch {
+      await route.abort();
+    }
+  });
+}
+
+/** One persona = one fresh context, already wired with the Supabase relay. */
+export async function newWalkContext(browser: Browser): Promise<BrowserContext> {
+  const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  await relaySupabase(ctx);
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Persona login + waiting helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Log in as a persona by manifest email-local (e.g. 'rsp.willow'). Passwords
+ * derive from SIM_DISTRICT_PASSWORD — computed here, never printed. Resolves
+ * once the URL reaches /dashboard; role-based redirects (admin/sea/teacher)
+ * may continue after — assert the final URL in the caller.
+ */
+export async function loginAs(ctx: BrowserContext, emailLocal: string): Promise<Page> {
+  const secret = requireEnv('SIM_DISTRICT_PASSWORD');
+  const email = simEmail(emailLocal);
+  const page = await ctx.newPage();
+  page.setDefaultTimeout(60_000);
+  await page.goto(`${BASE_URL}/login`, { waitUntil: 'domcontentloaded', timeout: 90_000 });
+  await page.fill('#email', email);
+  await page.fill('#password', derivePassword(secret, email));
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/dashboard/, { timeout: 90_000 });
+  return page;
+}
+
+/**
+ * Wait until the rendered body contains `text` — the reliable signal that a
+ * client-side fetch landed. Dev mode compiles routes on first hit, so fixed
+ * sleeps race; content waits don't. Returns false instead of throwing so it
+ * can feed record() directly.
+ */
+export async function bodyHas(page: Page, text: string, timeout = 45_000): Promise<boolean> {
+  try {
+    await page.waitForFunction(
+      (t: string) => document.body?.innerText?.includes(t) ?? false,
+      text,
+      { timeout },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Nav link labels once the role-specific nav has loaded (the base nav renders
+ * first while the client fetches the profile role — wait for a label only the
+ * target role has). Desktop + mobile menus both render, so expect duplicates.
+ */
+export async function navNames(page: Page, expectOne: string): Promise<string[]> {
+  try {
+    await page.waitForSelector(`nav a:has-text("${expectOne}")`, { timeout: 30_000 });
+  } catch {
+    /* read whatever nav exists — the caller's assertion reports it */
+  }
+  const texts = await page.locator('nav a').allInnerTexts();
+  return texts.map(t => t.trim()).filter(Boolean);
+}
+
+export const hasNav = (names: string[], label: string): boolean =>
+  names.some(n => n === label || n.startsWith(label));


### PR DESCRIPTION
## Summary

Makes sim-district verification runs repeatable by any future session (any model) instead of hard-won tribal knowledge. Prompted by a session that struggled to work out the mechanics that the first two runs (smoke walk, IEP meetings / SPE-217) had already solved.

**`.claude/skills/sim-run/SKILL.md`** — an auto-discovered project skill carrying the operational playbook:
- The non-negotiables in order: freshness contract (reset + green verify first), sweep contract (classify new tables in the manifest before the run creates rows, with the cascade-path check), scripts-only data access, derived credentials never printed.
- This environment's mechanics: run the app locally against the prod DB (gateway blocks the prod URL), fetch the anon key via MCP, and the big trap — **the sandboxed browser can't reach Supabase while Node can**, solved by the route-interception relay.
- A persona quick-reference table, the 8-step run procedure, product-bug handling policy (minimal Node probe → Linear → stop for owner approval), the Sim Run Report format, and a minimal example act.

**`scripts/sim-district/walk.ts`** — the Playwright plumbing from the first two runs promoted to a shared module: `launchBrowser` (sandbox executable fallbacks), `relaySupabase`/`newWalkContext`, `loginAs` (manifest emails + derived passwords), `bodyHas` content waits, `navNames`/`hasNav`, and check recording/summary — so a run script is just persona acts and assertions.

`CLAUDE.md`'s sim bullet and `docs/SIM_DISTRICT.md` §9 now point at the skill.

## Verification

- Sim scripts standalone typecheck + full `npm run typecheck` clean.
- The documented scratchpad absolute-path import pattern smoke-tested (`walk.ts` exports verified via `npx tsx`).
- The skill is already picked up by the session harness (appears in the available-skills list).
- No runtime/product code touched; `walk.ts` is internal tooling used only by run scripts.

Note: the standing high-effort self-review was explicitly waived by the owner for this PR (skill/docs + tooling-only addition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCkoy5NKwbydGevxJfKSLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCkoy5NKwbydGevxJfKSLS)_