### PR TITLE
fix(import): make student identity school-aware (SPE-269, PR 2/2)

### DIFF
--- a/__tests__/unit/app/import-students-preview.characterization.test.ts
+++ b/__tests__/unit/app/import-students-preview.characterization.test.ts
@@ -426,3 +426,56 @@ describe('POST /api/import-students — multi-school first-import regression (SP
     expect(error).not.toMatch(/All \d+ students/); // the misleading count is gone
   });
 });
+
+/**
+ * SPE-269 — cross-school candidate scoping. Even with name-based matching
+ * (SPE-266), a same-name student can exist at two schools, so match candidates
+ * are scoped to the selected school. A Mt Diablo import must NOT match — and on
+ * confirm update — a same-name/grade student stored at Bancroft.
+ */
+describe('POST /api/import-students — cross-school candidate scoping (SPE-269)', () => {
+  it('does not match a same-name/grade student stored at a different school (scoped out → insert)', async () => {
+    const dbAtOtherSchool = [
+      {
+        id: 'stu-other', initials: 'SR', grade_level: '3',
+        school_site: 'Bancroft Elementary School', school_id: 'school-2',
+        sessions_per_week: null, minutes_per_session: null, teacher_id: null,
+      },
+    ];
+    const tables = (): TableData => ({
+      profiles: { data: { works_at_multiple_schools: true, role: 'resource' }, error: null },
+      students: { data: dbAtOtherSchool, error: null },
+      student_details: {
+        data: [{ student_id: 'stu-other', first_name: 'Sam', last_name: 'Rivers', iep_goals: ['An old Bancroft goal.'] }],
+        error: null,
+      },
+      teachers: { data: DB_TEACHERS, error: null },
+    });
+
+    // Same student name + grade as the Bancroft record, but at the selected
+    // school (Mt Diablo). Without scoping, name+grade would match cross-school.
+    const csv = () =>
+      fileFrom(
+        buildSeisGoalsCsvFrom([
+          {
+            0: '2000501', 2: 'Rivers', 3: 'Sam', 5: '03', 6: 'Mt Diablo Elementary School',
+            9: '05/01/2026', 11: 'Reading', 12: 'Academic #1: 2026 - 2027', 17: 'Resource Specialist',
+            14: 'By 5/1/2027, Sam will read 90 words per minute with 95% accuracy in 3 of 4 trials.',
+          },
+        ]),
+        'students.csv',
+        'text/csv',
+      );
+
+    const result = await runPost(tables(), requestWith({ studentsFile: csv() }, schoolCtx));
+    expect(result.status).toBe(200);
+
+    const data = (result.body as {
+      data?: { students?: Array<{ lastName?: string; action?: string; goals?: Array<{ text?: string }> }> };
+    }).data;
+    const rivers = (data?.students ?? []).find((s) => s.lastName === 'Rivers');
+    expect(rivers?.action).toBe('insert'); // NOT matched to the Bancroft Sam Rivers
+    // And no cross-school goal contamination.
+    expect((rivers?.goals ?? []).map((g) => g.text).join(' ')).not.toContain('Bancroft');
+  });
+});

--- a/__tests__/unit/app/import-students-preview.characterization.test.ts
+++ b/__tests__/unit/app/import-students-preview.characterization.test.ts
@@ -479,3 +479,88 @@ describe('POST /api/import-students — cross-school candidate scoping (SPE-269)
     expect((rivers?.goals ?? []).map((g) => g.text).join(' ')).not.toContain('Bancroft');
   });
 });
