### PR TITLE
SPE-287: auto-scheduler avoids cross-provider double-books (batched)

### DIFF
--- a/__tests__/unit/lib/scheduling/auto-scheduler-cross-provider.test.ts
+++ b/__tests__/unit/lib/scheduling/auto-scheduler-cross-provider.test.ts
@@ -1,0 +1,81 @@
+import { createMockSupabaseClient } from '@/test-utils/supabase-test-helpers';
+import type { OtherProviderSessionLite } from '@/lib/services/session-update-service';
+
+// The scheduler constructs a Supabase client and the singleton data manager on
+// construction; mock the client module so both resolve to a harmless stub. This test
+// exercises the pure hard-avoid decision (hasCrossProviderConflict), not any I/O.
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => createMockSupabaseClient(),
+}));
+
+import { OptimizedScheduler } from '@/lib/scheduling/optimized-scheduler';
+
+// A cross-provider Speech session for a shared child: Monday 09:00–09:30.
+const other = (over: Partial<OtherProviderSessionLite> = {}): OtherProviderSessionLite => ({
+  day_of_week: 1,
+  start_time: '09:00:00',
+  end_time: '09:30:00',
+  provider_role: 'speech',
+  ...over,
+});
+
+/**
+ * SPE-287: the auto-scheduler must hard-avoid a slot that would double-book a shared
+ * student with another provider. hasCrossProviderConflict is the private decision the
+ * slot search consults; inject a minimal context and assert it directly.
+ */
+function withContext(
+  crossProviderSessionsByStudent: Map<string, OtherProviderSessionLite[]>,
+): { conflicts: (studentId: string, day: number, start: string, end: string) => boolean } {
+  const scheduler = new OptimizedScheduler('provider-1', 'resource') as any;
+  scheduler.context = { crossProviderSessionsByStudent };
+  return {
+    conflicts: (studentId, day, start, end) =>
+      scheduler.hasCrossProviderConflict(studentId, day, start, end),
+  };
+}
+
+describe('OptimizedScheduler.hasCrossProviderConflict (SPE-287)', () => {
+  const SHARED = 'shared-student';
+  const base = () => new Map<string, OtherProviderSessionLite[]>([[SHARED, [other()]]]);
+
+  it('hard-avoids a slot overlapping the shared student\'s other-provider session', () => {
+    // Scheduler passes startTime as "HH:MM" and endTime as "HH:MM:00" (addMinutesToTime).
+    expect(withContext(base()).conflicts(SHARED, 1, '09:15', '09:45:00')).toBe(true);
+  });
+
+  it('allows an adjacent slot (half-open intervals — touching is not overlapping)', () => {
+    // Starts exactly when the other session ends.
+    expect(withContext(base()).conflicts(SHARED, 1, '09:30', '10:00:00')).toBe(false);
+    // Ends exactly when the other session starts.
+    expect(withContext(base()).conflicts(SHARED, 1, '08:30', '09:00:00')).toBe(false);
+  });
+
+  it('does not block a different day', () => {
+    expect(withContext(base()).conflicts(SHARED, 2, '09:15', '09:45:00')).toBe(false);
+  });
+
+  it('does not block a non-overlapping time on the same day', () => {
+    expect(withContext(base()).conflicts(SHARED, 1, '11:00', '11:30:00')).toBe(false);
+  });
+
+  it('never conflicts for a student with no cross-provider match (not in the map)', () => {
+    expect(withContext(base()).conflicts('solo-student', 1, '09:15', '09:45:00')).toBe(false);
+  });
+
+  it('never conflicts when the student has an empty cross-provider list', () => {
+    const map = new Map<string, OtherProviderSessionLite[]>([[SHARED, []]]);
+    expect(withContext(map).conflicts(SHARED, 1, '09:15', '09:45:00')).toBe(false);
+  });
+
+  it('detects an overlap among several cross-provider sessions for the same student', () => {
+    const map = new Map<string, OtherProviderSessionLite[]>([[
+      SHARED,
+      [
+        other({ start_time: '11:00:00', end_time: '11:30:00', provider_role: 'ot' }),
+        other(), // the Monday 09:00–09:30 speech session
+      ],
+    ]]);
+    expect(withContext(map).conflicts(SHARED, 1, '09:10', '09:20:00')).toBe(true);
+  });
+});

