### PR TITLE
docs(compliance): sync subprocessors.md after AI-upload removal (SPE-243)

### DIFF
--- a/docs/subprocessors.md
+++ b/docs/subprocessors.md
@@ -43,7 +43,7 @@ tiers (SPE-163). **Still do not enable AI** until Zero Data Retention is request
 | Service | Role (when enabled) | Student data (when enabled) | Where (code) |
 |---|---|---|---|
 | **OpenAI** | Default lesson-generation provider (`AI_PROVIDER` defaults to `openai`, model `gpt-5-mini`). | Initials + IEP goals in prompts. | `lib/lessons/providers.ts` |
-| **Anthropic (Claude)** | Lessons, exit tickets, progress checks, worksheet vision. | Initials + IEP goals. | `lib/exit-tickets/generator.ts`, `app/api/submit-worksheet/route.ts`, `lib/lessons/*`, `lib/progress-checks/*` |
+| **Anthropic (Claude)** | Lessons, exit tickets, progress checks, worksheet vision. | Initials + IEP goals; plus the completed-worksheet image (the student's written work) and its questions/answers on the worksheet-submission path (`submit-worksheet` sends the photo to Claude Vision). | `lib/exit-tickets/generator.ts`, `app/api/submit-worksheet/route.ts`, `lib/lessons/*`, `lib/progress-checks/*` |
 
 ## Data sources (NOT downstream processors)
 

--- a/docs/subprocessors.md
+++ b/docs/subprocessors.md
@@ -8,7 +8,7 @@ exhibit (see SPE-59) and for student-data-privacy disclosures.
 > touch student data is an NDPA change-notification trigger — update this list in
 > the same PR, and notify LEAs per the executed agreement.
 
-_Last reviewed: 2026-06-11._
+_Last reviewed: 2026-07-16._
 
 ## Data categories
 
@@ -43,7 +43,7 @@ tiers (SPE-163). **Still do not enable AI** until Zero Data Retention is request
 | Service | Role (when enabled) | Student data (when enabled) | Where (code) |
 |---|---|---|---|
 | **OpenAI** | Default lesson-generation provider (`AI_PROVIDER` defaults to `openai`, model `gpt-5-mini`). | Initials + IEP goals in prompts. | `lib/lessons/providers.ts` |
-| **Anthropic (Claude)** | Lessons, exit tickets, progress checks, worksheet vision, document parsing. | Initials + IEP goals; raw document text on the upload path. | `lib/exit-tickets/generator.ts`, `app/api/submit-worksheet/route.ts`, `lib/lessons/*`, `lib/progress-checks/*` |
+| **Anthropic (Claude)** | Lessons, exit tickets, progress checks, worksheet vision. | Initials + IEP goals. | `lib/exit-tickets/generator.ts`, `app/api/submit-worksheet/route.ts`, `lib/lessons/*`, `lib/progress-checks/*` |
 
 ## Data sources (NOT downstream processors)
 


### PR DESCRIPTION
## What

Syncs the CA-NDPA subprocessor register (`docs/subprocessors.md`) with the code reality after SPE-219 (PR #708) removed two never-active, `AI_FEATURES_ENABLED`-gated Anthropic flows: the `/api/ai-upload` document-parsing route and the `lib/utils/pii-scrubber.ts` Anthropic branch. The Anthropic "Planned — disclosed but NOT enabled" row still listed them.

**Verified before editing** (compliance direction is a *reduction* — over-disclosure → accurate):
- `app/api/ai-upload` — gone.
- `lib/utils/pii-scrubber.ts` — gone.
- Zero runtime references to either in `app/`/`lib/`.

**Edits:**
- Drop **"document parsing"** from the Anthropic *Role (when enabled)* cell.
- Drop **"raw document text on the upload path"** from the *Student data* cell (kept "Initials + IEP goals" — lessons / exit tickets / progress checks / worksheet vision still send those when enabled).
- The *Where (code)* cell already no longer listed `pii-scrubber.ts` (removed in an earlier edit) — no change needed.
- Bumped **Last reviewed** to 2026-07-16.

## ⚠️ Needs your review before merge — two compliance calls are yours, not mine

1. **NDPA change-notification decision.** The register's header says touching a student-data service is a change-notification trigger. This change *removes* never-active planned flows, but whether that requires notifying LEAs per the executed agreement is a **compliance-owner call** (the ticket's open checkbox). I have **not** notified anyone.
2. **"Last reviewed" date.** I set it to today assuming you review/sign off today — adjust if it should reflect a different date.

Docs-only; no code change. **Holding merge for you.**

Closes SPE-243 (pending your sign-off + the notification decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0123jrkRqzWDChSQZ6BfHVtH)_