### PR TITLE
feat(students): fast consecutive Add Student entry + keyboard-navigable teacher picker (SPE-237)

### DIFF
--- a/app/(dashboard)/dashboard/students/page.tsx
+++ b/app/(dashboard)/dashboard/students/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Button } from '../../../components/ui/button';
 import { LongHoverTooltip } from '../../../components/ui/long-hover-tooltip';
 import { Card, CardHeader, CardTitle, CardBody } from '../../../components/ui/card';
@@ -38,6 +38,11 @@ type Student = {
 
 export default function StudentsPage() {
   const [showAddForm, setShowAddForm] = useState(false);
+  // SPE-237: the Add Student form stays open for consecutive entries — inline
+  // feedback (no alert()) and an initials ref so we can refocus after each add.
+  const [addFormError, setAddFormError] = useState<string | null>(null);
+  const [addFormConfirmation, setAddFormConfirmation] = useState<string | null>(null);
+  const initialsInputRef = useRef<HTMLInputElement>(null);
   const [students, setStudents] = useState<Student[]>([]);
   const [loading, setLoading] = useState(true);
   const [userRole, setUserRole] = useState<string | null>(null);
@@ -180,16 +185,24 @@ export default function StudentsPage() {
     checkUnscheduledSessions();
   }, [currentSchool, fetchStudents, checkUnscheduledSessions]);
 
+  // Focus Initials when the form opens so entry starts at the keyboard.
+  useEffect(() => {
+    if (showAddForm) initialsInputRef.current?.focus();
+  }, [showAddForm]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setAddFormError(null);
+    setAddFormConfirmation(null);
 
     if (!currentSchool) {
-      alert('No school selected');
+      setAddFormError('No school selected.');
       return;
     }
 
+    const addedInitials = formData.initials;
     try {
-      const newStudent = await createStudent({
+      await createStudent({
         initials: formData.initials,
         grade_level: formData.grade_level,
         teacher_id: formData.teacher_id,
@@ -203,23 +216,43 @@ export default function StudentsPage() {
         state_id: currentSchool?.state_id,
       });
 
-      // Reset form
+      // SPE-237: stay open for the next entry. Reset the per-student fields but
+      // keep the grade preselected (caseloads cluster by grade), confirm inline,
+      // and refocus Initials so the next student can be typed without the mouse.
       setFormData({
         initials: '',
-        grade_level: '',
+        grade_level: formData.grade_level,
         teacher_id: null,
         teacherName: null,
         sessions_per_week: '',
         minutes_per_session: '30'
       });
-
-      setShowAddForm(false);
+      setAddFormConfirmation(`${addedInitials} added`);
       fetchStudents();
       checkUnscheduledSessions();
+      initialsInputRef.current?.focus();
     } catch (error) {
       console.error('Error creating student:', error);
-      alert(error instanceof Error ? error.message : 'Failed to add student');
+      // Inline error — keep the form open and the other fields intact so the
+      // user can correct (e.g. duplicate initials) without re-entering everything.
+      setAddFormError(error instanceof Error ? error.message : 'Failed to add student');
     }
+  };
+
+  // Finish adding — closes the form and clears its inline state (the header × and
+  // the Done button both route here).
+  const handleCloseAddForm = () => {
+    setShowAddForm(false);
+    setAddFormError(null);
+    setAddFormConfirmation(null);
+    setFormData({
+      initials: '',
+      grade_level: '',
+      teacher_id: null,
+      teacherName: null,
+      sessions_per_week: '',
+      minutes_per_session: '30'
+    });
   };
 
   const handleDelete = async (studentId: string, studentInitials: string) => {
@@ -418,7 +451,7 @@ export default function StudentsPage() {
                   <CardTitle>Add New Student</CardTitle>
                   <Button
                     variant="secondary"
-                    onClick={() => setShowAddForm(false)}
+                    onClick={handleCloseAddForm}
                     className="text-gray-500 hover:text-gray-700"
                   >
                     ×
@@ -426,6 +459,11 @@ export default function StudentsPage() {
                 </div>
               </CardHeader>
               <CardBody>
+                {addFormError && (
+                  <div className="mb-4 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md p-3">
+                    {addFormError}
+                  </div>
+                )}
                   <form onSubmit={handleSubmit} className="grid grid-cols-1 md:grid-cols-6 gap-4">
                   <div className="md:col-span-1">
                     <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -433,6 +471,7 @@ export default function StudentsPage() {
                     </label>
                     <input
                       type="text"
+                      ref={initialsInputRef}
                       required
                       value={formData.initials}
                       onChange={(e) => setFormData({...formData, initials: e.target.value})}
@@ -515,12 +554,17 @@ export default function StudentsPage() {
                     </select>
                   </div>
 
-                  <div className="md:col-span-6 flex justify-end gap-3 pt-4">
-                    <Button variant="secondary" type="button" onClick={() => setShowAddForm(false)}>
-                      Cancel
+                  <div className="md:col-span-6 flex items-center justify-end gap-3 pt-4">
+                    {addFormConfirmation && (
+                      <span className="mr-auto text-sm font-medium text-green-700">
+                        {addFormConfirmation}
+                      </span>
+                    )}
+                    <Button variant="secondary" type="button" onClick={handleCloseAddForm}>
+                      Done
                     </Button>
                     <Button variant="primary" type="submit">
-                      Add Student
+                      Add &amp; add another
                     </Button>
                   </div>
                 </form>

--- a/app/(dashboard)/dashboard/students/page.tsx
+++ b/app/(dashboard)/dashboard/students/page.tsx
@@ -42,7 +42,15 @@ export default function StudentsPage() {
   // feedback (no alert()) and an initials ref so we can refocus after each add.
   const [addFormError, setAddFormError] = useState<string | null>(null);
   const [addFormConfirmation, setAddFormConfirmation] = useState<string | null>(null);
+  const [savingStudent, setSavingStudent] = useState(false);
   const initialsInputRef = useRef<HTMLInputElement>(null);
+  // Synchronous guard against a double-submit (Enter pressed twice) before state
+  // re-renders; the form is built for rapid keyboard entry.
+  const savingStudentRef = useRef(false);
+  // Bumped after each add to remount TeacherAutocomplete — it keeps its own
+  // internal selected-teacher state, so without a fresh mount it would keep
+  // showing the previous teacher while formData.teacher_id has reset to null.
+  const [teacherFieldKey, setTeacherFieldKey] = useState(0);
   const [students, setStudents] = useState<Student[]>([]);
   const [loading, setLoading] = useState(true);
   const [userRole, setUserRole] = useState<string | null>(null);
@@ -192,6 +200,7 @@ export default function StudentsPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (savingStudentRef.current) return; // already submitting — ignore the repeat
     setAddFormError(null);
     setAddFormConfirmation(null);
 
@@ -201,6 +210,8 @@ export default function StudentsPage() {
     }
 
     const addedInitials = formData.initials;
+    savingStudentRef.current = true;
+    setSavingStudent(true);
     try {
       await createStudent({
         initials: formData.initials,
@@ -227,6 +238,7 @@ export default function StudentsPage() {
         sessions_per_week: '',
         minutes_per_session: '30'
       });
+      setTeacherFieldKey((k) => k + 1);
       setAddFormConfirmation(`${addedInitials} added`);
       fetchStudents();
       checkUnscheduledSessions();
@@ -236,6 +248,10 @@ export default function StudentsPage() {
       // Inline error — keep the form open and the other fields intact so the
       // user can correct (e.g. duplicate initials) without re-entering everything.
       setAddFormError(error instanceof Error ? error.message : 'Failed to add student');
+      initialsInputRef.current?.focus();
+    } finally {
+      savingStudentRef.current = false;
+      setSavingStudent(false);
     }
   };
 
@@ -474,7 +490,10 @@ export default function StudentsPage() {
                       ref={initialsInputRef}
                       required
                       value={formData.initials}
-                      onChange={(e) => setFormData({...formData, initials: e.target.value})}
+                      onChange={(e) => {
+                        setFormData({...formData, initials: e.target.value});
+                        if (addFormConfirmation) setAddFormConfirmation(null);
+                      }}
                       className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                       placeholder="e.g., JD"
                     />
@@ -513,6 +532,7 @@ export default function StudentsPage() {
                       Teacher*
                     </label>
                     <TeacherAutocomplete
+                      key={teacherFieldKey}
                       value={formData.teacher_id}
                       teacherName={formData.teacherName || undefined}
                       onChange={(teacherId, teacherName) => setFormData({ ...formData, teacher_id: teacherId, teacherName })}
@@ -563,8 +583,8 @@ export default function StudentsPage() {
                     <Button variant="secondary" type="button" onClick={handleCloseAddForm}>
                       Done
                     </Button>
-                    <Button variant="primary" type="submit">
-                      Add &amp; add another
+                    <Button variant="primary" type="submit" disabled={savingStudent}>
+                      {savingStudent ? 'Adding…' : 'Add & add another'}
                     </Button>
                   </div>
                 </form>

--- a/app/components/teachers/teacher-autocomplete.tsx
+++ b/app/components/teachers/teacher-autocomplete.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useId } from 'react';
 import { searchTeachers, formatTeacherName } from '@/lib/supabase/queries/school-directory';
 
 type Teacher = Awaited<ReturnType<typeof searchTeachers>>[number];
@@ -30,14 +30,17 @@ export function TeacherAutocomplete({
   const [teachers, setTeachers] = useState<Teacher[]>([]);
   const [loading, setLoading] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [selectedTeacher, setSelectedTeacher] = useState<Teacher | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const listboxId = useId();
 
   // Handle clicks outside dropdown
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
         setIsOpen(false);
+        setHighlightedIndex(-1);
       }
     }
 
@@ -50,6 +53,7 @@ export function TeacherAutocomplete({
     const searchForTeachers = async () => {
       if (searchTerm.length < 2) {
         setTeachers([]);
+        setHighlightedIndex(-1);
         return;
       }
 
@@ -57,6 +61,7 @@ export function TeacherAutocomplete({
         setLoading(true);
         const results = await searchTeachers(searchTerm, schoolId);
         setTeachers(results);
+        setHighlightedIndex(-1);
         setIsOpen(true);
       } catch (error) {
         console.error('Error searching teachers:', error);
@@ -75,13 +80,37 @@ export function TeacherAutocomplete({
     setSelectedTeacher(teacher);
     setSearchTerm('');
     setIsOpen(false);
+    setHighlightedIndex(-1);
     onChange(teacher.id, formatTeacherName(teacher));
   };
 
   const handleClear = () => {
     setSelectedTeacher(null);
     setSearchTerm('');
+    setHighlightedIndex(-1);
     onChange(null, null);
+  };
+
+  // Keyboard navigation so a teacher can be picked without the mouse (SPE-237).
+  // Enter here NEVER submits the parent form — it selects the highlighted (or
+  // first) result, so the user can't accidentally save a student with no teacher.
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (!isOpen && teachers.length > 0) setIsOpen(true);
+      setHighlightedIndex((i) => Math.min(i + 1, teachers.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (isOpen && teachers.length > 0) {
+        handleSelect(teachers[highlightedIndex >= 0 ? highlightedIndex : 0]);
+      }
+    } else if (e.key === 'Escape') {
+      setIsOpen(false);
+      setHighlightedIndex(-1);
+    }
   };
 
   // Display value
@@ -127,9 +156,14 @@ export function TeacherAutocomplete({
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               onFocus={() => searchTerm.length >= 2 && setIsOpen(true)}
+              onKeyDown={handleKeyDown}
               placeholder={placeholder}
               required={required && !value}
               disabled={disabled}
+              role="combobox"
+              aria-expanded={isOpen}
+              aria-controls={listboxId}
+              aria-autocomplete="list"
               className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
             />
             {loading && (
@@ -165,13 +199,16 @@ export function TeacherAutocomplete({
                   )}
                 </div>
               ) : (
-                <ul className="py-1">
-                  {teachers.map((teacher) => (
+                <ul className="py-1" role="listbox" id={listboxId}>
+                  {teachers.map((teacher, index) => (
                     <li key={teacher.id}>
                       <button
                         type="button"
+                        role="option"
+                        aria-selected={index === highlightedIndex}
                         onClick={() => handleSelect(teacher)}
-                        className="w-full text-left px-4 py-2 hover:bg-gray-100 focus:bg-gray-100 focus:outline-none transition-colors"
+                        onMouseEnter={() => setHighlightedIndex(index)}
+                        className={`w-full text-left px-4 py-2 focus:outline-none transition-colors ${index === highlightedIndex ? 'bg-gray-100' : 'hover:bg-gray-100'}`}
                       >
                         <div className="flex items-center justify-between">
                           <div>

--- a/app/components/teachers/teacher-autocomplete.tsx
+++ b/app/components/teachers/teacher-autocomplete.tsx
@@ -54,6 +54,7 @@ export function TeacherAutocomplete({
       if (searchTerm.length < 2) {
         setTeachers([]);
         setHighlightedIndex(-1);
+        setLoading(false);
         return;
       }
 
@@ -108,8 +109,14 @@ export function TeacherAutocomplete({
         handleSelect(teachers[highlightedIndex >= 0 ? highlightedIndex : 0]);
       }
     } else if (e.key === 'Escape') {
-      setIsOpen(false);
-      setHighlightedIndex(-1);
+      // Only consume Escape when there's a dropdown to close; otherwise let it
+      // bubble so a parent modal's Escape-to-close still works.
+      if (isOpen) {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsOpen(false);
+        setHighlightedIndex(-1);
+      }
     }
   };
 
@@ -154,7 +161,16 @@ export function TeacherAutocomplete({
             <input
               type="text"
               value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
+              onChange={(e) => {
+                const term = e.target.value;
+                setSearchTerm(term);
+                // Results belong to the previous term until the debounced search
+                // re-runs; clear them synchronously so a fast Enter can't select a
+                // stale teacher, and show "Searching…" rather than "no results".
+                setTeachers([]);
+                setHighlightedIndex(-1);
+                if (term.length >= 2) setLoading(true);
+              }}
               onFocus={() => searchTerm.length >= 2 && setIsOpen(true)}
               onKeyDown={handleKeyDown}
               placeholder={placeholder}


### PR DESCRIPTION
## What & why

Entering a caseload by hand was self-inflicted tedium: the Add Student form closed after **every** student (`setShowAddForm(false)`), so adding 25 students meant clicking "+ Add Student" 25 times. With the roster CSV repositioned as "already have a spreadsheet" (SPE-224), direct entry is the recommended manual path — it just needed to be fast.

Linear: **SPE-237** (Phase 2). Final Phase-2 feature before the cosmetic SPE-228.

## Changes

- **Form stays open** for consecutive entries: primary **"Add & add another"**, secondary **"Done"** (header × also closes). Single-add is unchanged (add one → Done).
- **After each save:** reset the per-student fields but **keep the grade preselected** (caseloads cluster by grade), show an inline **"⟨initials⟩ added"** confirmation (no `alert()`), and **refocus Initials** so the next student is typed without the mouse. The form autofocuses Initials on open.
- **Errors** (e.g. duplicate initials) render **inline** and keep the form open with the other fields intact.
- **Keyboard-navigable teacher picker** (`TeacherAutocomplete`, shared): arrow keys highlight, Enter selects, Escape closes — so a whole caseload can be entered without touching the mouse (the ticket's acceptance). **Enter in the teacher search now selects a result instead of submitting the form**, which also closes a path where pressing Enter mid-search could save a student with no teacher.

## Verification

- `typecheck` clean; `lint` clean.
- **Deep self-review (`/code-review`, high effort — focused passes for this diff)** caught and this branch fixes:
  - **Stale-teacher regression (high):** because the form now stays mounted, `TeacherAutocomplete`'s internal selected-teacher state kept *showing* the previous teacher after the field reset to null — and its "selected" chip hides the required input — so consecutive students could save **with no teacher despite the UI showing one**. Fixed by remounting the picker after each add (keyed).
  - **Double-submit** on rapid entry (a synchronous guard + disabled/"Adding…" button) so a double-Enter can't fire two creates and surface a confusing duplicate error for the student just added.
  - **Error-path focus:** on a failed add, refocus Initials so a keyboard user can correct without the mouse; clear the confirmation when the next student is started.

### Shared-component note
The teacher-picker keyboard nav touches `TeacherAutocomplete`, used on 8 screens. The change is **additive** — existing click-to-select is unchanged, and Enter-selects-a-result is the intuitive behavior everywhere it's used. Verified via typecheck across all call sites; the primary Add Student flow is verified in the sim district (below).

Sim-district verification (add several students end-to-end via keyboard, incl. keyboard teacher selection; assert each student's teacher is saved correctly) to follow in a comment.

## Note on commit signing

Commits are authored as `noreply@anthropic.com` but show **Unverified**: this sandbox has no usable SSH signing-key material, so signatures can't be produced here (config left intact, not bypassed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmVLoR4G2LYpDKGBY8ADtS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmVLoR4G2LYpDKGBY8ADtS)_