### PR TITLE
SPE-286: SEA Students page shows student full names

### DIFF
--- a/lib/supabase/queries/sea-students.ts
+++ b/lib/supabase/queries/sea-students.ts
@@ -8,7 +8,9 @@ export interface StudentData {
   school_id?: string;
   provider_id?: string;
   iep_goals?: string[]; // Always normalized to array at top level
-  student_details?: { iep_goals?: string[] }; // Optional nested format for compatibility
+  // Nested details (SPE-284 identity anchor). Full name is populated whenever known
+  // so the shared Students page can render it for SEAs; iep_goals only when requested.
+  student_details?: { iep_goals?: string[]; first_name?: string | null; last_name?: string | null };
 }
 
 export interface LoadStudentsOptions {
@@ -81,7 +83,13 @@ export async function loadStudentsForUser(
             created_at: student.created_at,
             updated_at: student.updated_at,
             iep_goals: iepGoals,
-            student_details: includeIEPGoals ? { iep_goals: iepGoals } : undefined,
+            // SPE-286: get_sea_students now returns first_name/last_name for the SEA's
+            // assigned students, so the Students page can show the full name.
+            student_details: {
+              first_name: student.first_name ?? null,
+              last_name: student.last_name ?? null,
+              ...(includeIEPGoals ? { iep_goals: iepGoals } : {}),
+            },
           } as StudentData;
         });
         return { data: transformedData, error: null };
