### PR TITLE
fix(import): scope multi-school students by selected school only (SPE-264)

### DIFF
--- a/__tests__/unit/app/__snapshots__/import-students-preview.characterization.test.ts.snap
+++ b/__tests__/unit/app/__snapshots__/import-students-preview.characterization.test.ts.snap
@@ -574,10 +574,6 @@ exports[`POST /api/import-students — preview characterization (SPE-230) goals-
           "matched": 3,
           "notes": [
             {
-              "message": "Student "Drew Diaz" attends "Out of District- MOU" which doesn't match your school(s). Skipping.",
-              "row": 5,
-            },
-            {
               "message": "Goal for student GG (grade 1) has no Area of Need, Annual Goal #, or Person Responsible and could not be routed to a provider — please review and assign it manually.",
               "row": 8,
             },
@@ -587,10 +583,6 @@ exports[`POST /api/import-students — preview characterization (SPE-230) goals-
       ],
       "parseErrors": [],
       "parseWarnings": [
-        {
-          "message": "Student "Drew Diaz" attends "Out of District- MOU" which doesn't match your school(s). Skipping.",
-          "row": 5,
-        },
         {
           "message": "Goal for student GG (grade 1) has no Area of Need, Annual Goal #, or Person Responsible and could not be routed to a provider — please review and assign it manually.",
           "row": 8,

--- a/__tests__/unit/app/import-students-preview.characterization.test.ts
+++ b/__tests__/unit/app/import-students-preview.characterization.test.ts
@@ -360,4 +360,44 @@ describe('POST /api/import-students — multi-school first-import regression (SP
     expect(lastNames).not.toContain('Barnes'); // other-school student scoped out
     expect(data?.summary?.filteredOutSchools).toContain('Bancroft Elementary School');
   });
+
+  it('does not merge same-name/same-grade students from different schools (no cross-school goal contamination)', async () => {
+    // Two DIFFERENT students share first name, last name, and grade but attend
+    // different schools. The selected-school (Mt Diablo) row appears first, so
+    // before the dedup-key fix its record would absorb the Bancroft namesake's
+    // goal (the parser merged by name+grade only, keeping the first row's
+    // school). After the fix, school is part of the consolidation key, so the
+    // two stay distinct and only the Mt Diablo student's own goal imports.
+    const collidingCsv = () =>
+      fileFrom(
+        buildSeisGoalsCsvFrom([
+          {
+            0: '2000301', 2: 'Rivers', 3: 'Sam', 5: '04', 6: 'Mt Diablo Elementary School',
+            9: '05/01/2026', 11: 'Reading', 12: 'Academic #1: 2026 - 2027', 17: 'Resource Specialist',
+            14: 'By 5/1/2027, Sam at Mt Diablo will read 90 words per minute with 95% accuracy in 3 of 4 trials.',
+          },
+          {
+            0: '2000302', 2: 'Rivers', 3: 'Sam', 5: '04', 6: 'Bancroft Elementary School',
+            9: '05/01/2026', 11: 'Reading', 12: 'Academic #1: 2026 - 2027', 17: 'Resource Specialist',
+            14: 'By 5/1/2027, Sam at Bancroft will read 80 words per minute with 90% accuracy in 3 of 4 trials.',
+          },
+        ]),
+        'students.csv',
+        'text/csv',
+      );
+
+    const result = await runPost(bancroftProviderTables(), requestWith({ studentsFile: collidingCsv() }, schoolCtx));
+    expect(result.status).toBe(200);
+
+    const data = (result.body as {
+      data?: { students?: Array<{ lastName?: string; goals?: Array<{ text?: string }> }> };
+    }).data;
+
+    const rivers = (data?.students ?? []).filter((s) => s.lastName === 'Rivers');
+    // Exactly one Rivers imports (the Mt Diablo one); the Bancroft namesake is scoped out.
+    expect(rivers).toHaveLength(1);
+    const goalText = (rivers[0]?.goals ?? []).map((g) => g.text).join(' | ');
+    expect(goalText).toContain('Mt Diablo'); // its own goal
+    expect(goalText).not.toContain('Bancroft'); // NOT the other student's goal
+  });
 });

