### PR TITLE
feat(ui): shared accessible Modal on Headless UI; adopt in the import modal (SPE-226)

### DIFF
--- a/__tests__/unit/components/StudentImportModal.test.tsx
+++ b/__tests__/unit/components/StudentImportModal.test.tsx
@@ -24,8 +24,10 @@ const SEIS_HEADER = 'SEIS ID,District ID,Last Name,First Name,Birthdate,Grade,Sc
 
 const makeFile = (content: string, name: string, type = 'text/csv') => new File([content], name, { type });
 
-const fileInput = (container: HTMLElement): HTMLInputElement => {
-  const input = container.querySelector('input[type="file"]') as HTMLInputElement | null;
+// The Modal renders through a Headless UI Dialog portal (document.body), so the
+// file input lives outside the render `container` — query the document instead.
+const fileInput = (): HTMLInputElement => {
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement | null;
   if (!input) throw new Error('file input not found');
   return input;
 };
@@ -62,8 +64,8 @@ describe('StudentImportModal (SPE-231)', () => {
   });
 
   it('detects a Deliveries CSV, labels its contribution, and enables Import', async () => {
-    const { container } = renderModal();
-    fireEvent.change(fileInput(container), {
+    renderModal();
+    fireEvent.change(fileInput(), {
       target: { files: [makeFile(`${DELIVERIES_HEADER}\n"A, B",1,330`, 'deliveries.csv')] },
     });
 
@@ -73,8 +75,8 @@ describe('StudentImportModal (SPE-231)', () => {
   });
 
   it('detects a SEIS student/goals CSV as students & goals', async () => {
-    const { container } = renderModal();
-    fireEvent.change(fileInput(container), {
+    renderModal();
+    fireEvent.change(fileInput(), {
       target: { files: [makeFile(`${SEIS_HEADER}\n1,2,Doe,Jane,,3,Mt Diablo`, 'goals.csv')] },
     });
 
@@ -83,8 +85,8 @@ describe('StudentImportModal (SPE-231)', () => {
   });
 
   it('detects a roster template as importable student data (SPE-225)', async () => {
-    const { container } = renderModal();
-    fireEvent.change(fileInput(container), {
+    renderModal();
+    fireEvent.change(fileInput(), {
       target: { files: [makeFile(`${ROSTER_HEADER}\nJD,3,Smith`, 'roster.csv')] },
     });
 
@@ -94,8 +96,8 @@ describe('StudentImportModal (SPE-231)', () => {
   });
 
   it('rejects an unsupported file with an actionable error and keeps Import disabled', async () => {
-    const { container } = renderModal();
-    fireEvent.change(fileInput(container), {
+    renderModal();
+    fireEvent.change(fileInput(), {
       target: { files: [makeFile('whatever', 'ParentLetter.docx', 'application/octet-stream')] },
     });
 
@@ -105,8 +107,8 @@ describe('StudentImportModal (SPE-231)', () => {
   });
 
   it('replace-last: a second file of the same type replaces the first, with a notice', async () => {
-    const { container } = renderModal();
-    const input = fileInput(container);
+    renderModal();
+    const input = fileInput();
 
     fireEvent.change(input, { target: { files: [makeFile(DELIVERIES_HEADER, 'first.csv')] } });
     expect(await screen.findByText('first.csv')).toBeInTheDocument();
@@ -128,8 +130,8 @@ describe('StudentImportModal (SPE-231)', () => {
       .mockImplementationOnce(() => firstPending) // A (picked first) — pending
       .mockImplementationOnce(() => Promise.resolve('deliveries')); // B (picked second) — immediate
 
-    const { container } = renderModal();
-    const input = fileInput(container);
+    renderModal();
+    const input = fileInput();
 
     fireEvent.change(input, { target: { files: [makeFile(DELIVERIES_HEADER, 'A.csv')] } });
     fireEvent.change(input, { target: { files: [makeFile(DELIVERIES_HEADER, 'B.csv')] } });
@@ -149,8 +151,8 @@ describe('StudentImportModal (SPE-231)', () => {
       .mockRejectedValueOnce(new Error('read failed')) // bad.csv
       .mockResolvedValueOnce('deliveries'); // good.csv
 
-    const { container } = renderModal();
-    fireEvent.change(fileInput(container), {
+    renderModal();
+    fireEvent.change(fileInput(), {
       target: { files: [makeFile('x', 'bad.csv'), makeFile(DELIVERIES_HEADER, 'good.csv')] },
     });
 
@@ -170,8 +172,8 @@ describe('StudentImportModal (SPE-231)', () => {
         })
     );
 
-    const { container } = renderModal();
-    fireEvent.change(fileInput(container), { target: { files: [makeFile(DELIVERIES_HEADER, 'x.csv')] } });
+    renderModal();
+    fireEvent.change(fileInput(), { target: { files: [makeFile(DELIVERIES_HEADER, 'x.csv')] } });
 
     // Reset the modal (Cancel) before detection resolves.
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
@@ -192,9 +194,9 @@ describe('StudentImportModal (SPE-231)', () => {
       json: async () => ({ data: { summary: { total: 1 } } }),
     });
     const onUploadComplete = jest.fn();
-    const { container } = renderModal({ onUploadComplete });
+    renderModal({ onUploadComplete });
 
-    fireEvent.change(fileInput(container), {
+    fireEvent.change(fileInput(), {
       target: { files: [makeFile(DELIVERIES_HEADER, 'deliveries.csv')] },
     });
     await screen.findByText('deliveries.csv');

--- a/app/components/students/student-import-modal.tsx
+++ b/app/components/students/student-import-modal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { Button } from '../ui/button';
+import { Modal } from '../ui/modal';
 import {
   ACCEPT_ATTR,
   IMPORT_TYPE_META,
@@ -80,17 +81,6 @@ export function StudentImportModal({
     onClose();
   };
 
-  // Close on Escape.
-  useEffect(() => {
-    if (!isOpen) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') handleClose();
-    };
-    document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, uploading]);
-
   const buildEntry = async (file: File): Promise<ImportEntry> => {
     const id = String(++idCounter.current);
     const ext = fileExtension(file.name);
@@ -114,7 +104,12 @@ export function StudentImportModal({
     } catch {
       // A file that can't be read shouldn't take down the whole batch — surface
       // it as an actionable per-file error.
-      return { id, file, type: 'unknown', error: 'Could not read this file. Please try selecting it again.' };
+      return {
+        id,
+        file,
+        type: 'unknown',
+        error: 'Could not read this file. Please try selecting it again.',
+      };
     }
     return { id, file, type };
   };
@@ -219,188 +214,207 @@ export function StudentImportModal({
       resetState();
       onClose();
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to process files. Please try again.';
+      const message =
+        err instanceof Error ? err.message : 'Failed to process files. Please try again.';
       setSubmitError(message);
     } finally {
       setUploading(false);
     }
   };
 
-  if (!isOpen) return null;
-
   const schoolLabel = currentSchool?.display_name || currentSchool?.school_site;
 
   return (
-    <div className="fixed inset-0 z-50 overflow-y-auto" role="dialog" aria-modal="true" aria-labelledby="import-students-title">
-      <div className="flex min-h-full items-center justify-center p-4">
-        <div
-          className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
-          onClick={handleClose}
-        />
-
-        <div className="relative bg-white rounded-lg shadow-xl max-w-2xl w-full overflow-hidden">
-          {/* Header */}
-          <div className="flex items-start justify-between gap-4 p-6 border-b">
-            <div>
-              <h2 id="import-students-title" className="text-xl font-semibold text-gray-900">
-                Import Students
-              </h2>
-              <p className="text-sm text-gray-600 mt-1">
-                Drop your SEIS and Aeries files — we&apos;ll detect what each one is.
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={handleClose}
-              aria-label="Close"
-              className="shrink-0 w-8 h-8 flex items-center justify-center rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100 text-2xl font-light"
-            >
-              &times;
-            </button>
-          </div>
-
-          {/* Content */}
-          <div className="p-6 space-y-4">
-            {submitError && (
-              <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-md p-3">
-                {submitError}
-              </div>
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="Import Students"
+      description="Drop your SEIS and Aeries files — we'll detect what each one is."
+      size="2xl"
+      dismissable={!uploading}
+      footer={
+        <>
+          <Button variant="secondary" onClick={handleClose} disabled={uploading}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleSubmit}
+            disabled={uploading || submittable.length === 0}
+          >
+            {uploading ? (
+              <>
+                <svg
+                  className="animate-spin -ml-1 mr-2 h-4 w-4"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                Processing...
+              </>
+            ) : submittable.length === 0 ? (
+              'Import'
+            ) : (
+              `Import ${submittable.length} ${submittable.length === 1 ? 'file' : 'files'}`
             )}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        {submitError && (
+          <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-md p-3">
+            {submitError}
+          </div>
+        )}
 
-            {/* Drop zone — a focusable region (Enter/Space opens the picker).
+        {/* Drop zone — a focusable region (Enter/Space opens the picker).
                 A div[role=button] rather than <button> so it can legally hold
                 the block content below (a real <button> allows phrasing only). */}
-            <div
-              role="button"
-              tabIndex={0}
-              aria-label="Add files: drag and drop here, or press Enter to browse"
-              onClick={() => inputRef.current?.click()}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  inputRef.current?.click();
-                }
-              }}
-              onDragOver={(e) => {
-                e.preventDefault();
-                setIsDragging(true);
-              }}
-              onDragLeave={() => setIsDragging(false)}
-              onDrop={handleDrop}
-              className={`w-full cursor-pointer rounded-lg border-2 border-dashed p-8 text-center transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                isDragging ? 'border-blue-500 bg-blue-50' : 'border-gray-300 hover:border-blue-400 hover:bg-blue-50'
-              }`}
-            >
-              <svg className="mx-auto h-10 w-10 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.9A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
-              </svg>
-              <p className="mt-3 text-sm font-medium text-gray-900">Drag files here, or click to browse</p>
-              <p className="mt-1 text-sm text-gray-600">
-                Any one file is enough to start — each extra file just fills in more.
-              </p>
-              <p className="mt-2 text-xs text-gray-400">.xlsx, .xls, .csv, .txt · up to {MAX_FILE_SIZE_MB}MB each</p>
-            </div>
-
-            <input
-              ref={inputRef}
-              type="file"
-              multiple
-              accept={ACCEPT_ATTR}
-              onChange={handleInputChange}
-              className="hidden"
+        <div
+          role="button"
+          tabIndex={0}
+          aria-label="Add files: drag and drop here, or press Enter to browse"
+          onClick={() => inputRef.current?.click()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              inputRef.current?.click();
+            }
+          }}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setIsDragging(true);
+          }}
+          onDragLeave={() => setIsDragging(false)}
+          onDrop={handleDrop}
+          className={`w-full cursor-pointer rounded-lg border-2 border-dashed p-8 text-center transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+            isDragging
+              ? 'border-blue-500 bg-blue-50'
+              : 'border-gray-300 hover:border-blue-400 hover:bg-blue-50'
+          }`}
+        >
+          <svg
+            className="mx-auto h-10 w-10 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M7 16a4 4 0 01-.88-7.9A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
             />
-
-            {/* Contribution legend */}
-            <p className="text-xs text-gray-500">
-              {CONTRIBUTION_LEGEND.map((item, i) => (
-                <span key={item.label}>
-                  {i > 0 && <span className="text-gray-300"> · </span>}
-                  <span className="font-medium text-gray-600">{item.label}</span> → {item.fills}
-                </span>
-              ))}
-            </p>
-
-            {/* Detected files */}
-            {entries.length > 0 && (
-              <ul className="space-y-2">
-                {entries.map((entry) => {
-                  const meta = IMPORT_TYPE_META[entry.type];
-                  const tone = entry.error ? 'border-red-200 bg-red-50' : 'border-gray-200 bg-white';
-                  return (
-                    <li
-                      key={entry.id}
-                      className={`flex items-start justify-between gap-3 rounded-md border p-3 ${tone}`}
-                    >
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className="truncate text-sm font-medium text-gray-900">{entry.file.name}</span>
-                          {!entry.error && (
-                            <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
-                              {meta.label}
-                            </span>
-                          )}
-                        </div>
-                        {entry.error ? (
-                          <p className="mt-0.5 text-xs text-red-600">{entry.error}</p>
-                        ) : (
-                          <p className="mt-0.5 text-xs text-gray-500">
-                            {meta.contribution && <>Fills in {meta.contribution}</>}
-                            {entry.note && <span className="text-amber-700"> · {entry.note}</span>}
-                          </p>
-                        )}
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => removeEntry(entry.id)}
-                        aria-label={`Remove ${entry.file.name}`}
-                        className="shrink-0 text-sm text-gray-500 hover:text-gray-800"
-                      >
-                        Remove
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-
-            {/* Roster template download */}
-            <p className="text-xs text-gray-500">
-              Have your caseload in a spreadsheet?{' '}
-              <button type="button" onClick={downloadTemplate} className="font-medium text-blue-600 hover:text-blue-800 underline">
-                Download the roster template
-              </button>
-            </p>
-
-            {schoolLabel && (
-              <div className="text-xs text-gray-700 bg-green-50 border border-green-200 rounded-md p-2">
-                <strong>Importing to:</strong> {schoolLabel}
-              </div>
-            )}
-          </div>
-
-          {/* Footer */}
-          <div className="flex justify-end gap-3 px-6 py-4 border-t bg-gray-50">
-            <Button variant="secondary" onClick={handleClose} disabled={uploading}>
-              Cancel
-            </Button>
-            <Button variant="primary" onClick={handleSubmit} disabled={uploading || submittable.length === 0}>
-              {uploading ? (
-                <>
-                  <svg className="animate-spin -ml-1 mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                  </svg>
-                  Processing...
-                </>
-              ) : submittable.length === 0 ? (
-                'Import'
-              ) : (
-                `Import ${submittable.length} ${submittable.length === 1 ? 'file' : 'files'}`
-              )}
-            </Button>
-          </div>
+          </svg>
+          <p className="mt-3 text-sm font-medium text-gray-900">
+            Drag files here, or click to browse
+          </p>
+          <p className="mt-1 text-sm text-gray-600">
+            Any one file is enough to start — each extra file just fills in more.
+          </p>
+          <p className="mt-2 text-xs text-gray-400">
+            .xlsx, .xls, .csv, .txt · up to {MAX_FILE_SIZE_MB}MB each
+          </p>
         </div>
+
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          accept={ACCEPT_ATTR}
+          onChange={handleInputChange}
+          className="hidden"
+        />
+
+        {/* Contribution legend */}
+        <p className="text-xs text-gray-500">
+          {CONTRIBUTION_LEGEND.map((item, i) => (
+            <span key={item.label}>
+              {i > 0 && <span className="text-gray-300"> · </span>}
+              <span className="font-medium text-gray-600">{item.label}</span> → {item.fills}
+            </span>
+          ))}
+        </p>
+
+        {/* Detected files */}
+        {entries.length > 0 && (
+          <ul className="space-y-2">
+            {entries.map((entry) => {
+              const meta = IMPORT_TYPE_META[entry.type];
+              const tone = entry.error ? 'border-red-200 bg-red-50' : 'border-gray-200 bg-white';
+              return (
+                <li
+                  key={entry.id}
+                  className={`flex items-start justify-between gap-3 rounded-md border p-3 ${tone}`}
+                >
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-sm font-medium text-gray-900">
+                        {entry.file.name}
+                      </span>
+                      {!entry.error && (
+                        <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+                          {meta.label}
+                        </span>
+                      )}
+                    </div>
+                    {entry.error ? (
+                      <p className="mt-0.5 text-xs text-red-600">{entry.error}</p>
+                    ) : (
+                      <p className="mt-0.5 text-xs text-gray-500">
+                        {meta.contribution && <>Fills in {meta.contribution}</>}
+                        {entry.note && <span className="text-amber-700"> · {entry.note}</span>}
+                      </p>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => removeEntry(entry.id)}
+                    aria-label={`Remove ${entry.file.name}`}
+                    className="shrink-0 text-sm text-gray-500 hover:text-gray-800"
+                  >
+                    Remove
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        {/* Roster template download */}
+        <p className="text-xs text-gray-500">
+          Have your caseload in a spreadsheet?{' '}
+          <button
+            type="button"
+            onClick={downloadTemplate}
+            className="font-medium text-blue-600 hover:text-blue-800 underline"
+          >
+            Download the roster template
+          </button>
+        </p>
+
+        {schoolLabel && (
+          <div className="text-xs text-gray-700 bg-green-50 border border-green-200 rounded-md p-2">
+            <strong>Importing to:</strong> {schoolLabel}
+          </div>
+        )}
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/app/components/ui/modal.tsx
+++ b/app/components/ui/modal.tsx
@@ -1,68 +1,153 @@
 'use client';
-import { useEffect } from 'react';
+
+import { Fragment } from 'react';
+import { Dialog as HeadlessDialog, Transition } from '@headlessui/react';
+import { X } from 'lucide-react';
+
+/**
+ * Shared accessible modal (SPE-226).
+ *
+ * Built on Headless UI's `Dialog`, so it comes with a focus trap, focus
+ * restoration to the trigger, `role="dialog"` + `aria-modal`, `Esc`-to-close,
+ * outside-click-to-close, and body scroll lock — the accessibility the
+ * hand-rolled upload dialogs were missing. Extends the previous Modal's simple
+ * `isOpen/onClose/title/children` API (kept backward compatible) with size
+ * variants, an optional footer slot, and a `dismissable` lock for
+ * work-in-flight states.
+ */
+
+export type ModalSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl';
+
+const SIZE_CLASS: Record<ModalSize, string> = {
+  sm: 'sm:max-w-sm',
+  md: 'sm:max-w-md',
+  lg: 'sm:max-w-lg',
+  xl: 'sm:max-w-xl',
+  '2xl': 'sm:max-w-2xl',
+  '3xl': 'sm:max-w-3xl',
+  '4xl': 'sm:max-w-4xl',
+  '5xl': 'sm:max-w-5xl',
+};
 
 interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
-  title: string;
+  /** Optional heading; when set, renders the default header and names the dialog for screen readers. */
+  title?: string;
+  /** Optional sub-heading rendered under the title. */
+  description?: string;
+  /** Body content. */
   children: React.ReactNode;
+  /** Optional footer (e.g. action buttons); rendered in a bordered footer bar. */
+  footer?: React.ReactNode;
+  /** Panel max width. Defaults to 'lg' to match the previous Modal. */
+  size?: ModalSize;
+  /**
+   * When false, backdrop clicks, the Escape key, and the header close button do
+   * not dismiss the modal. Use `dismissable={!isSubmitting}` to lock the modal
+   * while an operation is in flight (parity with the upload wizard's
+   * backdrop-disabled-while-uploading behavior). Defaults to true.
+   */
+  dismissable?: boolean;
+  /** Classes for the scrollable body wrapper; defaults to standard padding. Pass '' for full-bleed content. */
+  bodyClassName?: string;
+  /** Element to focus when the modal opens (defaults to the first focusable element). */
+  initialFocus?: React.MutableRefObject<HTMLElement | null>;
 }
 
-export function Modal({ isOpen, onClose, title, children }: ModalProps) {
-
-  // Add escape key handler and body scroll prevention
-  useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
-        onClose();
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener('keydown', handleEscape);
-      document.body.style.overflow = 'hidden';
-    }
-
-    return () => {
-      document.removeEventListener('keydown', handleEscape);
-      document.body.style.overflow = 'unset';
-    };
-  }, [isOpen, onClose]);
-
-  if (!isOpen) return null;
+export function Modal({
+  isOpen,
+  onClose,
+  title,
+  description,
+  children,
+  footer,
+  size = 'lg',
+  dismissable = true,
+  bodyClassName = 'px-6 py-4',
+  initialFocus,
+}: ModalProps) {
+  // Headless UI routes both Escape and outside-click through a single `onClose`;
+  // gate it so a locked (e.g. submitting) modal can't be dismissed.
+  const handleClose = () => {
+    if (dismissable) onClose();
+  };
 
   return (
-    <div className="fixed inset-0 z-50 overflow-y-auto">
-      {/* Backdrop - moved outside flex container for better layering */}
-      <div 
-        className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" 
-        onClick={onClose} 
-      />
+    <Transition.Root show={isOpen} as={Fragment}>
+      <HeadlessDialog
+        as="div"
+        className="relative z-50"
+        onClose={handleClose}
+        initialFocus={initialFocus}
+      >
+        {/* Backdrop */}
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div
+            className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+            aria-hidden="true"
+          />
+        </Transition.Child>
 
-      {/* Center modal properly */}
-      <div className="flex min-h-screen items-center justify-center p-4">
-        <div className="relative bg-white rounded-lg shadow-xl max-w-lg w-full max-h-[90vh]">
-          {/* Header with border */}
-          <div className="border-b border-gray-200 px-6 py-4">
-            <h3 className="text-lg font-medium text-gray-900">{title}</h3>
-            <button
-              onClick={onClose}
-              className="absolute top-4 right-4 text-gray-400 hover:text-gray-500 transition-colors"
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-200"
+              enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+              enterTo="opacity-100 translate-y-0 sm:scale-100"
+              leave="ease-in duration-150"
+              leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+              leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <span className="sr-only">Close</span>
-              <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
+              <HeadlessDialog.Panel
+                className={`relative my-8 flex max-h-[90vh] w-full ${SIZE_CLASS[size]} transform flex-col overflow-hidden rounded-lg bg-white text-left align-middle shadow-xl transition-all`}
+              >
+                {title && (
+                  <div className="flex items-start justify-between gap-4 border-b border-gray-200 px-6 py-4">
+                    <div className="min-w-0">
+                      <HeadlessDialog.Title as="h2" className="text-lg font-semibold text-gray-900">
+                        {title}
+                      </HeadlessDialog.Title>
+                      {description && (
+                        <HeadlessDialog.Description className="mt-1 text-sm text-gray-600">
+                          {description}
+                        </HeadlessDialog.Description>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={handleClose}
+                      disabled={!dismissable}
+                      aria-label="Close"
+                      className="shrink-0 rounded-full p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:pointer-events-none disabled:opacity-40"
+                    >
+                      <X className="h-5 w-5" aria-hidden="true" />
+                    </button>
+                  </div>
+                )}
 
-          {/* Body with scroll if needed */}
-          <div className="px-6 py-4 overflow-y-auto">
-            {children}
-          </div>       
+                <div className={`flex-1 overflow-y-auto ${bodyClassName}`}>{children}</div>
+
+                {footer && (
+                  <div className="flex justify-end gap-3 border-t border-gray-200 bg-gray-50 px-6 py-4">
+                    {footer}
+                  </div>
+                )}
+              </HeadlessDialog.Panel>
+            </Transition.Child>
+          </div>
         </div>
-      </div>
-    </div>
+      </HeadlessDialog>
+    </Transition.Root>
   );
 }
 


### PR DESCRIPTION
## What & why

Rebuilds the shared modal (`app/components/ui/modal.tsx`) on **Headless UI's `Dialog`** — already a dependency, and the basis of the existing `ui/dialog.tsx` — so every upload dialog gets a **focus trap, focus restore to the trigger, `role="dialog"` + `aria-modal`, Escape-to-close, outside-click-to-close, and body scroll lock**. These were all missing from the hand-rolled upload dialogs.

The simple `isOpen/onClose/title/children` API is **preserved** (the three existing consumers — CARE referral, new-chat, manual-placement — keep working unchanged), extended with:
- `size` variants (sm…5xl),
- an optional `footer` slot,
- `description` (wired to `aria-describedby` via `Dialog.Description`),
- a `dismissable` lock for work-in-flight states (parity with the wizard's backdrop-disabled-while-uploading behavior).

Linear: **SPE-226**.

## Adopted in

- **`student-import-modal.tsx`** (the unified Import Students modal) now renders through the shared `Modal`, replacing its hand-rolled backdrop/panel markup. The large diff there is **almost entirely re-indentation** from moving the content into the Modal — no logic change (a reviewer audit confirmed full behavior parity: the uploading-lock, state-reset-on-close, and every handler are preserved).

The **review modal (SPE-227)** and the **per-student IEP preview (SPE-232)** will adopt the shared Modal as they're rebuilt/retired in the next tickets — wiring them here would be thrown away.

## Verification

- typecheck + lint clean; all 348 tests pass.
- The import modal's component test now queries the Dialog **portal** (`document`) instead of the render container — a correct consequence of the modal now portaling to `document.body`.
- Deep self-review (`/code-review` high — component correctness/a11y, behavior-parity, test/cleanup): parity confirmed with no regressions; component correct on all axes; the one finding (description not wired to `aria-describedby`) is fixed here.
- Keyboard-only pass (focus lands inside → Tab cycles → Escape closes except mid-submit → focus returns to trigger) to be confirmed on the Vercel preview.

## Note on commit signing

Commits show **Unverified** — this sandbox has no usable SSH signing-key material, so signatures can't be produced here (config left intact, not bypassed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmVLoR4G2LYpDKGBY8ADtS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmVLoR4G2LYpDKGBY8ADtS)_