### PR TITLE
feat(import): move per-student IEP goal writes server-side (SPE-234)

### DIFF
--- a/__tests__/unit/lib/import/merge-goals.test.ts
+++ b/__tests__/unit/lib/import/merge-goals.test.ts
@@ -1,0 +1,33 @@
+import { mergeGoals } from '@/lib/import/merge-goals';
+
+// SPE-234: the per-student import merges goals server-side. This pins the exact
+// contract the acceptance requires (must match the retired client behavior):
+// append-only, case-insensitive + trimmed dedupe, never remove/reorder.
+describe('mergeGoals (SPE-234)', () => {
+  it('appends goals not already present', () => {
+    expect(mergeGoals(['A', 'B'], ['C'])).toEqual(['A', 'B', 'C']);
+  });
+
+  it('dedupes case-insensitively and after trimming, keeping the existing copy', () => {
+    expect(mergeGoals(['Read 90 wpm'], ['  read 90 WPM  ', 'Add 2-digit'])).toEqual([
+      'Read 90 wpm',
+      'Add 2-digit',
+    ]);
+  });
+
+  it('never removes or reorders existing goals (empty incoming is a no-op)', () => {
+    expect(mergeGoals(['A', 'B', 'C'], [])).toEqual(['A', 'B', 'C']);
+  });
+
+  it('dedupes duplicates within the incoming batch too', () => {
+    expect(mergeGoals([], ['G', 'g', ' G '])).toEqual(['G']);
+  });
+
+  it('does not mutate its inputs', () => {
+    const existing = ['A'];
+    const incoming = ['B'];
+    mergeGoals(existing, incoming);
+    expect(existing).toEqual(['A']);
+    expect(incoming).toEqual(['B']);
+  });
+});

--- a/app/api/import-iep-goals/confirm/route.ts
+++ b/app/api/import-iep-goals/confirm/route.ts
@@ -137,10 +137,11 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
       results.push({ success: true });
       succeeded++;
     } catch (err) {
-      results.push({
-        success: false,
-        error: (err as { message?: string })?.message ?? 'Failed to save goals',
-      });
+      // Never surface the raw DB/PostgREST error to the browser — log it
+      // server-side (with the provider for correlation) and return a neutral
+      // per-row message.
+      log.error('IEP goals confirm: write failed', err, { userId, studentId });
+      results.push({ success: false, error: 'Failed to save goals' });
     }
   }
 