--- a/__tests__/unit/app/import-students-preview.characterization.test.ts
+++ b/__tests__/unit/app/import-students-preview.characterization.test.ts
@@ -400,4 +400,29 @@ describe('POST /api/import-students — multi-school first-import regression (SP
     expect(goalText).toContain('Mt Diablo'); // its own goal
     expect(goalText).not.toContain('Bancroft'); // NOT the other student's goal
   });
+
+  it('errors with a clear "none are at your school" message (no misleading count) when the file has no selected-school students', async () => {
+    // Every student in the file is at another school; with Mt Diablo selected,
+    // all are scoped out. The message names the selected school and the schools
+    // actually found, and no longer leads with a confusing count.
+    const otherSchoolOnlyCsv = () =>
+      fileFrom(
+        buildSeisGoalsCsvFrom([
+          {
+            0: '2000401', 2: 'Torres', 3: 'Tina', 5: '02', 6: 'Bancroft Elementary School',
+            9: '05/01/2026', 11: 'Reading', 12: 'Academic #1: 2026 - 2027', 17: 'Resource Specialist',
+            14: 'By 5/1/2027, Tina will read 90 words per minute with 95% accuracy in 3 of 4 trials.',
+          },
+        ]),
+        'students.csv',
+        'text/csv',
+      );
+
+    const result = await runPost(bancroftProviderTables(), requestWith({ studentsFile: otherSchoolOnlyCsv() }, schoolCtx));
+    expect(result.status).toBe(400);
+    const error = (result.body as { error?: string }).error ?? '';
+    expect(error).toContain('None of the students in this file are at Mt Diablo Elementary');
+    expect(error).toContain('Bancroft Elementary School');
+    expect(error).not.toMatch(/All \d+ students/); // the misleading count is gone
+  });
 });

