### PR TITLE
refactor: consolidate duplicated escapeRegExp into a shared util (SPE-249)

### DIFF
--- a/lib/lessons/validator.ts
+++ b/lib/lessons/validator.ts
@@ -11,6 +11,7 @@ import {
   getWhiteboardExampleRange,
   getBaseMinimum
 } from './duration-constants';
+import { escapeRegExp } from '../utils/regex';
 
 export interface ValidationResult {
   isValid: boolean;
@@ -38,10 +39,6 @@ const COMPOUND_MATERIAL_PHRASES = [
 ];
 
 export class MaterialsValidator {
-  // Helper to escape special regex characters
-  private escapeRegExp(string: string): string {
-    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  }
 
   /**
    * Validates that a lesson response follows zero-prep rules
@@ -162,13 +159,13 @@ export class MaterialsValidator {
     
     for (const phrase of COMPOUND_MATERIAL_PHRASES) {
       // Use word boundaries and escape special characters for safety
-      const regex = new RegExp(`\\b${this.escapeRegExp(phrase)}\\b`, 'gi');
+      const regex = new RegExp(`\\b${escapeRegExp(phrase)}\\b`, 'gi');
       const matches = processedMaterials.match(regex);
       if (matches) {
         foundPhrases.push(...matches.map(m => m.toLowerCase()));
         // Replace with space to maintain word boundaries
         // Create a new RegExp instance for replace to avoid state issues
-        processedMaterials = processedMaterials.replace(new RegExp(`\\b${this.escapeRegExp(phrase)}\\b`, 'gi'), ' ');
+        processedMaterials = processedMaterials.replace(new RegExp(`\\b${escapeRegExp(phrase)}\\b`, 'gi'), ' ');
       }
     }
     
@@ -514,7 +511,7 @@ export class MaterialsValidator {
       
       // Use word boundaries for short words to reduce false positives
       if (forbiddenLower.length <= 3) {
-        const pattern = new RegExp(`\\b${this.escapeRegExp(forbiddenLower)}\\b`, 'i');
+        const pattern = new RegExp(`\\b${escapeRegExp(forbiddenLower)}\\b`, 'i');
         if (pattern.test(textLower)) {
           errors.push(`${context}: Contains forbidden term "${forbidden}"`);
         }

--- a/lib/parsers/service-type-mapping.ts
+++ b/lib/parsers/service-type-mapping.ts
@@ -3,6 +3,8 @@
  * Maps provider roles to SEIS service type codes for IEP goal filtering
  */
 
+import { escapeRegExp } from '../utils/regex';
+
 export const SERVICE_TYPE_CODES = {
   resource: '330',      // Specialized Academic Instruction
   speech: '415',        // Language and Speech
@@ -113,11 +115,6 @@ export const PROVIDER_KEYWORDS: Record<string, string[]> = {
     'counseling',
   ],
 };
-
-/** Escape a keyword so it can be embedded literally in a RegExp. */
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 /**
  * One word-boundary-anchored alternation per role, compiled once from

--- a/lib/utils/ai-lesson-formatter.ts
+++ b/lib/utils/ai-lesson-formatter.ts
@@ -7,6 +7,7 @@
 
 import { getSanitizedHTML } from '../sanitize-html';
 import { formatLessonContent } from './lesson-formatter';
+import { escapeRegExp } from './regex';
 // MERGED: standardizeLessonStructure functionality integrated directly to avoid duplicate processing (Issue #268)
 
 interface Student {
@@ -62,7 +63,6 @@ export function processAILessonContent(content: string, students: Student[] = []
       const colorClass = colors[index % colors.length];
       
       // Replace student references with styled badges - escape special RegExp characters
-      const escapeRegExp = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       const studentRegex = new RegExp(`\\b(${escapeRegExp(student.initials)}|Student ${index + 1})\\b`, 'g');
       processedContent = processedContent.replace(
         studentRegex,
@@ -125,7 +125,6 @@ export function processAILessonContentForPrint(content: string, students: Studen
   
   // For print, use simpler student name formatting
   if (students && students.length > 0) {
-    const escapeRegExp = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     students.forEach((student, index) => {
       const studentRegex = new RegExp(`\\b(${escapeRegExp(student.initials)}|Student ${index + 1})\\b`, 'g');
       processedContent = processedContent.replace(

--- a/lib/utils/regex.ts
+++ b/lib/utils/regex.ts
@@ -1,0 +1,10 @@
+/**
+ * Escape a string so it can be embedded literally inside a `RegExp`.
+ *
+ * Consolidated from four previously duplicated copies (SPE-249):
+ * `lib/parsers/service-type-mapping.ts`, `lib/utils/ai-lesson-formatter.ts`,
+ * `lib/lessons/validator.ts`, and `lib/utils/subject-classifier.ts`.
+ */
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/lib/utils/subject-classifier.ts
+++ b/lib/utils/subject-classifier.ts
@@ -2,6 +2,8 @@
  * Utility for classifying IEP goals by subject area (Math vs ELA)
  */
 
+import { escapeRegExp } from './regex';
+
 // Keywords to identify Math goals in IEP text
 const MATH_KEYWORDS = [
   'math', 'mathematics', 'number', 'numeral', 'computation', 'calculate', 
@@ -39,11 +41,11 @@ export interface ClassifiedIEPGoals {
 
 // Pre-compile regex patterns for better performance
 const MATH_PATTERNS = MATH_KEYWORDS.map(keyword => 
-  new RegExp(`\\b${keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i')
+  new RegExp(`\\b${escapeRegExp(keyword)}\\b`, 'i')
 );
 
 const ELA_PATTERNS = ELA_KEYWORDS.map(keyword => 
-  new RegExp(`\\b${keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i')
+  new RegExp(`\\b${escapeRegExp(keyword)}\\b`, 'i')
 );
 
 /**


### PR DESCRIPTION
Consolidates four copies of the "escape a string for literal use in a `RegExp`" helper into one shared util.

## What

- New `lib/utils/regex.ts` exporting `escapeRegExp(value)`.
- Removed the duplicated copies and imported the shared one in:
  - `lib/parsers/service-type-mapping.ts` (local `function`)
  - `lib/lessons/validator.ts` (private method → 3 call sites updated)
  - `lib/utils/ai-lesson-formatter.ts` (two inline arrow copies)
  - `lib/utils/subject-classifier.ts` (two inline `.replace(...)` copies)

## Why

Pure refactor, **no behavior change** — the extracted function is byte-identical to the four originals. Deferred from the SPE-247 PR to avoid touching unrelated files.

## Verification

- `npm run typecheck` — clean
- `npm test` — 50 suites, 450 passed, 0 failed
- `npm run lint` — no errors (2 pre-existing warnings in untouched files)

Tagged `auto-deployable` in Linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCH9uPP4K6Co57EgRxaX4q

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCH9uPP4K6Co57EgRxaX4q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when processing lesson content, materials, forbidden terms, and subject keywords containing special characters.
  * Maintained consistent matching and formatting behavior across lesson and print views.

* **Refactor**
  * Consolidated regular-expression escaping into a shared utility for more consistent results across features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->