--- a/app/api/import-iep-goals/confirm/route.ts
+++ b/app/api/import-iep-goals/confirm/route.ts
@@ -1,0 +1,149 @@
+/**
+ * Per-student IEP goals confirm (SPE-234).
+ *
+ * The server-side write for the target-student import flow — the last import
+ * write moved off the browser. Two import write semantics live in this codebase,
+ * documented here deliberately (ARCH-6):
+ *   - Bulk sync (`upsert_students_atomic`, /api/import-students/confirm) = REPLACE
+ *     a matched student's goals (with removal warnings shown in review).
+ *   - Per-student IEP import (this route) = MERGE: append the selected goals that
+ *     aren't already present (case-insensitive, trimmed), never removing any.
+ *
+ * Ownership is enforced server-side by scoping to the caller's students
+ * (`provider_id = userId`), the same pattern as the import RPCs; RLS on
+ * `student_details` (via the user-scoped client) is the backstop.
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { withRoute } from '@/lib/api/with-route';
+import { log } from '@/lib/monitoring/logger';
+import { mergeGoals } from '@/lib/import/merge-goals';
+
+export const runtime = 'nodejs';
+
+interface GoalMergeInput {
+  studentId: string;
+  goals: string[];
+  /** Sets goals_iep_date when present (the report's IEP date). */
+  iepDate?: string;
+}
+
+interface MergeResult {
+  success: boolean;
+  error?: string;
+}
+
+// Canonical UUID form; mirrors app/api/import-students/confirm/route.ts. A
+// studentId that isn't a UUID can't be one of the caller's students, so it's
+// dropped here (→ per-row "not found") rather than 500-ing the .in() uuid cast.
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const POST = withRoute({}, async ({ req: request, userId }) => {
+  const supabase = await createClient();
+  const body = await request.json();
+  const { students } = body as { students: GoalMergeInput[] };
+
+  if (!students || !Array.isArray(students) || students.length === 0) {
+    return NextResponse.json({ error: 'No students provided' }, { status: 400 });
+  }
+
+  // Ownership: only students that belong to the authenticated provider may be
+  // written. A studentId not returned here (another provider's, or nonexistent)
+  // is reported as a per-row failure rather than written.
+  const studentIds = [
+    ...new Set(students.map(s => s?.studentId).filter((id): id is string => typeof id === 'string' && UUID_REGEX.test(id))),
+  ];
+
+  const owned = new Set<string>();
+  const existingByStudent = new Map<string, string[]>();
+
+  if (studentIds.length > 0) {
+    const { data: ownedRows, error: ownedError } = await supabase
+      .from('students')
+      .select('id')
+      .eq('provider_id', userId)
+      .in('id', studentIds);
+    if (ownedError) {
+      log.error('IEP goals confirm: ownership lookup failed', ownedError, { userId });
+      return NextResponse.json({ error: 'Failed to verify students' }, { status: 500 });
+    }
+    for (const row of ownedRows ?? []) owned.add(row.id);
+
+    // Batch-fetch existing goals for the owned students (one query, not N).
+    if (owned.size > 0) {
+      const { data: existingDetails, error: detailsError } = await supabase
+        .from('student_details')
+        .select('student_id, iep_goals')
+        .in('student_id', [...owned]);
+      if (detailsError) {
+        log.error('IEP goals confirm: details fetch failed', detailsError, { userId });
+        return NextResponse.json({ error: 'Failed to load existing goals' }, { status: 500 });
+      }
+      for (const d of existingDetails ?? []) {
+        existingByStudent.set(d.student_id, d.iep_goals || []);
+      }
+    }
+  }
+
+  // Input-ordered results, so the caller maps each outcome back by position.
+  const results: MergeResult[] = [];
+  let succeeded = 0;
+
+  for (const entry of students) {
+    const studentId = entry?.studentId;
+    if (typeof studentId !== 'string' || !owned.has(studentId)) {
+      results.push({ success: false, error: 'Student not found in your caseload' });
+      continue;
+    }
+
+    // Only well-formed goal strings are merged; a row with none is a no-op skip.
+    const goals = Array.isArray(entry.goals)
+      ? entry.goals.filter((g): g is string => typeof g === 'string')
+      : [];
+    if (goals.length === 0) {
+      results.push({ success: true });
+      succeeded++;
+      continue;
+    }
+
+    try {
+      const existing = existingByStudent.get(studentId) ?? [];
+      const merged = mergeGoals(existing, goals);
+
+      const upsertData: {
+        student_id: string;
+        iep_goals: string[];
+        updated_at: string;
+        goals_iep_date?: string;
+      } = {
+        student_id: studentId,
+        iep_goals: merged,
+        updated_at: new Date().toISOString(),
+      };
+      if (typeof entry.iepDate === 'string' && entry.iepDate) {
+        upsertData.goals_iep_date = entry.iepDate;
+      }
+
+      const { error } = await supabase
+        .from('student_details')
+        .upsert(upsertData, { onConflict: 'student_id' });
+      if (error) throw error;
+
+      // Keep the in-memory copy current so a repeated studentId in the same
+      // request accumulates (matching the retired client's sequential re-read)
+      // instead of the second write clobbering the first.
+      existingByStudent.set(studentId, merged);
+      results.push({ success: true });
+      succeeded++;
+    } catch (err) {
+      results.push({
+        success: false,
+        error: (err as { message?: string })?.message ?? 'Failed to save goals',
+      });
+    }
+  }
+
+  log.info('IEP goals confirm complete', { userId, total: students.length, succeeded });
+  return NextResponse.json({ data: { results } });
+});

--- a/app/components/students/student-details-modal.tsx
+++ b/app/components/students/student-details-modal.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useMemo } from 'react';
 import { Button } from '../ui/button';
 import { Input, Label, FormGroup } from '../ui/form';
 import { getStudentDetails, upsertStudentDetails, StudentDetails, getMatchingProviderRoles } from '../../../lib/supabase/queries/student-details';
-import { createClient } from '@/lib/supabase/client';
 import { adaptTargetStudentPreview } from '@/lib/import/review-model';
 import AssessmentList from './assessment-list';
 import { IEPGoalsUploader } from './iep-goals-uploader';
@@ -204,73 +203,55 @@ export function StudentDetailsModal({
     }
   };
 
