### PR TITLE
fix(import): keep a named unresolved class-list teacher reviewable; stop fabricating a teacher change (SPE-262)

### DIFF
--- a/__tests__/unit/lib/import/classify.test.ts
+++ b/__tests__/unit/lib/import/classify.test.ts
@@ -159,6 +159,62 @@ describe('buildStudentPreviews (main path)', () => {
     expect(p.action).toBe('update');
     expect(p.changes?.teacher?.new).toEqual({ teacherId: 't-barrera', teacherName: 'Elena Barrera' });
   });
+
+  // SPE-262: an unresolved class-list teacher keeps the row actionable (so it can
+  // be resolved in the review's exceptions queue) but is NOT shown as a change.
+  const ghost = () => classListStudent({ teacher: { rawName: 'Ghost Q', lastName: 'Ghost', firstInitial: 'Q', teacherNumber: '' } });
+
+  it('keeps a matched student actionable for an unresolved class-list teacher, without a fabricated teacher change', () => {
+    const { studentPreviews } = buildStudentPreviews({
+      parsedStudents: [parsed({ goals: ['G'] })],
+      databaseStudents: [dbStudent({ iep_goals: ['G'], teacher_id: 't-existing' })],
+      deliveriesData: null,
+      classListData: new Map([['doe_john', ghost()]]), // 'Ghost' won't resolve against TEACHERS
+      dbTeachers: TEACHERS,
+    });
+    const p = studentPreviews[0];
+    expect(p.action).toBe('update'); // stays selectable so the user can resolve the teacher
+    expect(p.changes?.teacher).toBeUndefined(); // no misleading "teacher → none"
+    expect(p.teacher).toMatchObject({ teacherId: null, teacherName: 'Ghost Q' }); // surfaced for resolution
+  });
+
+  it('omits an unresolved class-list teacher from changes even alongside a real goal change', () => {
+    const { studentPreviews } = buildStudentPreviews({
+      parsedStudents: [parsed({ goals: ['New goal'] })],
+      databaseStudents: [dbStudent({ iep_goals: ['Old goal'], teacher_id: 't-existing' })],
+      deliveriesData: null,
+      classListData: new Map([['doe_john', ghost()]]),
+      dbTeachers: TEACHERS,
+    });
+    const p = studentPreviews[0];
+    expect(p.action).toBe('update');
+    expect(p.changes?.goals).toBeDefined();
+    expect(p.changes?.teacher).toBeUndefined();
+  });
+
+  it('skips a matched student when the resolved teacher is unchanged and goals match', () => {
+    const { studentPreviews } = buildStudentPreviews({
+      parsedStudents: [parsed({ goals: ['G'] })],
+      databaseStudents: [dbStudent({ iep_goals: ['G'], teacher_id: 't-barrera' })], // already Barrera
+      deliveriesData: null,
+      classListData: new Map([['doe_john', classListStudent()]]), // resolves to Barrera
+      dbTeachers: TEACHERS,
+    });
+    const p = studentPreviews[0];
+    expect(p.action).toBe('skip'); // resolved teacher matches existing + goals match = no change
+    expect(p.changes).toBeUndefined();
+  });
+
+  it('does not force an update for a class-list match whose teacher name is blank (nothing to review)', () => {
+    const { studentPreviews } = buildStudentPreviews({
+      parsedStudents: [parsed({ goals: ['G'] })],
+      databaseStudents: [dbStudent({ iep_goals: ['G'], teacher_id: 't-existing' })],
+      deliveriesData: null,
+      classListData: new Map([['doe_john', classListStudent({ teacher: { rawName: '', lastName: '', firstInitial: '', teacherNumber: '' } })]]),
+      dbTeachers: TEACHERS,
+    });
+    expect(studentPreviews[0].action).toBe('skip'); // no teacher name to resolve + goals match = no change
+  });
 });
 
 describe('buildUpdatePreviews (deliveries/class-list update-only path)', () => {

--- a/lib/import/classify.ts
+++ b/lib/import/classify.ts
@@ -227,16 +227,34 @@ export function buildStudentPreviews(params: {
     let goalsRemoved: string[] | undefined;
 
     if (!isNew && matchedStudent) {
-      // Check for changes to determine if update or skip
+      // An unresolved class-list teacher (teacherId === null) is not a real
+      // change — pass undefined so hasChanges doesn't fabricate a "teacher → none"
+      // change (SPE-262). The row is still kept actionable below.
       const changeCheck = hasChanges(
         matchedStudent,
         goalTexts,
         scheduleData,
-        teacherMatchResult?.teacherId
+        teacherMatchResult?.teacherId ?? undefined
       );
 
       const goalComparison = compareGoals(matchedStudent.iep_goals, goalTexts);
-      const anyChanges = changeCheck.hasGoalChanges || changeCheck.hasScheduleChanges || changeCheck.hasTeacherChanges;
+      // A named class-list teacher that didn't resolve to a DB teacher is surfaced
+      // as a reviewable exception, so keep the row actionable (an 'update') even
+      // when nothing else changed: the user resolves it in the review's exceptions
+      // queue and it's applied on confirm. We deliberately do NOT fabricate a
+      // teacher change for it (the teacher block below only fires for a resolved
+      // teacher), so the preview shows no misleading "teacher → none" (SPE-262).
+      // The non-blank name check mirrors the exception-creation rule in
+      // adaptBulkPreview, so we never mark a row 'update' with nothing to act on.
+      const hasUnresolvedTeacher =
+        !!teacherMatchResult &&
+        teacherMatchResult.teacherId === null &&
+        !!teacherMatchResult.teacherName?.trim();
+      const anyChanges =
+        changeCheck.hasGoalChanges ||
+        changeCheck.hasScheduleChanges ||
+        changeCheck.hasTeacherChanges ||
+        hasUnresolvedTeacher;
 
       if (anyChanges) {
         action = 'update';


### PR DESCRIPTION
## What

The completion of SPE-260 #1 (deferred from #743). When a matched student's class-list teacher name doesn't resolve to a DB teacher, `buildStudentPreviews` fabricated a spurious `changes.teacher` (`→ none`) and relied on `hasChanges` treating a `null` teacher as a change. This:
- keeps the row actionable via a **principled** flag (`hasUnresolvedTeacher`) instead of the `null`-teacher `hasChanges` quirk, and
- **stops fabricating** the `changes.teacher` entry (the teacher-change block now fires only for a *resolved* teacher).

## Why this shape (and why the naive fix was wrong)

The obvious fix — pass `?? undefined` so the row becomes `skip` — regressed a real flow: the review screen excludes `skip` rows from selection, so the low-confidence-teacher exception it still shows could never be applied (Codex P2 on #743). So the row must stay actionable.

Two facts made this low-risk to get right:
- On `main` the row was **already** an actionable `update` (selectable), and `adaptBulkPreview` renders **`changes.goals` only** — it never reads `changes.teacher`. So the fabricated change was a preview-payload inaccuracy, not something users saw. Net user-visible behaviour here **matches main**: the row stays `update`, the teacher shows a "needs review" ⚠, and it's resolved inline in the exceptions queue and applied on confirm.
- The `hasUnresolvedTeacher` flag is gated on a **non-blank** teacher name, mirroring `adaptBulkPreview`'s exception-creation rule (`teacherId || teacherName?.trim()`). A class-list entry with no teacher name has nothing to review, so it correctly stays `skip` — no "phantom update" with nothing to act on (that edge exists on `main` and is now closed).

So: real-time in-import teacher selection keeps working (it already did), the skip-regression is avoided, the preview payload is now accurate, and there are **no review-UI changes**.

## Tests

- `classify` unit tests: unresolved named teacher → `update` + no `changes.teacher` + teacher surfaced; unresolved teacher alongside a real goal change → `update` with goals but no teacher change; resolved-but-unchanged teacher → `skip`; **blank** teacher name → `skip` (no phantom update).
- Characterization snapshots unchanged (fixtures resolve their teachers); typecheck clean; all import/app suites pass.

Closes SPE-262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0123jrkRqzWDChSQZ6BfHVtH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved student import previews when a class-list teacher cannot be matched.
  - Rows with unresolved, non-blank teacher names now remain available for review without showing an incorrect teacher change.
  - Prevented unresolved teacher information from being included in reported changes, including when goals are updated.
  - Blank teacher names and already-matching teacher assignments no longer trigger unnecessary updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->