+
+/**
+ * SPE-269 (Codex follow-up) — the deliveries/class-list-only update path scopes
+ * to the selected school too. buildStudentsByName keys by normalized full name
+ * and overwrites collisions, so without scoping a deliveries upload could match —
+ * and update — a same-name student at a different school.
+ */
+describe('POST /api/import-students — cross-school update-only scoping (SPE-269)', () => {
+  it("deliveries-only updates the selected school's student, not a same-name student elsewhere", async () => {
+    // Same name ("Van Horn, Vera" — a weekly delivery, so it yields an update) at two
+    // schools; the other-school row is listed LAST so an unscoped name map
+    // (last-write-wins) would resolve the delivery to it.
+    const joinedCrossSchool = [
+      { id: 'stu-vanhorn-mtdiablo', initials: 'VV', grade_level: '4', school_site: 'Mt Diablo Elementary', school_id: 'school-1', student_details: { first_name: 'Vera', last_name: 'Van Horn' } },
+      { id: 'stu-vanhorn-bancroft', initials: 'VV', grade_level: '4', school_site: 'Bancroft Elementary School', school_id: 'school-2', student_details: { first_name: 'Vera', last_name: 'Van Horn' } },
+    ];
+    const tables = (): TableData => ({
+      profiles: { data: { role: 'resource' }, error: null },
+      students: { data: joinedCrossSchool, error: null },
+      teachers: { data: DB_TEACHERS, error: null },
+    });
+
+    const result = await runPost(tables(), requestWith({ deliveriesFile: deliveriesCsv() }, schoolCtx));
+    expect(result.status).toBe(200);
+    expect((result.body as { mode?: string }).mode).toBe('update');
+
+    const data = (result.body as { data?: { students?: Array<{ studentId?: string }> } }).data;
+    const ids = (data?.students ?? []).map((s) => s.studentId);
+    expect(ids).toContain('stu-vanhorn-mtdiablo'); // selected school updated
+    expect(ids).not.toContain('stu-vanhorn-bancroft'); // other-school same-name student not touched
+  });
+});
+
+/**
+ * SPE-269 (Codex follow-up) — a school with no school_id is submitted by the
+ * modal as currentSchoolId '' (`school_id || ''`), while legacy student rows
+ * carry school_id null. Those collapse to one bucket so a re-import of a legacy
+ * null-school student is matched, not previewed as a spurious insert that then
+ * dead-ends on confirm ("already exists").
+ */
+describe('POST /api/import-students — text-only school (null school_id) scoping (SPE-269)', () => {
+  it('matches a legacy null-school student when the selected school submits currentSchoolId ""', async () => {
+    const dbLegacy = [
+      {
+        id: 'stu-legacy', initials: 'SR', grade_level: '3',
+        school_site: 'Mt Diablo Elementary', school_id: null,
+        sessions_per_week: null, minutes_per_session: null, teacher_id: null,
+      },
+    ];
+    const tables = (): TableData => ({
+      profiles: { data: { works_at_multiple_schools: false, role: 'resource' }, error: null },
+      students: { data: dbLegacy, error: null },
+      student_details: {
+        data: [{ student_id: 'stu-legacy', first_name: 'Sam', last_name: 'Rivers', iep_goals: ['An existing goal.'] }],
+        error: null,
+      },
+      teachers: { data: DB_TEACHERS, error: null },
+    });
+
+    const csv = () =>
+      fileFrom(
+        buildSeisGoalsCsvFrom([
+          {
+            0: '2000501', 2: 'Rivers', 3: 'Sam', 5: '03', 6: 'Mt Diablo Elementary School',
+            9: '05/01/2026', 11: 'Reading', 12: 'Academic #1: 2026 - 2027', 17: 'Resource Specialist',
+            14: 'By 5/1/2027, Sam will read 90 words per minute with 95% accuracy in 3 of 4 trials.',
+          },
+        ]),
+        'students.csv',
+        'text/csv',
+      );
+
+    // Text-only school: the modal submits currentSchoolId '' (school_id || '').
+    const textOnlyCtx = { currentSchoolId: '', currentSchoolSite: 'Mt Diablo Elementary' };
+    const result = await runPost(tables(), requestWith({ studentsFile: csv() }, textOnlyCtx));
+    expect(result.status).toBe(200);
+
+    const data = (result.body as {
+      data?: { students?: Array<{ lastName?: string; action?: string }> };
+    }).data;
+    const rivers = (data?.students ?? []).find((s) => s.lastName === 'Rivers');
+    // The legacy null-school row is in the candidate set → matched, not a spurious insert.
+    expect(rivers?.action).not.toBe('insert');
+  });
+});

