### PR TITLE
Student full name as identity anchor: enrich on import + show on Students page (SPE-284)

### DIFF
--- a/__tests__/unit/lib/import/classify.test.ts
+++ b/__tests__/unit/lib/import/classify.test.ts
@@ -131,11 +131,12 @@ describe('buildStudentPreviews (main path)', () => {
     expect(p.goalsRemoved).toEqual(['Old goal']);
   });
 
-  it('enriches an initials-only existing student with the incoming name (SPE-284)', () => {
+  it('enriches an initials-only existing student with the incoming name when opted in (SPE-284)', () => {
     const { studentPreviews } = buildStudentPreviews({
       parsedStudents: [parsed({ goals: [] })],
       databaseStudents: [dbStudent({ first_name: '', last_name: '' })],
       deliveriesData: null, classListData: null, dbTeachers: [],
+      enrichNoNameByInitials: true,
     });
     const p = studentPreviews[0];
     expect(p.action).toBe('update');
@@ -144,6 +145,19 @@ describe('buildStudentPreviews (main path)', () => {
     // The incoming name flows through for the confirm write + review display.
     expect(p.firstName).toBe('John');
     expect(p.lastName).toBe('Doe');
+  });
+
+  it('does NOT enrich a no-name row when enrichment is off (fail-safe default)', () => {
+    // The pipeline turns enrichment off when student_details failed to load, so a
+    // merely-unloaded name can't be overwritten. Default off → treat as a new insert.
+    const { studentPreviews } = buildStudentPreviews({
+      parsedStudents: [parsed({ goals: [] })],
+      databaseStudents: [dbStudent({ first_name: '', last_name: '' })],
+      deliveriesData: null, classListData: null, dbTeachers: [],
+    });
+    const p = studentPreviews[0];
+    expect(p.action).toBe('insert');
+    expect(p.matchedStudentId).toBeUndefined();
   });
 
   it('does not fabricate a change when the existing student already has that name', () => {

--- a/__tests__/unit/lib/import/classify.test.ts
+++ b/__tests__/unit/lib/import/classify.test.ts
@@ -131,6 +131,30 @@ describe('buildStudentPreviews (main path)', () => {
     expect(p.goalsRemoved).toEqual(['Old goal']);
   });
 
+  it('enriches an initials-only existing student with the incoming name (SPE-284)', () => {
+    const { studentPreviews } = buildStudentPreviews({
+      parsedStudents: [parsed({ goals: [] })],
+      databaseStudents: [dbStudent({ first_name: '', last_name: '' })],
+      deliveriesData: null, classListData: null, dbTeachers: [],
+    });
+    const p = studentPreviews[0];
+    expect(p.action).toBe('update');
+    expect(p.matchedStudentId).toBe('s1');
+    expect(p.matchConfidence).toBe('low');
+    expect(p.changes?.name).toEqual({ old: null, new: 'John Doe' });
+  });
+
+  it('does not fabricate a name change when the existing student already has that name', () => {
+    const { studentPreviews } = buildStudentPreviews({
+      parsedStudents: [parsed({ goals: [] })],
+      databaseStudents: [dbStudent()], // already John Doe, JD, grade 3
+      deliveriesData: null, classListData: null, dbTeachers: [],
+    });
+    const p = studentPreviews[0];
+    expect(p.action).toBe('skip');
+    expect(p.changes?.name).toBeUndefined();
+  });
+
   it('enriches an insert with schedule and applies the weeklyMinutes fallback for a monthly (0) delivery', () => {
     const { studentPreviews, matchedDeliveryNames } = buildStudentPreviews({
       parsedStudents: [parsed({ goals: ['G'] })],

--- a/__tests__/unit/lib/import/classify.test.ts
+++ b/__tests__/unit/lib/import/classify.test.ts
@@ -141,10 +141,12 @@ describe('buildStudentPreviews (main path)', () => {
     expect(p.action).toBe('update');
     expect(p.matchedStudentId).toBe('s1');
     expect(p.matchConfidence).toBe('low');
-    expect(p.changes?.name).toEqual({ old: null, new: 'John Doe' });
+    // The incoming name flows through for the confirm write + review display.
+    expect(p.firstName).toBe('John');
+    expect(p.lastName).toBe('Doe');
   });
 
-  it('does not fabricate a name change when the existing student already has that name', () => {
+  it('does not fabricate a change when the existing student already has that name', () => {
     const { studentPreviews } = buildStudentPreviews({
       parsedStudents: [parsed({ goals: [] })],
       databaseStudents: [dbStudent()], // already John Doe, JD, grade 3
@@ -152,7 +154,6 @@ describe('buildStudentPreviews (main path)', () => {
     });
     const p = studentPreviews[0];
     expect(p.action).toBe('skip');
-    expect(p.changes?.name).toBeUndefined();
   });
 
   it('enriches an insert with schedule and applies the weeklyMinutes fallback for a monthly (0) delivery', () => {

--- a/__tests__/unit/lib/student-matcher.test.ts
+++ b/__tests__/unit/lib/student-matcher.test.ts
@@ -101,15 +101,86 @@ describe('matchStudents — name-based identity (SPE-266)', () => {
     expect(result.matches[0].confidence).toBe('none');
   });
 
-  it('does NOT match a DB student whose stored name is whitespace-only', () => {
-    // A whitespace-only stored name is truthy but normalizes to '' — it must be
-    // rejected before matching, or it would false-match via the empty-fuzzy path.
+  it('never name-matches a whitespace-only stored name via the empty-fuzzy path', () => {
+    // A whitespace-only stored name normalizes to '' — it must never satisfy the
+    // NAME match (which would false-match via compareNames' empty-prefix path).
+    // It is instead treated as a no-name record and only reached by the explicit
+    // initials-enrichment fallback below (SPE-284), never scored as a name match.
     const result = matchStudents(
       [{ initials: 'JS', gradeLevel: '3', firstName: 'John', lastName: 'Smith', goals: [] }] as any,
       [{ id: 'db-1', initials: 'JS', grade_level: '3', first_name: '   ', last_name: ' ' }],
     );
 
+    // Matched (for enrichment, see SPE-284 block) but NOT as a name match:
+    // a name match would be 'high'/'medium'; the enrichment fallback is 'low'.
+    expect(result.matches[0].confidence).not.toBe('high');
+    expect(result.matches[0].confidence).not.toBe('medium');
+  });
+});
+
+/**
+ * SPE-284: full name is becoming the identity anchor, but existing rows may still
+ * be initials-only during the transition. A NAMED upload must ENRICH the existing
+ * initials-only record (add the name) instead of erroring "already exists" or
+ * creating a duplicate. The fallback is deliberately narrow so SPE-266's core
+ * guarantee — a stored *real* name is never overwritten via an initials collision
+ * — still holds.
+ */
+describe('matchStudents — initials enrichment fallback (SPE-284)', () => {
+  it('enriches a no-name existing record by initials + grade (low confidence)', () => {
+    const result = matchStudents(
+      [{ initials: 'JS', gradeLevel: '3', firstName: 'John', lastName: 'Smith', goals: [] }] as any,
+      [{ id: 'db-1', initials: 'JS', grade_level: '3', first_name: '', last_name: '' }],
+    );
+
+    expect(result.matches[0].matchedStudent?.id).toBe('db-1');
+    expect(result.matches[0].confidence).toBe('low');
+    expect(result.summary.noMatch).toBe(0);
+  });
+
+  it('does NOT enrich when the grade differs (guards the reported incident)', () => {
+    const result = matchStudents(
+      [{ initials: 'JS', gradeLevel: 'TK', firstName: 'John', lastName: 'Smith', goals: [] }] as any,
+      [{ id: 'db-1', initials: 'JS', grade_level: '3', first_name: '', last_name: '' }],
+    );
+
     expect(result.matches[0].matchedStudent).toBeNull();
     expect(result.matches[0].confidence).toBe('none');
+  });
+
+  it('does NOT initials-match a candidate that HAS a real (differing) name (SPE-266 preserved)', () => {
+    const result = matchStudents(
+      [{ initials: 'JS', gradeLevel: '3', firstName: 'John', lastName: 'Smith', goals: [] }] as any,
+      [{ id: 'db-1', initials: 'JS', grade_level: '3', first_name: 'Jane', last_name: 'Sparrow' }],
+    );
+
+    expect(result.matches[0].matchedStudent).toBeNull();
+    expect(result.matches[0].confidence).toBe('none');
+  });
+
+  it('bails on ambiguity — two no-name candidates share initials + grade (no guess)', () => {
+    const result = matchStudents(
+      [{ initials: 'JS', gradeLevel: '3', firstName: 'John', lastName: 'Smith', goals: [] }] as any,
+      [
+        { id: 'db-1', initials: 'JS', grade_level: '3', first_name: '', last_name: '' },
+        { id: 'db-2', initials: 'JS', grade_level: '3', first_name: '', last_name: '' },
+      ],
+    );
+
+    expect(result.matches[0].matchedStudent).toBeNull();
+    expect(result.matches[0].confidence).toBe('none');
+  });
+
+  it('prefers a full-name match over the initials fallback when both are possible', () => {
+    const result = matchStudents(
+      [{ initials: 'JS', gradeLevel: '3', firstName: 'John', lastName: 'Smith', goals: [] }] as any,
+      [
+        { id: 'db-noname', initials: 'JS', grade_level: '3', first_name: '', last_name: '' },
+        { id: 'db-named', initials: 'JS', grade_level: '3', first_name: 'John', last_name: 'Smith' },
+      ],
+    );
+
+    expect(result.matches[0].matchedStudent?.id).toBe('db-named');
+    expect(result.matches[0].confidence).toBe('high');
   });
 });

--- a/__tests__/unit/lib/student-matcher.test.ts
+++ b/__tests__/unit/lib/student-matcher.test.ts
@@ -101,20 +101,18 @@ describe('matchStudents — name-based identity (SPE-266)', () => {
     expect(result.matches[0].confidence).toBe('none');
   });
 
-  it('never name-matches a whitespace-only stored name via the empty-fuzzy path', () => {
+  it('does NOT match a DB student whose stored name is whitespace-only (default: no enrichment)', () => {
     // A whitespace-only stored name normalizes to '' — it must never satisfy the
-    // NAME match (which would false-match via compareNames' empty-prefix path).
-    // It is instead treated as a no-name record and only reached by the explicit
-    // initials-enrichment fallback below (SPE-284), never scored as a name match.
+    // NAME match (compareNames' empty-prefix path would false-match). With the
+    // SPE-284 enrichment fallback OFF (the default, used by unscoped callers), it
+    // stays a non-match.
     const result = matchStudents(
       [{ initials: 'JS', gradeLevel: '3', firstName: 'John', lastName: 'Smith', goals: [] }] as any,
       [{ id: 'db-1', initials: 'JS', grade_level: '3', first_name: '   ', last_name: ' ' }],
     );
 
-    // Matched (for enrichment, see SPE-284 block) but NOT as a name match:
-    // a name match would be 'high'/'medium'; the enrichment fallback is 'low'.
-    expect(result.matches[0].confidence).not.toBe('high');
-    expect(result.matches[0].confidence).not.toBe('medium');
+    expect(result.matches[0].matchedStudent).toBeNull();
+    expect(result.matches[0].confidence).toBe('none');
   });
 });
 
@@ -127,10 +125,26 @@ describe('matchStudents — name-based identity (SPE-266)', () => {
  * — still holds.
  */
 describe('matchStudents — initials enrichment fallback (SPE-284)', () => {
-  it('enriches a no-name existing record by initials + grade (low confidence)', () => {
+  const ENRICH = { enrichNoNameByInitials: true };
+
+  it('is OFF by default — an unscoped caller never initials-matches a no-name row', () => {
+    // Guards the reported risk: the per-student IEP-goals import calls
+    // matchStudents WITHOUT opting in and against an unscoped roster; it must not
+    // silently misfile goals onto a same-initials child at another school.
     const result = matchStudents(
       [{ initials: 'JS', gradeLevel: '3', firstName: 'John', lastName: 'Smith', goals: [] }] as any,
       [{ id: 'db-1', initials: 'JS', grade_level: '3', first_name: '', last_name: '' }],
+    );
+
+    expect(result.matches[0].matchedStudent).toBeNull();
+    expect(result.matches[0].confidence).toBe('none');
+  });
+
+  it('enriches a no-name existing record by initials + grade when opted in (low confidence)', () => {
+    const result = matchStudents(
+      [{ initials: 'JS', gradeLevel: '3', firstName: 'John', lastName: 'Smith', goals: [] }] as any,
+      [{ id: 'db-1', initials: 'JS', grade_level: '3', first_name: '', last_name: '' }],
+      ENRICH,
     );
 
     expect(result.matches[0].matchedStudent?.id).toBe('db-1');
@@ -142,6 +156,7 @@ describe('matchStudents — initials enrichment fallback (SPE-284)', () => {
     const result = matchStudents(
       [{ initials: 'JS', gradeLevel: 'TK', firstName: 'John', lastName: 'Smith', goals: [] }] as any,
       [{ id: 'db-1', initials: 'JS', grade_level: '3', first_name: '', last_name: '' }],
+      ENRICH,
     );
 
     expect(result.matches[0].matchedStudent).toBeNull();
@@ -152,6 +167,20 @@ describe('matchStudents — initials enrichment fallback (SPE-284)', () => {
     const result = matchStudents(
       [{ initials: 'JS', gradeLevel: '3', firstName: 'John', lastName: 'Smith', goals: [] }] as any,
       [{ id: 'db-1', initials: 'JS', grade_level: '3', first_name: 'Jane', last_name: 'Sparrow' }],
+      ENRICH,
+    );
+
+    expect(result.matches[0].matchedStudent).toBeNull();
+    expect(result.matches[0].confidence).toBe('none');
+  });
+
+  it('does NOT initials-match a candidate with a partial name (first XOR last set)', () => {
+    // The no-name filter is `!first && !last`, so a partial-name row is not
+    // eligible for enrichment — its (partial) real name can never be overwritten.
+    const result = matchStudents(
+      [{ initials: 'JS', gradeLevel: '3', firstName: 'John', lastName: 'Smith', goals: [] }] as any,
+      [{ id: 'db-1', initials: 'JS', grade_level: '3', first_name: 'Jane', last_name: '' }],
+      ENRICH,
     );
 
     expect(result.matches[0].matchedStudent).toBeNull();
@@ -165,6 +194,7 @@ describe('matchStudents — initials enrichment fallback (SPE-284)', () => {
         { id: 'db-1', initials: 'JS', grade_level: '3', first_name: '', last_name: '' },
         { id: 'db-2', initials: 'JS', grade_level: '3', first_name: '', last_name: '' },
       ],
+      ENRICH,
     );
 
     expect(result.matches[0].matchedStudent).toBeNull();
@@ -178,6 +208,7 @@ describe('matchStudents — initials enrichment fallback (SPE-284)', () => {
         { id: 'db-noname', initials: 'JS', grade_level: '3', first_name: '', last_name: '' },
         { id: 'db-named', initials: 'JS', grade_level: '3', first_name: 'John', last_name: 'Smith' },
       ],
+      ENRICH,
     );
 
     expect(result.matches[0].matchedStudent?.id).toBe('db-named');

--- a/app/(dashboard)/dashboard/students/page.tsx
+++ b/app/(dashboard)/dashboard/students/page.tsx
@@ -35,7 +35,37 @@ type Student = {
   school_id?: string | null;
   district_id?: string | null;
   school_district?: string | null;
+  // Full name lives in student_details (the identity anchor, SPE-284). PostgREST
+  // returns the one-to-one embed as an object, but tolerate an array too.
+  student_details?:
+    | { first_name: string | null; last_name: string | null }
+    | Array<{ first_name: string | null; last_name: string | null }>
+    | null;
 };
+
+/** The student's full name from the joined details, or null when unnamed. */
+function studentFullName(student: Student): string | null {
+  const details = Array.isArray(student.student_details)
+    ? student.student_details[0]
+    : student.student_details;
+  const full = `${details?.first_name ?? ''} ${details?.last_name ?? ''}`.trim();
+  return full || null;
+}
+
+/**
+ * Student identity cell for the Students list (SPE-284): the initials tag plus
+ * the full name when we have one. Schedule surfaces intentionally show only the
+ * initials tag; the full name appears here on the Students page.
+ */
+function StudentIdentityCell({ student }: { student: Student }) {
+  const name = studentFullName(student);
+  return (
+    <span className="flex items-center gap-2">
+      <StudentTag initials={student.initials} />
+      {name ? <span className="text-sm font-medium text-gray-900">{name}</span> : null}
+    </span>
+  );
+}
 
 export default function StudentsPage() {
   const [showAddForm, setShowAddForm] = useState(false);
@@ -694,7 +724,7 @@ export default function StudentsPage() {
                         onClick={() => setSelectedStudent(student)}
                         className="hover:opacity-80 transition-opacity"
                       >
-                        <StudentTag initials={student.initials} />
+                        <StudentIdentityCell student={student} />
                       </button>
                     </TableCell>
                     <TableCell>

--- a/app/components/students/review/review-row.tsx
+++ b/app/components/students/review/review-row.tsx
@@ -124,6 +124,18 @@ export function ReviewRow({ row, selection, isExpanded, onToggleExpand, columnCo
         </tr>
       )}
 
+      {/* SPE-284: an initials-only existing record matched by initials + grade
+          (not by name). Surface it so a "select all → confirm" can't silently
+          enrich the wrong same-initials child. */}
+      {row.matchConfidence === 'low' && (
+        <tr>
+          <td colSpan={columnCount} className="px-3 pb-2 text-xs text-amber-700">
+            ⚠️ Matched by initials + grade to an existing record with no name yet —
+            &ldquo;{row.displayName}&rdquo; will be saved as its name. Confirm it&rsquo;s the same student.
+          </td>
+        </tr>
+      )}
+
       {isExpanded && (goalCount > 0 || row.goalsRemoved.length > 0) && (
         <tr>
           <td colSpan={columnCount} className="p-0">

--- a/app/components/students/student-details-modal.tsx
+++ b/app/components/students/student-details-modal.tsx
@@ -279,7 +279,13 @@ export function StudentDetailsModal({
           <div className="flex items-center justify-between p-6 border-b">
             <div className="flex items-center gap-3">
               <h2 className="text-xl font-semibold text-gray-900">
-                Student Details: {student.initials}
+                {/* SPE-284: lead with the full name (identity anchor) once loaded;
+                    fall back to initials for unnamed students. */}
+                Student Details:{' '}
+                {[details.first_name, details.last_name]
+                  .filter((n) => n?.trim())
+                  .join(' ')
+                  .trim() || student.initials}
               </h2>
               <SharedStudentBadge roles={matchingRoles} />
               <TeamChatButton studentId={student.id} onNavigate={onClose} />

--- a/lib/import/classify.ts
+++ b/lib/import/classify.ts
@@ -173,7 +173,13 @@ export function buildStudentPreviews(params: {
 }): MainPreviewResult {
   const { parsedStudents, databaseStudents, deliveriesData, classListData, dbTeachers } = params;
 
-  const matchResult = matchStudents(parsedStudents, databaseStudents);
+  // Opt into the SPE-284 initials-enrichment fallback: this path is fed
+  // school-scoped candidates by the pipeline, so matching a NAMED upload to an
+  // existing no-name row by initials+grade is safe here (unlike the unscoped
+  // per-student IEP goals import, which must not enable it).
+  const matchResult = matchStudents(parsedStudents, databaseStudents, {
+    enrichNoNameByInitials: true,
+  });
 
   // Track which students from deliveries/classList were matched
   const matchedDeliveryNames = new Set<string>();
@@ -312,16 +318,9 @@ export function buildStudentPreviews(params: {
             }
           };
         }
-
-        // Track name enrichment (SPE-284): the name being added to a previously
-        // initials-only record. `old` is null by construction (hasNameChange
-        // only fires when the existing name is blank).
-        if (hasNameChange) {
-          changes.name = {
-            old: null,
-            new: `${student.firstName} ${student.lastName}`.trim(),
-          };
-        }
+        // A name-only enrichment (SPE-284) carries no entry in `changes` — it is
+        // surfaced in the review via the row's low match confidence + the name in
+        // displayName, so a "select all → confirm" can't silently enrich by a guess.
       } else {
         action = 'skip';
       }

--- a/lib/import/classify.ts
+++ b/lib/import/classify.ts
@@ -170,16 +170,24 @@ export function buildStudentPreviews(params: {
   deliveriesData: Map<string, DeliveryRecord> | null;
   classListData: Map<string, ClassListStudent> | null;
   dbTeachers: DbTeacherRow[];
+  /**
+   * Opt into the SPE-284 initials-enrichment fallback. Safe only when the caller
+   * fed school-scoped candidates AND confirmed student_details loaded (so a
+   * missing name means "no details row", not "load failed"). The pipeline sets
+   * this; defaults off for other/unscoped callers.
+   */
+  enrichNoNameByInitials?: boolean;
 }): MainPreviewResult {
-  const { parsedStudents, databaseStudents, deliveriesData, classListData, dbTeachers } = params;
+  const {
+    parsedStudents,
+    databaseStudents,
+    deliveriesData,
+    classListData,
+    dbTeachers,
+    enrichNoNameByInitials = false,
+  } = params;
 
-  // Opt into the SPE-284 initials-enrichment fallback: this path is fed
-  // school-scoped candidates by the pipeline, so matching a NAMED upload to an
-  // existing no-name row by initials+grade is safe here (unlike the unscoped
-  // per-student IEP goals import, which must not enable it).
-  const matchResult = matchStudents(parsedStudents, databaseStudents, {
-    enrichNoNameByInitials: true,
-  });
+  const matchResult = matchStudents(parsedStudents, databaseStudents, { enrichNoNameByInitials });
 
   // Track which students from deliveries/classList were matched
   const matchedDeliveryNames = new Set<string>();

--- a/lib/import/classify.ts
+++ b/lib/import/classify.ts
@@ -250,11 +250,20 @@ export function buildStudentPreviews(params: {
         !!teacherMatchResult &&
         teacherMatchResult.teacherId === null &&
         !!teacherMatchResult.teacherName?.trim();
+      // SPE-284: fill an existing initials-only record's empty name from a named
+      // upload (enrichment). Only fills a blank name — never overwrites an
+      // existing one (correcting a stored name is out of scope for the
+      // foundation). This is what turns an otherwise-unchanged enrichment match
+      // into an 'update' instead of a 'skip', so the name is applied on confirm.
+      const incomingHasName = !!(student.firstName?.trim() && student.lastName?.trim());
+      const existingHasName = !!(matchedStudent.first_name?.trim() && matchedStudent.last_name?.trim());
+      const hasNameChange = incomingHasName && !existingHasName;
       const anyChanges =
         changeCheck.hasGoalChanges ||
         changeCheck.hasScheduleChanges ||
         changeCheck.hasTeacherChanges ||
-        hasUnresolvedTeacher;
+        hasUnresolvedTeacher ||
+        hasNameChange;
 
       if (anyChanges) {
         action = 'update';
@@ -301,6 +310,16 @@ export function buildStudentPreviews(params: {
               teacherId: teacherMatchResult.teacherId,
               teacherName: teacherMatchResult.teacherName
             }
+          };
+        }
+
+        // Track name enrichment (SPE-284): the name being added to a previously
+        // initials-only record. `old` is null by construction (hasNameChange
+        // only fires when the existing name is blank).
+        if (hasNameChange) {
+          changes.name = {
+            old: null,
+            new: `${student.firstName} ${student.lastName}`.trim(),
           };
         }
       } else {

--- a/lib/import/classify.ts
+++ b/lib/import/classify.ts
@@ -265,13 +265,17 @@ export function buildStudentPreviews(params: {
         teacherMatchResult.teacherId === null &&
         !!teacherMatchResult.teacherName?.trim();
       // SPE-284: fill an existing initials-only record's empty name from a named
-      // upload (enrichment). Only fills a blank name — never overwrites an
+      // upload (enrichment). Only fills a fully-blank name — never overwrites an
       // existing one (correcting a stored name is out of scope for the
       // foundation). This is what turns an otherwise-unchanged enrichment match
       // into an 'update' instead of a 'skip', so the name is applied on confirm.
+      // Any non-blank stored name (even a partial first-XOR-last) counts as an
+      // existing identity and blocks enrichment. The matcher already restricts
+      // enrichment matches to both-blank rows, so this is defense-in-depth —
+      // classify stays correct even if that upstream guarantee ever changes.
       const incomingHasName = !!(student.firstName?.trim() && student.lastName?.trim());
-      const existingHasName = !!(matchedStudent.first_name?.trim() && matchedStudent.last_name?.trim());
-      const hasNameChange = incomingHasName && !existingHasName;
+      const existingHasAnyName = !!(matchedStudent.first_name?.trim() || matchedStudent.last_name?.trim());
+      const hasNameChange = incomingHasName && !existingHasAnyName;
       const anyChanges =
         changeCheck.hasGoalChanges ||
         changeCheck.hasScheduleChanges ||

--- a/lib/import/enrich.ts
+++ b/lib/import/enrich.ts
@@ -57,17 +57,23 @@ export async function loadExistingStudents(
   return { data: (data as unknown as ExistingStudentRow[] | null), error };
 }
 
-/** Fetch student details (names + goals) for the given students, for matching. */
+/**
+ * Fetch student details (names + goals) for the given students, for matching.
+ * Surfaces the query error (SPE-284): the caller must know whether a null result
+ * means "no details rows" vs "the load failed" — treating a failed load as
+ * "every student is nameless" would let the initials-enrichment fallback
+ * overwrite a real (merely-unloaded) name.
+ */
 export async function loadStudentDetails(
   supabase: ImportSupabaseClient,
   dbStudents: Array<{ id: string }> | null | undefined
-): Promise<StudentDetailRow[] | null> {
-  if (!dbStudents || dbStudents.length === 0) return null;
-  const { data } = await supabase
+): Promise<{ data: StudentDetailRow[] | null; error: unknown }> {
+  if (!dbStudents || dbStudents.length === 0) return { data: null, error: null };
+  const { data, error } = await supabase
     .from('student_details')
     .select('student_id, first_name, last_name, iep_goals')
     .in('student_id', dbStudents.map(s => s.id));
-  return (data as unknown as StudentDetailRow[] | null);
+  return { data: (data as unknown as StudentDetailRow[] | null), error };
 }
 
 /** Fetch the provider's existing students joined to details (update-only path). */

--- a/lib/import/pipeline.ts
+++ b/lib/import/pipeline.ts
@@ -288,7 +288,18 @@ export async function runStudentsPreview(ctx: PipelineContext, file: File): Prom
   const dbStudentsInSchool = (dbStudents ?? []).filter(
     s => (s.school_id ?? '') === (currentSchoolId ?? ''),
   );
-  const studentDetails = await loadStudentDetails(supabase, dbStudentsInSchool);
+  const { data: studentDetails, error: detailsError } = await loadStudentDetails(supabase, dbStudentsInSchool);
+  if (detailsError) {
+    // Fail safe (SPE-284): if the details query failed, every student looks
+    // nameless. Log it and disable initials-enrichment below so an unloaded real
+    // name can't be overwritten — unmatched rows just fall through as inserts,
+    // the pre-existing degraded behavior.
+    log.error(
+      'Failed to load student details for import matching',
+      detailsError instanceof Error ? detailsError : null,
+      { userId },
+    );
+  }
   const databaseStudents = toDatabaseStudents(dbStudentsInSchool, studentDetails);
 
   const { studentPreviews, matchedDeliveryNames, matchedClassListNames } = buildStudentPreviews({
@@ -297,6 +308,9 @@ export async function runStudentsPreview(ctx: PipelineContext, file: File): Prom
     deliveriesData: deliveries?.deliveries ?? null,
     classListData: classList?.students ?? null,
     dbTeachers,
+    // Only enrich no-name rows by initials+grade when details actually loaded
+    // (otherwise a merely-unloaded name would look blank and could be overwritten).
+    enrichNoNameByInitials: !detailsError,
   });
 
   // A Deliveries/Class List row for a student the goals report placed at another

--- a/lib/import/preview-types.ts
+++ b/lib/import/preview-types.ts
@@ -47,10 +47,22 @@ export interface TeacherChange {
   new: { teacherId: string | null; teacherName: string | null } | null;
 }
 
+/**
+ * A student's full name being added on an enrichment update (SPE-284). Today
+ * only used to fill an existing initials-only record's empty name — `old` is
+ * therefore always null; the field exists so the review can show the name that
+ * will be added.
+ */
+export interface NameChange {
+  old: string | null;
+  new: string | null;
+}
+
 export interface StudentChanges {
   goals?: GoalChange;
   schedule?: ScheduleChange;
   teacher?: TeacherChange;
+  name?: NameChange;
 }
 
 /** A preview row from the main SEIS path and the roster-template path. */

--- a/lib/import/preview-types.ts
+++ b/lib/import/preview-types.ts
@@ -47,22 +47,10 @@ export interface TeacherChange {
   new: { teacherId: string | null; teacherName: string | null } | null;
 }
 
-/**
- * A student's full name being added on an enrichment update (SPE-284). Today
- * only used to fill an existing initials-only record's empty name — `old` is
- * therefore always null; the field exists so the review can show the name that
- * will be added.
- */
-export interface NameChange {
-  old: string | null;
-  new: string | null;
-}
-
 export interface StudentChanges {
   goals?: GoalChange;
   schedule?: ScheduleChange;
   teacher?: TeacherChange;
-  name?: NameChange;
 }
 
 /** A preview row from the main SEIS path and the roster-template path. */

--- a/lib/supabase/queries/students.ts
+++ b/lib/supabase/queries/students.ts
@@ -204,9 +204,14 @@ export async function getStudents(school?: SchoolIdentifier) {
   const fetchPerf = measurePerformanceWithAlerts('fetch_students', 'database');
   const fetchResult = await safeQuery(
     async () => {
+      // Join student_details for the full name (SPE-284). The name is the
+      // identity anchor and is shown on the Students page; schedule surfaces keep
+      // using the derived `initials`. Additive — existing callers ignore the
+      // nested field. student_details.student_id is UNIQUE, so PostgREST returns
+      // it as a single embedded object (nullable when the row has no details).
       let query = supabase
         .from('students')
-        .select('*')
+        .select('*, student_details(first_name, last_name)')
         .eq('provider_id', user.id);
 
       // Apply intelligent school filter for optimal performance

--- a/lib/utils/student-matcher.ts
+++ b/lib/utils/student-matcher.ts
@@ -130,29 +130,62 @@ function findBestMatch(
   // Sort by score (highest first)
   possibleMatches.sort((a, b) => b.score - a.score);
 
-  // No name+grade match → treat as a new student.
-  if (possibleMatches.length === 0) {
+  // Prefer a full-name match when one exists (SPE-266).
+  if (possibleMatches.length > 0) {
+    const bestMatch = possibleMatches[0];
+    const confidence: 'high' | 'medium' = bestMatch.score >= 100 ? 'high' : 'medium';
+    const reason =
+      possibleMatches.length > 1
+        ? `${bestMatch.reasons.join('; ')} (${possibleMatches.length} candidates)`
+        : bestMatch.reasons.join('; ');
+
     return {
       excelStudent,
-      matchedStudent: null,
-      confidence: 'none',
-      reason: `No existing student matches "${excelStudent.firstName} ${excelStudent.lastName}" in grade "${excelStudent.gradeLevel}"`
+      matchedStudent: bestMatch.student,
+      confidence,
+      reason,
+      allPossibleMatches: possibleMatches.map(m => m.student)
     };
   }
 
-  const bestMatch = possibleMatches[0];
-  const confidence: 'high' | 'medium' = bestMatch.score >= 100 ? 'high' : 'medium';
-  const reason =
-    possibleMatches.length > 1
-      ? `${bestMatch.reasons.join('; ')} (${possibleMatches.length} candidates)`
-      : bestMatch.reasons.join('; ');
+  // SPE-284 enrichment fallback: no full-name match, but during the transition
+  // to storing names an existing row may still be initials-only (its name was
+  // never captured). Match it by initials + grade so a later NAMED upload
+  // ENRICHES that row (adds the name) instead of erroring "already exists" or
+  // creating a duplicate. Deliberately narrow:
+  //   - only candidates with NO stored name — a named candidate that failed the
+  //     name check above is a genuinely different student (SPE-266), never a
+  //     silent initials overwrite;
+  //   - only when exactly one such candidate exists. The
+  //     (provider, school_id, grade, initials) unique index guarantees at most
+  //     one, and the caller has already scoped candidates to the active school;
+  //     bail on any ambiguity rather than guess.
+  const incomingInitials = normalizeInitials(excelStudent.initials);
+  if (incomingInitials.length > 0) {
+    const initialsOnlyMatches = databaseStudents.filter(
+      dbStudent =>
+        (!dbStudent.first_name?.trim() || !dbStudent.last_name?.trim()) &&
+        normalizeInitials(dbStudent.initials) === incomingInitials &&
+        compareGrades(excelStudent.gradeLevel, dbStudent.grade_level).matches
+    );
+    if (initialsOnlyMatches.length === 1) {
+      return {
+        excelStudent,
+        matchedStudent: initialsOnlyMatches[0],
+        confidence: 'low',
+        reason:
+          'Matched by initials + grade — existing record has no name yet; the name will be added',
+        allPossibleMatches: initialsOnlyMatches,
+      };
+    }
+  }
 
+  // Nothing matched → treat as a new student.
   return {
     excelStudent,
-    matchedStudent: bestMatch.student,
-    confidence,
-    reason,
-    allPossibleMatches: possibleMatches.map(m => m.student)
+    matchedStudent: null,
+    confidence: 'none',
+    reason: `No existing student matches "${excelStudent.firstName} ${excelStudent.lastName}" in grade "${excelStudent.gradeLevel}"`
   };
 }
 
@@ -225,6 +258,15 @@ function normalizeGrade(grade: string): string {
  */
 function normalizeName(name: string): string {
   return name.toLowerCase().trim().replace(/[^a-z]/g, '');
+}
+
+/**
+ * Normalize initials for comparison — uppercase A–Z only, matching the
+ * normalization the confirm route and the school-scoped dedup key use, so the
+ * enrichment fallback lines up with the DB uniqueness backstop.
+ */
+function normalizeInitials(initials: string | undefined | null): string {
+  return (initials || '').toUpperCase().replace(/[^A-Z]/g, '');
 }
 
 /**

--- a/lib/utils/student-matcher.ts
+++ b/lib/utils/student-matcher.ts
@@ -38,16 +38,35 @@ export interface MatchResult {
 }
 
 /**
+ * Matcher options.
+ *
+ * `enrichNoNameByInitials` opts INTO the SPE-284 fallback that matches an
+ * incoming NAMED record to an existing NO-NAME record by initials+grade (so a
+ * later named upload enriches the record instead of duplicating). It is OFF by
+ * default: a caller that matches against an UNSCOPED roster — e.g. the
+ * per-student IEP goals import (`app/api/import-iep-goals/route.ts`), which
+ * fetches candidates by `provider_id` only — must keep SPE-266's strict
+ * name-only identity, or it could initials-match (and misfile goals onto) a
+ * different, same-initials child at another school. Only the school-scoped bulk
+ * import (`buildStudentPreviews`, fed school-filtered candidates in
+ * `lib/import/pipeline.ts`) opts in.
+ */
+export interface MatchOptions {
+  enrichNoNameByInitials?: boolean;
+}
+
+/**
  * Match parsed students to database students
  */
 export function matchStudents(
   parsedStudents: ParsedStudent[],
-  databaseStudents: DatabaseStudent[]
+  databaseStudents: DatabaseStudent[],
+  options: MatchOptions = {}
 ): MatchResult {
   const matches: StudentMatch[] = [];
 
   for (const excelStudent of parsedStudents) {
-    const match = findBestMatch(excelStudent, databaseStudents);
+    const match = findBestMatch(excelStudent, databaseStudents, options);
     matches.push(match);
   }
 
@@ -72,11 +91,15 @@ export function matchStudents(
  * initials (e.g. a same-initials student at another school). Now that names are
  * stored, a candidate counts as "the same student" only when both the full name
  * and the grade agree. A DB student with no stored name can't be name-matched,
- * so it's treated as a non-match (→ the incoming student is a new insert).
+ * so it's treated as a non-match (→ the incoming student is a new insert) —
+ * UNLESS the caller opts into the SPE-284 initials-enrichment fallback below
+ * (`options.enrichNoNameByInitials`), which is reserved for the school-scoped
+ * bulk import.
  */
 function findBestMatch(
   excelStudent: ParsedStudent,
-  databaseStudents: DatabaseStudent[]
+  databaseStudents: DatabaseStudent[],
+  options: MatchOptions = {}
 ): StudentMatch {
   const possibleMatches: Array<{ student: DatabaseStudent; score: number; reasons: string[] }> = [];
 
@@ -148,23 +171,28 @@ function findBestMatch(
     };
   }
 
-  // SPE-284 enrichment fallback: no full-name match, but during the transition
-  // to storing names an existing row may still be initials-only (its name was
-  // never captured). Match it by initials + grade so a later NAMED upload
-  // ENRICHES that row (adds the name) instead of erroring "already exists" or
-  // creating a duplicate. Deliberately narrow:
-  //   - only candidates with NO stored name — a named candidate that failed the
-  //     name check above is a genuinely different student (SPE-266), never a
-  //     silent initials overwrite;
+  // SPE-284 enrichment fallback (opt-in via options.enrichNoNameByInitials): no
+  // full-name match, but during the transition to storing names an existing row
+  // may still be initials-only (its name was never captured). Match it by
+  // initials + grade so a later NAMED upload ENRICHES that row (adds the name)
+  // instead of erroring "already exists" or creating a duplicate. Deliberately
+  // narrow:
+  //   - opt-in only, because it relies on the caller having school-scoped its
+  //     candidates (the bulk pipeline does; the unscoped IEP-goals import does
+  //     not and must NOT enable this);
+  //   - only candidates with NO stored name at all (both first AND last blank) —
+  //     a candidate with any real name that failed the name check above is a
+  //     genuinely different student (SPE-266) and is never initials-matched, so
+  //     no real (even partial) name can be silently overwritten;
   //   - only when exactly one such candidate exists. The
   //     (provider, school_id, grade, initials) unique index guarantees at most
-  //     one, and the caller has already scoped candidates to the active school;
-  //     bail on any ambiguity rather than guess.
+  //     one within a school; bail on any ambiguity rather than guess.
   const incomingInitials = normalizeInitials(excelStudent.initials);
-  if (incomingInitials.length > 0) {
+  if (options.enrichNoNameByInitials && incomingInitials.length > 0) {
     const initialsOnlyMatches = databaseStudents.filter(
       dbStudent =>
-        (!dbStudent.first_name?.trim() || !dbStudent.last_name?.trim()) &&
+        !dbStudent.first_name?.trim() &&
+        !dbStudent.last_name?.trim() &&
         normalizeInitials(dbStudent.initials) === incomingInitials &&
         compareGrades(excelStudent.gradeLevel, dbStudent.grade_level).matches
     );

--- a/supabase/migrations/20260721_upsert_student_details_on_bulk_update.sql
+++ b/supabase/migrations/20260721_upsert_student_details_on_bulk_update.sql
@@ -1,0 +1,263 @@
+-- SPE-284: make bulk-import UPDATE enrich student_details even when no row exists.
+--
+-- Background: student full name is becoming the identity anchor. A named upload
+-- (SEIS/AERIES) should ENRICH an existing initials-only student by filling in the
+-- name. The student-matcher now recognizes that case and routes it as an
+-- 'update'. But the update branch of upsert_students_atomic wrote the name with a
+-- plain `UPDATE public.student_details ... WHERE student_id = ...`, which affects
+-- ZERO rows for a student that has no student_details row yet (many pre-existing
+-- students, plus every roster-template / manual-add student, have none). The
+-- incoming name was therefore silently dropped.
+--
+-- Fix: upsert student_details on update (INSERT ... ON CONFLICT (student_id) DO
+-- UPDATE). `student_details.student_id` is UNIQUE, so the conflict target is
+-- valid. Name COALESCE and goals-only-when-provided semantics are preserved
+-- exactly; the only behavior change is that a missing details row is now created
+-- instead of ignored.
+--
+-- Everything else in this function is reproduced verbatim from the current live
+-- definition (post-SPE-261 auth binding, post-SPE-251 teacher_name handling).
+
+CREATE OR REPLACE FUNCTION public.upsert_students_atomic(
+  p_provider_id uuid,
+  p_students jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_student jsonb;
+  v_action text;
+  v_student_id uuid;
+  v_new_student_id uuid;
+  v_results jsonb := '[]'::jsonb;
+  v_result jsonb;
+  v_inserted integer := 0;
+  v_updated integer := 0;
+  v_skipped integer := 0;
+  v_errors integer := 0;
+  v_new_sessions_per_week integer;
+  v_provider_role text;
+BEGIN
+  -- Defense-in-depth (SPE-261): this SECURITY DEFINER function bypasses RLS, so
+  -- bind it to the caller — reject any p_provider_id that isn't the authenticated
+  -- user, and fail closed when there is no JWT. The confirm route (the only
+  -- caller) passes the authenticated user's id via the JWT-authenticated client,
+  -- so legitimate calls are unaffected; this stops a signed-in client from
+  -- calling the RPC directly with someone else's provider id.
+  IF auth.uid() IS NULL OR p_provider_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Unauthorized' USING ERRCODE = '42501';
+  END IF;
+
+  -- Look up the provider's role to use as service_type
+  SELECT role INTO v_provider_role
+  FROM public.profiles
+  WHERE id = p_provider_id;
+
+  -- Default to 'resource' if role not found
+  v_provider_role := COALESCE(v_provider_role, 'resource');
+
+  -- Loop through each student in the array
+  FOR v_student IN SELECT * FROM jsonb_array_elements(p_students)
+  LOOP
+    v_action := v_student->>'action';
+    v_student_id := (v_student->>'studentId')::uuid;
+
+    BEGIN
+      CASE v_action
+        WHEN 'insert' THEN
+          -- Insert new student record
+          INSERT INTO public.students (
+            provider_id,
+            initials,
+            grade_level,
+            school_site,
+            school_id,
+            district_id,
+            state_id,
+            sessions_per_week,
+            minutes_per_session,
+            teacher_id,
+            teacher_name
+          )
+          VALUES (
+            p_provider_id,
+            v_student->>'initials',
+            v_student->>'gradeLevel',
+            v_student->>'schoolSite',
+            v_student->>'schoolId',
+            v_student->>'districtId',
+            v_student->>'stateId',
+            (v_student->>'sessionsPerWeek')::integer,
+            (v_student->>'minutesPerSession')::integer,
+            (v_student->>'teacherId')::uuid,
+            v_student->>'teacherName'
+          )
+          RETURNING id INTO v_new_student_id;
+
+          -- Insert student_details record
+          INSERT INTO public.student_details (
+            student_id,
+            first_name,
+            last_name,
+            iep_goals
+          )
+          VALUES (
+            v_new_student_id,
+            v_student->>'firstName',
+            v_student->>'lastName',
+            ARRAY(SELECT jsonb_array_elements_text(v_student->'goals'))
+          );
+
+          -- Create unscheduled sessions for NEW students only
+          v_new_sessions_per_week := (v_student->>'sessionsPerWeek')::integer;
+
+          IF v_new_sessions_per_week IS NOT NULL AND v_new_sessions_per_week > 0 THEN
+            INSERT INTO public.schedule_sessions (
+              student_id,
+              provider_id,
+              day_of_week,
+              start_time,
+              end_time,
+              service_type,
+              status,
+              delivered_by
+            )
+            SELECT
+              v_new_student_id,
+              p_provider_id,
+              NULL,
+              NULL,
+              NULL,
+              v_provider_role,  -- Use provider's role instead of hardcoded value
+              'active',
+              'provider'
+            FROM generate_series(1, v_new_sessions_per_week);
+          END IF;
+
+          v_inserted := v_inserted + 1;
+          v_result := jsonb_build_object(
+            'action', 'inserted',
+            'studentId', v_new_student_id,
+            'initials', v_student->>'initials',
+            'success', true
+          );
+
+        WHEN 'update' THEN
+          -- Ownership: only the caller's own students may be updated. p_provider_id
+          -- is bound to auth.uid() at the top of this function (SPE-261), so this
+          -- also confirms the row belongs to the authenticated caller.
+          IF NOT EXISTS (
+            SELECT 1 FROM public.students
+            WHERE id = v_student_id AND provider_id = p_provider_id
+          ) THEN
+            RAISE EXCEPTION 'Student % not found or not owned by provider', v_student_id;
+          END IF;
+
+          -- Update students table (only non-null fields from the request)
+          -- NOTE: Session syncing is handled by updateExistingSessionsForStudent in the API
+          UPDATE public.students
+          SET
+            grade_level = COALESCE(v_student->>'gradeLevel', grade_level),
+            sessions_per_week = COALESCE((v_student->>'sessionsPerWeek')::integer, sessions_per_week),
+            minutes_per_session = COALESCE((v_student->>'minutesPerSession')::integer, minutes_per_session),
+            teacher_id = CASE
+              WHEN v_student ? 'teacherId' THEN (v_student->>'teacherId')::uuid
+              ELSE teacher_id
+            END,
+            teacher_name = CASE
+              WHEN v_student ? 'teacherName' THEN v_student->>'teacherName'
+              ELSE teacher_name
+            END,
+            updated_at = now()
+          WHERE id = v_student_id;
+
+          -- Upsert student_details (SPE-284). A plain UPDATE dropped the incoming
+          -- name for any student with no details row yet (pre-existing rows, plus
+          -- roster-template / manual-add students). INSERT ... ON CONFLICT ensures
+          -- the row exists so enrichment names persist. Name COALESCE and the
+          -- goals-only-when-provided rule are unchanged; a fresh insert with no
+          -- goals defaults to an empty array (matching the insert branch).
+          INSERT INTO public.student_details (
+            student_id,
+            first_name,
+            last_name,
+            iep_goals
+          )
+          VALUES (
+            v_student_id,
+            v_student->>'firstName',
+            v_student->>'lastName',
+            CASE
+              WHEN v_student ? 'goals' AND jsonb_array_length(v_student->'goals') > 0
+              THEN ARRAY(SELECT jsonb_array_elements_text(v_student->'goals'))
+              ELSE '{}'::text[]
+            END
+          )
+          ON CONFLICT (student_id) DO UPDATE
+          SET
+            first_name = COALESCE(EXCLUDED.first_name, student_details.first_name),
+            last_name = COALESCE(EXCLUDED.last_name, student_details.last_name),
+            iep_goals = CASE
+              WHEN v_student ? 'goals' AND jsonb_array_length(v_student->'goals') > 0
+              THEN EXCLUDED.iep_goals
+              ELSE student_details.iep_goals
+            END,
+            updated_at = now();
+
+          v_updated := v_updated + 1;
+          v_result := jsonb_build_object(
+            'action', 'updated',
+            'studentId', v_student_id,
+            'initials', v_student->>'initials',
+            'success', true
+          );
+
+        WHEN 'skip' THEN
+          v_skipped := v_skipped + 1;
+          v_result := jsonb_build_object(
+            'action', 'skipped',
+            'studentId', v_student_id,
+            'initials', v_student->>'initials',
+            'success', true
+          );
+
+        ELSE
+          RAISE EXCEPTION 'Unknown action: %', v_action;
+      END CASE;
+
+    EXCEPTION
+      WHEN OTHERS THEN
+        v_errors := v_errors + 1;
+        v_result := jsonb_build_object(
+          'action', v_action,
+          'studentId', COALESCE(v_student_id, v_new_student_id),
+          'initials', v_student->>'initials',
+          'success', false,
+          'error', SQLERRM
+        );
+    END;
+
+    v_results := v_results || v_result;
+  END LOOP;
+
+  -- Return summary with detailed results
+  RETURN jsonb_build_object(
+    'inserted', v_inserted,
+    'updated', v_updated,
+    'skipped', v_skipped,
+    'errors', v_errors,
+    'results', v_results
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.upsert_students_atomic(uuid, jsonb) IS
+  'Atomically processes an array of student upsert operations (insert, update, or skip).
+   Each student object should have an "action" field and appropriate data fields.
+   Update now upserts student_details so an added name persists even when the row
+   had none (SPE-284). Returns summary counts and detailed results for each student.';
+
+GRANT EXECUTE ON FUNCTION public.upsert_students_atomic(uuid, jsonb) TO authenticated;


### PR DESCRIPTION
## What & why

Foundation for SPE-255 / SPE-258: make the student **full name** the identity anchor — captured on import — while every schedule surface keeps showing **initials**. Approved direction (2026-07-20): move from privacy-by-avoidance to holding student names responsibly and disclosing that to districts. Full context in **SPE-284**.

## Changes

**Import — enrich, don't duplicate**
- A named SEIS/AERIES upload now recognizes an existing **initials-only** student (by initials + grade, **same-school only**, exactly-one-match) and **enriches** it — adds the name — instead of erroring "already exists" or creating a duplicate. Surfaced as a low-confidence `update` in review.
- `upsert_students_atomic`'s update branch now **upserts** `student_details` (`ON CONFLICT (student_id)`), so the added name persists even for the students that have no details row yet (~173 of 307 today). The migration faithfully reproduces the live function; only the `student_details` write changed.

**Display — the split**
- Students list + student pop-up header show the **full name** (fallback to initials). `getStudents` joins `student_details(first_name, last_name)`.
- Main Schedule / Dashboard "Today" / Plan / session blocks are **unchanged** — still initials.

## Safety (mixed state — must not interfere)
- Names stay optional; existing initials-only students keep working everywhere. **No backfill.**
- Enrichment only ever fills a **blank** name (never overwrites a real or partial name — SPE-266 preserved), only matches **same-school** candidates, and only when exactly one exists.
- The initials-enrichment fallback is **opt-in**: only the school-scoped bulk import enables it; the unscoped per-student IEP-goals import is unaffected and keeps strict name-only matching.

## Testing
- Unit tests for the enrichment matcher (opt-in default-off, grade guard, real-name & partial-name guards, ambiguity bail) and classify (name enrichment → `update`; no false change when the name already matches).
- Typecheck, lint, and the scoped gate (`jest __tests__ lib`) green — 459 passed.
- Ran an adversarial self-review of the diff and fixed its findings (the opt-in gating above was one; also tightened the no-name filter and added a review-row caution for low-confidence enrichment).

## Out of scope / follow-ups
- **Add Student form** name field — fast-follow. Manual name entry already works today via the student pop-up (First/Last Name fields).
- **Privacy / FERPA copy** — review-gated in **SPE-285** (wording approved before it goes public).
- Recommend a **sim-district end-to-end pass** before merge.

Holding for merge (user-facing + schema + privacy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYEo9UCTeTRCo8rSCjRw6m

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYEo9UCTeTRCo8rSCjRw6m)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Student lists, detail modals, and student previews now show the student’s full name when available, falling back to initials.
  * Bulk student imports can optionally enrich existing unnamed records using initials and grade, when first/last names are provided.

* **Bug Fixes**
  * Prevent enrichment when grades differ, names are partially missing, or initials-based matching is ambiguous.
  * Import review now adds an amber warning for low-confidence matches (matched by initials + grade) and prompts confirmation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->