### PR TITLE
SPE-285: privacy & FERPA copy — disclose that Speddy stores student full names

### DIFF
--- a/app/ferpa/page.tsx
+++ b/app/ferpa/page.tsx
@@ -6,7 +6,7 @@ export default function FERPAPage() {
           {/* Header */}
           <div className="mb-8 text-center">
             <h1 className="text-3xl font-bold text-gray-900 mb-2">FERPA Compliance Notice</h1>
-            <p className="text-gray-600">Last Updated: January 19, 2026</p>
+            <p className="text-gray-600">Last Updated: July 21, 2026</p>
           </div>
 
           {/* Content */}

--- a/app/ferpa/page.tsx
+++ b/app/ferpa/page.tsx
@@ -133,7 +133,7 @@ export default function FERPAPage() {
                 <li>Use professional, objective language in all documentation</li>
                 <li>Enter only information necessary for service delivery</li>
                 <li>Double-check accuracy of all data entered</li>
-                <li>Use privacy-protective identifiers when possible (initials, student IDs)</li>
+                <li>Rely on Speddy's role-based access controls to protect student names and records — access is limited to authorized staff, and shared scheduling views display initials to minimize on-screen exposure</li>
               </ul>
 
               <h3 className="text-lg font-semibold text-gray-800 mt-6 mb-3">When Sharing Information</h3>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -6,7 +6,7 @@ export default function PrivacyPage() {
           {/* Header */}
           <div className="mb-8 text-center">
             <h1 className="text-3xl font-bold text-gray-900 mb-2">Privacy Policy</h1>
-            <p className="text-gray-600">Last Updated: July 11, 2026</p>
+            <p className="text-gray-600">Last Updated: July 21, 2026</p>
           </div>
 
           {/* Content */}
@@ -39,7 +39,7 @@ export default function PrivacyPage() {
               <li>Assessment data (when authorized)</li>
             </ul>
             <p className="text-gray-700 mb-4">
-              Speddy stores each student's full name and protects it with database access controls (row-level security): a student's records are visible only to their assigned provider(s), any delegated staff, and authorized school or district administrators, and student data is encrypted at rest. To limit on-screen exposure, scheduling and planning views show initials — the full name appears on the student's own record.
+              Speddy stores each student's full name and protects it with database access controls (row-level security): a student's records are visible only to their assigned provider(s), any delegated staff, and authorized school or district administrators, and student data is encrypted at rest. To limit on-screen exposure, scheduling and planning views show only initials; the full name appears on the Students page — both in the caseload list and on each student's record.
             </p>
             <p className="text-gray-700 mb-4">
               <strong>Important:</strong> You are responsible for ensuring you are authorized to access and input all student data you enter into Speddy.

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -31,13 +31,16 @@ export default function PrivacyPage() {
             <h3 className="text-lg font-semibold text-gray-800 mt-6 mb-3">2.2 Student Educational Data</h3>
             <p className="text-gray-700 mb-4">As an authorized education professional, you may input student data including:</p>
             <ul className="list-disc pl-6 mb-4 text-gray-700">
-              <li>Student identifiers (typically initials or student IDs)</li>
+              <li>Student names (first and last) and other identifiers such as student IDs</li>
               <li>Grade level and program information</li>
               <li>Service schedules and appointments</li>
               <li>IEP goals and progress data (when authorized)</li>
               <li>Session notes and service documentation</li>
               <li>Assessment data (when authorized)</li>
             </ul>
+            <p className="text-gray-700 mb-4">
+              Speddy stores each student's full name and protects it with database access controls (row-level security): a student's records are visible only to their assigned provider(s), any delegated staff, and authorized school or district administrators, and student data is encrypted at rest. To limit on-screen exposure, scheduling and planning views show initials — the full name appears on the student's own record.
+            </p>
             <p className="text-gray-700 mb-4">
               <strong>Important:</strong> You are responsible for ensuring you are authorized to access and input all student data you enter into Speddy.
             </p>


### PR DESCRIPTION
## What & why

SPE-284 moved the student **identity anchor** to the full name (stored in `student_details`). Our public-facing copy still described student data as "typically initials or student IDs," so it no longer matches how the product works. This updates the disclosure. Copy was **drafted and approved with the owner before applying** (review-gated — SPE-285).

## Changes

**Privacy policy — §2.2 Student Educational Data (`app/privacy/page.tsx`)**
- Bullet: _"Student identifiers (typically initials or student IDs)"_ → _"Student names (first and last) and other identifiers such as student IDs"_
- Added a sentence on how names are protected: row-level-security scoping (visible only to the student's assigned provider(s), delegated staff, and authorized school/district admins), encryption at rest, and initials-on-schedule-surfaces to minimize on-screen exposure.

**FERPA page — "While Entering Data" (`app/ferpa/page.tsx`)**
- Bullet: _"Use privacy-protective identifiers when possible (initials, student IDs)"_ → guidance to rely on Speddy's role-based access controls, with initials shown on shared scheduling views.

## Notes for review

- **Deliberately not claimed:** audit-logging of student-data access (that work is unfinished, tracked in SPE-169). The two protections stated — role-based access (RLS) and encryption at rest — hold today.
- **Owner still to confirm** (can't be seen from code): that no *signed* district DPA promises "initials only." Today's copy hedged ("typically", "when possible"), so this reads as an evolution of disclosed posture, not the breaking of a hard promise.
- Copy-only diff (no logic); typecheck + lint green.

Closes SPE-285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYEo9UCTeTRCo8rSCjRw6m

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYEo9UCTeTRCo8rSCjRw6m)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the FERPA Compliance Notice with the new “Last Updated” date and revised guidance to emphasize role-based access controls and initials in shared scheduling views to reduce on-screen exposure.
  * Updated the privacy policy with the new “Last Updated” date, clarified what student identifiers may be entered (including full names), and added details on how full names are protected (access controls/row-level security and encryption at rest) while initials are used in scheduling/planning views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->