### PR TITLE
feat(import): don't auto-select IEP goals with a past target date (SPE-267)

### DIFF
--- a/__tests__/unit/components/review/review-goal-list.test.tsx
+++ b/__tests__/unit/components/review/review-goal-list.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Render test for the import-review goal list (SPE-267): a past-dated goal is
+ * still shown, carries a "past date" hint, and renders unchecked, while a
+ * current goal renders checked and unbadged. All data is fictional.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { ReviewGoalList } from '@/app/components/students/review/review-goal-list';
+import type { ReviewRow } from '@/lib/import/review-model';
+
+function rowWith(goalTexts: string[]): ReviewRow {
+  return {
+    id: 'r1',
+    srcIndex: 0,
+    action: 'insert',
+    firstName: 'Test',
+    lastName: 'Student',
+    displayName: 'Test Student',
+    initials: 'TS',
+    gradeLevel: '3',
+    goals: goalTexts.map((text) => ({ text, status: 'added' as const })),
+    goalsRemoved: [],
+  };
+}
+
+describe('ReviewGoalList — past-dated goal hint (SPE-267)', () => {
+  it('shows a past-dated goal unchecked with a "past date" hint, current goal checked', () => {
+    const row = rowWith([
+      'By 5/1/2027, Ana will read 90 wpm.',        // current → selected
+      'By April 2026, Ana will decode CVC words.', // past → unselected + badged
+    ]);
+
+    render(
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <ReviewGoalList
+                row={row}
+                goalsSelected={new Set([0])}
+                pastDatedGoals={new Set([1])}
+                onToggleGoal={() => {}}
+                onToggleAllGoals={() => {}}
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>,
+    );
+
+    // Both goals are still shown.
+    expect(screen.getByText(/Ana will read 90 wpm/)).toBeInTheDocument();
+    expect(screen.getByText(/decode CVC words/)).toBeInTheDocument();
+
+    // Exactly one "past date" hint, on the expired goal.
+    expect(screen.getAllByText('past date')).toHaveLength(1);
+
+    // Checkbox state mirrors selection: current checked, expired unchecked.
+    const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+    expect(checkboxes[0].checked).toBe(true);
+    expect(checkboxes[1].checked).toBe(false);
+  });
+
+  it('shows no hint when no goal is past-dated', () => {
+    const row = rowWith(['By 5/1/2027, Ana will read 90 wpm.']);
+    render(
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <ReviewGoalList
+                row={row}
+                goalsSelected={new Set([0])}
+                pastDatedGoals={new Set()}
+                onToggleGoal={() => {}}
+                onToggleAllGoals={() => {}}
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>,
+    );
+    expect(screen.queryByText('past date')).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/components/review/use-review-selection.test.ts
+++ b/__tests__/unit/components/review/use-review-selection.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Hook test for the import-review selection defaults (SPE-267): goals whose
+ * target date is already past must be shown but NOT selected by default, while
+ * future/undated goals stay selected. All data is fictional.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useReviewSelection } from '@/app/components/students/review/use-review-selection';
+import type { ReviewRow, ReviewGoal } from '@/lib/import/review-model';
+
+function makeRow(id: string, goals: string[], action: ReviewRow['action'] = 'insert'): ReviewRow {
+  return {
+    id,
+    srcIndex: 0,
+    action,
+    firstName: 'Test',
+    lastName: 'Student',
+    displayName: 'Test Student',
+    initials: 'TS',
+    gradeLevel: '3',
+    goals: goals.map<ReviewGoal>((text) => ({ text, status: 'added' })),
+    goalsRemoved: [],
+  };
+}
+
+describe('useReviewSelection — past-dated goal defaults (SPE-267)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date(2026, 6, 17)); // 2026-07-17
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('default-selects future/undated goals but leaves past-dated ones unchecked', () => {
+    const row = makeRow('r1', [
+      'By 5/1/2027, Ana will read 90 wpm.',         // future → selected
+      'By April 2026, Ana will decode CVC words.',  // past → unselected
+      'Ana will participate in group discussion.',  // no date → selected
+    ]);
+    const { result } = renderHook(() => useReviewSelection([row]));
+
+    const selected = result.current.goalsSelectedFor('r1');
+    expect(selected.has(0)).toBe(true);
+    expect(selected.has(1)).toBe(false);
+    expect(selected.has(2)).toBe(true);
+
+    const past = result.current.pastDatedGoalsFor('r1');
+    expect([...past]).toEqual([1]);
+  });
+
+  it('keeps the past-date set and the default selection in agreement', () => {
+    const row = makeRow('r1', ['By June 2026, ...', 'By 5/1/2027, ...']);
+    const { result } = renderHook(() => useReviewSelection([row]));
+
+    const selected = result.current.goalsSelectedFor('r1');
+    const past = result.current.pastDatedGoalsFor('r1');
+    for (const i of past) expect(selected.has(i)).toBe(false);
+    expect([...past]).toEqual([0]);
+  });
+
+  it('counts only default-selected (non-expired) goals in totalSelectedGoals', () => {
+    const row = makeRow('r1', [
+      'By April 2026, ...',  // past
+      'By 5/1/2027, ...',    // future
+      'Undated goal.',       // no date
+    ]);
+    const { result } = renderHook(() => useReviewSelection([row]));
+    expect(result.current.totalSelectedGoals).toBe(2);
+  });
+});

--- a/__tests__/unit/lib/import/goal-target-date.test.ts
+++ b/__tests__/unit/lib/import/goal-target-date.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for the IEP goal target-date parser (SPE-267). All goal text is
+ * fictional. The parser must be conservative: only a confidently-parsed date
+ * counts as "past"; anything ambiguous returns null so the goal stays selected.
+ */
+
+import { parseGoalTargetDate, isGoalTargetDatePast } from '@/lib/import/goal-target-date';
+
+const iso = (d: Date | null) =>
+  d ? `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}` : null;
+
+describe('parseGoalTargetDate', () => {
+  it('parses numeric M/D/YYYY at the start of a goal', () => {
+    expect(iso(parseGoalTargetDate('By 5/1/2027, Ana will read 90 wpm with 95% accuracy in 3 of 4 trials.')))
+      .toBe('2027-05-01');
+    expect(iso(parseGoalTargetDate('4/30/2026 target'))).toBe('2026-04-30');
+  });
+
+  it('does not parse an ambiguous 2- or 3-digit year (stays conservative → null)', () => {
+    // Only a confident 4-digit year counts; a short/typo'd year must not resolve
+    // to some ancient date and wrongly expire a current goal.
+    expect(parseGoalTargetDate('by 4/30/26')).toBeNull();
+    expect(parseGoalTargetDate('by 5/1/202')).toBeNull();
+  });
+
+  it('parses "Month YYYY" to the LAST day of that month', () => {
+    expect(iso(parseGoalTargetDate('By April 2026, the student will ...'))).toBe('2026-04-30');
+    expect(iso(parseGoalTargetDate('By May 2026 ...'))).toBe('2026-05-31');
+    expect(iso(parseGoalTargetDate('By February 2028 ...'))).toBe('2028-02-29'); // leap year
+  });
+
+  it('parses month abbreviations and "Month D, YYYY"', () => {
+    expect(iso(parseGoalTargetDate('By Apr 5, 2026 ...'))).toBe('2026-04-05');
+    expect(iso(parseGoalTargetDate('Sept 2026'))).toBe('2026-09-30');
+    expect(iso(parseGoalTargetDate('by Dec 2025'))).toBe('2025-12-31');
+  });
+
+  it('parses numeric M/YYYY (no day) to end of month', () => {
+    expect(iso(parseGoalTargetDate('by 5/2027, ...'))).toBe('2027-05-31');
+  });
+
+  it('returns null when no date is confidently parseable', () => {
+    expect(parseGoalTargetDate('By the end of the 2026-2027 school year, ...')).toBeNull();
+    expect(parseGoalTargetDate('Ana will read fluently across settings.')).toBeNull();
+    // Non-date numbers must not be mistaken for a date.
+    expect(parseGoalTargetDate('read 90 words per minute with 95% accuracy in 3 of 4 trials')).toBeNull();
+  });
+
+  it('returns null for impossible dates rather than a wrong date', () => {
+    expect(parseGoalTargetDate('13/45/2026')).toBeNull();
+    expect(parseGoalTargetDate('2/30/2026')).toBeNull();
+  });
+
+  it('handles null/undefined/empty without throwing', () => {
+    expect(parseGoalTargetDate(null)).toBeNull();
+    expect(parseGoalTargetDate(undefined)).toBeNull();
+    expect(parseGoalTargetDate('')).toBeNull();
+  });
+});
+
+describe('isGoalTargetDatePast', () => {
+  const now = new Date(2026, 6, 17); // 2026-07-17 (local)
+
+  it('is true for a target date strictly before today', () => {
+    expect(isGoalTargetDatePast('By April 2026, ...', now)).toBe(true);
+    expect(isGoalTargetDatePast('By June 2026, ...', now)).toBe(true);
+    expect(isGoalTargetDatePast('by 7/16/2026', now)).toBe(true);
+  });
+
+  it('is false for a future target date', () => {
+    expect(isGoalTargetDatePast('By 5/1/2027, ...', now)).toBe(false);
+  });
+
+  it('does not treat the current month as past (month resolves to end of month)', () => {
+    // July 2026 → 2026-07-31, which is not before 2026-07-17.
+    expect(isGoalTargetDatePast('By July 2026, ...', now)).toBe(false);
+  });
+
+  it('is false on the target day itself (strictly-before comparison)', () => {
+    expect(isGoalTargetDatePast('by 7/17/2026', now)).toBe(false);
+  });
+
+  it('is false when the date is unparseable (goal stays selected)', () => {
+    expect(isGoalTargetDatePast('By the end of the 2026-2027 school year, ...', now)).toBe(false);
+    expect(isGoalTargetDatePast('Ana will read fluently.', now)).toBe(false);
+  });
+});

--- a/__tests__/unit/lib/import/goal-target-date.test.ts
+++ b/__tests__/unit/lib/import/goal-target-date.test.ts
@@ -51,6 +51,13 @@ describe('parseGoalTargetDate', () => {
     expect(parseGoalTargetDate('2/30/2026')).toBeNull();
   });
 
+  it('does not misread the D/YYYY tail of an invalid M/D/YYYY as a month/year', () => {
+    // Regression: month 13 is invalid, so M/D/YYYY fails; the "1/2026" tail must
+    // NOT then parse as Jan 2026 and wrongly expire the goal.
+    expect(parseGoalTargetDate('by 13/1/2026, the student will ...')).toBeNull();
+    expect(parseGoalTargetDate('99/2/2027')).toBeNull();
+  });
+
   it('handles null/undefined/empty without throwing', () => {
     expect(parseGoalTargetDate(null)).toBeNull();
     expect(parseGoalTargetDate(undefined)).toBeNull();

--- a/app/components/students/review/review-goal-list.tsx
+++ b/app/components/students/review/review-goal-list.tsx
@@ -11,11 +11,13 @@ import { ReviewSignalIcon } from './review-signal';
 interface ReviewGoalListProps {
   row: ReviewRow;
   goalsSelected: Set<number>;
+  /** Goal indices whose target date is already past — unchecked by default (SPE-267). */
+  pastDatedGoals: Set<number>;
   onToggleGoal: (goalIndex: number) => void;
   onToggleAllGoals: () => void;
 }
 
-export function ReviewGoalList({ row, goalsSelected, onToggleGoal, onToggleAllGoals }: ReviewGoalListProps) {
+export function ReviewGoalList({ row, goalsSelected, pastDatedGoals, onToggleGoal, onToggleAllGoals }: ReviewGoalListProps) {
   const hasGoals = row.goals.length > 0;
   const allSelected = hasGoals && goalsSelected.size === row.goals.length;
 
@@ -50,6 +52,14 @@ export function ReviewGoalList({ row, goalsSelected, onToggleGoal, onToggleAllGo
               className="mt-0.5 h-4 w-4 shrink-0 rounded border-gray-300 text-blue-600"
             />
             <span className="flex-1 text-gray-900">{goal.text}</span>
+            {pastDatedGoals.has(i) && (
+              <span
+                className="inline-flex shrink-0 items-center rounded-full bg-amber-50 px-1.5 py-0.5 text-xs font-medium text-amber-700"
+                title="This goal's target date has already passed. Left unchecked by default — check it to import anyway."
+              >
+                past date
+              </span>
+            )}
             {goal.status === 'added' && row.action === 'update' && (
               <span className="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-green-50 px-1.5 py-0.5 text-xs font-medium text-green-700">
                 <ReviewSignalIcon signal="confident" className="h-3 w-3" decorative /> added

--- a/app/components/students/review/review-row.tsx
+++ b/app/components/students/review/review-row.tsx
@@ -130,6 +130,7 @@ export function ReviewRow({ row, selection, isExpanded, onToggleExpand, columnCo
             <ReviewGoalList
               row={row}
               goalsSelected={goalsSelected}
+              pastDatedGoals={selection.pastDatedGoalsFor(row.id)}
               onToggleGoal={(i) => selection.toggleGoal(row.id, i)}
               onToggleAllGoals={() => selection.toggleAllGoals(row)}
             />

--- a/app/components/students/review/use-review-selection.ts
+++ b/app/components/students/review/use-review-selection.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState } from 'react';
 import type { ReviewRow } from '@/lib/import/review-model';
+import { isGoalTargetDatePast } from '@/lib/import/goal-target-date';
 
 /**
  * Selection state for the import review screen (SPE-227), keyed by stable
@@ -16,11 +17,35 @@ export function useReviewSelection(rows: ReviewRow[]) {
     [rows]
   );
 
+  // Goal indices whose target date is already in the past, keyed by row id.
+  // Computed once from "now" and used as the single source of truth for both the
+  // default-unselect below and the "past date" hint in the goal list, so the two
+  // can never disagree (SPE-267).
+  const pastDatedGoals = useMemo(() => {
+    const now = new Date();
+    const map: Record<string, Set<number>> = {};
+    for (const row of rows) {
+      const past = new Set<number>();
+      row.goals.forEach((goal, i) => {
+        if (isGoalTargetDatePast(goal.text, now)) past.add(i);
+      });
+      map[row.id] = past;
+    }
+    return map;
+  }, [rows]);
+
   const [selectedRowIds, setSelectedRowIds] = useState<Set<string>>(() => new Set(selectableIds));
   const [editedInitials, setEditedInitials] = useState<Record<string, string>>({});
   const [selectedGoals, setSelectedGoals] = useState<Record<string, Set<number>>>(() => {
+    // Default-select every incoming goal EXCEPT ones whose target date is already
+    // past: SEIS exports sometimes carry expired goals, and auto-importing them
+    // silently adds stale goals (SPE-267). The provider can still opt in by
+    // checking the box; a goal with no parseable date stays selected.
     const initial: Record<string, Set<number>> = {};
-    for (const row of rows) initial[row.id] = new Set(row.goals.map((_, i) => i));
+    for (const row of rows) {
+      const past = pastDatedGoals[row.id];
+      initial[row.id] = new Set(row.goals.map((_, i) => i).filter((i) => !past?.has(i)));
+    }
     return initial;
   });
 
@@ -58,6 +83,11 @@ export function useReviewSelection(rows: ReviewRow[]) {
   const goalsSelectedFor = useCallback(
     (rowId: string): Set<number> => selectedGoals[rowId] ?? new Set<number>(),
     [selectedGoals]
+  );
+
+  const pastDatedGoalsFor = useCallback(
+    (rowId: string): Set<number> => pastDatedGoals[rowId] ?? new Set<number>(),
+    [pastDatedGoals]
   );
 
   const toggleGoal = useCallback((rowId: string, goalIndex: number) => {
@@ -104,6 +134,7 @@ export function useReviewSelection(rows: ReviewRow[]) {
     initialsFor,
     setInitials,
     goalsSelectedFor,
+    pastDatedGoalsFor,
     toggleGoal,
     toggleAllGoals,
     selectedRows,

--- a/lib/import/goal-target-date.ts
+++ b/lib/import/goal-target-date.ts
@@ -1,0 +1,95 @@
+/**
+ * Best-effort parse of an IEP goal's *target date* from its free text (SPE-267).
+ *
+ * SEIS goal statements typically open "By <date>, <student> will …". SEIS
+ * exports sometimes still carry goals whose target date is already in the past
+ * (an expired goal left in the IEP); the import review uses this to leave those
+ * goals unchecked by default so a provider opts in consciously rather than
+ * silently re-importing stale goals.
+ *
+ * The parser is deliberately conservative: it recognizes a few common shapes and
+ * returns `null` when nothing is confidently parseable, so the caller keeps the
+ * goal selected (we only ever *demote* a goal on a date we're sure of). A month
+ * with no day resolves to the LAST day of that month, so a goal isn't treated as
+ * expired until the whole month has passed.
+ *
+ * All matching is on the raw goal text; no PII is stored or logged here.
+ */
+
+const MONTHS: Record<string, number> = {
+  january: 0, jan: 0,
+  february: 1, feb: 1,
+  march: 2, mar: 2,
+  april: 3, apr: 3,
+  may: 4,
+  june: 5, jun: 5,
+  july: 6, jul: 6,
+  august: 7, aug: 7,
+  september: 8, sept: 8, sep: 8,
+  october: 9, oct: 9,
+  november: 10, nov: 10,
+  december: 11, dec: 11,
+};
+
+/** Last calendar day of a month (handles leap Februaries). */
+function lastDayOfMonth(year: number, monthIndex: number): number {
+  return new Date(year, monthIndex + 1, 0).getDate();
+}
+
+/** Build a Date only when the components form a real calendar date. */
+function makeDate(year: number, monthIndex: number, day: number): Date | null {
+  if (monthIndex < 0 || monthIndex > 11) return null;
+  if (day < 1 || day > lastDayOfMonth(year, monthIndex)) return null;
+  return new Date(year, monthIndex, day);
+}
+
+export function parseGoalTargetDate(text: string | null | undefined): Date | null {
+  if (!text) return null;
+  const lower = text.toLowerCase();
+
+  // 1) Numeric M/D/YYYY, e.g. "by 5/1/2027". Require a 4-digit year: a 2- or
+  //    3-digit year is ambiguous (a typo like "5/1/202" would resolve to year
+  //    202 and wrongly expire a current goal), and we only demote a goal on a
+  //    date we're sure of — so an ambiguous year stays selected.
+  const numeric = lower.match(/\b(\d{1,2})\/(\d{1,2})\/(\d{4})\b/);
+  if (numeric) {
+    const d = makeDate(parseInt(numeric[3], 10), parseInt(numeric[1], 10) - 1, parseInt(numeric[2], 10));
+    if (d) return d;
+  }
+
+  // 2) Month name + optional day + 4-digit year, e.g. "April 2026" or "Apr 5, 2026".
+  const named = lower.match(
+    /\b(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sept?(?:ember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\.?\s+(?:(\d{1,2})(?:st|nd|rd|th)?,?\s+)?(\d{4})\b/,
+  );
+  if (named) {
+    const monthIndex = MONTHS[named[1]];
+    if (monthIndex !== undefined) {
+      const year = parseInt(named[3], 10);
+      const day = named[2] ? parseInt(named[2], 10) : lastDayOfMonth(year, monthIndex);
+      const d = makeDate(year, monthIndex, day);
+      if (d) return d;
+    }
+  }
+
+  // 3) Numeric month/year with no day, e.g. "by 5/2027" → end of that month.
+  const monthYear = lower.match(/\b(\d{1,2})\/(\d{4})\b/);
+  if (monthYear) {
+    const monthIndex = parseInt(monthYear[1], 10) - 1;
+    const year = parseInt(monthYear[2], 10);
+    const d = makeDate(year, monthIndex, lastDayOfMonth(year, monthIndex));
+    if (d) return d;
+  }
+
+  return null;
+}
+
+/**
+ * True only when a goal's target date parses AND falls strictly before `now`'s
+ * calendar day. An unparseable date returns `false` (the goal stays selected).
+ */
+export function isGoalTargetDatePast(text: string | null | undefined, now: Date): boolean {
+  const target = parseGoalTargetDate(text);
+  if (!target) return false;
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return target.getTime() < today.getTime();
+}

--- a/lib/import/goal-target-date.ts
+++ b/lib/import/goal-target-date.ts
@@ -72,7 +72,13 @@ export function parseGoalTargetDate(text: string | null | undefined): Date | nul
   }
 
   // 3) Numeric month/year with no day, e.g. "by 5/2027" → end of that month.
-  const monthYear = lower.match(/\b(\d{1,2})\/(\d{4})\b/);
+  //    The leading `(?:^|[^\d/])` guard stops this from matching the `D/YYYY`
+  //    tail of a malformed `M/D/YYYY` (e.g. "13/1/2026" must stay unparsed, not
+  //    become Jan 2026): pattern 1 already consumed any real M/D/YYYY, so a slash
+  //    immediately before the month here means we're on the tail of a bad date,
+  //    not a standalone M/YYYY. (A lookbehind would be cleaner but isn't supported
+  //    on older Safari, and this parser runs client-side.)
+  const monthYear = lower.match(/(?:^|[^\d/])(\d{1,2})\/(\d{4})\b/);
   if (monthYear) {
     const monthIndex = parseInt(monthYear[1], 10) - 1;
     const year = parseInt(monthYear[2], 10);


### PR DESCRIPTION
## What this does

On the import review screen, every detected IEP goal was **checked by default**. SEIS exports sometimes still contain **expired** goals — a target date already in the past (e.g. "By April 2026…" seen in July 2026) — so a provider could silently re-import stale goals they didn't intend to.

**Now:** a goal whose target date parses as already past is still **shown**, but left **unchecked by default** with a small "past date" hint, so the provider consciously opts in. If the date detection is wrong or the goal is actually current, the provider just checks the box. Goals with **no parseable date keep the current behavior** (selected) — we only ever demote a goal on a date we're sure of.

Found during Blair's import QC.

## Changes

- **`lib/import/goal-target-date.ts`** (new, pure): `parseGoalTargetDate` + `isGoalTargetDatePast`. Recognizes `M/D/YYYY`, `Month YYYY` (resolved to the **end of that month**, so a goal isn't treated as expired until the whole month has passed), `Month D, YYYY`, and `M/YYYY`. Conservative by design — only a confident **4-digit-year** date counts; anything ambiguous (short/typo'd year, non-date numbers, "2026-2027 school year") returns `null` and the goal stays selected.
- **`use-review-selection.ts`**: computes the past-dated goal set once (single source of truth for both the default-unselect and the hint), excludes those indices from the initial selection, and exposes `pastDatedGoalsFor`.
- **`review-row.tsx` / `review-goal-list.tsx`**: threads the set through and renders the "past date" hint.

## Verification

- `npm run typecheck` clean; `jest __tests__ lib` → **438 passed / 12 skipped**, 26 snapshots unchanged (no behavior change to the preview API — this is review-screen selection only).
- New tests: parser format coverage (M/D/YYYY, month-name, end-of-month leniency, leap year, unparseable → null, impossible dates → null), the hook's default-selection (past unselected, future/undated selected, `pastDatedGoalsFor` agrees with the default), and a goal-list render test (expired goal shown, unchecked, badged; current goal checked).
- `/code-review` (high) run on the diff: caught that the numeric year pattern accepted a 3-digit year (a typo like `5/1/202` would resolve to year 202 and wrongly expire a current goal); tightened to a 4-digit year only. No other findings.

## Notes

- No API/DB/wire changes — the confirm payload already sends only the checked goals, so leaving an expired goal unchecked simply omits it unless the provider opts in.
- The "past date" hint is intentionally minimal so an unchecked goal is self-explanatory rather than a mystery.


---
_Generated by [Claude Code](https://claude.ai/code/session_0123jrkRqzWDChSQZ6BfHVtH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic detection of “past date” target dates for IEP goals, displayed as an amber “past date” indicator.
  - Past-dated goals are no longer selected by default; future, current, and undated goals stay selected.
  - Review UI now reflects past-dated status consistently per row, including correct checkbox behavior.

- **Bug Fixes**
  - Improved target-date parsing across supported numeric and month-based formats, with stricter handling of invalid/ambiguous inputs.

- **Tests**
  - Added unit tests covering goal target-date parsing and past-dated selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->