-  // Per-student IEP goals import writes client-side today (server-side merge is
-  // SPE-234). Merge semantics: append each selected goal that isn't already on
-  // the student (case-insensitive), preserving goals_iep_date when the report
-  // carries one — the same stored result as the retired preview modal.
+  // Per-student IEP goals import (SPE-234): the write runs server-side at
+  // /api/import-iep-goals/confirm (provider-scoped, RLS-backstopped), which
+  // merges the selected goals into each student — nothing is removed. A selected
+  // row with no goals is a no-op (skipped, not sent).
   const handleTargetImport = async ({ rows }: ReviewConfirmSelection): Promise<ReviewWriteResult> => {
-    const supabase = createClient();
-    const outcomes: ReviewWriteResult['outcomes'] = [];
+    const entries = rows
+      .filter(({ row, selectedGoalTexts }) => row.targetStudentId && selectedGoalTexts.length > 0)
+      .map(({ row, selectedGoalTexts }) => ({
+        rowId: row.id,
+        studentId: row.targetStudentId as string,
+        goals: selectedGoalTexts,
+        iepDate: row.iepDate,
+      }));
 
-    for (const { row, selectedGoalTexts } of rows) {
-      const studentId = row.targetStudentId;
-      // Skip a selected student with no selected goals: merging nothing is a
-      // no-op, and writing anyway would bump updated_at / overwrite goals_iep_date.
-      if (!studentId || selectedGoalTexts.length === 0) continue;
-
-      try {
-        const { data: currentDetails, error: readError } = await supabase
-          .from('student_details')
-          .select('iep_goals')
-          .eq('student_id', studentId)
-          .maybeSingle();
-        // Abort on a real read failure — never overwrite goals we couldn't read.
-        // maybeSingle returns null data + no error when the row simply doesn't
-        // exist yet, which is a legitimate "no existing goals" case.
-        if (readError) throw readError;
-
-        const existingGoals: string[] = currentDetails?.iep_goals || [];
-        const newGoals = [...existingGoals];
-        for (const goal of selectedGoalTexts) {
-          if (!newGoals.some(existing => existing.trim().toLowerCase() === goal.trim().toLowerCase())) {
-            newGoals.push(goal);
-          }
-        }
-
-        const upsertData: {
-          student_id: string;
-          iep_goals: string[];
-          updated_at: string;
-          goals_iep_date?: string;
-        } = {
-          student_id: studentId,
-          iep_goals: newGoals,
-          updated_at: new Date().toISOString(),
-        };
-        if (row.iepDate) upsertData.goals_iep_date = row.iepDate;
-
-        const { error } = await supabase
-          .from('student_details')
-          .upsert(upsertData, { onConflict: 'student_id' });
-        if (error) throw error;
-
-        outcomes.push({ rowId: row.id, success: true });
-      } catch (err) {
-        // Supabase/PostgREST errors are often plain objects (not Error
-        // instances), so read .message directly to keep the real DB error.
-        outcomes.push({
-          rowId: row.id,
-          success: false,
-          error: (err as { message?: string })?.message ?? 'Failed to save goals',
-        });
-      }
+    if (entries.length === 0) {
+      return { outcomes: [], succeeded: 0, failed: 0 };
     }
 
-    return {
-      outcomes,
-      succeeded: outcomes.filter(o => o.success).length,
-      failed: outcomes.filter(o => !o.success).length,
-    };
+    try {
+      const response = await fetch('/api/import-iep-goals/confirm', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          students: entries.map(({ studentId, goals, iepDate }) => ({ studentId, goals, iepDate })),
+        }),
+      });
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result.error || 'Failed to save goals');
+      }
+
+      // The route returns input-ordered results; map each back to its row.
+      const serverResults: Array<{ success: boolean; error?: string }> = result.data?.results ?? [];
+      const outcomes = entries.map((entry, i) => ({
+        rowId: entry.rowId,
+        success: serverResults[i]?.success ?? false,
+        error: serverResults[i]?.error,
+      }));
+      return {
+        outcomes,
+        succeeded: outcomes.filter(o => o.success).length,
+        failed: outcomes.filter(o => !o.success).length,
+      };
+    } catch (err) {
+      // Whole-request failure (network / non-OK) — every submitted row failed.
+      const message = err instanceof Error ? err.message : 'Failed to save goals';
+      const outcomes = entries.map(entry => ({ rowId: entry.rowId, success: false, error: message }));
+      return { outcomes, succeeded: 0, failed: outcomes.length };
+    }
   };
 
   // Adapt the per-student IEP preview into the shared review model once per upload.

