### PR TITLE
fix(import): don't flag deliveries for school-filtered-out students as "needs review" (SPE-268)

### DIFF
--- a/__tests__/unit/app/import-students-preview.characterization.test.ts
+++ b/__tests__/unit/app/import-students-preview.characterization.test.ts
@@ -564,3 +564,86 @@ describe('POST /api/import-students — text-only school (null school_id) scopin
     expect(rivers?.action).not.toBe('insert');
   });
 });
+
+/**
+ * SPE-268 — a Deliveries/Class List row for a student the goals report placed at
+ * ANOTHER school (correctly filtered out by school) must not be flagged as "needs
+ * your review." The Deliveries file has no school column, so an other-school
+ * student's schedule would otherwise be swept into the review queue as
+ * "add via roster" even though it was correctly excluded. Only students genuinely
+ * unknown at the selected school should remain.
+ */
+describe('POST /api/import-students — suppress filtered-out deliveries from review (SPE-268)', () => {
+  it('drops a deliveries row for an other-school (filtered-out) student, still flags a genuinely unknown one', async () => {
+    // Multi-school provider importing Mt Diablo. Goals report has one Mt Diablo
+    // student (kept) and one Bancroft student (filtered out by school).
+    const goalsCsv = () =>
+      fileFrom(
+        buildSeisGoalsCsvFrom([
+          {
+            0: '2000001', 2: 'Alvarez', 3: 'Ana', 5: '01', 6: 'Mt Diablo Elementary School',
+            9: '05/01/2026', 11: 'Reading', 12: 'Academic #1: 2026 - 2027', 17: 'Resource Specialist',
+            14: 'By 5/1/2027, Ana will read 90 words per minute.',
+          },
+          {
+            0: '2000002', 2: 'Bishop', 3: 'Ben', 5: '02', 6: 'Bancroft Elementary School',
+            9: '05/01/2026', 11: 'Reading', 12: 'Academic #1: 2026 - 2027', 17: 'Resource Specialist',
+            14: 'By 5/1/2027, Ben will read 80 words per minute.',
+          },
+        ]),
+        'students.csv',
+        'text/csv',
+      );
+
+    // Deliveries (no school column): Ana matches the imported Mt Diablo student;
+    // Ben matches the FILTERED-OUT Bancroft student (suppress); Uma is unknown (flag).
+    const dHeader =
+      'Name,SEIS ID,Service,Delivery,Start Date,End Date,Sessions / Frequency,Location,Total Minutes (min/year),Total Delivered,Medi-Cal Billing Consent';
+    const dRow = (name: string, id: string, room: string) =>
+      `"${name}",${id},330 - Specialized Academic Instruction,Direct,08/15/2025,06/10/2026,45 min Weekly,${room},1620,0,Yes`;
+    const deliveries = () =>
+      fileFrom(
+        Buffer.from(
+          [
+            dHeader,
+            dRow('Alvarez, Ana', '2000001', 'Room 1'),
+            dRow('Bishop, Ben', '2000002', 'Room 2'),
+            dRow('Unknown, Uma', '2000003', 'Room 3'),
+          ].join('\n'),
+        ),
+        'deliveries.csv',
+        'text/csv',
+      );
+
+    const tables = (): TableData => ({
+      profiles: { data: { works_at_multiple_schools: true, role: 'resource' }, error: null },
+      students: { data: [], error: null },
+      student_details: { data: [], error: null },
+      teachers: { data: DB_TEACHERS, error: null },
+    });
+
+    const result = await runPost(
+      tables(),
+      requestWith({ studentsFile: goalsCsv(), deliveriesFile: deliveries() }, schoolCtx),
+    );
+    expect(result.status).toBe(200);
+
+    const data = (result.body as {
+      data?: {
+        students?: Array<{ lastName?: string }>;
+        unmatchedStudents?: Array<{ name?: string; source?: string }>;
+      };
+    }).data;
+
+    // Bishop was filtered out by school (not imported) — this is the case the fix
+    // targets. Asserting it means the test can only pass via suppression, not
+    // because Bishop happened to be matched/imported.
+    expect((data?.students ?? []).some((s) => s.lastName === 'Bishop')).toBe(false);
+
+    const unmatchedNames = (data?.unmatchedStudents ?? []).map((u) => u.name);
+    // The genuinely-unknown deliveries student is still surfaced for review ...
+    expect(unmatchedNames).toContain('Unknown, Uma');
+    // ... but the other-school (filtered-out) student is NOT flagged (suppressed).
+    expect(unmatchedNames).not.toContain('Bishop, Ben');
+  });
+});