@@ -101,9 +109,10 @@ export async function loadStudentsForUser(
       let fallbackQuery = supabase
         .from('students')
         .select(
+          // Always embed the name (SPE-286); iep_goals only when requested.
           includeIEPGoals
-            ? 'id, initials, grade_level, teacher_name, teacher_id, sessions_per_week, minutes_per_session, school_id, provider_id, created_at, updated_at, student_details(iep_goals)'
-            : 'id, initials, grade_level, teacher_name, teacher_id, sessions_per_week, minutes_per_session, school_id, provider_id, created_at, updated_at'
+            ? 'id, initials, grade_level, teacher_name, teacher_id, sessions_per_week, minutes_per_session, school_id, provider_id, created_at, updated_at, student_details(iep_goals, first_name, last_name)'
+            : 'id, initials, grade_level, teacher_name, teacher_id, sessions_per_week, minutes_per_session, school_id, provider_id, created_at, updated_at, student_details(first_name, last_name)'
         )
         .order('initials');
 
@@ -144,7 +153,12 @@ export async function loadStudentsForUser(
           created_at: student.created_at,
           updated_at: student.updated_at,
           iep_goals: iepGoals,
-          student_details: includeIEPGoals ? { iep_goals: iepGoals } : undefined,
+          // SPE-286: surface the full name (RLS-scoped to the SEA's assigned students).
+          student_details: {
+            first_name: studentDetails?.first_name ?? null,
+            last_name: studentDetails?.last_name ?? null,
+            ...(includeIEPGoals ? { iep_goals: iepGoals } : {}),
+          },
         } as StudentData;
       });
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -4626,10 +4626,12 @@ export type Database = {
         }
         Returns: {
           created_at: string
+          first_name: string
           grade_level: string
           id: string
           iep_goals: string[]
           initials: string
+          last_name: string
           minutes_per_session: number
           provider_id: string
           school_id: string

--- a/supabase/migrations/20260721_get_sea_students_return_names.sql
+++ b/supabase/migrations/20260721_get_sea_students_return_names.sql
@@ -1,0 +1,70 @@
+-- SPE-286: get_sea_students returned only iep_goals from student_details, so SEA
+-- (view-only) users still saw initials-only on the shared Students page — providers
+-- already see full names via getStudents after SPE-284. Return first_name/last_name
+-- from the LEFT JOIN on student_details that the function already performs, so the
+-- Students page can show the name for the SEA's assigned students.
+--
+-- Scope is UNCHANGED: rows are still restricted to ss.assigned_to_sea_id = auth.uid()
+-- AND ss.delivered_by = 'sea', so an SEA only ever sees names for students they are
+-- actually assigned to serve. Only the two name columns are added.
+--
+-- Changing the RETURNS TABLE shape is a return-type change, which CREATE OR REPLACE
+-- cannot do, so this DROPs and re-creates. Body reproduced verbatim from the live
+-- definition. ACL reproduced exactly (authenticated + service_role; no anon/PUBLIC).
+-- search_path left as-is — SECURITY DEFINER search_path hardening is tracked in SPE-289.
+
+DROP FUNCTION IF EXISTS public.get_sea_students(character varying, text, text);
+
+CREATE OR REPLACE FUNCTION public.get_sea_students(
+  p_school_id character varying DEFAULT NULL::character varying,
+  p_school_site text DEFAULT NULL::text,
+  p_school_district text DEFAULT NULL::text
+)
+ RETURNS TABLE(id uuid, initials text, grade_level text, teacher_name text, teacher_id uuid, sessions_per_week integer, minutes_per_session integer, school_id character varying, provider_id uuid, created_at timestamp with time zone, updated_at timestamp with time zone, iep_goals text[], first_name text, last_name text)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+  -- Return unique students that have sessions assigned to the CURRENT authenticated SEA
+  -- Uses auth.uid() to prevent passing arbitrary user IDs from client (security)
+  -- Supports both school_id (migrated) and school_site+school_district (legacy) filtering
+  RETURN QUERY
+  SELECT DISTINCT
+    s.id,
+    s.initials,
+    s.grade_level,
+    s.teacher_name,
+    s.teacher_id,
+    s.sessions_per_week,
+    s.minutes_per_session,
+    s.school_id,
+    s.provider_id,
+    s.created_at,
+    s.updated_at,
+    COALESCE(sd.iep_goals, '{}'::TEXT[]) as iep_goals,
+    sd.first_name,
+    sd.last_name
+  FROM students s
+  INNER JOIN schedule_sessions ss ON ss.student_id = s.id
+  LEFT JOIN student_details sd ON sd.student_id = s.id
+  WHERE ss.assigned_to_sea_id = auth.uid()  -- Use auth.uid() instead of parameter
+    AND ss.delivered_by = 'sea'
+    AND (
+      -- No school filter provided - return all students
+      (p_school_id IS NULL AND p_school_site IS NULL AND p_school_district IS NULL)
+      OR
+      -- Match by school_id if both student and filter have it (migrated schools)
+      (p_school_id IS NOT NULL AND s.school_id IS NOT NULL AND s.school_id = p_school_id)
+      OR
+      -- Match by school_site + school_district (legacy schools or fallback during migration)
+      (p_school_site IS NOT NULL AND p_school_district IS NOT NULL
+       AND s.school_site = p_school_site AND s.school_district = p_school_district)
+    )
+  ORDER BY s.initials;
+END;
+$function$;
+
+-- Reproduce the exact ACL (no anon / PUBLIC on this view-only SEA path).
+REVOKE ALL ON FUNCTION public.get_sea_students(character varying, text, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_sea_students(character varying, text, text) TO authenticated, service_role;


### PR DESCRIPTION
## What & why

After SPE-284, providers see student full names on the Students page (via `getStudents`), but **SEA** (special-ed aide, view-only) users still saw **initials-only**. The SEA path (`loadStudentsForUser` → `get_sea_students` RPC / RLS fallback) only returned `iep_goals` from `student_details`, never the name — so `studentFullName()` had nothing to render.

## Changes

- **Migration `20260721_get_sea_students_return_names.sql`:** `get_sea_students` now returns `first_name`/`last_name` from the `student_details` LEFT JOIN it already performs. A return-shape change can't be done with `CREATE OR REPLACE`, so this DROPs + re-creates; the body is reproduced verbatim and the ACL is reproduced exactly.
- **`lib/supabase/queries/sea-students.ts`:** wire the names into `student_details.{first_name,last_name}` in both the RPC-success transform and the RLS fallback; extend `StudentData`. Names are populated regardless of `includeIEPGoals` (the Students-page SEA call passes it false).

## Safety (security-sensitive SEA path)

- **Scope unchanged:** rows still restricted to `ss.assigned_to_sea_id = auth.uid() AND ss.delivered_by = 'sea'` (+ the same school filter). An SEA only ever sees names for students they're assigned to serve — no widening.
- **ACL reproduced exactly:** `REVOKE … FROM PUBLIC, anon` then `GRANT EXECUTE … TO authenticated, service_role` — matches the original (no anon/PUBLIC).
- Verified before writing: `student_details.first_name/last_name` are `text` (match the `RETURNS TABLE`), and no DB object depends on the function (DROP is safe).
- Provider path (`getStudents`) untouched. `search_path` hardening intentionally deferred to SPE-289.

The migration applies to prod on merge (per this repo's manual-migration convention).

Closes SPE-286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYEo9UCTeTRCo8rSCjRw6m

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYEo9UCTeTRCo8rSCjRw6m)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Student listings for SEA users now include students’ first and last names.
  * IEP goals remain available when the IEP goals option is enabled.
* **Bug Fixes**
  * Improved consistency between standard and fallback data loading so student names and optional IEP goals appear reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->