### PR TITLE
chore(api): emit rejection telemetry from withRoute (SPE-81)

### DIFF
--- a/lib/api/rate-limit-user.ts
+++ b/lib/api/rate-limit-user.ts
@@ -20,6 +20,13 @@ export interface RateLimitOutcome {
   remaining: number;
   /** Seconds until the window resets (used for the Retry-After header). */
   resetSeconds: number;
+  /**
+   * When `allowed` is false, why it was denied: `rate_limited` for a genuinely
+   * exhausted quota, or `rate_limiter_error` when the limiter itself failed
+   * closed (a DB/storage error on a `failClosed` endpoint). Lets callers keep
+   * the two apart in telemetry. Undefined when the request is allowed.
+   */
+  reason?: 'rate_limited' | 'rate_limiter_error';
 }
 
 /**
@@ -44,7 +51,7 @@ export async function checkUserRateLimit(
   // fail open (allow) so a transient DB issue doesn't block cheap traffic.
   const onError = (): RateLimitOutcome =>
     rule.failClosed
-      ? { allowed: false, remaining: 0, resetSeconds: rule.windowSeconds }
+      ? { allowed: false, remaining: 0, resetSeconds: rule.windowSeconds, reason: 'rate_limiter_error' }
       : allow();
 
   try {
@@ -74,7 +81,7 @@ export async function checkUserRateLimit(
 
     const used = count ?? 0;
     if (used >= rule.requests) {
-      return { allowed: false, remaining: 0, resetSeconds: rule.windowSeconds };
+      return { allowed: false, remaining: 0, resetSeconds: rule.windowSeconds, reason: 'rate_limited' };
     }
 
     const { error: insertError } = await supabase

--- a/lib/api/with-route.ts
+++ b/lib/api/with-route.ts
@@ -127,7 +127,7 @@ export function withRoute<
         const endpoint = config.rateLimit.name ?? req.nextUrl.pathname;
         const outcome = await checkUserRateLimit(userId, endpoint, config.rateLimit);
         if (!outcome.allowed) {
-          logRejection(429, 'rate_limited');
+          logRejection(429, outcome.reason ?? 'rate_limited');
           return NextResponse.json(
             { error: 'Too many requests. Please try again later.' },
             { status: 429, headers: { 'Retry-After': String(outcome.resetSeconds) } }

--- a/lib/api/with-route.ts
+++ b/lib/api/with-route.ts
@@ -62,6 +62,18 @@ export function withRoute<
   handler: Handler<TBody, TQuery, TParams>
 ) {
   return async (req: NextRequest, context?: NextContext<TParams>): Promise<NextResponse> => {
+    // Emit one consistent telemetry line whenever the wrapper rejects a request
+    // before the handler runs (auth / validation / rate-limit). Handlers own
+    // their own success/error telemetry, so these early returns previously went
+    // unrecorded (SPE-81). Responses are unchanged — this only adds a log line.
+    const logRejection = (status: number, reason: string) =>
+      log.warn('API route rejected', {
+        endpoint: req.nextUrl.pathname,
+        method: req.method,
+        status,
+        reason,
+      });
+
     try {
       // AI kill-switch: gated routes do not exist while AI features are off.
       // Checked before auth so the feature is fully hidden and makes no
@@ -75,6 +87,7 @@ export function withRoute<
         const supabase = await createClient();
         const { data: { user }, error } = await supabase.auth.getUser();
         if (error || !user) {
+          logRejection(401, 'unauthorized');
           return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
         }
         userId = user.id;
@@ -88,10 +101,14 @@ export function withRoute<
         try {
           raw = await req.json();
         } catch {
+          logRejection(400, 'invalid_json');
           return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
         }
         const parsed = config.body.safeParse(raw);
-        if (!parsed.success) return validationError(parsed.error.flatten());
+        if (!parsed.success) {
+          logRejection(400, 'body_validation');
+          return validationError(parsed.error.flatten());
+        }
         body = parsed.data;
       }
 
@@ -99,7 +116,10 @@ export function withRoute<
       if (config.query) {
         const raw = Object.fromEntries(req.nextUrl.searchParams.entries());
         const parsed = config.query.safeParse(raw);
-        if (!parsed.success) return validationError(parsed.error.flatten());
+        if (!parsed.success) {
+          logRejection(400, 'query_validation');
+          return validationError(parsed.error.flatten());
+        }
         query = parsed.data;
       }
 
@@ -107,6 +127,7 @@ export function withRoute<
         const endpoint = config.rateLimit.name ?? req.nextUrl.pathname;
         const outcome = await checkUserRateLimit(userId, endpoint, config.rateLimit);
         if (!outcome.allowed) {
+          logRejection(429, 'rate_limited');
           return NextResponse.json(
             { error: 'Too many requests. Please try again later.' },
             { status: 429, headers: { 'Retry-After': String(outcome.resetSeconds) } }


### PR DESCRIPTION
Adds consistent telemetry for requests the shared `withRoute` wrapper rejects *before* the handler runs.

## What & why

`withRoute` resolves auth and validation before the handler, and handlers own their own success/error perf telemetry — so auth (401), validation (400), and rate-limit (429) early returns went **unrecorded** after the wrapper migration (noted in the SPE-74 review). This instruments them **once, in the wrapper** (not per-route) via a small `logRejection(status, reason)` helper that emits a `warn` line with endpoint, method, status, and reason on each rejection branch:

- `401 unauthorized`
- `400 invalid_json` / `400 body_validation` / `400 query_validation`
- `429 rate_limited`

Responses are **unchanged** — this only adds a log line, so there's no behavior/UX change.

## Verification

- `npm run typecheck` — clean
- `npm test` — 50 suites, 450 passed, 0 failed (incl. `with-route.test.ts`)
- `npm run lint` — no errors (2 pre-existing warnings in untouched files)

Tagged `auto-deployable` in Linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCH9uPP4K6Co57EgRxaX4q

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCH9uPP4K6Co57EgRxaX4q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Monitoring**
  * Improved warning telemetry for requests rejected before reaching the handler, including unauthorized access, invalid input, validation failures, and rate-limit denials.
  * Existing response payloads, status codes, and request handling behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->