--- a/__tests__/unit/lib/scheduling/auto-scheduler-cross-provider.test.ts
+++ b/__tests__/unit/lib/scheduling/auto-scheduler-cross-provider.test.ts
@@ -79,3 +79,52 @@ describe('OptimizedScheduler.hasCrossProviderConflict (SPE-287)', () => {
     expect(withContext(map).conflicts(SHARED, 1, '09:10', '09:20:00')).toBe(true);
   });
 });
+
+/**
+ * SPE-287: guard the WIRING, not just the decision. A unit test of hasCrossProviderConflict
+ * alone would still pass if someone deleted its call site in the slot search — so exercise
+ * findSlotsWithCapacityLimit (the single choke point both scheduling passes flow through)
+ * with a minimal context and assert an otherwise-valid slot is dropped iff a shared
+ * student's cross-provider session overlaps it.
+ */
+describe('OptimizedScheduler slot search consults the hard-avoid (SPE-287)', () => {
+  const SHARED = 'shared-student';
+  // One free Monday 09:00 slot, wide-open school hours, no bells/activities/own-sessions.
+  const schedulerWith = (crossMap: Map<string, OtherProviderSessionLite[]>) => {
+    const scheduler = new OptimizedScheduler('provider-1', 'resource') as any;
+    scheduler.context = {
+      schoolSite: 'Willow',
+      workDays: [1],
+      bellSchedules: [],
+      specialActivities: [],
+      existingSessions: [],
+      validSlots: new Map([
+        ['1-09:00', { dayOfWeek: 1, startTime: '09:00', endTime: '', available: true, capacity: 8, conflicts: [] }],
+      ]),
+      schoolHours: [],
+      studentGradeMap: new Map(),
+      crossProviderSessionsByStudent: crossMap,
+      providerAvailability: new Map(),
+      bellSchedulesByGrade: new Map(),
+      specialActivitiesByTeacher: new Map(),
+      cacheMetadata: { lastFetched: new Date(), isStale: false, fetchErrors: [], queryCount: 0 },
+    };
+    return scheduler;
+  };
+  const student = { id: SHARED, grade_level: '3', teacher_name: 'Teacher A', initials: 'AB' };
+
+  it('places the slot when the shared student has no overlapping cross-provider session', () => {
+    const slots = schedulerWith(new Map()).findSlotsWithCapacityLimit(student, 30, 1, [1], 8, []);
+    expect(slots).toHaveLength(1);
+    expect(slots[0].startTime).toBe('09:00');
+  });
+
+  it('drops the only slot when a cross-provider session overlaps it (hard-avoid engaged)', () => {
+    const blocked = new Map<string, OtherProviderSessionLite[]>([[
+      SHARED,
+      [{ day_of_week: 1, start_time: '09:00:00', end_time: '09:30:00', provider_role: 'speech' }],
+    ]]);
+    const slots = schedulerWith(blocked).findSlotsWithCapacityLimit(student, 30, 1, [1], 8, []);
+    expect(slots).toHaveLength(0);
+  });
+});

