### PR TITLE
SPE-291/SPE-292: rolling session-instance top-up + calendar-path indexes

### DIFF
--- a/__tests__/unit/app/api/cron/cleanup-uploads-topup.test.ts
+++ b/__tests__/unit/app/api/cron/cleanup-uploads-topup.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for the session-instance top-up riding along with the daily
+ * cleanup-uploads cron (SPE-291). The cleanup cron is the production trigger
+ * (Vercel Hobby's two cron slots are both taken), so its contract matters:
+ * top-up runs after cleanup, its counts are reported, and a top-up failure
+ * fails the whole run loud (5xx).
+ */
+import { NextRequest } from 'next/server';
+
+const mockRpc = jest.fn();
+const mockLt = jest.fn();
+jest.mock('@/lib/supabase/server', () => ({
+  createServiceClient: () => ({
+    rpc: mockRpc,
+    from: () => ({ delete: () => ({ lt: mockLt }) }),
+  }),
+}));
+
+import { GET } from '@/app/api/cron/cleanup-uploads/route';
+
+const makeRequest = () =>
+  new NextRequest('http://localhost/api/cron/cleanup-uploads', {
+    method: 'GET',
+    headers: { 'x-cron-secret': 'test-secret' },
+  });
+
+describe('/api/cron/cleanup-uploads session top-up integration', () => {
+  const originalSecret = process.env.CRON_SECRET;
+  const originalAnalytics = process.env.CLEANUP_ANALYTICS;
+
+  beforeEach(() => {
+    mockRpc.mockReset();
+    mockLt.mockReset();
+    mockLt.mockResolvedValue({ error: null, count: 3 });
+    process.env.CRON_SECRET = 'test-secret';
+    delete process.env.CLEANUP_ANALYTICS;
+  });
+
+  afterAll(() => {
+    if (originalSecret === undefined) delete process.env.CRON_SECRET;
+    else process.env.CRON_SECRET = originalSecret;
+    if (originalAnalytics === undefined) delete process.env.CLEANUP_ANALYTICS;
+    else process.env.CLEANUP_ANALYTICS = originalAnalytics;
+  });
+
+  it('runs the top-up after cleanup and reports its counts', async () => {
+    mockRpc.mockResolvedValue({
+      data: [{ templates_processed: 371, instances_created: 4200 }],
+      error: null,
+    });
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockRpc).toHaveBeenCalledWith('topup_session_instances', {
+      p_weeks_ahead: 12,
+    });
+    expect(body).toMatchObject({
+      success: true,
+      deleted: 3,
+      sessionTopup: {
+        templatesProcessed: 371,
+        instancesCreated: 4200,
+        weeksAhead: 12,
+      },
+    });
+  });
+
+  it('fails the run loud (5xx) when the top-up errors, preserving the cleanup count', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'boom' } });
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('session top-up');
+    // The cleanup already ran; its count must survive in the failure body.
+    expect(body.deleted).toBe(3);
+  });
+
+  it('500s via the outer catch when the top-up rejects (rpc throws)', async () => {
+    mockRpc.mockRejectedValue(new Error('network down'));
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.success).toBe(false);
+  });
+});

