### PR TITLE
chore(ui): one Spinner + single accent across the upload surfaces (SPE-228)

### DIFF
--- a/app/components/students/iep-goals-uploader.tsx
+++ b/app/components/students/iep-goals-uploader.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useState, useRef } from 'react';
-import { Upload, Loader2 } from 'lucide-react';
+import { Upload } from 'lucide-react';
 import { Button } from '../ui/button';
+import { Spinner } from '../ui/spinner';
 
 interface IEPGoalsUploaderProps {
   onUploadComplete: (data: any) => void;
@@ -116,7 +117,7 @@ export function IEPGoalsUploader({ onUploadComplete, disabled = false, targetStu
       >
         {uploading ? (
           <>
-            <Loader2 className="animate-spin -ml-1 mr-2 h-4 w-4" aria-hidden="true" />
+            <Spinner className="-ml-1 mr-2 h-4 w-4" />
             {targetStudent ? `Importing goals for ${targetStudent.initials}…` : 'Importing…'}
           </>
         ) : (

--- a/app/components/students/student-import-modal.tsx
+++ b/app/components/students/student-import-modal.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from 'react';
 import { Button } from '../ui/button';
 import { Modal } from '../ui/modal';
+import { Spinner } from '../ui/spinner';
 import {
   ACCEPT_ATTR,
   IMPORT_TYPE_META,
@@ -244,26 +245,7 @@ export function StudentImportModal({
           >
             {uploading ? (
               <>
-                <svg
-                  className="animate-spin -ml-1 mr-2 h-4 w-4"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="4"
-                  />
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                  />
-                </svg>
+                <Spinner className="-ml-1 mr-2 h-4 w-4" />
                 Processing...
               </>
             ) : submittable.length === 0 ? (
@@ -410,7 +392,7 @@ export function StudentImportModal({
         </p>
 
         {schoolLabel && (
-          <div className="text-xs text-gray-700 bg-green-50 border border-green-200 rounded-md p-2">
+          <div className="text-xs text-gray-700 bg-gray-50 border border-gray-200 rounded-md p-2">
             <strong>Importing to:</strong> {schoolLabel}
           </div>
         )}

--- a/app/components/ui/spinner.tsx
+++ b/app/components/ui/spinner.tsx
@@ -1,0 +1,15 @@
+import { Loader2 } from 'lucide-react';
+
+interface SpinnerProps {
+  /** Size/positioning utility classes (default `h-4 w-4`). */
+  className?: string;
+}
+
+/**
+ * The one spinner for the app (SPE-228) — a single lucide-based implementation
+ * so the upload surfaces (and anywhere else) stop hand-rolling inline SVGs.
+ * Decorative: pair it with adjacent text (e.g. "Importing…") that conveys state.
+ */
+export function Spinner({ className = 'h-4 w-4' }: SpinnerProps) {
+  return <Loader2 className={`animate-spin ${className}`} aria-hidden="true" />;
+}


### PR DESCRIPTION
## What & why

The upload flows used to mix three icon systems (emoji glyphs, lucide, two hand-copied SVG spinners) and three accent identities (green CSV card, blue wizard, purple AI gradient), so they read as three different products. This is the final Phase 2 cleanup (SPE-228) to make them one.

Linear: **SPE-228** (Phase 2 — closing ticket).

## Changes

- **One shared `Spinner`** (`app/components/ui/spinner.tsx`, lucide `Loader2`) — adopted in the **Import Students modal** (replacing its hand-rolled inline SVG spinner) and the **IEP-goals uploader** (replacing its inline `Loader2`), so there's a single spinner implementation.
- **Single accent:** neutralized the lone green accent on the import modal's "Importing to …" box (green → neutral gray). The upload surfaces now use one accent (product blue) plus the neutral palette.

## Already handled by earlier Phase 2 work

Most of this ticket's original targets are gone:
- The **emoji-as-icons** (📄 ⚠ ↻ ○ ✏️ ℹ️) and the **purple gradient** lived in the preview modals and the SEIS wizard — all **retired** in SPE-227 / SPE-232.
- The rebuilt **review screen** (SPE-227) is already lucide-only + blue.
- The **📄 emoji + hand-rolled spinner** in the IEP uploader were already swapped to lucide in SPE-232 (now further unified to the shared `Spinner` here).

A repo scan confirms **no emoji-as-icon and no purple/gradient remain** in the upload surfaces.

## Verification

- `typecheck` clean; `lint` clean. This is a mechanical, no-behavior-change cosmetic sweep (a spinner component swap that preserves the existing size/positioning classes, and one accent-color swap), so it's covered by the gates and the Vercel preview rather than a sim-district walk.

## Note on commit signing

Commits are authored as `noreply@anthropic.com` but show **Unverified**: this sandbox has no usable SSH signing-key material, so signatures can't be produced here (config left intact, not bypassed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmVLoR4G2LYpDKGBY8ADtS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmVLoR4G2LYpDKGBY8ADtS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable loading spinner for consistent progress indicators.
* **UI Improvements**
  * Updated student upload and import actions to use the new spinner while processing.
  * Refined the school import badge with a neutral gray style for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->