--- a/__tests__/unit/lib/scheduling/auto-scheduler-cross-provider.test.ts
+++ b/__tests__/unit/lib/scheduling/auto-scheduler-cross-provider.test.ts
@@ -1,11 +1,13 @@
-import { createMockSupabaseClient } from '@/test-utils/supabase-test-helpers';
+// Aliased with a `mock` prefix so the jest.mock factory (hoisted above imports by
+// babel-plugin-jest-hoist) may reference it.
+import { createMockSupabaseClient as mockCreateSupabaseClient } from '@/test-utils/supabase-test-helpers';
 import type { OtherProviderSessionLite } from '@/lib/services/session-update-service';
 
 // The scheduler constructs a Supabase client and the singleton data manager on
 // construction; mock the client module so both resolve to a harmless stub. This test
 // exercises the pure hard-avoid decision (hasCrossProviderConflict), not any I/O.
 jest.mock('@/lib/supabase/client', () => ({
-  createClient: () => createMockSupabaseClient(),
+  createClient: () => mockCreateSupabaseClient(),
 }));
 
 import { OptimizedScheduler } from '@/lib/scheduling/optimized-scheduler';

--- a/lib/scheduling/optimized-scheduler.ts
+++ b/lib/scheduling/optimized-scheduler.ts
@@ -4,6 +4,7 @@ import { Database } from "../../src/types/database";
 import { SchedulingDataManager } from './scheduling-data-manager';
 import { ManualPlacementService } from '../services/manual-placement-service';
 import { filterScheduledSessions, type ScheduledSession } from '../utils/session-helpers';