--- a/__tests__/unit/app/api/cron/topup-session-instances.test.ts
+++ b/__tests__/unit/app/api/cron/topup-session-instances.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for /api/cron/topup-session-instances (SPE-291).
+ *
+ * Contract: header-authenticated by CRON_SECRET (x-cron-secret or Bearer),
+ * fails loud (5xx) on misconfiguration or DB error, and on success invokes the
+ * topup_session_instances RPC with the 12-week rolling horizon and reports its
+ * counts.
+ */
+import { NextRequest } from 'next/server';
+
+const mockRpc = jest.fn();
+jest.mock('@/lib/supabase/server', () => ({
+  createServiceClient: () => ({ rpc: mockRpc }),
+}));
+
+import { GET, POST } from '@/app/api/cron/topup-session-instances/route';
+
+const makeRequest = (headers: Record<string, string> = {}) =>
+  new NextRequest('http://localhost/api/cron/topup-session-instances', {
+    method: 'GET',
+    headers,
+  });
+
+describe('/api/cron/topup-session-instances', () => {
+  const originalSecret = process.env.CRON_SECRET;
+
+  beforeEach(() => {
+    mockRpc.mockReset();
+    process.env.CRON_SECRET = 'test-secret';
+  });
+
+  afterAll(() => {
+    if (originalSecret === undefined) delete process.env.CRON_SECRET;
+    else process.env.CRON_SECRET = originalSecret;
+  });
+
+  it('500s when CRON_SECRET is not configured, without touching the DB', async () => {
+    delete process.env.CRON_SECRET;
+
+    const res = await GET(makeRequest({ 'x-cron-secret': 'anything' }));
+
+    expect(res.status).toBe(500);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('401s without a valid secret, without touching the DB', async () => {
+    const missing = await GET(makeRequest());
+    const wrong = await GET(makeRequest({ 'x-cron-secret': 'nope' }));
+
+    expect(missing.status).toBe(401);
+    expect(wrong.status).toBe(401);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('runs the top-up RPC with the 12-week horizon and reports counts', async () => {
+    mockRpc.mockResolvedValue({
+      data: [{ templates_processed: 371, instances_created: 4200 }],
+      error: null,
+    });
+
+    const res = await GET(makeRequest({ 'x-cron-secret': 'test-secret' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockRpc).toHaveBeenCalledWith('topup_session_instances', {
+      p_weeks_ahead: 12,
+    });
+    expect(body).toMatchObject({
+      success: true,
+      templatesProcessed: 371,
+      instancesCreated: 4200,
+      weeksAhead: 12,
+    });
+  });
+
+  it('accepts the Authorization: Bearer form (Vercel Cron)', async () => {
+    mockRpc.mockResolvedValue({
+      data: [{ templates_processed: 0, instances_created: 0 }],
+      error: null,
+    });
+
+    const res = await GET(makeRequest({ authorization: 'Bearer test-secret' }));
+
+    expect(res.status).toBe(200);
+    expect(mockRpc).toHaveBeenCalledTimes(1);
+  });
+
+  it('500s (fails loud) when the RPC errors', async () => {
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { message: 'boom' },
+    });
+
+    const res = await GET(makeRequest({ 'x-cron-secret': 'test-secret' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.success).toBe(false);
+  });
+
+  it('POST delegates to the same handler', async () => {
+    mockRpc.mockResolvedValue({
+      data: [{ templates_processed: 1, instances_created: 12 }],
+      error: null,
+    });
+
+    const res = await POST(makeRequest({ 'x-cron-secret': 'test-secret' }));
+
+    expect(res.status).toBe(200);
+    expect(mockRpc).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/api/cron/cleanup-uploads/route.ts
+++ b/app/api/cron/cleanup-uploads/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createServiceClient } from '@/lib/supabase/server';
+import {
+  runSessionInstanceTopup,
+  SESSION_TOPUP_WEEKS_AHEAD
+} from '@/lib/services/session-instance-topup';
 
 export async function GET(request: NextRequest) {
   const startTime = Date.now();
@@ -92,13 +96,41 @@ export async function GET(request: NextRequest) {
       }
     }
     
+    // SPE-291: daily session-instance top-up rides along with this cron.
+    // Vercel Hobby allows only two cron jobs (both slots used), so this daily
+    // job is the trigger; /api/cron/topup-session-instances remains available
+    // for manual runs. Idempotent and set-based, so daily execution is cheap.
+    const topupResult = await runSessionInstanceTopup(supabase);
+
+    if (!topupResult.success) {
+      console.error('Error running session instance top-up:', topupResult.error);
+      // Fail loud (5xx) so a broken top-up is visible instead of the future-
+      // instance supply quietly running dry behind a 200.
+      return NextResponse.json({
+        success: false,
+        error: 'Database error during session top-up',
+        details: topupResult.error,
+        deleted: deletedCount,
+        timestamp: new Date().toISOString()
+      }, { status: 500 });
+    }
+
+    console.log(
+      `Session top-up completed: ${topupResult.instancesCreated} instances created from ${topupResult.templatesProcessed} templates (${SESSION_TOPUP_WEEKS_AHEAD}w horizon)`
+    );
+
     // Return success response
     return NextResponse.json({
       success: true,
       deleted: deletedCount,
       analyticsDeleted: analyticsEnabled ? analyticsDeleted : undefined,
+      sessionTopup: {
+        templatesProcessed: topupResult.templatesProcessed,
+        instancesCreated: topupResult.instancesCreated,
+        weeksAhead: SESSION_TOPUP_WEEKS_AHEAD
+      },
       cutoffDate: cutoffDate.toISOString(),
-      processingTimeMs: processingTime,
+      processingTimeMs: Date.now() - startTime,
       timestamp: new Date().toISOString()
     }, { status: 200 });
     

--- a/app/api/cron/topup-session-instances/route.ts
+++ b/app/api/cron/topup-session-instances/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServiceClient } from '@/lib/supabase/server';
+import {
+  runSessionInstanceTopup,
+  SESSION_TOPUP_WEEKS_AHEAD
+} from '@/lib/services/session-instance-topup';
+
+// SPE-291: dedicated trigger for the session-instance top-up.
+//
+// NOT scheduled in vercel.json: the Vercel Hobby plan allows at most two cron
+// jobs and both slots are used by the cleanup crons, so the daily trigger for
+// this top-up lives inside /api/cron/cleanup-uploads. This route exists for
+// manual/ops invocation (same CRON_SECRET auth) and as the ready-made cron
+// target if the project moves to a plan with more cron slots.
+
+export async function GET(request: NextRequest) {
+  const startTime = Date.now();
+
+  try {
+    // Read the cron secret from a header only — never the query string, which
+    // leaks into access logs, monitoring dashboards, and copied links. Accept
+    // the `x-cron-secret` header or the standard `Authorization: Bearer
+    // <secret>` form (e.g. Vercel Cron).
+    const authHeader = request.headers.get('authorization');
+    const bearerToken = authHeader?.toLowerCase().startsWith('bearer ')
+      ? authHeader.slice(7).trim()
+      : null;
+    const token = request.headers.get('x-cron-secret') || bearerToken;
+
+    const expectedToken = process.env.CRON_SECRET;
+
+    if (!expectedToken) {
+      console.error('CRON_SECRET environment variable not set');
+      // Surface misconfiguration as a 5xx so the cron service/monitoring
+      // notices instead of silently succeeding.
+      return NextResponse.json({
+        success: false,
+        error: 'Server configuration error',
+        timestamp: new Date().toISOString()
+      }, { status: 500 });
+    }
+
+    if (!token || token !== expectedToken) {
+      console.warn('Unauthorized session top-up attempt');
+      return NextResponse.json({
+        success: false,
+        error: 'Unauthorized',
+        timestamp: new Date().toISOString()
+      }, { status: 401 });
+    }
+
+    // Service-role client: unauthenticated cron request, and the top-up spans
+    // every provider's templates (RLS would scope a user client to one).
+    const supabase = createServiceClient();
+
+    const result = await runSessionInstanceTopup(supabase);
+
+    if (!result.success) {
+      console.error('Error running session instance top-up:', result.error);
+      // Fail loud (5xx) so a broken top-up is visible instead of the future-
+      // instance supply quietly running dry behind a 200.
+      return NextResponse.json({
+        success: false,
+        error: 'Database error during session top-up',
+        details: result.error,
+        timestamp: new Date().toISOString()
+      }, { status: 500 });
+    }
+
+    const processingTime = Date.now() - startTime;
+
+    console.log(
+      `Session top-up completed: ${result.instancesCreated} instances created from ${result.templatesProcessed} templates (${SESSION_TOPUP_WEEKS_AHEAD}w horizon) in ${processingTime}ms`
+    );
+
+    return NextResponse.json({
+      success: true,
+      templatesProcessed: result.templatesProcessed,
+      instancesCreated: result.instancesCreated,
+      weeksAhead: SESSION_TOPUP_WEEKS_AHEAD,
+      processingTimeMs: processingTime,
+      timestamp: new Date().toISOString()
+    }, { status: 200 });
+
+  } catch (error: any) {
+    console.error('Unexpected error in session top-up cron job:', error);
+
+    return NextResponse.json({
+      success: false,
+      error: 'Unexpected error during session top-up',
+      details: error.message || 'Unknown error',
+      timestamp: new Date().toISOString()
+    }, { status: 500 });
+  }
+}
+
+// Also support POST for flexibility with different cron services
+export async function POST(request: NextRequest) {
+  return GET(request);
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -414,22 +414,33 @@ erDiagram
 - **Completion & grouping:** `is_completed` / `completed_at` / `completed_by` /
   `session_notes`; group sessions via `group_id` / `group_name` / `group_color`.
 - **Soft delete:** `deleted_at` (rows are not always hard-deleted here).
+- **Instance horizon (SPE-291):** dated instances are materialized to a
+  **rolling 12-week horizon** by `topup_session_instances()` (set-based,
+  `ON CONFLICT DO NOTHING`), triggered daily from the `cleanup-uploads` cron.
+  Scheduling a template by drag also generates instances immediately
+  (`/api/sessions/generate-instances`, legacy school-year-end horizon); the
+  calendar's client-side virtual layer renders slots beyond the horizon and
+  persists them on first touch (`lib/services/session-persistence.ts`).
 
 **Source of truth:** live `schedule_sessions` table + `session_status` enum;
-`lib/scheduling/`; `lib/auth/role-utils.ts` (delivered_by derivation).
+`lib/scheduling/`; `lib/auth/role-utils.ts` (delivered_by derivation);
+`lib/services/session-instance-topup.ts` + `topup_session_instances()` fn
+(rolling horizon).
 
 ---
 
 ## 7. Data Lifecycle & Retention
 
 ### Scheduled cleanup (cron)
-Both cron routes authenticate with a shared `CRON_SECRET` (header
-`x-cron-secret` or `Authorization: Bearer …`) and are scheduled in `vercel.json`.
+All cron routes authenticate with a shared `CRON_SECRET` (header
+`x-cron-secret` or `Authorization: Bearer …`); the scheduled ones live in
+`vercel.json`.
 
-| Job | Schedule (UTC) | What it deletes |
+| Job | Schedule (UTC) | What it does |
 |---|---|---|
-| `cleanup-uploads` | `0 8 * * *` (08:00 daily) | `upload_rate_limits` older than **7 days**; optionally `analytics_events` older than **90 days** when `CLEANUP_ANALYTICS=true`. |
-| `cleanup-worksheet-images` | `0 9 * * *` (09:00 daily) | `worksheet_submissions` older than **12 months** + their Storage objects (storage-first, chunked, `moreRemaining` flag for backlog). |
+| `cleanup-uploads` | `0 8 * * *` (08:00 daily) | Deletes `upload_rate_limits` older than **7 days**; optionally `analytics_events` older than **90 days** when `CLEANUP_ANALYTICS=true`. Then runs the **session-instance top-up** (SPE-291): extends every active scheduled template's dated instances to a rolling 12-week horizon. |
+| `topup-session-instances` | — (not scheduled) | Same top-up, standalone. Manual/ops trigger only — Vercel Hobby caps cron jobs at two, so the daily trigger rides on `cleanup-uploads`; becomes its own cron slot on a paid plan. |
+| `cleanup-worksheet-images` | `0 9 * * *` (09:00 daily) | Deletes `worksheet_submissions` older than **12 months** + their Storage objects (storage-first, chunked, `moreRemaining` flag for backlog). |
 | `health` | — | unauthenticated, read-only status. |
 
 ### Deletion semantics

--- a/docs/SESSION_ARCHITECTURE.md
+++ b/docs/SESSION_ARCHITECTURE.md
@@ -102,12 +102,21 @@ Dated instances generated for upcoming weeks
 ```
 Scheduled template (e.g., Monday 9:00-9:30)
     ↓
-Generate instances for next 8 weeks
+Instances generated two ways:
+  a) On manual scheduling: /api/sessions/generate-instances
+     (through school-year end — legacy horizon)
+  b) Daily top-up cron: topup_session_instances() extends EVERY active
+     scheduled template to a rolling 12-week horizon (SPE-291) —
+     covers auto-scheduled templates and the school-year rollover
     ↓
 Dated instances created (e.g., 2024-12-09, 2024-12-16, ...)
     ↓
 Instances appear in Calendar view and Today's Schedule
 ```
+
+Beyond the materialized horizon, calendar views fabricate virtual `temp-`
+sessions from templates for display and persist them on first interaction
+(`lib/services/session-persistence.ts`).
 
 ### 4. Session Delivery
 

--- a/lib/services/session-instance-topup.ts
+++ b/lib/services/session-instance-topup.ts
@@ -1,0 +1,41 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/src/types';
+
+// Rolling materialization horizon (SPE-291). Every active scheduled template
+// keeps dated instances covering the next N weeks; the calendar's virtual
+// layer renders anything beyond. With a daily trigger, a failed run leaves
+// ~11 weeks of slack before anyone could notice.
+export const SESSION_TOPUP_WEEKS_AHEAD = 12;
+
+export type SessionTopupResult =
+  | { success: true; templatesProcessed: number; instancesCreated: number }
+  | { success: false; error: string };
+
+/**
+ * Extends every active scheduled template's dated instances to the rolling
+ * horizon via the set-based `topup_session_instances` Postgres function
+ * (idempotent: ON CONFLICT DO NOTHING). Must be called with the service-role
+ * client — the function spans all providers and is not granted to
+ * authenticated users.
+ *
+ * `templatesProcessed` counts templates ELIGIBLE for top-up, not templates
+ * that received rows — after a full run, (616, 0) is the healthy steady state.
+ */
+export async function runSessionInstanceTopup(
+  supabase: SupabaseClient<Database>
+): Promise<SessionTopupResult> {
+  const { data, error } = await supabase.rpc('topup_session_instances', {
+    p_weeks_ahead: SESSION_TOPUP_WEEKS_AHEAD
+  });
+
+  if (error) {
+    return { success: false, error: error.message };
+  }
+
+  const row = Array.isArray(data) ? data[0] : data;
+  return {
+    success: true,
+    templatesProcessed: Number(row?.templates_processed ?? 0),
+    instancesCreated: Number(row?.instances_created ?? 0)
+  };
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -4729,6 +4729,13 @@ export type Database = {
         Args: { p_minutes_per_session: number; p_start_time: string }
         Returns: string
       }
+      topup_session_instances: {
+        Args: { p_weeks_ahead?: number }
+        Returns: {
+          instances_created: number
+          templates_processed: number
+        }[]
+      }
       upsert_bell_schedule:
         | {
             Args: {

--- a/supabase/migrations/20260721_add_session_instance_indexes.sql
+++ b/supabase/migrations/20260721_add_session_instance_indexes.sql
@@ -1,0 +1,30 @@
+-- SPE-292: indexes for the hottest read shape on schedule_sessions —
+-- "dated instances for a provider/assignee within a date range" (calendar
+-- week/day views, Today's Schedule, weekly view, all via
+-- SessionGenerator.getSessionsForDateRange).
+--
+-- Until now no index led with provider_id or an assignee column, so these
+-- reads walked the whole table or the full width of unique_session_per_date
+-- (leading column student_id is never constrained by these queries):
+-- pg_stat_user_tables showed ~54k seq scans / 130M tuples read. Cost grew
+-- linearly with TOTAL rows across all tenants.
+--
+-- The role-based OR filter (provider_id = X OR assigned_to_sea_id = X OR
+-- assigned_to_specialist_id = X) can now resolve as a BitmapOr across the
+-- three indexes below. The assignee indexes are partial because those columns
+-- are NULL on the vast majority of rows.
+--
+-- Note: 20250813_performance_optimization.sql promised similar indexes but
+-- referenced columns that don't exist (`date`, `completed`), so they were
+-- never created (cleanup tracked in SPE-299).
+
+CREATE INDEX IF NOT EXISTS idx_schedule_sessions_provider_session_date
+  ON schedule_sessions (provider_id, session_date);
+
+CREATE INDEX IF NOT EXISTS idx_schedule_sessions_sea_session_date
+  ON schedule_sessions (assigned_to_sea_id, session_date)
+  WHERE assigned_to_sea_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_schedule_sessions_specialist_session_date
+  ON schedule_sessions (assigned_to_specialist_id, session_date)
+  WHERE assigned_to_specialist_id IS NOT NULL;

--- a/supabase/migrations/20260721_add_session_instance_indexes.sql
+++ b/supabase/migrations/20260721_add_session_instance_indexes.sql
@@ -17,6 +17,14 @@
 -- Note: 20250813_performance_optimization.sql promised similar indexes but
 -- referenced columns that don't exist (`date`, `completed`), so they were
 -- never created (cleanup tracked in SPE-299).
+--
+-- Deliberately NOT `CONCURRENTLY`: this migration is applied transactionally
+-- (CONCURRENTLY cannot run inside a transaction — 20250813 made that exact
+-- mistake and silently built nothing), the table was ~3.4MB/16k rows at apply
+-- time (write-blocking ShareLock held ~100ms), and IF NOT EXISTS makes any
+-- replay a no-op against the already-built indexes. If this table is ever
+-- orders of magnitude larger, future index work needs a non-transactional
+-- CONCURRENTLY path instead.
 
 CREATE INDEX IF NOT EXISTS idx_schedule_sessions_provider_session_date
   ON schedule_sessions (provider_id, session_date);

--- a/supabase/migrations/20260721_add_topup_session_instances_fn.sql
+++ b/supabase/migrations/20260721_add_topup_session_instances_fn.sql
@@ -1,0 +1,97 @@
+-- SPE-291: rolling top-up of dated session instances from active templates.
+--
+-- Dated instances used to be generated only when a template transitioned
+-- unscheduled -> scheduled (through school-year end), so the supply of future
+-- instances expired every July 1 with nothing renewing it. This function
+-- extends every active scheduled template to a rolling N-week horizon in one
+-- set-based, conflict-tolerant statement. It is invoked daily from the
+-- cleanup-uploads cron route (Vercel Hobby caps cron jobs at two, so the
+-- dedicated /api/cron/topup-session-instances route is manual-only) and is
+-- safe to re-run at any time (ON CONFLICT DO NOTHING against
+-- unique_session_per_date).
+--
+-- Deliberate parity with existing generation behavior
+-- (lib/services/session-instance-generator.ts): copies the same template
+-- fields, sets template_id, does NOT skip holidays (SPE-299 tracks doc drift;
+-- holiday awareness would be a separate product decision).
+--
+-- Duplicate semantics: unique_session_per_date is global on
+-- (student_id, session_date, start_time), so if two providers' templates
+-- target the same student/date/time (possible via the SPE-255 double-book
+-- override), this insert claims the slot for whichever template it reaches
+-- first and skips the other — and because it runs daily, the other provider's
+-- lazy persist-on-touch path will keep losing the race until the overlap is
+-- resolved. Zero colliding template pairs exist today; making the per-template
+-- generators conflict-tolerant is tracked in SPE-293.
+
+CREATE OR REPLACE FUNCTION public.topup_session_instances(p_weeks_ahead integer DEFAULT 12)
+-- templates_processed = templates ELIGIBLE for top-up (counted before the
+-- insert); a template whose dates all already exist still counts. In steady
+-- state expect (N, ~N/7 per day) — (616, 0) right after a full run is normal.
+RETURNS TABLE (templates_processed bigint, instances_created bigint)
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+  -- Clamp to a sane range: at least 1 week, at most 26 (half a year) so a bad
+  -- caller can't mass-materialize rows.
+  v_weeks integer := LEAST(GREATEST(COALESCE(p_weeks_ahead, 12), 1), 26);
+  v_templates bigint;
+  v_created bigint;
+BEGIN
+  SELECT count(*) INTO v_templates
+  FROM schedule_sessions t
+  WHERE t.session_date IS NULL
+    AND t.deleted_at IS NULL
+    AND t.day_of_week IS NOT NULL
+    AND t.start_time IS NOT NULL
+    AND t.end_time IS NOT NULL
+    AND t.student_id IS NOT NULL
+    AND t.provider_id IS NOT NULL;
+
+  INSERT INTO schedule_sessions (
+    student_id, provider_id, day_of_week, start_time, end_time,
+    service_type, session_date, delivered_by,
+    assigned_to_specialist_id, assigned_to_sea_id,
+    manually_placed, group_id, group_name, group_color, status,
+    student_absent, outside_schedule_conflict, is_completed,
+    template_id, is_template
+  )
+  SELECT
+    t.student_id, t.provider_id, t.day_of_week, t.start_time, t.end_time,
+    t.service_type, d.instance_date, t.delivered_by,
+    t.assigned_to_specialist_id, t.assigned_to_sea_id,
+    t.manually_placed, t.group_id, t.group_name, t.group_color, t.status,
+    false, false, false,
+    t.id, false
+  FROM schedule_sessions t
+  CROSS JOIN LATERAL (
+    -- Next occurrence of the template's weekday (today counts), then one date
+    -- per week out to the horizon. day_of_week uses Postgres DOW numbering
+    -- (1-5 = Mon-Fri), verified against live instance data.
+    SELECT (CURRENT_DATE
+            + ((t.day_of_week - EXTRACT(DOW FROM CURRENT_DATE)::int + 7) % 7)
+            + (n * 7))::date AS instance_date
+    FROM generate_series(0, v_weeks - 1) AS n
+  ) d
+  WHERE t.session_date IS NULL
+    AND t.deleted_at IS NULL
+    AND t.day_of_week IS NOT NULL
+    AND t.start_time IS NOT NULL
+    AND t.end_time IS NOT NULL
+    AND t.student_id IS NOT NULL
+    AND t.provider_id IS NOT NULL
+  ON CONFLICT (student_id, session_date, start_time) DO NOTHING;
+
+  GET DIAGNOSTICS v_created = ROW_COUNT;
+
+  RETURN QUERY SELECT v_templates, v_created;
+END;
+$$;
+
+-- Service-role only: the cron route is the sole intended caller. Authenticated
+-- users must not be able to mass-insert rows for templates RLS lets them see.
+REVOKE ALL ON FUNCTION public.topup_session_instances(integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.topup_session_instances(integer) FROM anon;
+REVOKE ALL ON FUNCTION public.topup_session_instances(integer) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.topup_session_instances(integer) TO service_role;


### PR DESCRIPTION
## Problem

The session-persistence review (July 2026) found that future dated session instances were only generated when a template was manually dragged onto the schedule (fire-and-forget browser fetch, school-year-end horizon). The auto-scheduler never generated instances and no job renewed them, so the supply expired every July 1: real accounts entered the new school year with **371 active weekly templates and zero future instances** (newest row exactly 2026-06-30). Separately, no index served "instances for a provider in a date range" — the hottest calendar query — so those reads scanned the whole table (~54k seq scans / 130M tuples read observed).

## What this does

**SPE-291 — rolling top-up (self-renewing supply):**
- New Postgres function `topup_session_instances(p_weeks_ahead)` — one set-based `INSERT…SELECT` from all active scheduled templates, `ON CONFLICT (student_id, session_date, start_time) DO NOTHING`, sets `template_id`, clamped to [1,26] weeks, EXECUTE granted to `service_role` only.
- Triggered **daily** from the existing `cleanup-uploads` cron (Vercel Hobby caps cron jobs at two and both slots are used, so no new `vercel.json` entry; deviation from the originally discussed weekly slot). A top-up failure fails the cron run loud (5xx).
- Dedicated `/api/cron/topup-session-instances` route (same CRON_SECRET auth) for manual/ops runs and as the ready-made cron target on a paid plan.
- Rolling 12-week horizon replaces the generate-through-June-30 model and self-heals the annual rollover; the calendar's virtual layer keeps covering display beyond the horizon.

**SPE-292 — calendar-path indexes:**
- `(provider_id, session_date)`, plus partial `(assigned_to_sea_id, session_date)` and `(assigned_to_specialist_id, session_date)` — the role-based OR filter now resolves as a BitmapOr instead of a full scan.

**Docs:** ARCHITECTURE.md §6/§7 and SESSION_ARCHITECTURE.md updated to match the new wiring.

## Already applied to prod (per approved plan)

Both migrations are applied and the one-time catch-up ran: **6,844 instances created from 616 templates**, verified idempotent (second run: 0 created), weekday-correct (0 mismatches), all rows template-linked, and EXPLAIN confirms the new indexes serve the calendar query shape. The daily trigger goes live when this merges and deploys; until then the materialized horizon is static (through 2026-10-12).

## Deep self-review (2 adversarial reviewers, verified against live DB)

- **Privilege/RLS:** clean — live exploit attempt as `authenticated` gets `42501`; `CREATE OR REPLACE` replay preserves the stripped ACL; plan shape scales with template count, not table size; `ROW_COUNT` after `DO NOTHING` counts only real inserts (empirically probed).
- **Known interaction surfaced (pre-existing gap, now more visible):** unschedule/archive paths don't delete future instances, and the attendance widget counts past instances with no liveness check — with universal materialization this becomes the main data-quality gap. Tracked and raised to High in **SPE-294**; cross-provider collision semantics and writer-consistency notes folded into **SPE-293**; index-drop + timing-safe-compare hygiene into **SPE-299**.
- Non-blocking review fixes applied here: honest migration comments (daily wiring, duplicate semantics, `templates_processed` = eligible count), test hardening (cleanup count preserved in failure body; rpc-rejection path).

## Tests

- `__tests__/unit/app/api/cron/topup-session-instances.test.ts` (6 cases: auth, misconfig, happy path, Bearer form, RPC error, POST).
- `__tests__/unit/app/api/cron/cleanup-uploads-topup.test.ts` (3 cases: counts reported, fail-loud with cleanup count preserved, rpc rejection).
- Full suite: 53/53 green; `tsc --noEmit` and `next lint` clean.

Linear: SPE-291, SPE-292 (follow-ups: SPE-293…SPE-299)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvVt9inLswnVdsawNRG7QM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvVt9inLswnVdsawNRG7QM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated rolling 12-week generation of scheduled session instances.
  * Added a secured endpoint for manually triggering session-instance top-ups.
  * Cleanup processing now includes session top-ups and reports processing metrics.
  * Improved session date-range query performance.

* **Bug Fixes**
  * Prevented duplicate session instances during repeated top-up runs.

* **Documentation**
  * Updated scheduling, cleanup, and session-generation architecture documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->