--- a/lib/import/merge-goals.ts
+++ b/lib/import/merge-goals.ts
@@ -1,0 +1,17 @@
+/**
+ * Merge incoming IEP goals into a student's existing goals — the per-student
+ * import semantic (SPE-234), as opposed to the bulk sync's replace.
+ *
+ * Append-only: an incoming goal is added unless an existing goal already matches
+ * it case-insensitively after trimming. Existing goals are never removed or
+ * reordered, and incoming goals keep their order. Returns a new array.
+ */
+export function mergeGoals(existing: string[], incoming: string[]): string[] {
+  const merged = [...existing];
+  for (const goal of incoming) {
+    if (!merged.some(e => e.trim().toLowerCase() === goal.trim().toLowerCase())) {
+      merged.push(goal);
+    }
+  }
+  return merged;
+}


### PR DESCRIPTION
## What & why

The per-student IEP goals flow parsed server-side but **wrote from the browser** — a per-student `student_details` read + upsert, the last remaining browser write path in the import flows, protected by RLS alone. This moves that write to the server with explicit provider-ownership enforcement, closing ARCH-1/ARCH-6.

Linear: **SPE-234** (Phase 3 — Backend consolidation; labeled `security`). Follows SPE-232, which deliberately kept the write client-side so the UI change and the write-path change stayed separate.

## Changes

- **New `POST /api/import-iep-goals/confirm`** — takes `{ students: [{ studentId, goals[], iepDate? }] }` and **merge-writes** each student's goals: append the selected goals not already present (case-insensitive, trimmed), set `goals_iep_date` when provided, **never remove** existing goals.
- **Ownership enforced server-side:** the write is gated on an app-level `provider_id = userId` ownership set (only the caller's students), which is *stricter* than the `student_details` RLS policies enforced by the user-scoped client — two independent layers each block a cross-tenant write. A studentId that isn't the caller's is a per-row failure, never written, with a neutral "not found in your caseload" message (no existence oracle).
- **Shared review screen's target-student mode now POSTs to it**; the client-side `student_details` read/merge/upsert loop is **deleted** — no more browser writes to `student_details` in the import flows.
- **`mergeGoals()`** extracted as a pure, unit-pinned helper so the dedupe contract provably matches the retired client behavior.
- The two import write semantics are documented where they live: **bulk sync = replace**, **per-student = merge**.

## Verification

- `typecheck` clean; `lint` clean; unit tests green (new `mergeGoals` suite pins the exact append/dedupe/no-remove contract).
- **Dedicated security review** (the `security-review` skill) — **no findings ≥ confidence 8**. It verified against the live DB that `student_details` INSERT `WITH CHECK` / UPDATE `USING` both require `students.provider_id = auth.uid()`, so the app-level check + RLS independently prevent cross-tenant writes; confirmed no injection (all PostgREST-parameterized), no mass assignment (explicit column allow-list), no enumeration oracle, and that `withRoute` enforces auth.
- **Behavior-parity review** — no reachable divergence: for every input the UI can produce, the stored result (order, dedupe, `goals_iep_date`, succeeded/failed counts, skip set) matches the retired client exactly. Two latent, UI-unreachable robustness gaps it/the security pass noted were closed anyway (UUID pre-validation so a malformed id can't 500 the whole request; keep the in-memory copy current so a repeated studentId in one request accumulates rather than clobbering).
- **Sim-district run in progress**, including the key negative test: as one provider, attempt to merge goals into another provider's student → assert the row fails server-side and nothing is written. Report to follow in a comment.

## Note on commit signing

Commits are authored as `noreply@anthropic.com` but show **Unverified**: this sandbox has no usable SSH signing-key material, so signatures can't be produced here (config left intact, not bypassed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmVLoR4G2LYpDKGBY8ADtS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmVLoR4G2LYpDKGBY8ADtS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation support for importing IEP goals for multiple students.
  * Existing goals are preserved while new goals are appended without case-insensitive duplicates.
  * Added per-student success and error results, including ownership validation.
  * IEP dates can be saved during goal confirmation.

* **Bug Fixes**
  * Prevented existing goals from being removed or reordered during imports.
  * Improved handling of duplicate goals and repeated student entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->