--- a/__tests__/unit/app/import-students-preview.characterization.test.ts
+++ b/__tests__/unit/app/import-students-preview.characterization.test.ts
@@ -32,7 +32,7 @@ jest.mock('@/lib/monitoring/performance-alerts', () => ({
 
 import { createClient } from '@/lib/supabase/server';
 import { POST } from '@/app/api/import-students/route';
-import { SEIS_GOALS_CSV, readFixture } from '../lib/parsers/fixtures/builders';
+import { SEIS_GOALS_CSV, buildSeisGoalsCsvFrom, readFixture } from '../lib/parsers/fixtures/builders';
 
 const USER_ID = 'provider-1';
 
@@ -285,5 +285,79 @@ describe('POST /api/import-students — upload size guard (SPE-260)', () => {
     } as unknown as Request;
     const res = await POST(req as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(413);
+  });
+});
+
+/**
+ * SPE-264 regression: a multi-school provider's FIRST import into a school where
+ * they have no students yet.
+ *
+ * Before the fix, the pipeline derived a parse-time school filter from the
+ * schools where the provider ALREADY had students. When the selected school was
+ * not among them (the first-import case), every student for that school was
+ * dropped before the real (selected-school) filter ran, and the request failed
+ * with a false "All N students belong to other schools" error. The scenario here
+ * — existing students only at Bancroft, importing into Mt Diablo — reproduced it:
+ * the Mt Diablo student was dropped at parse time, then the surviving Bancroft
+ * student was scoped out, yielding the false 400. School scoping now happens in
+ * exactly one place (applySchoolFilter), so the Mt Diablo student imports and
+ * Bancroft is correctly scoped out.
+ */
+const DB_STUDENTS_BANCROFT_ONLY = [
+  {
+    id: 'stu-bancroft-1', initials: 'ZZ', grade_level: '5',
+    school_site: 'Bancroft Elementary School', school_id: 'school-2',
+    sessions_per_week: null, minutes_per_session: null, teacher_id: null,
+  },
+];
+
+const bancroftProviderTables = (): TableData => ({
+  profiles: { data: { works_at_multiple_schools: true, role: 'resource' }, error: null },
+  students: { data: DB_STUDENTS_BANCROFT_ONLY, error: null },
+  student_details: { data: [], error: null },
+  teachers: { data: DB_TEACHERS, error: null },
+});
+
+// One student at the selected school (Mt Diablo), one at the provider's existing
+// school (Bancroft) — both with a resource-matching Reading goal.
+const firstImportCsv = () =>
+  fileFrom(
+    buildSeisGoalsCsvFrom([
+      {
+        0: '2000201', 2: 'Keller', 3: 'Kim', 5: '02', 6: 'Mt Diablo Elementary School',
+        9: '05/01/2026', 11: 'Reading', 12: 'Academic #1: 2026 - 2027', 17: 'Resource Specialist',
+        14: 'By 5/1/2027, given a grade-level passage, Kim will read 90 words per minute with 95% accuracy in 3 of 4 trials.',
+      },
+      {
+        0: '2000202', 2: 'Barnes', 3: 'Ben', 5: '03', 6: 'Bancroft Elementary School',
+        9: '05/01/2026', 11: 'Reading', 12: 'Academic #1: 2026 - 2027', 17: 'Resource Specialist',
+        14: 'By 5/1/2027, given a grade-level passage, Ben will read 100 words per minute with 95% accuracy in 3 of 4 trials.',
+      },
+    ]),
+    'students.csv',
+    'text/csv',
+  );
+
+describe('POST /api/import-students — multi-school first-import regression (SPE-264)', () => {
+  it('imports selected-school students even when the provider has no existing students there', async () => {
+    const result = await runPost(
+      bancroftProviderTables(),
+      requestWith({ studentsFile: firstImportCsv() }, schoolCtx),
+    );
+
+    // Must NOT be the false "all belong to other schools" 400.
+    expect(result.status).toBe(200);
+
+    const data = (result.body as {
+      data?: {
+        students?: Array<{ lastName?: string }>;
+        summary?: { filteredOutSchools?: string[] };
+      };
+    }).data;
+
+    const lastNames = (data?.students ?? []).map((s) => s.lastName);
+    expect(lastNames).toContain('Keller'); // selected-school student imports
+    expect(lastNames).not.toContain('Barnes'); // other-school student scoped out
+    expect(data?.summary?.filteredOutSchools).toContain('Bancroft Elementary School');
   });
 });

--- a/__tests__/unit/lib/parsers/fixtures/builders.ts
+++ b/__tests__/unit/lib/parsers/fixtures/builders.ts
@@ -217,6 +217,22 @@ export const SEIS_GOALS_CSV_BOM = (): Buffer =>
   Buffer.concat([UTF8_BOM, Buffer.from(buildSeisGoalsCsv(), 'utf-8')]);
 
 /**
+ * Build a SEIS goals CSV from caller-supplied sparse rows (same 59-column width
+ * and \r\n format as SEIS_GOALS_CSV). For targeted school-scoping tests that need
+ * students at specific School-of-Attendance values — e.g. the multi-school
+ * first-import regression (SPE-264). Fill positions per SEIS_HEADERS: Last @ 2,
+ * First @ 3, Grade @ 5, School @ 6, IEP Date @ 9, Area Of Need @ 11,
+ * Annual Goal # @ 12, Goal @ 14, Person Responsible @ 17.
+ */
+export function buildSeisGoalsCsvFrom(rows: Array<Record<number, string>>): Buffer {
+  const lines = [
+    SEIS_HEADERS.map(csvCell).join(','),
+    ...rows.map((r) => seisCsvLine(r)),
+  ];
+  return Buffer.from(lines.join('\r\n'), 'utf-8');
+}
+
+/**
  * A column-shifted SEIS export (every column moved right by one) so the fixed
  * position detector matches fewer than 5 of its 6 key columns and falls back
  * to the generic parser. Pins the 5-of-6 detection boundary at the file level.

--- a/lib/import/parse-files.ts
+++ b/lib/import/parse-files.ts
@@ -84,11 +84,14 @@ export function classifyStudentsFileType(file: File): { isExcel: boolean; isCSV:
  */
 export async function parseStudentsFile(
   file: File,
-  opts: { isCSV: boolean; userSchools?: string[]; providerRole?: string }
+  opts: { isCSV: boolean; providerRole?: string }
 ): Promise<SEISParseResult | CSVParseResult> {
   const buffer = Buffer.from(await file.arrayBuffer());
   if (opts.isCSV) {
-    return parseCSVReport(buffer, { userSchools: opts.userSchools, providerRole: opts.providerRole });
+    // No `userSchools` school filter here on purpose: scoping students to the
+    // provider's current school is done once, downstream, by applySchoolFilter.
+    // See the note in runStudentsPreview (SPE-264).
+    return parseCSVReport(buffer, { providerRole: opts.providerRole });
   }
   return parseSEISReport(buffer, { providerRole: opts.providerRole });
 }

--- a/lib/import/pipeline.ts
+++ b/lib/import/pipeline.ts
@@ -179,24 +179,18 @@ export async function runStudentsPreview(ctx: PipelineContext, file: File): Prom
     return NextResponse.json({ error: 'Failed to fetch your students from database' }, { status: 500 });
   }
 
