### PR TITLE
docs(claude): add Linear issue-status workflow convention

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -99,6 +99,33 @@ standing rule for the work at hand (then merge on green without checking back).
 The purely-internal, non-UX, all-gates-green case above is the standing
 exception where that go-ahead is already granted.
 
+## How we use Linear (issue statuses)
+
+The workflow is one director (me) and one executor (Claude Code), and work
+usually goes from decided to shipped in a single focused push. So statuses stay
+deliberately minimal — and, above all, honest. The failure mode here is a
+*drifting board* (a ticket stuck "In Progress" long after it shipped; finished
+tickets never archived), not too few columns. Keep the statuses true and they
+cost nothing.
+
+- **Backlog** — not started. The pool, including follow-ups you discover
+  mid-task and log instead of doing right then.
+- **In Progress** — actively being worked right now. Usually short-lived.
+- **In Review** — a finished, green PR waiting on my merge call. This is the one
+  genuine "ball's in my court" state (see "merging is the pause point" above).
+- **Done** — merged / shipped.
+- **To-do** — NOT a required step. Optional only, to stage a visible short-list
+  when we deliberately line up a multi-ticket initiative. Don't pre-stage a
+  queue by default; the next thing is whatever I point you at.
+
+**Move your own ticket as you work** — this is the habit that keeps the board
+honest: to **In Progress** when you start it, to **In Review** when you open its
+PR, to **Done** when it merges. Never leave a ticket **In Progress** after its
+work has shipped.
+
+Auto-archive is on, so completed tickets clear themselves — don't hand-manage
+done-ticket clutter.
+
 ## Standing rule: deep self-review before any substantive PR
 
 Before marking any substantive PR ready for review (features, bug fixes,

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -119,9 +119,9 @@ cost nothing.
   queue by default; the next thing is whatever I point you at.
 
 **Move your own ticket as you work** — this is the habit that keeps the board
-honest: to **In Progress** when you start it, to **In Review** when you open its
-PR, to **Done** when it merges. Never leave a ticket **In Progress** after its
-work has shipped.
+honest: to **In Progress** when you start it, to **In Review** once its PR is up
+*and green* (the merge decision is now mine), to **Done** when it merges. Never
+leave a ticket **In Progress** after its work has shipped.
 
 Auto-archive is on, so completed tickets clear themselves — don't hand-manage
 done-ticket clutter.


### PR DESCRIPTION
Adds a **How we use Linear (issue statuses)** section to `.claude/CLAUDE.md`, capturing the lean status workflow we agreed on.

## What & why

The Linear board had drifted — a ticket sat "In Progress" for weeks after it had actually shipped, and 100+ finished tickets were never archived. The fix isn't more process; it's a small, honest convention:

- **Backlog** — not started (the pool, incl. deferred follow-ups)
- **In Progress** — actively being worked right now
- **In Review** — a finished, green PR waiting on a merge decision
- **Done** — merged / shipped
- **To-do** — optional only, to stage a short-list for a multi-ticket initiative

Plus the habit that prevents drift: **move your own ticket as you work** (→ In Progress on start, → In Review on PR open, → Done on merge), relying on Linear auto-archive for done-ticket cleanup.

Docs-only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCH9uPP4K6Co57EgRxaX4q

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCH9uPP4K6Co57EgRxaX4q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on the team’s issue-status workflow.
  * Documented the meanings of Backlog, In Progress, In Review, Done, and optional To-do.
  * Clarified expected ticket progression (including moving out of In Progress only when ready for review) and that completed tickets are automatically archived.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->