--- a/__tests__/unit/lib/utils/student-dedup-key.test.ts
+++ b/__tests__/unit/lib/utils/student-dedup-key.test.ts
@@ -8,6 +8,7 @@
 
 import {
   buildStudentDedupKey,
+  buildSchoolScopedDedupKey,
   normalizeInitialsForKey,
 } from '@/lib/utils/student-dedup-key';
 
@@ -48,5 +49,30 @@ describe('normalizeInitialsForKey', () => {
     expect(normalizeInitialsForKey('j.s.')).toBe('JS');
     expect(normalizeInitialsForKey(' a-b ')).toBe('AB');
     expect(normalizeInitialsForKey(null)).toBe('');
+  });
+});
+
+describe('buildSchoolScopedDedupKey (SPE-269)', () => {
+  it('keeps the same initials+grade distinct across different schools', () => {
+    expect(buildSchoolScopedDedupKey('school-a', 'ML', '3'))
+      .not.toBe(buildSchoolScopedDedupKey('school-b', 'ML', '3'));
+  });
+
+  it('dedups the same initials+grade within the same school', () => {
+    expect(buildSchoolScopedDedupKey('school-a', 'ML', '3'))
+      .toBe(buildSchoolScopedDedupKey('school-a', 'ml', '3'));
+  });
+
+  it('collapses null/undefined school to one bucket (matches the index NULLS NOT DISTINCT)', () => {
+    expect(buildSchoolScopedDedupKey(null, 'ML', '3'))
+      .toBe(buildSchoolScopedDedupKey(undefined, 'ML', '3'));
+    // ...and a null-school key differs from a real-school one.
+    expect(buildSchoolScopedDedupKey(null, 'ML', '3'))
+      .not.toBe(buildSchoolScopedDedupKey('school-a', 'ML', '3'));
+  });
+
+  it('still reconciles legacy SEIS grades within a school (18/TK)', () => {
+    expect(buildSchoolScopedDedupKey('school-a', 'JS', '18'))
+      .toBe(buildSchoolScopedDedupKey('school-a', 'JS', 'TK'));
   });
 });

--- a/app/api/import-students/confirm/route.ts
+++ b/app/api/import-students/confirm/route.ts
@@ -10,7 +10,7 @@ import { log } from '@/lib/monitoring/logger';
 import { track } from '@/lib/monitoring/analytics';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
 import { updateExistingSessionsForStudent } from '@/lib/scheduling/session-requirement-sync';
-import { buildStudentDedupKey } from '@/lib/utils/student-dedup-key';
+import { buildSchoolScopedDedupKey } from '@/lib/utils/student-dedup-key';
 import { mapUpsertResults, PendingUpsert, ImportResult } from '@/lib/import/upsert-result-mapper';
 import type { StudentToImport } from '@/lib/types/student-import';
 
@@ -51,21 +51,24 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
         .select('school_id, district_id, state_id, school_site')
         .eq('id', userId)
         .single(),
-      // 2. Batch fetch ALL existing students for this provider (for duplicate checking)
+      // 2. Batch fetch ALL existing students for this provider (for duplicate
+      //    checking). school_id is included so duplicate detection is school-aware
+      //    (SPE-269) — the same initials+grade can legitimately exist at two schools.
       supabase
         .from('students')
-        .select('id, initials, grade_level')
+        .select('id, initials, grade_level, school_id')
         .eq('provider_id', userId),
       // 3. Fetch accessible schools once
       supabase.rpc('user_accessible_school_ids')
     ]);
 