+import { findOverlappingOtherProviderSession, type OtherProviderSessionLite } from '../services/session-update-service';
 import type {
   Student,
   ScheduleSession,
@@ -43,7 +44,12 @@ interface SchedulingContext {
     end_time: string;
   }>;
   studentGradeMap: Map<string, string>; // Map student ID to grade level
-  
+
+  // SPE-287: cross-provider template sessions per owned student (studentId -> the other
+  // provider's sessions for the SAME shared child). Used to hard-avoid double-booking a
+  // shared student across providers. Only shared students have entries.
+  crossProviderSessionsByStudent: Map<string, OtherProviderSessionLite[]>;
+
   // Enhanced caching structures for O(1) lookups
   providerAvailability: Map<string, Map<number, AvailabilitySlot[]>>; // provider -> day -> slots
   bellSchedulesByGrade: Map<string, Map<number, BellSchedule[]>>; // grade -> day -> schedules
@@ -129,6 +135,9 @@ export class OptimizedScheduler {
 
     // Get all existing sessions (filter to only scheduled sessions with non-null day/time fields)
     const existingSessions = filterScheduledSessions(this.dataManager.getExistingSessions());
+
+    // SPE-287: cross-provider sessions for shared students (loaded once by the DataManager).
+    const crossProviderSessionsByStudent = this.dataManager.getCrossProviderSessions();
     
     // Get bell schedules for all grades
     const bellSchedules: BellSchedule[] = [];
@@ -160,10 +169,11 @@ export class OptimizedScheduler {
       bellSchedules,
       specialActivities,
       existingSessions,
-      schoolHours
+      schoolHours,
+      crossProviderSessionsByStudent
     };
   }
-  
+
   /**
    * Validate that cache is populated and not stale
    */
@@ -274,7 +284,8 @@ export class OptimizedScheduler {
       validSlots: new Map(),
       schoolHours: preloadedData.schoolHours || [],
       studentGradeMap: new Map(),
-      
+      crossProviderSessionsByStudent: preloadedData.crossProviderSessionsByStudent || new Map(),
+
       // Enhanced caching structures
       providerAvailability,
       bellSchedulesByGrade,
@@ -920,6 +931,15 @@ export class OptimizedScheduler {
           continue;
         }
 
+        // SPE-287: hard-avoid double-booking a SHARED student across providers. The other
+        // provider's session is blocked time for THIS child (one kid can't be in two rooms
+        // at once), so the auto-scheduler never places on top of it — unlike the interactive
+        // drag, which warns but lets the provider override.
+        if (this.hasCrossProviderConflict(student.id, day, slot.startTime, endTime)) {
+          this.log(`    ❌ Cross-provider double-book (shared student with another provider)`);
+          continue;
+        }
+
         // Check consecutive session rules (max 60 minutes without break)
         if (!this.validateConsecutiveSessionRules(student, day, slot.startTime, endTime, [...existingFoundSlots, ...foundSlots])) {
           this.log(`    ❌ Consecutive session rule violation`);
@@ -998,7 +1018,25 @@ export class OptimizedScheduler {
 
     return true;
   }
-  
+
+  /**
+   * SPE-287: does placing this student here double-book them with ANOTHER provider?
+   * True when the slot overlaps one of the student's cross-provider sessions (a shared
+   * child, e.g. RSP + Speech). Reuses findOverlappingOtherProviderSession so the
+   * auto-scheduler, the interactive drag warning, and the grey "other provider" bands
+   * share identical overlap semantics. No entry for a student => never a conflict.
+   */
+  private hasCrossProviderConflict(
+    studentId: string,
+    day: number,
+    startTime: string,
+    endTime: string
+  ): boolean {
+    const sessions = this.context!.crossProviderSessionsByStudent.get(studentId);
+    if (!sessions || sessions.length === 0) return false;
+    return findOverlappingOtherProviderSession(sessions, day, startTime, endTime) !== null;
+  }
+
   /**
    * Validate consecutive session rules (max 60 minutes without break)
    */

--- a/lib/scheduling/optimized-scheduler.ts
+++ b/lib/scheduling/optimized-scheduler.ts
@@ -137,7 +137,10 @@ export class OptimizedScheduler {
     const existingSessions = filterScheduledSessions(this.dataManager.getExistingSessions());
 
     // SPE-287: cross-provider sessions for shared students (loaded once by the DataManager).
-    const crossProviderSessionsByStudent = this.dataManager.getCrossProviderSessions();
+    // Snapshot per run (mirrors the existingSessions copy) so a concurrent DataManager
+    // refresh — which clears then repopulates the shared singleton map — cannot empty it
+    // mid-run and cause a missed hard-avoid.
+    const crossProviderSessionsByStudent = new Map(this.dataManager.getCrossProviderSessions());
     
     // Get bell schedules for all grades
     const bellSchedules: BellSchedule[] = [];

--- a/lib/scheduling/scheduling-data-manager.ts
+++ b/lib/scheduling/scheduling-data-manager.ts
@@ -16,6 +16,7 @@ import type {
   SchedulingConflict,
   SchedulingDataManagerInterface
 } from './types/scheduling-data';
+import type { OtherProviderSessionLite } from '@/lib/services/session-update-service';
 
 const DEFAULT_CONFIG: DataManagerConfig = {
   maxCacheAge: 15 * 60 * 1000, // 15 minutes
@@ -69,7 +70,12 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
   
   // Conflict tracking
   private conflicts: SchedulingConflict[] = [];
-  
+
+  // SPE-287: cross-provider template sessions per owned student (studentId -> the other
+  // provider's sessions for the SAME shared child), so the auto-scheduler can hard-avoid
+  // double-booking that child. Loaded once per context; only shared students appear.
+  private crossProviderSessions: Map<string, OtherProviderSessionLite[]> = new Map();
+
   private constructor(config?: DataManagerConfig) {
     this.config = { ...DEFAULT_CONFIG, ...config };
   }
@@ -137,7 +143,11 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
       } else {
         this.processBatchData(data);
       }
-      
+
+      // SPE-287: load cross-provider sessions regardless of which path above ran (the
+      // batch RPC does not include them). Best-effort — never blocks the main load.
+      await this.loadCrossProviderSessions();
+
       this.cacheMetadata.lastFetched = new Date();
       this.cacheMetadata.isStale = false;
       this.cacheMetadata.queryCount++;
@@ -390,7 +400,78 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
     console.log(`[DataManager] Fetched ${sessionsResult.data?.length || 0} sessions for ${studentIds.length} students at ${this.schoolSite}`);
     return sessionsResult.data || [];
   }
-  
+
+  /**
+   * SPE-287: the provider's own student ids at the current school (school_id when available,
+   * else legacy school_site/district). Scopes the batched cross-provider read.
+   */
+  private async fetchProviderStudentIds(): Promise<string[]> {
+    let studentQuery = this.supabase
+      .from('students')
+      .select('id')
+      .eq('provider_id', this.providerId!);
+
+    if (this.schoolId) {
+      studentQuery = studentQuery.eq('school_id', this.schoolId);
+    } else {
+      studentQuery = studentQuery
+        .eq('school_site', this.schoolSite!)
+        .eq('school_district', this.schoolDistrict!);
+    }
+
+    const { data, error } = await studentQuery;
+    if (error) {
+      this.cacheMetadata.fetchErrors.push(`Provider student ids: ${error.message}`);
+      return [];
+    }
+    return (data || []).map((s: { id: string }) => s.id);
+  }
+
+  /**
+   * SPE-287: load cross-provider template sessions for the provider's students at this
+   * school, so the auto-scheduler can hard-avoid double-booking a shared child across
+   * providers. ONE batched RPC (find_matching_provider_sessions_batch) reusing the SPE-290
+   * shared matcher — never a per-student call. Best-effort: on error the map stays empty
+   * (scheduler falls back to today's own-provider-only behavior) and the error is recorded.
+   */
+  private async loadCrossProviderSessions(): Promise<void> {
+    this.crossProviderSessions.clear();
+    try {
+      const studentIds = await this.fetchProviderStudentIds();
+      if (studentIds.length === 0) return;
+
+      const { data, error } = await this.supabase.rpc('find_matching_provider_sessions_batch', {
+        p_student_ids: studentIds,
+      });
+
+      if (error) {
+        this.cacheMetadata.fetchErrors.push(`Cross-provider sessions: ${error.message}`);
+        return;
+      }
+
+      (data || []).forEach((row: {
+        source_student_id: string;
+        day_of_week: number | null;
+        start_time: string | null;
+        end_time: string | null;
+        provider_role: string | null;
+      }) => {
+        const list = this.crossProviderSessions.get(row.source_student_id) ?? [];
+        list.push({
+          day_of_week: row.day_of_week,
+          start_time: row.start_time,
+          end_time: row.end_time,
+          provider_role: row.provider_role,
+        });
+        this.crossProviderSessions.set(row.source_student_id, list);
+      });
+
+      console.log(`[DataManager] Loaded cross-provider sessions for ${this.crossProviderSessions.size} shared students`);
+    } catch (e) {
+      this.cacheMetadata.fetchErrors.push(`Cross-provider sessions: ${e instanceof Error ? e.message : 'unknown error'}`);
+    }
+  }
+
   /**
    * Fetch school hours
    */
@@ -662,7 +743,16 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
     this.metrics.cacheHits++;
     return sessions;
   }
-  
+
+  /**
+   * SPE-287: cross-provider template sessions per owned student (studentId -> the other
+   * provider's sessions for the same shared child). Consumed by the auto-scheduler to
+   * hard-avoid double-booking. Only shared students have entries.
+   */
+  public getCrossProviderSessions(): Map<string, OtherProviderSessionLite[]> {
+    return this.crossProviderSessions;
+  }
+
   /**
    * Check if a time slot is available (respecting 8 concurrent session limit)
    */
@@ -756,7 +846,8 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
     this.data.data.specialActivities.clear();
     this.data.data.existingSessions.clear();
     this.data.data.schoolHours = [];
-    
+    this.crossProviderSessions.clear();
+
     this.cacheMetadata.isStale = true;
     this.conflicts = [];
     

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -4439,6 +4439,16 @@ export type Database = {
           start_time: string
         }[]
       }
+      find_matching_provider_sessions_batch: {
+        Args: { p_student_ids: string[] }
+        Returns: {
+          day_of_week: number
+          end_time: string
+          provider_role: string
+          source_student_id: string
+          start_time: string
+        }[]
+      }
       find_school_ids_by_names: {
         Args: {
           p_school_district_name: string

--- a/supabase/migrations/20260721_scheduler_batch_cross_provider_sessions.sql
+++ b/supabase/migrations/20260721_scheduler_batch_cross_provider_sessions.sql
@@ -44,8 +44,11 @@ BEGIN
   WHERE src.id = ANY(p_student_ids)
     AND src.provider_id = auth.uid()
     -- Template (unscheduled-date) sessions only, actually scheduled, not soft-deleted — same
-    -- session predicates as find_matching_provider_sessions (SPE-255/290).
+    -- session predicates as find_matching_provider_sessions (SPE-255/290). day_of_week is also
+    -- required non-null so results honor the RETURNS TABLE contract (day_of_week integer) and
+    -- only usable per-day conflicts come back (a slotless template can't block a specific day).
     AND ss.session_date IS NULL
+    AND ss.day_of_week IS NOT NULL
     AND ss.start_time IS NOT NULL
     AND ss.end_time IS NOT NULL
     AND ss.deleted_at IS NULL;

--- a/supabase/migrations/20260721_scheduler_batch_cross_provider_sessions.sql
+++ b/supabase/migrations/20260721_scheduler_batch_cross_provider_sessions.sql
@@ -1,0 +1,56 @@
+-- SPE-287: auto-scheduler cross-provider awareness (batched).
+--
+-- SPE-255 made the INTERACTIVE drag/drop placement warn (override-able) when a shared
+-- student would be double-booked with another provider, via find_matching_provider_sessions
+-- (per-student). The AUTO-scheduler (lib/scheduling/*) still finds free slots using only the
+-- current provider's own sessions, so it can still auto-place a shared student on top of
+-- another provider's session — a physical impossibility (one child, two rooms at once).
+--
+-- Owner decision (2026-07-21): the auto-scheduler should HARD-AVOID such slots (treat the
+-- other provider's session as blocked time), not place-and-flag — an unattended batch run
+-- should never knowingly create an impossible schedule. If no free slot remains, the student
+-- falls into the existing "needs manual placement" path, where the interactive override lives.
+--
+-- The scheduler processes many students per run, so a per-student RPC per placement attempt
+-- would be far too slow. This adds a BATCHED read: all cross-provider template sessions for a
+-- set of the caller's students in ONE call, loaded into the scheduling context once. It reuses
+-- the SPE-290 shared matcher (matching_provider_student_ids) so the grey bands, the interactive
+-- warning, and the auto-scheduler can never disagree on "same child". Privacy is preserved:
+-- like find_matching_provider_sessions, it returns only day/time/role — never the other
+-- provider's student name. Owner scoping is enforced twice: the explicit src.provider_id =
+-- auth.uid() filter, and the per-source owner check inside matching_provider_student_ids.
+
+CREATE OR REPLACE FUNCTION public.find_matching_provider_sessions_batch(p_student_ids uuid[])
+RETURNS TABLE(source_student_id uuid, day_of_week integer, start_time time without time zone, end_time time without time zone, provider_role text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'auth'
+AS $function$
+BEGIN
+  RETURN QUERY
+  SELECT
+    src.id AS source_student_id,
+    ss.day_of_week::INTEGER,
+    ss.start_time::TIME,
+    ss.end_time::TIME,
+    p.role AS provider_role
+  FROM students src
+  -- Only resolve matches for students the caller actually owns (defense in depth: the
+  -- LATERAL helper repeats this owner check per source student).
+  CROSS JOIN LATERAL public.matching_provider_student_ids(src.id) AS m(mid)
+  JOIN students s ON s.id = m.mid
+  JOIN profiles p ON p.id = s.provider_id
+  JOIN schedule_sessions ss ON ss.student_id = s.id
+  WHERE src.id = ANY(p_student_ids)
+    AND src.provider_id = auth.uid()
+    -- Template (unscheduled-date) sessions only, actually scheduled, not soft-deleted — same
+    -- session predicates as find_matching_provider_sessions (SPE-255/290).
+    AND ss.session_date IS NULL
+    AND ss.start_time IS NOT NULL
+    AND ss.end_time IS NOT NULL
+    AND ss.deleted_at IS NULL;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.find_matching_provider_sessions_batch(uuid[]) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.find_matching_provider_sessions_batch(uuid[]) TO authenticated, service_role;


### PR DESCRIPTION
## What & why

SPE-255 made the **interactive** drag/drop placement warn (override-able) when a shared student would be double-booked with another provider. But the **auto-scheduler** (`lib/scheduling/*`) still found free slots using only the current provider's own sessions — so an automatic run could place a shared child (e.g. RSP + Speech, the same kid on two caseloads) on top of another provider's session: a physical impossibility.

This finishes the SPE-255 slice by making the auto-scheduler cross-provider aware.

## The rule (owner decision 2026-07-21)

**Hard-avoid.** The auto-scheduler treats another provider's session as blocked time for that shared child and never places on top of it. An unattended batch run should not knowingly create an impossible schedule; if no free slot remains, the student falls into the existing manual-placement path, where the interactive override lives. (Chosen over place-and-flag.)

## How

- **New batched RPC** `find_matching_provider_sessions_batch(p_student_ids uuid[])` (`SECURITY DEFINER`) returns cross-provider template sessions for **all** of a provider's students in one call — the scheduler processes many students per run, so a per-student RPC per placement would be far too slow. It **reuses the SPE-290 shared matcher** (`matching_provider_student_ids`) so the grey bands, the interactive warning, and the auto-scheduler can never disagree on "same child". Owner-scoped twice (explicit `src.provider_id = auth.uid()` filter + the per-source owner check inside the helper). Returns only day/time/role — **never** the other provider's student name.
- **`SchedulingDataManager`** loads these once per context into a `studentId -> sessions` map (best-effort: on error the map stays empty and the scheduler falls back to today's own-provider-only behavior).
- **`OptimizedScheduler`** hard-avoids any slot overlapping a shared student's cross-provider session, in **both** distribution passes, reusing the pure `findOverlappingOtherProviderSession` helper for identical half-open overlap semantics.

**Scope:** auto-scheduler only. Manual placement keeps the human-in-the-loop interactive override unchanged.

## Verification

- **Batched RPC, end-to-end under real provider auth** (signed-in client, `auth.uid()` populated): the two shared students resolve to exactly the other provider's Speech sessions; the owner check correctly returns nothing for a student the caller doesn't own; every returned `source_student_id` is owned by the caller.
- **Unit tests** for the hard-avoid decision (`hasCrossProviderConflict`): overlap → avoid, adjacent (half-open) → allow, different day → allow, unknown/empty student → no conflict, multi-session overlap detected. Existing SPE-255 overlap tests still green.
- **Composition proof of the hard-avoid:** the batched RPC returns the shared student's blocking slots (Mon 08:45–09:15, Wed 09:30–10:00); the unit-tested decision marks exactly those slots blocked.
- Typecheck, lint, existing tests green. Migration filename sorts **after** `20260721_prefer_full_name_cross_provider_matching.sql` so the shared matcher it depends on exists first on a fresh replay.
- **Not covered:** a full click-through auto-schedule sim walk — the sim's shared students are already fully scheduled, so there's no empty slot to watch the scheduler avoid without fixture changes. The evidence chain above (proven RPC data × unit-tested decision × reviewed wiring) substitutes.

Closes SPE-287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYEo9UCTeTRCo8rSCjRw6m

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYEo9UCTeTRCo8rSCjRw6m)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduling now prevents double-booking shared students across providers.
  * Cross-provider template sessions are automatically considered when selecting available time slots.
  * Overlapping sessions are blocked, while adjacent sessions remain available.
* **Bug Fixes**
  * Improved conflict detection across multiple sessions and providers.
  * Scheduling continues gracefully if cross-provider session data cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->