### PR TITLE
fix(import): surface blank-metadata goal rows for review on the XLSX SEIS path (SPE-248)

### DIFF
--- a/__tests__/unit/lib/parsers/__snapshots__/seis-goals-xlsx.test.ts.snap
+++ b/__tests__/unit/lib/parsers/__snapshots__/seis-goals-xlsx.test.ts.snap
@@ -16,6 +16,7 @@ exports[`parseSEISReport — ~5 metadata rows above the header matches the golde
     "totalRows": 1,
   },
   "students": [],
+  "warnings": [],
 }
 `;
 
@@ -115,6 +116,7 @@ exports[`parseSEISReport — header on row 1 (row-skip fixed) matches the golden
       "schoolOfAttendance": "Mt Diablo Elementary School",
     },
   ],
+  "warnings": [],
 }
 `;
 
@@ -166,5 +168,6 @@ exports[`parseSEISReport — title rows then header on row 3 matches the golden 
       "schoolOfAttendance": "Mt Diablo Elementary School",
     },
   ],
+  "warnings": [],
 }
 `;

--- a/__tests__/unit/lib/parsers/seis-goals-xlsx.test.ts
+++ b/__tests__/unit/lib/parsers/seis-goals-xlsx.test.ts
@@ -93,3 +93,27 @@ describe('parseSEISReport — ~5 metadata rows above the header', () => {
     expect(result).toMatchSnapshot();
   });
 });
+
+describe('parseSEISReport — blank-metadata goal warning (SPE-248)', () => {
+  it('surfaces a blank-metadata goal row for a keyworded role (it would otherwise be filtered out)', async () => {
+    // 'resource' has a service code, so keyword filtering applies. The Gomez row
+    // has blank Area of Need / Annual Goal # / Person Responsible, so it has no
+    // routing signal and its goal is dropped — but surfaced as a review warning
+    // instead of vanishing silently (matches the CSV path).
+    const buffer = await buildSeisXlsxHeaderRow1();
+    const result = await parseSEISReport(buffer, { providerRole: 'resource' });
+
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].message).toMatch(
+      /^Goal for student GG \(grade .+?\) has no Area of Need, Annual Goal #, or Person Responsible/
+    );
+    // The unroutable goal itself is filtered from this role's import.
+    expect(result.students.some((s) => s.lastName === 'Gomez')).toBe(false);
+  });
+
+  it('emits no such warning for a role with no service code (psychologist imports everything)', async () => {
+    const buffer = await buildSeisXlsxHeaderRow1();
+    const result = await parseSEISReport(buffer, { providerRole: 'psychologist' });
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/lib/parsers/csv-parser.ts
+++ b/lib/parsers/csv-parser.ts
@@ -6,7 +6,7 @@
 import { parse } from 'csv-parse/sync';
 import { TextDecoder } from 'util';
 import { normalizeSchoolName } from '../school-helpers';
-import { getServiceTypeCode, getServiceTypeNameForRole, isGoalForProviderByKeywords, hasNoProviderRoutingSignal } from './service-type-mapping';
+import { getServiceTypeCode, getServiceTypeNameForRole, isGoalForProviderByKeywords, hasNoProviderRoutingSignal, blankMetadataGoalWarning } from './service-type-mapping';
 import { normalizeGradeLevel } from '../utils/grade-parser';
 import { buildStudentDedupKey, normalizeInitialsForKey } from '../utils/student-dedup-key';
 
@@ -314,7 +314,7 @@ export async function parseCSVReport(buffer: Buffer, options: ParseOptions = {})
           if (hasGoalText) {
             warnings.push({
               row: rowIndex + 1,
-              message: `Goal for student ${initials} (grade ${normalizedGrade}) has no Area of Need, Annual Goal #, or Person Responsible and could not be routed to a provider — please review and assign it manually.`,
+              message: blankMetadataGoalWarning(initials, normalizedGrade),
             });
           }
         }

--- a/lib/parsers/seis-parser.ts
+++ b/lib/parsers/seis-parser.ts
@@ -4,7 +4,7 @@
  */
 
 import * as ExcelJS from 'exceljs';
-import { getServiceTypeCode, isGoalForProviderByKeywords } from './service-type-mapping';
+import { getServiceTypeCode, isGoalForProviderByKeywords, hasNoProviderRoutingSignal, blankMetadataGoalWarning } from './service-type-mapping';
 import { normalizeGradeLevel } from '../utils/grade-parser';
 
 // ExcelJS cell value types for rich text and formula results
@@ -30,6 +30,10 @@ export interface ParsedStudent {
 export interface ParseResult {
   students: ParsedStudent[];
   errors: Array<{ row: number; message: string }>;
+  /** Rows that parsed but need manual attention — e.g. a goal with no provider
+   *  routing signal that keyword filtering would otherwise silently drop.
+   *  Mirrors the CSV parser's `warnings` (SPE-248). */
+  warnings: Array<{ row: number; message: string }>;
   metadata: {
     totalRows: number;
     sheetsProcessed: string[];
@@ -69,6 +73,7 @@ export async function parseSEISReport(
 
   const students: ParsedStudent[] = [];
   const errors: Array<{ row: number; message: string }> = [];
+  const warnings: Array<{ row: number; message: string }> = [];
   const sheetsProcessed: string[] = [];
 
   // Get the service type code for the provider's role
@@ -143,6 +148,25 @@ export async function parseSEISReport(
             ? getCellValue(row, columnMapping.personResponsible)
             : undefined;
 
+          // Initials + normalized grade, used by the review warning below and the
+          // student key further down.
+          const initials = `${firstName.charAt(0).toUpperCase()}${lastName.charAt(0).toUpperCase()}`;
+          const normalizedGrade = normalizeGradeLevel(grade);
+
+          // A SEIS goal row with blank Area of Need, Annual Goal #, AND Person
+          // Responsible has no signal to route it to a keyworded provider role, so
+          // keyword filtering would silently drop it. Surface it for manual review
+          // instead (mirrors the CSV path, SPE-247/SPE-248). Roles with no service
+          // code (psychologist/specialist) import everything, so they're exempt.
+          if (serviceTypeCode && hasNoProviderRoutingSignal(areaOfNeed, goalType, personResponsible)) {
+            const hasGoalText = columnMapping.goalColumns.some(
+              (i) => getCellValue(row, i).trim().length > 10
+            );
+            if (hasGoalText) {
+              warnings.push({ row: rowNumber, message: blankMetadataGoalWarning(initials, normalizedGrade) });
+            }
+          }
+
           // Extract goals from all goal columns, filtering by provider type
           const goals: string[] = [];
           for (const goalColIndex of columnMapping.goalColumns) {
@@ -176,12 +200,6 @@ export async function parseSEISReport(
 
           // Only process if they have at least one goal
           if (goals.length === 0) return;
-
-          // Generate initials
-          const initials = `${firstName.charAt(0).toUpperCase()}${lastName.charAt(0).toUpperCase()}`;
-
-          // Normalize grade level
-          const normalizedGrade = normalizeGradeLevel(grade);
 
           // Create unique key for student (name + grade)
           const studentKey = `${firstName.trim().toLowerCase()}_${lastName.trim().toLowerCase()}_${normalizedGrade}`;
@@ -233,6 +251,7 @@ export async function parseSEISReport(
   return {
     students,
     errors,
+    warnings,
     metadata: {
       totalRows: students.length + errors.length,
       sheetsProcessed,

--- a/lib/parsers/service-type-mapping.ts
+++ b/lib/parsers/service-type-mapping.ts
@@ -171,6 +171,15 @@ export function hasNoProviderRoutingSignal(
 }
 
 /**
+ * The single "needs review" message for a goal row that hasNoProviderRoutingSignal.
+ * Shared so the CSV (parseCSVReport) and XLSX (parseSEISReport) paths can't drift
+ * (SPE-247/SPE-248).
+ */
+export function blankMetadataGoalWarning(initials: string, gradeLevel: string): string {
+  return `Goal for student ${initials} (grade ${gradeLevel}) has no Area of Need, Annual Goal #, or Person Responsible and could not be routed to a provider — please review and assign it manually.`;
+}
+
+/**
  * Check if a goal belongs to a provider based on multiple column values
  * Checks Area of Need, Annual Goal #, and Person Responsible columns
  *


### PR DESCRIPTION
## What

The CSV SEIS parser (`parseCSVReport`) already warns when a goal row has blank **Area of Need + Annual Goal # + Person Responsible** (SPE-247): under keyword routing such a row has no signal to attribute it to a provider, so it would silently vanish for every keyworded role — instead it's surfaced for manual review. The XLSX path (`parseSEISReport`) had **no `warnings` field at all**, so the same row silently dropped there.

This brings the XLSX path to parity:
- Adds a `warnings` field to `parseSEISReport`'s `ParseResult` (matching the CSV shape; the `import-iep-goals` route already reads `'warnings' in parseResult` and surfaces them as `parseWarnings`).
- Emits the blank-metadata review warning in the XLSX goal loop, reusing `hasNoProviderRoutingSignal` and gating on `serviceTypeCode` (no-service-code roles like *psychologist* import everything, so they're exempt — same as CSV).
- Extracts the shared warning message into `blankMetadataGoalWarning()` so the two parsers can't drift.

## Tests

- New XLSX tests: a **keyworded role** (`resource`) surfaces the blank-metadata Gomez row as a warning (and drops its goal from the import); a **no-service-code role** (`psychologist`) emits no warning.
- The three existing XLSX snapshots are regenerated — the **only** change is `warnings: []` added; all student/error/metadata output is byte-identical.
- CSV snapshots unchanged (shared message is byte-identical). Typecheck clean; all parser/import/app suites pass.

Closes SPE-248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0123jrkRqzWDChSQZ6BfHVtH)_