-    // Build lookup map for O(1) duplicate detection: key = "INITIALS-GRADE".
-    // The key normalizes both components so a stored legacy SEIS grade
-    // (grade_level '18'/'0') still matches an incoming normalized 'TK'/'K'.
+    // Build lookup map for O(1) duplicate detection: key = "SCHOOL::INITIALS-GRADE".
+    // The initials/grade components normalize so a stored legacy SEIS grade
+    // (grade_level '18'/'0') still matches an incoming normalized 'TK'/'K'; the
+    // school prefix keeps the check school-aware (SPE-269).
     const existingStudentMap = new Map<string, boolean>();
     for (const student of existingStudents || []) {
-      const key = buildStudentDedupKey(student.initials, student.grade_level);
+      const key = buildSchoolScopedDedupKey(student.school_id, student.initials, student.grade_level);
       existingStudentMap.set(key, true);
     }
 
@@ -184,7 +187,12 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
           continue;
         }
 
-        const duplicateKey = buildStudentDedupKey(initialsNormalized, student.gradeLevel);
+        // Determine school context up front so the duplicate key is school-aware
+        // (matches the (provider, school_id, grade, initials) DB uniqueness, SPE-269).
+        // Priority: student-specific (current school selection) > user profile > null.
+        // Access to this school is validated below before the row is queued.
+        const requestedSchoolId = student.schoolId || userProfile?.school_id || null;
+        const duplicateKey = buildSchoolScopedDedupKey(requestedSchoolId, initialsNormalized, student.gradeLevel);
 
         // For inserts, check for duplicates (against existing DB rows and earlier
         // rows in this same batch) - O(1) instead of a database query.
@@ -212,12 +220,8 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
           }
         }
 