-  // Multi-school CSV users: derive their school sites so the parser can annotate
-  // school-of-attendance.
-  let userSchools: string[] | undefined;
-  if (isCSV && profile?.works_at_multiple_schools && dbStudents && dbStudents.length > 0) {
-    userSchools = Array.from(
-      new Set(
-        dbStudents
-          .map(s => s.school_site)
-          .filter((site): site is string => site !== null && site !== undefined && site.trim() !== ''),
-      ),
-    );
-  }
-
+  // Parse the whole file — do NOT pre-filter students by school here. Scoping to
+  // the provider's current school happens once, downstream, in applySchoolFilter
+  // (which keys off the selected school). A previous parse-time filter keyed off
+  // the schools where the provider ALREADY had students; when importing into a
+  // school with no students yet (the first-import case), it dropped every student
+  // in the file, producing a false "all belong to other schools" error. Keep
+  // school scoping in exactly one place (SPE-264).
   const fileType = isCSV ? 'CSV' : 'Excel';
   const parsePerf = measurePerformanceWithAlerts(`parse_${fileType.toLowerCase()}`, 'api');
   let parseResult;
   try {
-    parseResult = await parseStudentsFile(file, { isCSV, userSchools, providerRole: profile?.role ?? undefined });
+    parseResult = await parseStudentsFile(file, { isCSV, providerRole: profile?.role ?? undefined });
     parsePerf.end({ success: true });
   } catch (error) {
     parsePerf.end({ success: false });

--- a/lib/import/pipeline.ts
+++ b/lib/import/pipeline.ts
@@ -235,7 +235,7 @@ export async function runStudentsPreview(ctx: PipelineContext, file: File): Prom
     perf.end({ success: false });
     return NextResponse.json(
       {
-        error: `All ${filter.filteredOutCount} students in this file belong to other schools (${filter.filteredOutSchools.join(', ')}). Please switch to the correct school or upload a file with students from ${currentSchoolSite}.`,
+        error: `None of the students in this file are at ${currentSchoolSite} — they're at ${filter.filteredOutSchools.join(', ')}. Switch to the matching school in the top-bar selector, or upload a file that includes ${currentSchoolSite} students.`,
         filteredOutSchools: filter.filteredOutSchools,
       },
       { status: 400 },

--- a/lib/parsers/csv-parser.ts
+++ b/lib/parsers/csv-parser.ts
@@ -340,8 +340,16 @@ export async function parseCSVReport(buffer: Buffer, options: ParseOptions = {})
           continue;
         }
 
-        // Create unique key for student (name + grade)
-        const studentKey = `${firstName.trim().toLowerCase()}_${lastName.trim().toLowerCase()}_${normalizedGrade}`;
+        // Create unique key for consolidating a student's goal rows: name +
+        // grade + school. School is part of the key because two DIFFERENT
+        // students who share first name, last name, and grade but attend
+        // different schools must NOT merge — merging would drop one student or
+        // graft the other's IEP goals onto the wrong student once the
+        // selected-school filter runs downstream. A single student's goal rows
+        // all carry the same School of Attendance, so intended merges are
+        // unaffected. (SPE-264)
+        const schoolKeyPart = schoolOfAttendance ? normalizeSchoolName(schoolOfAttendance.trim()) : '';
+        const studentKey = `${firstName.trim().toLowerCase()}_${lastName.trim().toLowerCase()}_${normalizedGrade}_${schoolKeyPart}`;
 
         // Check if student already exists
         if (studentMap.has(studentKey)) {


### PR DESCRIPTION
## What & why

A provider who works at multiple schools, selecting School A and uploading a SEIS student-goals CSV that contains School A students, hit a **false** error:

> All N students in this file belong to other schools (School B). Please switch to the correct school…

…even though the file genuinely contained School A students who should import. Found during QC with a real SEIS export (12 Mt Diablo students in the file, but the app saw only 10 Bancroft students and errored).

## Root cause

The CSV import ran **two** school filters with **different** bases:

1. **Parse-time filter** (`userSchools`, in `csv-parser.ts`) — `userSchools` was derived in `pipeline.ts` from the schools where the provider **already had students** (`dbStudents.school_site`). Any student whose School of Attendance wasn't in that set was dropped *before* the real filter ran.
2. **Post-parse filter** (`applySchoolFilter`) — correctly scopes to the **currently-selected** school.

When importing into a school the provider has **no students at yet** (the first-import / onboarding case), that school is absent from `userSchools`, so filter #1 dropped all its students and filter #2 dropped whatever survived → everything filtered out → false error. A chicken-and-egg trap: you couldn't import a new school's students because you didn't yet have any of that school's students.

Verified by running the real file through the parser: with the existing-student set = `[Bancroft]`, the parser returned only the 10 Bancroft students, which `applySchoolFilter(Mt Diablo)` then dropped → the exact error. With the filter off, all 12 Mt Diablo students import.

## The fix

Remove the parse-time `userSchools` filter from the main import pipeline and rely solely on `applySchoolFilter` — keeping school scoping in **exactly one place** (the selected school). Net effect:

- The parser returns all students; the selected-school filter scopes correctly.
- The "all belong to other schools" guard still fires — accurately — only when the file truly has no students for the selected school.
- The **Excel/XLSX path already worked this way** (it never had the parse-time filter), so this aligns CSV with Excel.

## Tests

- **New route-level regression test** (`SPE-264`): existing students only at Bancroft, importing into Mt Diablo, file contains both → the Mt Diablo student imports, Bancroft is scoped out, no false error. Confirmed it **fails on the old code** (400) and passes with the fix.
- New fixtures helper `buildSeisGoalsCsvFrom` for targeted school-scoping tests.
- Multi-school **characterization snapshot** updated: the only change is the removal of two now-obsolete "doesn't match your school(s)" warnings — imported students and filtered-out reporting are unchanged.
- `npm test` (CI's `jest __tests__ lib`) green: 46 suites, 413 passed, 26 snapshots. Typecheck clean.

## Scope notes (from self-review)

- **Not a regression from the SPE-230 refactor** — both filters pre-date it; the double-filter is long-standing.
- `app/api/import-iep-goals/route.ts` has the same `userSchools`-from-existing-students pattern, but that path is **target-student-based** (the target is an existing student, so their school is always in `userSchools`) → not vulnerable. Left as-is, noted in SPE-264.
- **Defense-in-depth gap (not fixed here):** `applySchoolFilter` no-ops when `currentSchoolSite` is empty, so a multi-school provider reaching import with **no school selected** would import unscoped. Low reachability (the page gates actions on a selected school) and not a regression of any working flow, but the server doesn't enforce it. Flagged for a possible follow-up guard.

Closes SPE-264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0123jrkRqzWDChSQZ6BfHVtH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved student import previews for providers serving multiple schools.
  * Students from the selected school are now included correctly, even when the provider has no existing students at that school.
  * Students associated with other schools are excluded from the preview, with those schools identified in the filtered results.
  * Improved handling of school-of-attendance data during student file imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->