### PR TITLE
fix(email-webhook): lazy-init Resend client to avoid module-load instantiation (SPE-113)

### DIFF
--- a/app/api/email-webhook/route.ts
+++ b/app/api/email-webhook/route.ts
@@ -3,7 +3,16 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { Resend } from 'resend';
 
-const resend = new Resend(process.env['RESEND_API_KEY']);
+// Lazy-init so the Resend client isn't constructed at module load — its
+// constructor throws on a missing key, which breaks `next build` in CI when
+// RESEND_API_KEY isn't set (SPE-113).
+let resendClient: Resend | null = null;
+function getResend(): Resend {
+  if (!resendClient) {
+    resendClient = new Resend(process.env['RESEND_API_KEY']);
+  }
+  return resendClient;
+}
 
 // SPE-128: The inbound email -> worksheet flow is not live, and this endpoint
 // had NO sender verification — an unauthenticated POST could trigger outbound
@@ -43,7 +52,7 @@ export async function POST(request: NextRequest) {
     // Process attachments (images)
     if (!attachments || attachments.length === 0) {
       // Send error email back
-      await resend.emails.send({
+      await getResend().emails.send({
         from: 'IEP Progress <progress@speddy.xyz>',
         to: from,
         subject: 'No image attached - Please resend',
@@ -93,7 +102,7 @@ export async function POST(request: NextRequest) {
 
         // Send success confirmation
         if (result.success) {
-          await resend.emails.send({
+          await getResend().emails.send({
             from: 'IEP Progress <progress@speddy.xyz>',
             to: from,
             subject: 'Worksheet processed successfully!',
@@ -232,7 +241,7 @@ async function processWorksheetSubmission(
 // Send error email
 async function sendErrorEmail(to: string, message: string) {
   try {
-    await resend.emails.send({
+    await getResend().emails.send({
       from: 'IEP Progress <progress@speddy.xyz>',
       to: to,
       subject: 'Error processing worksheet',


### PR DESCRIPTION
Moves the Resend client off module load in `app/api/email-webhook/route.ts`.

## What & why

The client was built at module load (`const resend = new Resend(process.env['RESEND_API_KEY'])`). Resend's constructor throws on a missing key, so `next build` fails during "Collecting page data" whenever `RESEND_API_KEY` isn't set (e.g. CI). It was worked around with a placeholder key in the build env; this removes the fragility at the source.

Now behind a lazy `getResend()` getter (constructed on first use), with the 3 send sites updated. Behavior-preserving when the key is present; it's the only top-level `new Resend(` in the app.

## Verification

- `npm run typecheck` — clean
- `npm test` — 50 suites, 450 passed, 0 failed
- `npm run lint` — no errors (2 pre-existing warnings in untouched files)

Tagged `auto-deployable` in Linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCH9uPP4K6Co57EgRxaX4q

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCH9uPP4K6Co57EgRxaX4q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email webhook reliability when email service configuration is unavailable during application startup.
  * Ensured outbound notifications are initialized only when needed, helping prevent build-time failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->