-        // Determine school context
-        // Priority: student-specific (from current school selection) > user profile > null
-        // IMPORTANT: Must validate user has access to the school for security
-        const requestedSchoolId = student.schoolId || userProfile?.school_id || null;
-
-        // Validate user has access to the requested school using Set - O(1)
+        // Validate user has access to the requested school using Set - O(1).
+        // (requestedSchoolId is computed above so the duplicate key can be school-aware.)
         if (requestedSchoolId) {
           if (schoolsError) {
             log.error('Failed to fetch accessible schools', schoolsError, {

--- a/lib/import/classify.ts
+++ b/lib/import/classify.ts
@@ -498,9 +498,11 @@ export function buildRosterPreviews(params: {
   // the active school: a roster row is keyed only by initials+grade (no names),
   // so for a multi-school provider an unscoped match could update a same-initials
   // student at a different school.
+  // Null school_id / empty currentSchoolId collapse to one bucket, matching the
+  // main path and the confirm dedup key (buildSchoolScopedDedupKey).
   const existingByKey = new Map<string, RosterExistingStudentRow>();
   for (const s of dbStudents) {
-    if (s.school_id !== currentSchoolId) continue;
+    if ((s.school_id ?? '') !== (currentSchoolId ?? '')) continue;
     existingByKey.set(buildStudentDedupKey(s.initials, s.grade_level), s);
   }
 

--- a/lib/import/pipeline.ts
+++ b/lib/import/pipeline.ts
@@ -90,7 +90,15 @@ export async function runUpdateOnlyPreview(ctx: PipelineContext): Promise<NextRe
     );
   }
 
-  const studentsByName = buildStudentsByName(dbStudents);
+  // Scope to the selected school (SPE-269) before name-keying. buildStudentsByName
+  // keys by normalized full name and overwrites collisions, so for a multi-school
+  // provider an unscoped map could match — and update — a same-name student at a
+  // different school. Null school_id / empty currentSchoolId collapse to one bucket,
+  // consistent with the main path and the confirm dedup key.
+  const dbStudentsInSchool = dbStudents.filter(
+    s => (s.school_id ?? '') === (currentSchoolId ?? ''),
+  );
+  const studentsByName = buildStudentsByName(dbStudentsInSchool);
 
   // Parse enrichment files. Update-only hard-fails on a parse error (there is no
   // other data to preview).
@@ -273,7 +281,12 @@ export async function runStudentsPreview(ctx: PipelineContext, file: File): Prom
   // path (buildRosterPreviews). Identity is name+grade (SPE-266), but a same-name
   // student can exist at two schools, so a Mt-Diablo import must not match — and
   // on confirm update — a same-name student at another school. Same-school only.
-  const dbStudentsInSchool = (dbStudents ?? []).filter(s => s.school_id === currentSchoolId);
+  // A null school_id and an empty currentSchoolId ('' — what the modal submits for
+  // a school with no school_id) collapse to one bucket, matching the confirm dedup
+  // key (buildSchoolScopedDedupKey) and the DB index's NULLS NOT DISTINCT.
+  const dbStudentsInSchool = (dbStudents ?? []).filter(
+    s => (s.school_id ?? '') === (currentSchoolId ?? ''),
+  );
   const studentDetails = await loadStudentDetails(supabase, dbStudentsInSchool);
   const databaseStudents = toDatabaseStudents(dbStudentsInSchool, studentDetails);
 

--- a/lib/import/pipeline.ts
+++ b/lib/import/pipeline.ts
@@ -268,8 +268,14 @@ export async function runStudentsPreview(ctx: PipelineContext, file: File): Prom
   }
 
   const dbTeachers = classList && classList.students.size > 0 ? await fetchTeachers(supabase, currentSchoolId) : [];
-  const studentDetails = await loadStudentDetails(supabase, dbStudents);
-  const databaseStudents = toDatabaseStudents(dbStudents, studentDetails);
+
+  // Scope match candidates to the selected school (SPE-269), mirroring the roster
+  // path (buildRosterPreviews). Identity is name+grade (SPE-266), but a same-name
+  // student can exist at two schools, so a Mt-Diablo import must not match — and
+  // on confirm update — a same-name student at another school. Same-school only.
+  const dbStudentsInSchool = (dbStudents ?? []).filter(s => s.school_id === currentSchoolId);
+  const studentDetails = await loadStudentDetails(supabase, dbStudentsInSchool);
+  const databaseStudents = toDatabaseStudents(dbStudentsInSchool, studentDetails);
 
   const { studentPreviews, matchedDeliveryNames, matchedClassListNames } = buildStudentPreviews({
     parsedStudents: filteredStudents,

--- a/lib/utils/student-dedup-key.ts
+++ b/lib/utils/student-dedup-key.ts
@@ -27,3 +27,21 @@ export function buildStudentDedupKey(
 ): string {
   return `${normalizeInitialsForKey(initials)}-${normalizeGradeLevel(String(gradeLevel ?? ''))}`;
 }
+
+/**
+ * School-scoped duplicate-detection key (SPE-269): `buildStudentDedupKey`
+ * prefixed with the school, matching the `(provider_id, school_id, grade_level,
+ * initials)` DB uniqueness. A null/absent school collapses to one bucket so the
+ * app-level check lines up with the index's `NULLS NOT DISTINCT` (all
+ * school-less rows for a provider dedup together on grade+initials).
+ *
+ * Used by the import confirm route so a same-initials+grade student at a
+ * *different* school is not wrongly rejected as a duplicate on insert.
+ */
+export function buildSchoolScopedDedupKey(
+  schoolId: string | null | undefined,
+  initials: string | null | undefined,
+  gradeLevel: string | null | undefined,
+): string {
+  return `${schoolId ?? ''}::${buildStudentDedupKey(initials, gradeLevel)}`;
+}

--- a/supabase/migrations/20260717_school_aware_student_uniqueness.sql
+++ b/supabase/migrations/20260717_school_aware_student_uniqueness.sql
@@ -1,0 +1,29 @@
+-- SPE-269: school-aware student identity.
+--
+-- Student identity was keyed on (provider_id, grade_level, initials) — school-
+-- blind — so one provider could not have the same initials+grade at two schools,
+-- and a cross-school import falsely collided on confirm ("already exists"). With
+-- SPE-266 the precise "same student?" decision is name-based in the app layer;
+-- this database backstop becomes school-aware so identity is scoped per school.
+--
+-- No production student data to preserve at time of writing (owner confirmed),
+-- so no data backfill/cleanup is required here.
+
+-- Drop the school-blind uniqueness (a plain unique index) ...
+DROP INDEX IF EXISTS public.ux_students_provider_grade_initials;
+
+-- ... and the legacy initials+grade+teacher_name unique constraint (and its
+-- backing index, defensively, in case it exists as a bare index somewhere).
+ALTER TABLE public.students
+  DROP CONSTRAINT IF EXISTS students_provider_id_initials_grade_level_teacher_name_key;
+DROP INDEX IF EXISTS public.students_provider_id_initials_grade_level_teacher_name_key;
+
+-- School-aware uniqueness backstop. NULLS NOT DISTINCT so students without a
+-- school_id still dedup by (provider, grade, initials) instead of slipping the
+-- backstop entirely (Postgres treats NULLs as distinct in unique indexes by
+-- default, which would allow unlimited null-school duplicates).
+CREATE UNIQUE INDEX IF NOT EXISTS ux_students_provider_school_grade_initials
+  ON public.students (provider_id, school_id, grade_level, initials) NULLS NOT DISTINCT;
+
+COMMENT ON INDEX public.ux_students_provider_school_grade_initials IS
+  'Student identity backstop, school-aware (SPE-269): unique per provider + school + grade + initials, so the same initials+grade can exist at different schools. Precise same-student matching is name-based in the app layer (SPE-266).';


### PR DESCRIPTION
## What this does

Completes the school-aware student-identity model started in **SPE-266** (PR #748, match on **name + grade** instead of initials alone). This is **PR 2 of 2**.

Before this change, student identity was keyed on `(provider, grade, initials)` — **school-blind**. That had two consequences for a provider who works across multiple schools:

1. The same initials+grade student **could not coexist at two schools** (the DB rejected the second one).
2. A legitimate cross-school import **falsely collided on confirm** with `"…already exists"`.

## Changes

- **DB migration** (`20260717_school_aware_student_uniqueness.sql`): replaces the school-blind unique index `ux_students_provider_grade_initials` **and** the legacy `initials+grade+teacher_name` unique constraint with a school-aware unique index on `(provider_id, school_id, grade_level, initials) NULLS NOT DISTINCT`. `NULLS NOT DISTINCT` keeps school-less rows deduping by `(provider, grade, initials)` instead of allowing unlimited null-school duplicates.
- **Preview** (`lib/import/pipeline.ts`): scopes SEIS match candidates to the selected school, mirroring the existing roster path, so a same-name/grade student stored at **another** school is not matched — and not updated — during a different school's import.
- **Confirm** (`app/api/import-students/confirm/route.ts`): fetches `school_id` and makes the insert duplicate-check school-aware via a new `buildSchoolScopedDedupKey` helper. `requestedSchoolId` is computed before the dup-check; the school-access validation is unchanged.

## Verification

- **Migration validated on a throwaway Supabase branch**: cross-school coexistence ✓, same-school rejection ✓, null-school rejection ✓. The four-column index is strictly more permissive than the two it replaces, so `CREATE` cannot fail on existing rows.
- **DROP object names verified against production** — `ux_students_provider_grade_initials` (index) and `students_provider_id_initials_grade_level_teacher_name_key` (constraint) both exist with exact name matches, so the migration is not a silent no-op.
- **No production student data to preserve** (owner confirmed) — the migration requires no backfill or cleanup.
- `npm run typecheck` clean; `jest __tests__ lib` → **425 passed / 12 skipped**, 26 snapshots passing. Adds unit tests for `buildSchoolScopedDedupKey` and a characterization test asserting a Mt-Diablo import does not match a same-name/grade student stored at Bancroft.
- `/code-review` (high) run on the branch diff: no code changes required.

## Notes

- Legacy blank-name-record cleanup is intentionally out of scope (owner confirmed no data to preserve).


---
_Generated by [Claude Code](https://claude.ai/code/session_0123jrkRqzWDChSQZ6BfHVtH)_