--- a/__tests__/unit/lib/import/collect-unmatched.test.ts
+++ b/__tests__/unit/lib/import/collect-unmatched.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for collectUnmatched's school-filter suppression (SPE-268).
+ *
+ * An unmatched Deliveries/Class List row whose normalized name matches a
+ * goals-report student that was excluded by school is suppressed (it was
+ * correctly set aside, not "missing"); genuinely-unknown names still surface.
+ * Keys here stand in for createNormalizedKey output — the point is that the
+ * suppress set and the enrichment-map keys share one normalization. All data is
+ * fictional.
+ */
+
+import { collectUnmatched } from '@/lib/import/respond';
+import type { DeliveryRecord } from '@/lib/parsers/deliveries-parser';
+import type { ClassListStudent } from '@/lib/parsers/class-list-parser';
+
+const delivery = (name: string) => ({ name }) as unknown as DeliveryRecord;
+const classListStudent = (name: string) => ({ name }) as unknown as ClassListStudent;
+
+describe('collectUnmatched — school-filter suppression (SPE-268)', () => {
+  it('suppresses a filtered-out (other-school) delivery but keeps genuinely-unknown ones', () => {
+    const deliveries = new Map<string, DeliveryRecord>([
+      ['ana-alvarez', delivery('Alvarez, Ana')], // matched — never unmatched
+      ['ben-bishop', delivery('Bishop, Ben')], // filtered out by school → suppress
+      ['uma-unknown', delivery('Unknown, Uma')], // genuinely unknown → keep
+    ]);
+    const result = collectUnmatched(
+      deliveries,
+      null,
+      new Set(['ana-alvarez']), // matched delivery names
+      new Set(),
+      new Set(['ben-bishop']), // filtered-out (other-school) names
+    );
+    expect(result.map(r => r.name)).toEqual(['Unknown, Uma']);
+  });
+
+  it('applies the same suppression to the class-list source', () => {
+    const classList = new Map<string, ClassListStudent>([
+      ['ben-bishop', classListStudent('Bishop, Ben')],
+      ['uma-unknown', classListStudent('Unknown, Uma')],
+    ]);
+    const result = collectUnmatched(null, classList, new Set(), new Set(), new Set(['ben-bishop']));
+    expect(result.map(r => r.name)).toEqual(['Unknown, Uma']);
+  });
+
+  it('flags every unmatched student when no suppress set is passed (unchanged behavior)', () => {
+    const deliveries = new Map<string, DeliveryRecord>([
+      ['ben-bishop', delivery('Bishop, Ben')],
+      ['uma-unknown', delivery('Unknown, Uma')],
+    ]);
+    const result = collectUnmatched(deliveries, null, new Set(), new Set());
+    expect(result.map(r => r.name).sort()).toEqual(['Bishop, Ben', 'Unknown, Uma']);
+  });
+});

