### PR TITLE
docs(claude): note the auto-deployable Linear label

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -99,6 +99,15 @@ standing rule for the work at hand (then merge on green without checking back).
 The purely-internal, non-UX, all-gates-green case above is the standing
 exception where that go-ahead is already granted.
 
+**Tracked in Linear via the `auto-deployable` label.** A ticket carries this
+label only if it meets the bar above: purely internal/technical, no user-facing
+or UX change, no schema/data migration, no dependency/security/auth/infra
+change, CI-verifiable, reversible. Apply it when you file or groom a qualifying
+ticket (and strip it if scope grows past the bar); filter to it to find work you
+can take to merge without me. Per the standing exception above, `auto-deployable`
+tickets may be cleared end-to-end — implement → verify → PR → merge on green —
+without checking back. When in doubt, leave the label off.
+
 ## How we use Linear (issue statuses)
 
 The workflow is one director (me) and one executor (Claude Code), and work

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -105,7 +105,8 @@ or UX change, no schema/data migration, no dependency/security/auth/infra
 change, CI-verifiable, reversible. Apply it when you file or groom a qualifying
 ticket (and strip it if scope grows past the bar); filter to it to find work you
 can take to merge without me. Per the standing exception above, `auto-deployable`
-tickets may be cleared end-to-end — implement → verify → PR → merge on green —
+tickets may be cleared end-to-end — implement → verify → PR → merge once every
+gate is green (typecheck, lint, tests, CI, and zero unresolved review threads) —
 without checking back. When in doubt, leave the label off.
 
 ## How we use Linear (issue statuses)


### PR DESCRIPTION
Adds a short pointer in `.claude/CLAUDE.md` to the new **`auto-deployable`** Linear label, so future sessions apply and consume it.

## What & why

We created an `auto-deployable` label in Linear to track — as first-class metadata, not just prose — which backlog tickets Claude Code can drive to merge without director involvement. This note ties the label to the existing "Autonomous execution" bar and tells future sessions to:
- apply it only when a ticket is purely internal/technical (no UX/behavior/schema/dependency/security/auth/infra change, CI-verifiable, reversible),
- strip it if scope grows past the bar,
- and filter to it to find work that can be cleared end-to-end on green.

Docs-only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCH9uPP4K6Co57EgRxaX4q

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCH9uPP4K6Co57EgRxaX4q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for applying an “auto-deployable” label to narrowly scoped, low-risk technical tickets.
  * Defined clear eligibility criteria (including what qualifies and when to remove/avoid the label).
  * Explained how the label should be used as a filter for work that can proceed end-to-end once quality gates are green, without further author check-ins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->