--- a/lib/import/parse-files.ts
+++ b/lib/import/parse-files.ts
@@ -135,6 +135,10 @@ export async function parseClassListFile(file: File): Promise<ParsedClassList> {
 
 export interface SchoolFilterResult<T> {
   students: T[];
+  /** The students excluded by school — used to reclassify enrichment rows (e.g.
+   *  Deliveries) for other-school students as "filtered out" rather than
+   *  "needs review" (SPE-268). Empty when no filtering was applied. */
+  filteredOutStudents: T[];
   filteredOutCount: number;
   filteredOutSchools: string[];
 }
@@ -142,9 +146,9 @@ export interface SchoolFilterResult<T> {
 /**
  * Scope parsed students to the current school for a multi-school provider.
  * Students without a school-of-attendance are kept (assigned to the current
- * school). `filteredOutSchools` is derived from the ORIGINAL (pre-filter) list,
- * preserving the previous behavior. Returns the filtered list + counts; the
- * caller decides whether an all-filtered-out result is an error.
+ * school). Returns the kept list, the excluded (filtered-out) list, and derived
+ * counts/schools; the caller decides whether an all-filtered-out result is an
+ * error.
  */
 export function applySchoolFilter<T extends { schoolOfAttendance?: string }>(
   students: T[],
@@ -152,33 +156,31 @@ export function applySchoolFilter<T extends { schoolOfAttendance?: string }>(
   worksAtMultipleSchools: boolean | null | undefined
 ): SchoolFilterResult<T> {
   if (!currentSchoolSite || !worksAtMultipleSchools) {
-    return { students, filteredOutCount: 0, filteredOutSchools: [] };
+    return { students, filteredOutStudents: [], filteredOutCount: 0, filteredOutSchools: [] };
   }
 
   const normalizedCurrentSchool = normalizeSchoolName(currentSchoolSite);
-  const beforeCount = students.length;
 
-  const filteredStudents = students.filter(student => {
-    // If student has no school info, include them (they'll be assigned to current school)
-    if (!student.schoolOfAttendance) return true;
-    return normalizeSchoolName(student.schoolOfAttendance) === normalizedCurrentSchool;
-  });
-
-  const filteredOutCount = beforeCount - filteredStudents.length;
-
-  let filteredOutSchools: string[] = [];
-  if (filteredOutCount > 0) {
-    const otherSchools = new Set<string>();
-    for (const student of students) {
-      if (student.schoolOfAttendance) {
-        const studentSchool = normalizeSchoolName(student.schoolOfAttendance);
-        if (studentSchool !== normalizedCurrentSchool) {
-          otherSchools.add(student.schoolOfAttendance);
-        }
-      }
-    }
-    filteredOutSchools = Array.from(otherSchools);
+  const filteredStudents: T[] = [];
+  const filteredOutStudents: T[] = [];
+  for (const student of students) {
+    // A student with no school info is kept (assigned to the current school).
+    const keep =
+      !student.schoolOfAttendance ||
+      normalizeSchoolName(student.schoolOfAttendance) === normalizedCurrentSchool;
+    (keep ? filteredStudents : filteredOutStudents).push(student);
   }
 
-  return { students: filteredStudents, filteredOutCount, filteredOutSchools };
+  // Distinct other-school labels (raw casing) come from exactly the excluded
+  // students — every filtered-out student has a non-current schoolOfAttendance.
+  const filteredOutSchools = Array.from(
+    new Set(filteredOutStudents.map(s => s.schoolOfAttendance).filter((s): s is string => !!s))
+  );
+
+  return {
+    students: filteredStudents,
+    filteredOutStudents,
+    filteredOutCount: filteredOutStudents.length,
+    filteredOutSchools,
+  };
 }

--- a/lib/import/pipeline.ts
+++ b/lib/import/pipeline.ts
@@ -45,6 +45,7 @@ import {
   summarizePreviews,
 } from '@/lib/import/respond';
 import type { ImportSupabaseClient } from '@/lib/import/preview-types';
+import { createNormalizedKey } from '@/lib/parsers/name-utils';
 
 type Perf = ReturnType<typeof measurePerformanceWithAlerts>;
 type Note = { row: number; message: string };
@@ -298,11 +299,21 @@ export async function runStudentsPreview(ctx: PipelineContext, file: File): Prom
     dbTeachers,
   });
 
+  // A Deliveries/Class List row for a student the goals report placed at another
+  // school was correctly set aside by school (the top banner already reports it),
+  // not genuinely missing — suppress it from the review queue rather than flag it
+  // as "needs review / add via roster" (SPE-268). Keyed the same way the deliveries
+  // map is (createNormalizedKey), so the names line up.
+  const filteredOutNames = new Set(
+    filter.filteredOutStudents.map(s => createNormalizedKey(s.firstName, s.lastName)),
+  );
+
   const unmatchedStudents = collectUnmatched(
     deliveries?.deliveries ?? null,
     classList?.students ?? null,
     matchedDeliveryNames,
     matchedClassListNames,
+    filteredOutNames,
   );
 
   const counts = summarizePreviews(studentPreviews);

--- a/lib/import/respond.ts
+++ b/lib/import/respond.ts
@@ -52,13 +52,21 @@ export function collectUnmatched(
   deliveriesData: Map<string, DeliveryRecord> | null,
   classListData: Map<string, ClassListStudent> | null,
   matchedDeliveryNames: Set<string>,
-  matchedClassListNames: Set<string>
+  matchedClassListNames: Set<string>,
+  // Normalized names (createNormalizedKey) of goals-report students excluded by
+  // school. An enrichment row for one of them isn't a genuine "needs review" —
+  // the student was correctly set aside by school and there's nothing to add, so
+  // suppress it instead of flagging it (SPE-268). The Deliveries/Class List files
+  // carry no school column, so this is the only way to tell an other-school
+  // student apart from one genuinely missing at the selected school.
+  filteredOutNames?: Set<string>
 ): UnmatchedStudent[] {
+  const suppressed = filteredOutNames ?? new Set<string>();
   const unmatchedStudents: UnmatchedStudent[] = [];
 
   if (deliveriesData) {
     for (const [normalizedName, record] of deliveriesData) {
-      if (!matchedDeliveryNames.has(normalizedName)) {
+      if (!matchedDeliveryNames.has(normalizedName) && !suppressed.has(normalizedName)) {
         unmatchedStudents.push({ name: record.name, source: 'deliveries' });
       }
     }
@@ -66,7 +74,7 @@ export function collectUnmatched(
 
   if (classListData) {
     for (const [normalizedName, student] of classListData) {
-      if (!matchedClassListNames.has(normalizedName)) {
+      if (!matchedClassListNames.has(normalizedName) && !suppressed.has(normalizedName)) {
         unmatchedStudents.push({ name: student.name, source: 'classList' });
       }
     }


### PR DESCRIPTION
## What this does

The import review's **"Needs your review"** queue listed every Deliveries/Class-List student who didn't match a student being imported into the selected school, labeled *"Not in the goals report — won't be imported. Add via the roster…"*.

The problem: the Deliveries file has **no school column**, so a multi-school provider's students from *other* schools (e.g. Bancroft students when importing Mt Diablo) got swept into that list and flagged as "add this student" — even though the banner at the top already reports them as **filtered out by school**. Same students called out twice; noise that buries the genuine cases. (Found in QC.)

**Now:** an unmatched enrichment row whose name matches a goals-report student who was **filtered out by school** is suppressed — they were correctly set aside and there's nothing to add. Only students *genuinely unknown at the selected school* remain in the queue.

Why suppress is safe: an unmatched delivery is always "a schedule with no student to attach to," and the only reason to surface one is "you might want to add this student." That reason never applies to an other-school student (they belong to their own school's import), so listing them serves no purpose.

## Changes

- **`applySchoolFilter`** now also returns the **excluded** students (single-pass partition; `filteredOutSchools`/`filteredOutCount` derived from that set — existing behavior preserved exactly).
- **`collectUnmatched`** takes an optional `filteredOutNames` set and skips any unmatched row whose normalized name is in it.
- **`runStudentsPreview`** builds that set from the filtered-out students via `createNormalizedKey` — the *same* normalization the deliveries/class-list maps and `matchedDeliveryNames` use, so suppression targets exactly the right rows and can't over-suppress a genuinely-unknown student.

## Scope

This covers the main **goals + enrichment** path (the QC-reported flow). The deliveries/class-list-**only** path keys off DB students rather than a goals report, so its equivalent noise is a separate mechanism — noted as a potential follow-up, not addressed here.

## Verification

- `npm run typecheck` clean; `jest __tests__ lib` → **450 passed / 12 skipped**, **26 snapshots unchanged** (no change to any existing preview response — the fix only fires for multi-school filtering + enrichment, a combination no existing snapshot exercised).
- New tests: a route-level case (other-school delivery suppressed, genuinely-unknown one still flagged, and asserting the other-school student was *actually* filtered out — so the test can only pass via suppression, not by the student happening to be matched), plus `collectUnmatched` unit tests (deliveries + class-list suppression, and unchanged behavior when no suppress set is passed).
- `/code-review` (high) on the diff: verified the `applySchoolFilter` refactor is behavior-equivalent (kept/excluded partition, `filteredOutSchools` raw values + order, count, and the null-`schoolOfAttendance` "keep" rule); its one finding was that the route test didn't robustly prove suppression — hardened as described above.


---
_Generated by [Claude Code](https://claude.ai/code/session_0123jrkRqzWDChSQZ6BfHVtH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved student import previews by excluding students from other schools when class-list enrichment is unavailable.
  * Prevented filtered-out students from appearing in matched results or the review queue.
  * Continued surfacing genuinely unknown students for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->