### PR TITLE
SPE-303: accept the SEIS "IEP Dates" report as a 4th import file type

### DIFF
--- a/__tests__/unit/lib/import/classify.test.ts
+++ b/__tests__/unit/lib/import/classify.test.ts
@@ -27,6 +27,7 @@ import type { ParsedStudent as SeisParsedStudent } from '@/lib/parsers/seis-pars
 import type { ParsedStudent as CsvParsedStudent } from '@/lib/parsers/csv-parser';
 import type { DeliveryRecord } from '@/lib/parsers/deliveries-parser';
 import type { ClassListStudent } from '@/lib/parsers/class-list-parser';
+import type { IepDatesRecord } from '@/lib/parsers/iep-dates-parser';
 import type { DbTeacherRow, JoinedExistingStudent } from '@/lib/import/preview-types';
 
 // ---- factories ----
@@ -48,6 +49,12 @@ const classListStudent = (over: Partial<ClassListStudent> = {}): ClassListStuden
   normalizedName: 'doe_john', name: 'Doe, John',
   teacher: { rawName: 'Barrera E', lastName: 'Barrera', firstInitial: 'E', teacherNumber: '' },
   ...over,
+});
+
+const iepDates = (over: Partial<IepDatesRecord> = {}): IepDatesRecord => ({
+  normalizedName: 'doe_john', firstName: 'John', lastName: 'Doe', gradeLevel: '3',
+  schoolOfAttendance: 'Maple Elementary',
+  upcomingIepDate: '2026-09-01', upcomingTriennialDate: '2027-05-12', ...over,
 });
 
 const TEACHERS: DbTeacherRow[] = [{ id: 't-barrera', first_name: 'Elena', last_name: 'Barrera' }];
@@ -254,6 +261,63 @@ describe('buildStudentPreviews (main path)', () => {
     });
     expect(studentPreviews[0].action).toBe('skip'); // no teacher name to resolve + goals match = no change
   });
+
+  // SPE-303: the IEP Dates report fills the two compliance dates on a matched student.
+  it('marks a matched student as update when an IEP date differs from what is stored (file wins)', () => {
+    const { studentPreviews, matchedIepDatesNames } = buildStudentPreviews({
+      parsedStudents: [parsed({ goals: ['G'] })],
+      databaseStudents: [dbStudent({ iep_goals: ['G'], upcoming_iep_date: '2026-01-01', upcoming_triennial_date: '2027-05-12' })],
+      deliveriesData: null, classListData: null,
+      iepDatesData: new Map([['doe_john', iepDates({ upcomingIepDate: '2026-09-01', upcomingTriennialDate: '2027-05-12' })]]),
+      dbTeachers: [],
+    });
+    expect(matchedIepDatesNames.has('doe_john')).toBe(true);
+    const p = studentPreviews[0];
+    expect(p.action).toBe('update');
+    // Only the changed date is flagged as changed; the unchanged one carries with changed=false.
+    expect(p.iepDates?.upcomingIepDate).toEqual({ value: '2026-09-01', old: '2026-01-01', changed: true });
+    expect(p.iepDates?.upcomingTriennialDate).toEqual({ value: '2027-05-12', old: '2027-05-12', changed: false });
+  });
+
+  it('marks a matched student as skip when the IEP dates already match what is stored', () => {
+    const { studentPreviews } = buildStudentPreviews({
+      parsedStudents: [parsed({ goals: ['G'] })],
+      databaseStudents: [dbStudent({ iep_goals: ['G'], upcoming_iep_date: '2026-09-01', upcoming_triennial_date: '2027-05-12' })],
+      deliveriesData: null, classListData: null,
+      iepDatesData: new Map([['doe_john', iepDates()]]),
+      dbTeachers: [],
+    });
+    const p = studentPreviews[0];
+    expect(p.action).toBe('skip'); // no phantom update
+    expect(p.iepDates?.upcomingIepDate?.changed).toBe(false);
+  });
+
+  it('carries IEP dates onto a NEW student (insert) matched by the file, with a null old', () => {
+    const { studentPreviews } = buildStudentPreviews({
+      parsedStudents: [parsed({ goals: ['G'] })],
+      databaseStudents: [], // no match → insert
+      deliveriesData: null, classListData: null,
+      iepDatesData: new Map([['doe_john', iepDates()]]),
+      dbTeachers: [],
+    });
+    const p = studentPreviews[0];
+    expect(p.action).toBe('insert');
+    expect(p.iepDates?.upcomingIepDate).toEqual({ value: '2026-09-01', old: null, changed: true });
+  });
+
+  it('treats a present-only triennial as a change without touching the (absent) IEP review date', () => {
+    const { studentPreviews } = buildStudentPreviews({
+      parsedStudents: [parsed({ goals: ['G'] })],
+      databaseStudents: [dbStudent({ iep_goals: ['G'], upcoming_iep_date: '2026-09-01', upcoming_triennial_date: null })],
+      deliveriesData: null, classListData: null,
+      iepDatesData: new Map([['doe_john', iepDates({ upcomingIepDate: undefined, upcomingTriennialDate: '2027-05-12' })]]),
+      dbTeachers: [],
+    });
+    const p = studentPreviews[0];
+    expect(p.action).toBe('update');
+    expect(p.iepDates?.upcomingIepDate).toBeUndefined(); // file had no review date
+    expect(p.iepDates?.upcomingTriennialDate).toEqual({ value: '2027-05-12', old: null, changed: true });
+  });
 });
 
 describe('buildUpdatePreviews (deliveries/class-list update-only path)', () => {
@@ -317,6 +381,64 @@ describe('buildUpdatePreviews (deliveries/class-list update-only path)', () => {
     });
     expect(studentUpdates).toHaveLength(0);
     expect(unmatchedStudents).toEqual([{ name: 'Here, Nobody', source: 'deliveries' }]);
+  });
+
+  // SPE-303: dropping ONLY the IEP Dates file refreshes dates for the caseload.
+  const studentsByNameWithDates = (iep: string | null, tri: string | null) =>
+    buildStudentsByName([
+      {
+        id: 's1', initials: 'JD', grade_level: '3', school_site: null, school_id: 'sch1',
+        student_details: { first_name: 'John', last_name: 'Doe', upcoming_iep_date: iep, upcoming_triennial_date: tri },
+      } as unknown as JoinedExistingStudent,
+    ]);
+
+  it('updates an existing student when an IEP date differs (file wins) and carries old → new', () => {
+    const { studentUpdates, matchedIepDatesNames } = buildUpdatePreviews({
+      studentsByName: studentsByNameWithDates('2026-01-01', '2027-05-12'),
+      deliveriesData: null, classListData: null,
+      iepDatesData: new Map([['doe_john', iepDates({ upcomingIepDate: '2026-09-01', upcomingTriennialDate: '2027-05-12' })]]),
+      dbTeachers: [],
+    });
+    expect(matchedIepDatesNames.has('doe_john')).toBe(true);
+    expect(studentUpdates).toHaveLength(1);
+    expect(studentUpdates[0].action).toBe('update');
+    expect(studentUpdates[0].iepDates?.upcomingIepDate).toEqual({ value: '2026-09-01', old: '2026-01-01', changed: true });
+  });
+
+  it('marks an IEP-dates-only match as skip when the dates already match (no phantom update)', () => {
+    const { studentUpdates } = buildUpdatePreviews({
+      studentsByName: studentsByNameWithDates('2026-09-01', '2027-05-12'),
+      deliveriesData: null, classListData: null,
+      iepDatesData: new Map([['doe_john', iepDates()]]),
+      dbTeachers: [],
+    });
+    expect(studentUpdates).toHaveLength(1);
+    expect(studentUpdates[0].action).toBe('skip');
+  });
+
+  it('collects an IEP-dates row with no existing student as unmatched (source iepDates)', () => {
+    const { studentUpdates, unmatchedStudents } = buildUpdatePreviews({
+      studentsByName: studentsByNameWithDates(null, null),
+      deliveriesData: null, classListData: null,
+      iepDatesData: new Map([['nobody_here', iepDates({ normalizedName: 'nobody_here', firstName: 'Nobody', lastName: 'Here' })]]),
+      dbTeachers: [],
+    });
+    expect(studentUpdates).toHaveLength(0);
+    expect(unmatchedStudents).toEqual([{ name: 'Nobody Here', source: 'iepDates' }]);
+  });
+
+  it('merges IEP dates onto a delivery update row (dedup by studentId)', () => {
+    const { studentUpdates } = buildUpdatePreviews({
+      studentsByName: studentsByNameWithDates(null, null),
+      deliveriesData: new Map([['doe_john', delivery()]]),
+      classListData: null,
+      iepDatesData: new Map([['doe_john', iepDates()]]),
+      dbTeachers: [],
+    });
+    expect(studentUpdates).toHaveLength(1);
+    expect(studentUpdates[0].action).toBe('update');
+    expect(studentUpdates[0].schedule).toBeDefined();
+    expect(studentUpdates[0].iepDates?.upcomingIepDate?.value).toBe('2026-09-01');
   });
 });
 

--- a/__tests__/unit/lib/import/collect-unmatched.test.ts
+++ b/__tests__/unit/lib/import/collect-unmatched.test.ts
@@ -12,9 +12,12 @@
 import { collectUnmatched } from '@/lib/import/respond';
 import type { DeliveryRecord } from '@/lib/parsers/deliveries-parser';
 import type { ClassListStudent } from '@/lib/parsers/class-list-parser';
+import type { IepDatesRecord } from '@/lib/parsers/iep-dates-parser';
 
 const delivery = (name: string) => ({ name }) as unknown as DeliveryRecord;
 const classListStudent = (name: string) => ({ name }) as unknown as ClassListStudent;
+const iepRecord = (firstName: string, lastName: string) =>
+  ({ firstName, lastName }) as unknown as IepDatesRecord;
 
 describe('collectUnmatched — school-filter suppression (SPE-268)', () => {
   it('suppresses a filtered-out (other-school) delivery but keeps genuinely-unknown ones', () => {
@@ -49,5 +52,22 @@ describe('collectUnmatched — school-filter suppression (SPE-268)', () => {
     ]);
     const result = collectUnmatched(deliveries, null, new Set(), new Set());
     expect(result.map(r => r.name).sort()).toEqual(['Bishop, Ben', 'Unknown, Uma']);
+  });
+
+  it('collects unmatched IEP-dates rows under source iepDates (SPE-303)', () => {
+    const iepDates = new Map<string, IepDatesRecord>([
+      ['ana-alvarez', iepRecord('Ana', 'Alvarez')], // matched — never unmatched
+      ['uma-unknown', iepRecord('Uma', 'Unknown')], // genuinely unknown → keep
+    ]);
+    const result = collectUnmatched(
+      null,
+      null,
+      new Set(),
+      new Set(),
+      undefined,
+      iepDates,
+      new Set(['ana-alvarez']), // matched IEP-dates names
+    );
+    expect(result).toEqual([{ name: 'Uma Unknown', source: 'iepDates' }]);
   });
 });

--- a/__tests__/unit/lib/import/detect-import-file.test.ts
+++ b/__tests__/unit/lib/import/detect-import-file.test.ts
@@ -18,6 +18,8 @@ const DELIVERIES_HEADER =
 const ROSTER_HEADER = 'Initials,Grade,Teacher,Sessions Per Week,Minutes Per Session';
 const SEIS_GOALS_HEADER =
   'SEIS ID,District ID,Last Name,First Name,Birthdate,Grade,School of Attendance,District of Service,Case Manager,IEP Date';
+const IEP_DATES_HEADER =
+  'SEIS ID,SSID,Last Name,First Name,Student Middle Name,Preferred Name,Date of Birth,District of Service,District of SPED Accountability,School of Attendance,Grade Level,Case Manager,Disability 1,Date of Next Annual Plan Review,Date of Next Reevaluation,Date of IEP (Meeting Date on Future IEP forms),Meeting Type';
 const GENERIC_HEADER = 'Student ID,First Name,Last Name,Grade,Goal';
 
 describe('fileExtension', () => {
@@ -47,6 +49,18 @@ describe('classifyImportFile', () => {
   });
 
   it('routes a SEIS Student Goals CSV to seis-report', () => {
+    expect(classifyImportFile('StudentGoals.csv', SEIS_GOALS_HEADER)).toBe('seis-report');
+  });
+
+  it('routes a SEIS IEP Dates CSV by its compliance-date columns (SPE-303)', () => {
+    expect(classifyImportFile('IEPDates.csv', IEP_DATES_HEADER)).toBe('iep-dates');
+    // Either column alone is sufficient.
+    expect(classifyImportFile('x.csv', 'First Name,Last Name,Date of Next Annual Plan Review')).toBe('iep-dates');
+    expect(classifyImportFile('x.csv', 'First Name,Last Name,Date of Next Reevaluation')).toBe('iep-dates');
+  });
+
+  it('does not misroute the goals report (with an "IEP Date" column) as iep-dates', () => {
+    // The goals report has "IEP Date" but not the "Date of Next ..." columns.
     expect(classifyImportFile('StudentGoals.csv', SEIS_GOALS_HEADER)).toBe('seis-report');
   });
 
@@ -83,6 +97,10 @@ describe('IMPORT_TYPE_META form keys', () => {
   it('maps the roster template to the students file (SPE-225); only unknown has no key', () => {
     expect(IMPORT_TYPE_META['roster-template'].formKey).toBe('studentsFile');
     expect(IMPORT_TYPE_META.unknown.formKey).toBeNull();
+  });
+
+  it('maps IEP dates to its own form key (SPE-303)', () => {
+    expect(IMPORT_TYPE_META['iep-dates'].formKey).toBe('iepDatesFile');
   });
 });
 

--- a/__tests__/unit/lib/import/review-model.test.ts
+++ b/__tests__/unit/lib/import/review-model.test.ts
@@ -133,6 +133,42 @@ describe('adaptBulkPreview (SPE-227)', () => {
     expect(model.files).toEqual([]); // no files field on the payload → empty receipts
   });
 
+  it('carries IEP dates onto the row and derives the IEP dates receipt (SPE-303)', () => {
+    const data: BulkPreviewData = {
+      mode: 'update',
+      students: [
+        {
+          firstName: 'Ivy',
+          lastName: 'Ng',
+          initials: 'IN',
+          gradeLevel: '3',
+          action: 'update',
+          studentId: 'stu-11',
+          iepDates: {
+            upcomingIepDate: { value: '2026-09-01', old: '2026-01-01', changed: true },
+            upcomingTriennialDate: { value: '2027-05-12', old: '2027-05-12', changed: false },
+          },
+        },
+      ],
+      summary: { total: 1, inserts: 0, updates: 1, skips: 0 },
+      files: [{ fileKey: 'iepDatesFile', fileName: 'IEPDates.csv', read: 1, matched: 1, filtered: 0 }],
+      unmatchedStudents: [{ name: 'Other Kid', source: 'iepDates' }],
+    };
+
+    const model = adaptBulkPreview(data);
+    const row = model.rows[0];
+    expect(row.iepDates?.upcomingIepDate).toEqual({ value: '2026-09-01', old: '2026-01-01', changed: true });
+    expect(row.iepDates?.upcomingTriennialDate?.changed).toBe(false);
+    // Receipt label/fills derive from the iepDatesFile key.
+    expect(model.files[0]).toMatchObject({ label: 'IEP dates', fills: 'review & triennial dates' });
+    // Unmatched IEP-dates row surfaces as an exception under its own source.
+    expect(model.exceptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'unmatched-student', name: 'Other Kid', source: 'iepDates' }),
+      ]),
+    );
+  });
+
   it('counts inserts/updates/skips and totals goals over selectable rows only', () => {
     const data: BulkPreviewData = {
       students: [

--- a/__tests__/unit/lib/import/scope-iep-dates.test.ts
+++ b/__tests__/unit/lib/import/scope-iep-dates.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for the SPE-303 IEP Dates pipeline seams surfaced by PR review:
+ *   - scopeIepDatesToSchool: school scoping runs BEFORE name-dedup, so a
+ *     same-name student at another school can't shadow the current-school one;
+ *     a genuine same-school collision is flagged, not silently dropped.
+ *   - parseIepDatesFile: a wrong-shape / empty file propagates as a throw (which
+ *     the pipeline turns into a 400 or a warning) instead of a silent empty parse.
+ * All data is fictional.
+ */
+import { parseIepDatesFile, scopeIepDatesToSchool } from '@/lib/import/parse-files';
+import type { IepDatesRecord } from '@/lib/parsers/iep-dates-parser';
+import { createNormalizedKey } from '@/lib/parsers/name-utils';
+
+const HEADER =
+  'First Name,Last Name,School of Attendance,Grade Level,Date of Next Annual Plan Review,Date of Next Reevaluation';
+
+const rec = (
+  first: string,
+  last: string,
+  school: string,
+  iep?: string,
+): IepDatesRecord => ({
+  normalizedName: createNormalizedKey(first, last),
+  firstName: first,
+  lastName: last,
+  gradeLevel: '3',
+  schoolOfAttendance: school,
+  upcomingIepDate: iep,
+  upcomingTriennialDate: undefined,
+});
+
+describe('scopeIepDatesToSchool', () => {
+  it('keeps the CURRENT-school student when a same-name student exists at another school', () => {
+    // Other-school row first (would have won a parser-level first-wins dedup),
+    // then the current-school row. Scoping-before-dedup must keep the latter.
+    const records = [
+      rec('John', 'Smith', 'Birch Elementary', '2027-01-01'),
+      rec('John', 'Smith', 'Willow Elementary', '2027-09-01'),
+    ];
+    const { records: map } = scopeIepDatesToSchool(records, 'Willow Elementary', true);
+    expect(map.size).toBe(1);
+    expect(map.get(createNormalizedKey('John', 'Smith'))?.upcomingIepDate).toBe('2027-09-01');
+    expect(map.get(createNormalizedKey('John', 'Smith'))?.schoolOfAttendance).toBe('Willow Elementary');
+  });
+
+  it('flags a genuine same-school duplicate (first-wins) instead of dropping silently', () => {
+    const records = [
+      rec('Jane', 'Doe', 'Willow Elementary', '2027-01-01'),
+      rec('Jane', 'Doe', 'Willow Elementary', '2027-02-02'),
+    ];
+    const { records: map, warnings } = scopeIepDatesToSchool(records, 'Willow Elementary', true);
+    expect(map.size).toBe(1);
+    expect(map.get(createNormalizedKey('Jane', 'Doe'))?.upcomingIepDate).toBe('2027-01-01'); // first-wins
+    expect(warnings.some((w) => /duplicate student/i.test(w.message))).toBe(true);
+  });
+
+  it('does not school-filter for a single-school provider (keeps all, deduped by name)', () => {
+    const records = [rec('Ann', 'Lee', 'Somewhere Else', '2027-03-03')];
+    const { records: map } = scopeIepDatesToSchool(records, 'Willow Elementary', false);
+    expect(map.size).toBe(1);
+    expect(map.get(createNormalizedKey('Ann', 'Lee'))?.upcomingIepDate).toBe('2027-03-03');
+  });
+
+  it('keeps a blank-school row (assigned to the current school)', () => {
+    const records = [rec('Sam', 'Ray', '', '2027-04-04')];
+    const { records: map } = scopeIepDatesToSchool(records, 'Willow Elementary', true);
+    expect(map.get(createNormalizedKey('Sam', 'Ray'))?.upcomingIepDate).toBe('2027-04-04');
+  });
+});
+
+describe('parseIepDatesFile', () => {
+  // jsdom's File doesn't implement arrayBuffer(); the Node API runtime (where this
+  // actually runs) does. Stub just the method parseIepDatesFile calls.
+  const file = (content: string) =>
+    ({ arrayBuffer: async () => new TextEncoder().encode(content).buffer } as unknown as File);
+
+  it('throws on a wrong-shape file (missing the compliance-date columns)', async () => {
+    await expect(parseIepDatesFile(file('First Name,Last Name,Grade\nJohn,Doe,3'))).rejects.toThrow(
+      /date of next/i,
+    );
+  });
+
+  it('throws on a file missing the name columns', async () => {
+    await expect(
+      parseIepDatesFile(file('Date of Next Annual Plan Review,Date of Next Reevaluation\n09/01/2026,05/12/2027')),
+    ).rejects.toThrow(/first name \/ last name/i);
+  });
+
+  it('throws on an empty file', async () => {
+    await expect(parseIepDatesFile(file(''))).rejects.toThrow(/empty/i);
+  });
+
+  it('returns an array of rows for a valid file', async () => {
+    const { records, read } = await parseIepDatesFile(
+      file(`${HEADER}\nJohn,Doe,Willow Elementary,3,09/01/2026,05/12/2027`),
+    );
+    expect(Array.isArray(records)).toBe(true);
+    expect(records).toHaveLength(1);
+    expect(read).toBe(1);
+    expect(records[0].upcomingIepDate).toBe('2026-09-01');
+  });
+});

--- a/__tests__/unit/lib/import/student-import-contract.test.ts
+++ b/__tests__/unit/lib/import/student-import-contract.test.ts
@@ -96,4 +96,40 @@ describe('student-import shared contract (SPE-236)', () => {
     expect(row.action).toBe('insert');
     expect(row.goals).toEqual(['Read 90 wpm']);
   });
+
+  it('pins the IEP Dates wire + confirm fields (SPE-303)', () => {
+    const payload = {
+      students: [
+        {
+          firstName: 'Ivy',
+          lastName: 'Ng',
+          initials: 'IN',
+          gradeLevel: '3',
+          action: 'update',
+          studentId: 'stu-1',
+          iepDates: {
+            upcomingIepDate: { value: '2026-09-01', old: '2026-01-01', changed: true },
+            upcomingTriennialDate: { value: '2027-05-12', old: null, changed: true },
+          },
+        },
+      ],
+      summary: { total: 1, updates: 1 },
+    } satisfies BulkPreviewData;
+
+    const model = adaptBulkPreview(payload);
+    expect(model.rows[0].iepDates?.upcomingIepDate?.value).toBe('2026-09-01');
+
+    const confirmRow = {
+      firstName: 'Ivy',
+      lastName: 'Ng',
+      initials: 'IN',
+      gradeLevel: '3',
+      goals: [],
+      action: 'update',
+      studentId: 'stu-1',
+      upcomingIepDate: '2026-09-01',
+      upcomingTriennialDate: '2027-05-12',
+    } satisfies StudentToImport;
+    expect(confirmRow.upcomingIepDate).toBe('2026-09-01');
+  });
 });

--- a/__tests__/unit/lib/parsers/fixtures/README.md
+++ b/__tests__/unit/lib/parsers/fixtures/README.md
@@ -1,8 +1,8 @@
 # Parser golden fixtures (SPE-239)
 
-Fictional data mirroring the *shape* of the three verified real exports (SEIS
-Student Goals Report, SEIS Deliveries, Aeries Class List) plus a roster
-template and encoding/messy-value edge cases.
+Fictional data mirroring the *shape* of the verified real exports (SEIS
+Student Goals Report, SEIS Deliveries, Aeries Class List, SEIS IEP Dates report)
+plus a roster template and encoding/messy-value edge cases.
 
 **No real student data lives here.** Every name, SEIS ID, birthdate, school,
 and goal is invented. Real exports contain student PII (names, birthdates, SEIS
@@ -14,6 +14,7 @@ IDs) and must never enter the repo, tests, or tickets.
 | --- | --- | --- |
 | `deliveries.csv` | `parseDeliveriesCSV` | 11-column deliveries layout; all frequency shapes; 330/415/450/510/900 codes; most-recent-start dedup; two-word / hyphenated names |
 | `class-list.txt` | `parseClassListTXT` | Two-page Aeries export; banners; every teacher-header format; co-teacher; quoted comma-names; cross-page dedup |
+| `iep-dates.csv` | `parseIepDatesCSV` | SEIS "IEP Dates" report (SPE-303); 17-column layout; both dates, one-date-only, an invalid date, an other-school/other-case-manager row |
 | `roster-template.csv` | `parseCSVReport` (generic) | The current Students template; pins that it fails detection today (SPE-225 target) |
 | `messy-values.csv` | `parseCSVReport` (generic) | Spelled-out / zero-padded / out-of-range grades; leading-space name |
 | `builders.ts` | all | Byte-precise fixtures generated in code: the 59-column SEIS Goals CSV (+ BOM and column-shifted variants), the Windows-1252 buffer, and the SEIS XLSX workbooks |

--- a/__tests__/unit/lib/parsers/fixtures/iep-dates.csv
+++ b/__tests__/unit/lib/parsers/fixtures/iep-dates.csv
@@ -1,0 +1,6 @@
+SEIS ID,SSID,Last Name,First Name,Student Middle Name,Preferred Name,Date of Birth,District of Service,District of SPED Accountability,School of Attendance,Grade Level,Case Manager,Disability 1,Date of Next Annual Plan Review,Date of Next Reevaluation,Date of IEP (Meeting Date on Future IEP forms),Meeting Type
+3100001,9000000001,Doe,John,Q,Johnny,01/05/2016,Maple USD,Maple USD,Maple Elementary,3,"Ramos, Elena",SLD,09/01/2026,05/12/2027,09/01/2025,20|
+3100002,9000000002,Smith,Jane,,,03/22/2015,Maple USD,Maple USD,Maple Elementary,4,"Ramos, Elena",OHI,10/15/2026,04/30/2028,10/15/2025,20|
+3100003,9000000003,Garcia,Maria,Luz,,07/09/2017,Maple USD,Maple USD,Maple Elementary,2,"Ramos, Elena",SLI,11/03/2026,,11/03/2025,10|
+3100004,9000000004,Brown,Bob,,Bobby,12/01/2014,Maple USD,Maple USD,Maple Elementary,5,"Ramos, Elena",SLD,13/45/2026,06/20/2027,08/15/2025,20|
+3100005,9000000005,Nguyen,Kim,,,05/18/2016,Maple USD,Maple USD,Birch Elementary,3,"Okafor, Dele",SLD,02/10/2027,03/15/2028,02/10/2026,20|

--- a/__tests__/unit/lib/parsers/iep-dates-parser.test.ts
+++ b/__tests__/unit/lib/parsers/iep-dates-parser.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for the SEIS "IEP Dates" report parser (SPE-303).
+ *
+ * Pins: header-based column lookup (order-independent), MM/DD/YYYY → ISO date
+ * parsing for both compliance dates, per-row warnings on an unparseable date,
+ * BOM + latin1 tolerance, duplicate-name / no-name handling, and the golden
+ * fixture shape. All data is fictional.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { parseIepDatesCSV } from '@/lib/parsers/iep-dates-parser';
+import { createNormalizedKey } from '@/lib/parsers/name-utils';
+
+const HEADER =
+  'SEIS ID,SSID,Last Name,First Name,Student Middle Name,Preferred Name,Date of Birth,District of Service,District of SPED Accountability,School of Attendance,Grade Level,Case Manager,Disability 1,Date of Next Annual Plan Review,Date of Next Reevaluation,Date of IEP (Meeting Date on Future IEP forms),Meeting Type';
+
+const buf = (csv: string) => Buffer.from(csv, 'utf-8');
+
+describe('parseIepDatesCSV', () => {
+  it('maps both compliance dates to ISO, keyed by normalized full name', async () => {
+    const csv = `${HEADER}\n1,2,Doe,John,,,01/05/2016,D,D,Maple Elementary,3,CM,SLD,09/01/2026,05/12/2027,09/01/2025,20|`;
+    const { records } = await parseIepDatesCSV(buf(csv));
+
+    const rec = records.get(createNormalizedKey('John', 'Doe'));
+    expect(rec).toBeDefined();
+    expect(rec!.upcomingIepDate).toBe('2026-09-01');
+    expect(rec!.upcomingTriennialDate).toBe('2027-05-12');
+    expect(rec!.firstName).toBe('John');
+    expect(rec!.lastName).toBe('Doe');
+    expect(rec!.gradeLevel).toBe('3');
+    expect(rec!.schoolOfAttendance).toBe('Maple Elementary');
+  });
+
+  it('is order-independent — locates columns by header, not position', async () => {
+    // Reversed column order; only the two dates + names present.
+    const csv =
+      'Date of Next Reevaluation,First Name,Last Name,Date of Next Annual Plan Review\n' +
+      '05/12/2027,John,Doe,09/01/2026';
+    const { records } = await parseIepDatesCSV(buf(csv));
+    const rec = records.get(createNormalizedKey('John', 'Doe'));
+    expect(rec!.upcomingIepDate).toBe('2026-09-01');
+    expect(rec!.upcomingTriennialDate).toBe('2027-05-12');
+  });
+
+  it('leaves a blank date undefined (present-only), without a warning', async () => {
+    const csv = `${HEADER}\n1,2,Garcia,Maria,,,,D,D,Maple Elementary,2,CM,SLI,11/03/2026,,11/03/2025,10|`;
+    const { records, warnings } = await parseIepDatesCSV(buf(csv));
+    const rec = records.get(createNormalizedKey('Maria', 'Garcia'));
+    expect(rec!.upcomingIepDate).toBe('2026-11-03');
+    expect(rec!.upcomingTriennialDate).toBeUndefined();
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('warns on a present-but-unparseable date and drops just that field', async () => {
+    const csv = `${HEADER}\n1,2,Brown,Bob,,,,D,D,Maple Elementary,5,CM,SLD,13/45/2026,06/20/2027,08/15/2025,20|`;
+    const { records, warnings } = await parseIepDatesCSV(buf(csv));
+    const rec = records.get(createNormalizedKey('Bob', 'Brown'));
+    expect(rec!.upcomingIepDate).toBeUndefined(); // 13/45/2026 is invalid
+    expect(rec!.upcomingTriennialDate).toBe('2027-06-20'); // the valid one is kept
+    expect(warnings.some((w) => /invalid iep review date/i.test(w.message))).toBe(true);
+  });
+
+  it('skips a row with no name and warns', async () => {
+    const csv = `${HEADER}\n1,2,,,,,,D,D,Maple Elementary,3,CM,SLD,09/01/2026,05/12/2027,09/01/2025,20|`;
+    const { records, warnings } = await parseIepDatesCSV(buf(csv));
+    expect(records.size).toBe(0);
+    expect(warnings.some((w) => /no student name/i.test(w.message))).toBe(true);
+  });
+
+  it('keeps the first row on a duplicate normalized name and warns', async () => {
+    const csv =
+      `${HEADER}\n` +
+      '1,2,Doe,John,,,,D,D,Maple Elementary,3,CM,SLD,09/01/2026,05/12/2027,09/01/2025,20|\n' +
+      '2,3,Doe,John,,,,D,D,Maple Elementary,3,CM,SLD,01/01/2030,01/01/2031,01/01/2029,20|';
+    const { records, warnings } = await parseIepDatesCSV(buf(csv));
+    expect(records.size).toBe(1);
+    expect(records.get(createNormalizedKey('John', 'Doe'))!.upcomingIepDate).toBe('2026-09-01');
+    expect(warnings.some((w) => /duplicate student/i.test(w.message))).toBe(true);
+  });
+
+  it('tolerates a UTF-8 BOM and quoted header cells (as SEIS exports ship)', async () => {
+    const csv =
+      '﻿"First Name","Last Name","Date of Next Annual Plan Review","Date of Next Reevaluation"\n' +
+      '"John","Doe","09/01/2026","05/12/2027"';
+    const { records } = await parseIepDatesCSV(buf(csv));
+    expect(records.get(createNormalizedKey('John', 'Doe'))!.upcomingIepDate).toBe('2026-09-01');
+  });
+
+  it('decodes a latin1 / Windows-1252 name (byte 0xF1 → ñ)', async () => {
+    // "Muñoz" with the ñ as a single latin1 byte 0xF1 (not valid UTF-8).
+    const header = Buffer.from(
+      'First Name,Last Name,Date of Next Annual Plan Review,Date of Next Reevaluation\n',
+      'utf-8',
+    );
+    const row = Buffer.from([
+      ...Buffer.from('Ana,Mu', 'latin1'),
+      0xf1,
+      ...Buffer.from('oz,09/01/2026,05/12/2027', 'latin1'),
+    ]);
+    const { records } = await parseIepDatesCSV(Buffer.concat([header, row]));
+    const rec = records.get(createNormalizedKey('Ana', 'Muñoz'));
+    expect(rec).toBeDefined();
+    expect(rec!.upcomingIepDate).toBe('2026-09-01');
+  });
+
+  it('errors when neither compliance-date column is present', async () => {
+    const csv = 'First Name,Last Name,Grade Level\nJohn,Doe,3';
+    const { records, errors } = await parseIepDatesCSV(buf(csv));
+    expect(records.size).toBe(0);
+    expect(errors.some((e) => /date of next/i.test(e.message))).toBe(true);
+  });
+
+  it('parses the golden fixture: dates, one-date-only, invalid date, other-school row', async () => {
+    const csv = readFileSync(
+      join(__dirname, 'fixtures', 'iep-dates.csv'),
+    );
+    const { records, warnings, metadata } = await parseIepDatesCSV(csv);
+
+    // 5 students read; every name keyed.
+    expect(metadata.uniqueStudents).toBe(5);
+    expect(records.get(createNormalizedKey('John', 'Doe'))!.upcomingIepDate).toBe('2026-09-01');
+    expect(records.get(createNormalizedKey('Maria', 'Garcia'))!.upcomingTriennialDate).toBeUndefined();
+    // Bob Brown's IEP review date is invalid (13/45/2026) → warned + dropped.
+    expect(records.get(createNormalizedKey('Bob', 'Brown'))!.upcomingIepDate).toBeUndefined();
+    expect(warnings.some((w) => /invalid iep review date/i.test(w.message))).toBe(true);
+    // The other-school student is still parsed here; school scoping happens in the pipeline.
+    expect(records.get(createNormalizedKey('Kim', 'Nguyen'))!.schoolOfAttendance).toBe('Birch Elementary');
+  });
+});

--- a/__tests__/unit/lib/parsers/iep-dates-parser.test.ts
+++ b/__tests__/unit/lib/parsers/iep-dates-parser.test.ts
@@ -3,26 +3,29 @@
  *
  * Pins: header-based column lookup (order-independent), MM/DD/YYYY → ISO date
  * parsing for both compliance dates, per-row warnings on an unparseable date,
- * BOM + latin1 tolerance, duplicate-name / no-name handling, and the golden
- * fixture shape. All data is fictional.
+ * BOM + latin1 tolerance, and the golden fixture shape. The parser deliberately
+ * returns ALL named rows (no name-dedup) — collision handling is deferred to the
+ * pipeline's school-scoped dedup (see scope-iep-dates.test.ts). All data is fictional.
  */
 
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { parseIepDatesCSV } from '@/lib/parsers/iep-dates-parser';
+import { parseIepDatesCSV, IepDatesRecord } from '@/lib/parsers/iep-dates-parser';
 import { createNormalizedKey } from '@/lib/parsers/name-utils';
 
 const HEADER =
   'SEIS ID,SSID,Last Name,First Name,Student Middle Name,Preferred Name,Date of Birth,District of Service,District of SPED Accountability,School of Attendance,Grade Level,Case Manager,Disability 1,Date of Next Annual Plan Review,Date of Next Reevaluation,Date of IEP (Meeting Date on Future IEP forms),Meeting Type';
 
 const buf = (csv: string) => Buffer.from(csv, 'utf-8');
+const byName = (records: IepDatesRecord[], first: string, last: string) =>
+  records.find((r) => r.normalizedName === createNormalizedKey(first, last));
 
 describe('parseIepDatesCSV', () => {
   it('maps both compliance dates to ISO, keyed by normalized full name', async () => {
     const csv = `${HEADER}\n1,2,Doe,John,,,01/05/2016,D,D,Maple Elementary,3,CM,SLD,09/01/2026,05/12/2027,09/01/2025,20|`;
     const { records } = await parseIepDatesCSV(buf(csv));
 
-    const rec = records.get(createNormalizedKey('John', 'Doe'));
+    const rec = byName(records, 'John', 'Doe');
     expect(rec).toBeDefined();
     expect(rec!.upcomingIepDate).toBe('2026-09-01');
     expect(rec!.upcomingTriennialDate).toBe('2027-05-12');
@@ -33,12 +36,11 @@ describe('parseIepDatesCSV', () => {
   });
 
   it('is order-independent — locates columns by header, not position', async () => {
-    // Reversed column order; only the two dates + names present.
     const csv =
       'Date of Next Reevaluation,First Name,Last Name,Date of Next Annual Plan Review\n' +
       '05/12/2027,John,Doe,09/01/2026';
     const { records } = await parseIepDatesCSV(buf(csv));
-    const rec = records.get(createNormalizedKey('John', 'Doe'));
+    const rec = byName(records, 'John', 'Doe');
     expect(rec!.upcomingIepDate).toBe('2026-09-01');
     expect(rec!.upcomingTriennialDate).toBe('2027-05-12');
   });
@@ -46,7 +48,7 @@ describe('parseIepDatesCSV', () => {
   it('leaves a blank date undefined (present-only), without a warning', async () => {
     const csv = `${HEADER}\n1,2,Garcia,Maria,,,,D,D,Maple Elementary,2,CM,SLI,11/03/2026,,11/03/2025,10|`;
     const { records, warnings } = await parseIepDatesCSV(buf(csv));
-    const rec = records.get(createNormalizedKey('Maria', 'Garcia'));
+    const rec = byName(records, 'Maria', 'Garcia');
     expect(rec!.upcomingIepDate).toBe('2026-11-03');
     expect(rec!.upcomingTriennialDate).toBeUndefined();
     expect(warnings).toHaveLength(0);
@@ -55,7 +57,7 @@ describe('parseIepDatesCSV', () => {
   it('warns on a present-but-unparseable date and drops just that field', async () => {
     const csv = `${HEADER}\n1,2,Brown,Bob,,,,D,D,Maple Elementary,5,CM,SLD,13/45/2026,06/20/2027,08/15/2025,20|`;
     const { records, warnings } = await parseIepDatesCSV(buf(csv));
-    const rec = records.get(createNormalizedKey('Bob', 'Brown'));
+    const rec = byName(records, 'Bob', 'Brown');
     expect(rec!.upcomingIepDate).toBeUndefined(); // 13/45/2026 is invalid
     expect(rec!.upcomingTriennialDate).toBe('2027-06-20'); // the valid one is kept
     expect(warnings.some((w) => /invalid iep review date/i.test(w.message))).toBe(true);
@@ -64,19 +66,21 @@ describe('parseIepDatesCSV', () => {
   it('skips a row with no name and warns', async () => {
     const csv = `${HEADER}\n1,2,,,,,,D,D,Maple Elementary,3,CM,SLD,09/01/2026,05/12/2027,09/01/2025,20|`;
     const { records, warnings } = await parseIepDatesCSV(buf(csv));
-    expect(records.size).toBe(0);
+    expect(records).toHaveLength(0);
     expect(warnings.some((w) => /no student name/i.test(w.message))).toBe(true);
   });
 
-  it('keeps the first row on a duplicate normalized name and warns', async () => {
+  it('keeps ALL rows on a duplicate normalized name (dedup is deferred to school scoping)', async () => {
     const csv =
       `${HEADER}\n` +
       '1,2,Doe,John,,,,D,D,Maple Elementary,3,CM,SLD,09/01/2026,05/12/2027,09/01/2025,20|\n' +
-      '2,3,Doe,John,,,,D,D,Maple Elementary,3,CM,SLD,01/01/2030,01/01/2031,01/01/2029,20|';
-    const { records, warnings } = await parseIepDatesCSV(buf(csv));
-    expect(records.size).toBe(1);
-    expect(records.get(createNormalizedKey('John', 'Doe'))!.upcomingIepDate).toBe('2026-09-01');
-    expect(warnings.some((w) => /duplicate student/i.test(w.message))).toBe(true);
+      '2,3,Doe,John,,,,D,D,Birch Elementary,3,CM,SLD,01/01/2030,01/01/2031,01/01/2029,20|';
+    const { records, metadata } = await parseIepDatesCSV(buf(csv));
+    // Both rows retained (they may be different students at different schools).
+    expect(records).toHaveLength(2);
+    // uniqueStudents counts distinct normalized names, not rows.
+    expect(metadata.uniqueStudents).toBe(1);
+    expect(records.map((r) => r.schoolOfAttendance).sort()).toEqual(['Birch Elementary', 'Maple Elementary']);
   });
 
   it('tolerates a UTF-8 BOM and quoted header cells (as SEIS exports ship)', async () => {
@@ -84,11 +88,10 @@ describe('parseIepDatesCSV', () => {
       '﻿"First Name","Last Name","Date of Next Annual Plan Review","Date of Next Reevaluation"\n' +
       '"John","Doe","09/01/2026","05/12/2027"';
     const { records } = await parseIepDatesCSV(buf(csv));
-    expect(records.get(createNormalizedKey('John', 'Doe'))!.upcomingIepDate).toBe('2026-09-01');
+    expect(byName(records, 'John', 'Doe')!.upcomingIepDate).toBe('2026-09-01');
   });
 
   it('decodes a latin1 / Windows-1252 name (byte 0xF1 → ñ)', async () => {
-    // "Muñoz" with the ñ as a single latin1 byte 0xF1 (not valid UTF-8).
     const header = Buffer.from(
       'First Name,Last Name,Date of Next Annual Plan Review,Date of Next Reevaluation\n',
       'utf-8',
@@ -99,7 +102,7 @@ describe('parseIepDatesCSV', () => {
       ...Buffer.from('oz,09/01/2026,05/12/2027', 'latin1'),
     ]);
     const { records } = await parseIepDatesCSV(Buffer.concat([header, row]));
-    const rec = records.get(createNormalizedKey('Ana', 'Muñoz'));
+    const rec = byName(records, 'Ana', 'Muñoz');
     expect(rec).toBeDefined();
     expect(rec!.upcomingIepDate).toBe('2026-09-01');
   });
@@ -107,24 +110,28 @@ describe('parseIepDatesCSV', () => {
   it('errors when neither compliance-date column is present', async () => {
     const csv = 'First Name,Last Name,Grade Level\nJohn,Doe,3';
     const { records, errors } = await parseIepDatesCSV(buf(csv));
-    expect(records.size).toBe(0);
+    expect(records).toHaveLength(0);
     expect(errors.some((e) => /date of next/i.test(e.message))).toBe(true);
   });
 
+  it('errors when the name columns are missing', async () => {
+    const csv = 'Date of Next Annual Plan Review,Date of Next Reevaluation\n09/01/2026,05/12/2027';
+    const { records, errors } = await parseIepDatesCSV(buf(csv));
+    expect(records).toHaveLength(0);
+    expect(errors.some((e) => /first name \/ last name/i.test(e.message))).toBe(true);
+  });
+
   it('parses the golden fixture: dates, one-date-only, invalid date, other-school row', async () => {
-    const csv = readFileSync(
-      join(__dirname, 'fixtures', 'iep-dates.csv'),
-    );
+    const csv = readFileSync(join(__dirname, 'fixtures', 'iep-dates.csv'));
     const { records, warnings, metadata } = await parseIepDatesCSV(csv);
 
-    // 5 students read; every name keyed.
     expect(metadata.uniqueStudents).toBe(5);
-    expect(records.get(createNormalizedKey('John', 'Doe'))!.upcomingIepDate).toBe('2026-09-01');
-    expect(records.get(createNormalizedKey('Maria', 'Garcia'))!.upcomingTriennialDate).toBeUndefined();
+    expect(byName(records, 'John', 'Doe')!.upcomingIepDate).toBe('2026-09-01');
+    expect(byName(records, 'Maria', 'Garcia')!.upcomingTriennialDate).toBeUndefined();
     // Bob Brown's IEP review date is invalid (13/45/2026) → warned + dropped.
-    expect(records.get(createNormalizedKey('Bob', 'Brown'))!.upcomingIepDate).toBeUndefined();
+    expect(byName(records, 'Bob', 'Brown')!.upcomingIepDate).toBeUndefined();
     expect(warnings.some((w) => /invalid iep review date/i.test(w.message))).toBe(true);
     // The other-school student is still parsed here; school scoping happens in the pipeline.
-    expect(records.get(createNormalizedKey('Kim', 'Nguyen'))!.schoolOfAttendance).toBe('Birch Elementary');
+    expect(byName(records, 'Kim', 'Nguyen')!.schoolOfAttendance).toBe('Birch Elementary');
   });
 });

--- a/__tests__/unit/lib/parsers/iep-dates-parser.test.ts
+++ b/__tests__/unit/lib/parsers/iep-dates-parser.test.ts
@@ -91,7 +91,7 @@ describe('parseIepDatesCSV', () => {
     expect(byName(records, 'John', 'Doe')!.upcomingIepDate).toBe('2026-09-01');
   });
 
-  it('decodes a latin1 / Windows-1252 name (byte 0xF1 → ñ)', async () => {
+  it('decodes a Windows-1252 name (byte 0xF1 → ñ)', async () => {
     const header = Buffer.from(
       'First Name,Last Name,Date of Next Annual Plan Review,Date of Next Reevaluation\n',
       'utf-8',
@@ -104,6 +104,26 @@ describe('parseIepDatesCSV', () => {
     const { records } = await parseIepDatesCSV(Buffer.concat([header, row]));
     const rec = byName(records, 'Ana', 'Muñoz');
     expect(rec).toBeDefined();
+    expect(rec!.upcomingIepDate).toBe('2026-09-01');
+  });
+
+  it('decodes a Windows-1252 apostrophe (byte 0x92 → ’), not the latin1 control char', async () => {
+    // 0x92 is where Windows-1252 and latin1 diverge: win-1252 → ’ (U+2019),
+    // latin1 → U+0092 (a control char). "O’Connor" must keep a real apostrophe so
+    // its normalized match key lines up with the stored name.
+    const header = Buffer.from(
+      'First Name,Last Name,Date of Next Annual Plan Review,Date of Next Reevaluation\n',
+      'utf-8',
+    );
+    const row = Buffer.from([
+      ...Buffer.from('Sean,O', 'latin1'),
+      0x92,
+      ...Buffer.from('Connor,09/01/2026,05/12/2027', 'latin1'),
+    ]);
+    const { records } = await parseIepDatesCSV(Buffer.concat([header, row]));
+    const rec = byName(records, 'Sean', 'O’Connor'); // U+2019, not U+0092
+    expect(rec).toBeDefined();
+    expect(rec!.lastName).toBe('O’Connor');
     expect(rec!.upcomingIepDate).toBe('2026-09-01');
   });
 

--- a/app/(dashboard)/dashboard/students/page.tsx
+++ b/app/(dashboard)/dashboard/students/page.tsx
@@ -442,6 +442,11 @@ export default function StudentsPage() {
                 minutesPerSession: row.schedule?.minutesPerSession,
                 teacherId: row.teacher?.teacherId || undefined,
                 teacherName: row.teacher?.teacherName || undefined,
+                // IEP Dates (SPE-303): presence-keyed — send a date only when the
+                // IEP Dates file supplied one, so the confirm write overwrites on
+                // presence (file wins) and leaves it untouched on absence.
+                upcomingIepDate: row.iepDates?.upcomingIepDate?.value,
+                upcomingTriennialDate: row.iepDates?.upcomingTriennialDate?.value,
               }));
 
               const response = await fetch('/api/import-students/confirm', {

--- a/app/api/import-students/confirm/route.ts
+++ b/app/api/import-students/confirm/route.ts
@@ -301,6 +301,16 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
             updatePayload.teacherId = student.teacherId;
             updatePayload.teacherName = student.teacherName ?? null;
           }
+          // IEP Dates (SPE-303): presence-keyed like teacherId. The client sends a
+          // date only when the IEP Dates file supplied one, so the RPC overwrites
+          // the stored value (file wins) on presence and leaves it untouched on
+          // absence — an import without this file never nulls an existing date.
+          if (student.upcomingIepDate !== undefined) {
+            updatePayload.upcomingIepDate = student.upcomingIepDate;
+          }
+          if (student.upcomingTriennialDate !== undefined) {
+            updatePayload.upcomingTriennialDate = student.upcomingTriennialDate;
+          }
           batchPayload.push(updatePayload);
         } else {
           // Insert. Set `teacher_name` alongside `teacher_id` when a teacher
@@ -323,7 +333,11 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
             teacherName: student.teacherId ? (student.teacherName ?? null) : null,
             firstName: student.firstName,
             lastName: student.lastName,
-            goals: student.goals
+            goals: student.goals,
+            // IEP Dates (SPE-303): a new student created from the goals file may
+            // also match the IEP Dates file. Null when absent (a fresh row).
+            upcomingIepDate: student.upcomingIepDate ?? null,
+            upcomingTriennialDate: student.upcomingTriennialDate ?? null
           });
           addedInThisBatch.add(duplicateKey);
         }

--- a/app/api/import-students/route.ts
+++ b/app/api/import-students/route.ts
@@ -46,12 +46,13 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
       studentsFile: form.studentsFile?.name,
       deliveriesFile: form.deliveriesFile?.name,
       classListFile: form.classListFile?.name,
+      iepDatesFile: form.iepDatesFile?.name,
       currentSchoolId: form.currentSchoolId,
       currentSchoolSite: form.currentSchoolSite,
     });
 
     // At least one file is required.
-    if (!form.studentsFile && !form.deliveriesFile && !form.classListFile) {
+    if (!form.studentsFile && !form.deliveriesFile && !form.classListFile && !form.iepDatesFile) {
       log.warn('No files provided in student import request', { userId });
       perf.end({ success: false });
       return NextResponse.json({ error: 'No files provided' }, { status: 400 });

--- a/app/components/students/review/review-exception-row.tsx
+++ b/app/components/students/review/review-exception-row.tsx
@@ -28,10 +28,14 @@ export function ReviewExceptionRow({ exception, teacherOverride, onResolveTeache
         <div className="min-w-0">
           <span className="font-medium text-gray-900">{exception.name}</span>{' '}
           <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-600">
-            {exception.source === 'deliveries' ? 'Deliveries' : 'Class list'}
+            {exception.source === 'deliveries'
+              ? 'Deliveries'
+              : exception.source === 'iepDates'
+                ? 'IEP dates'
+                : 'Class list'}
           </span>
           <p className="mt-0.5 text-xs text-gray-500">
-            Not in the goals report — won&apos;t be imported. Add via the roster or the Add Student form.
+            Not matched to a student here — won&apos;t be imported. Add via the roster or the Add Student form.
           </p>
         </div>
       </li>

--- a/app/components/students/review/review-row.tsx
+++ b/app/components/students/review/review-row.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import type { ReviewRow as ReviewRowData } from '@/lib/import/review-model';
+import type { BulkIepDateChange } from '@/lib/types/student-import';
 import { ReviewGoalList } from './review-goal-list';
 import { ReviewSignalIcon } from './review-signal';
 import type { ReviewSelection } from './use-review-selection';
@@ -13,6 +14,31 @@ const ACTION_BADGE: Record<ReviewRowData['action'], { label: string; className: 
   skip: { label: 'No changes', className: 'bg-gray-100 text-gray-600' },
 };
 
+/** ISO YYYY-MM-DD → MM/DD/YYYY for display (the format SEIS exports use). */
+function formatIepDate(iso: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  return m ? `${m[2]}/${m[3]}/${m[1]}` : iso;
+}
+
+/** One IEP date line (SPE-303): shows old → new when the file changes it. */
+function IepDateLine({ label, change }: { label: string; change?: BulkIepDateChange }) {
+  if (!change) return null;
+  return (
+    <div className="whitespace-nowrap">
+      <span className="text-gray-400">{label}</span>{' '}
+      {change.changed && change.old && (
+        <>
+          <span className="text-gray-400 line-through">{formatIepDate(change.old)}</span>
+          <span className="text-gray-400"> → </span>
+        </>
+      )}
+      <span className={change.changed ? 'font-medium text-gray-900' : 'text-gray-900'}>
+        {formatIepDate(change.value)}
+      </span>
+    </div>
+  );
+}
+
 interface ReviewRowProps {
   row: ReviewRowData;
   selection: ReviewSelection;
@@ -20,9 +46,11 @@ interface ReviewRowProps {
   onToggleExpand: () => void;
   /** Total table columns, for the full-width expansion/warning rows. */
   columnCount: number;
+  /** Render the IEP dates column (only when an IEP Dates file is in play). */
+  showIepDates: boolean;
 }
 
-export function ReviewRow({ row, selection, isExpanded, onToggleExpand, columnCount }: ReviewRowProps) {
+export function ReviewRow({ row, selection, isExpanded, onToggleExpand, columnCount, showIepDates }: ReviewRowProps) {
   const isSkip = row.action === 'skip';
   const selected = selection.isRowSelected(row.id);
   const goalsSelected = selection.goalsSelectedFor(row.id);
@@ -83,6 +111,18 @@ export function ReviewRow({ row, selection, isExpanded, onToggleExpand, columnCo
             <span className="text-gray-400 italic">Not set</span>
           )}
         </td>
+        {showIepDates && (
+          <td className="px-3 py-2 align-top text-xs">
+            {row.iepDates ? (
+              <div className="space-y-0.5 tabular-nums">
+                <IepDateLine label="IEP" change={row.iepDates.upcomingIepDate} />
+                <IepDateLine label="Tri" change={row.iepDates.upcomingTriennialDate} />
+              </div>
+            ) : (
+              <span className="text-gray-400 italic">Not set</span>
+            )}
+          </td>
+        )}
         <td className="px-3 py-2 align-top text-sm">
           {goalCount > 0 ? (
             <button

--- a/app/components/students/review/review-table.tsx
+++ b/app/components/students/review/review-table.tsx
@@ -6,12 +6,16 @@ import type { ReviewRow as ReviewRowData } from '@/lib/import/review-model';
 import { ReviewRow } from './review-row';
 import type { ReviewSelection } from './use-review-selection';
 
-const COLUMN_COUNT = 8;
+const BASE_COLUMN_COUNT = 8;
 
 /**
  * Zone 4 (SPE-227): the column-scannable table. Uniform columns so verification
  * happens one attribute at a time (sweep Grade, then Teacher, then Schedule),
  * grouped New → Updated, with unchanged rows collapsed to a single line.
+ *
+ * The IEP dates column (SPE-303) appears only when an IEP Dates file is in play
+ * (any row carries dates) — so the goals-only and per-student modes don't show an
+ * always-empty column.
  */
 export function ReviewTable({
   rows,
@@ -25,6 +29,9 @@ export function ReviewTable({
 }) {
   const [expandedId, setExpandedId] = useState<string | null>(defaultExpandedId ?? null);
   const [showUnchanged, setShowUnchanged] = useState(false);
+
+  const showIepDates = rows.some((r) => r.iepDates);
+  const columnCount = BASE_COLUMN_COUNT + (showIepDates ? 1 : 0);
 
   const inserts = rows.filter((r) => r.action === 'insert');
   const updates = rows.filter((r) => r.action === 'update');
@@ -40,7 +47,8 @@ export function ReviewTable({
         selection={selection}
         isExpanded={expandedId === row.id}
         onToggleExpand={() => toggleExpand(row.id)}
-        columnCount={COLUMN_COUNT}
+        columnCount={columnCount}
+        showIepDates={showIepDates}
       />
     ));
 
@@ -63,24 +71,25 @@ export function ReviewTable({
               <th scope="col" className="px-3 py-2">Grade</th>
               <th scope="col" className="px-3 py-2">Teacher</th>
               <th scope="col" className="px-3 py-2">Schedule</th>
+              {showIepDates && <th scope="col" className="px-3 py-2">IEP / Triennial</th>}
               <th scope="col" className="px-3 py-2">Goals</th>
               <th scope="col" className="px-3 py-2">Action</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
-            {inserts.length > 0 && <GroupHeader label="New" count={inserts.length} />}
+            {inserts.length > 0 && <GroupHeader label="New" count={inserts.length} columnCount={columnCount} />}
             {renderGroup(inserts)}
-            {updates.length > 0 && <GroupHeader label="Updated" count={updates.length} />}
+            {updates.length > 0 && <GroupHeader label="Updated" count={updates.length} columnCount={columnCount} />}
             {renderGroup(updates)}
             {skips.length > 0 &&
               (showUnchanged ? (
                 <>
-                  <GroupHeader label="Unchanged" count={skips.length} onHide={() => setShowUnchanged(false)} />
+                  <GroupHeader label="Unchanged" count={skips.length} columnCount={columnCount} onHide={() => setShowUnchanged(false)} />
                   {renderGroup(skips)}
                 </>
               ) : (
                 <tr>
-                  <td colSpan={COLUMN_COUNT} className="px-3 py-2">
+                  <td colSpan={columnCount} className="px-3 py-2">
                     <button
                       type="button"
                       onClick={() => setShowUnchanged(true)}
@@ -98,10 +107,10 @@ export function ReviewTable({
   );
 }
 
-function GroupHeader({ label, count, onHide }: { label: string; count: number; onHide?: () => void }) {
+function GroupHeader({ label, count, columnCount, onHide }: { label: string; count: number; columnCount: number; onHide?: () => void }) {
   return (
     <tr className="bg-gray-50/70">
-      <td colSpan={COLUMN_COUNT} className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-gray-500">
+      <td colSpan={columnCount} className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-gray-500">
         {label} <span className="tabular-nums text-gray-400">({count})</span>
         {onHide && (
           <button type="button" onClick={onHide} className="ml-2 font-normal normal-case text-gray-500 underline hover:text-gray-700">

--- a/app/components/students/student-import-modal.tsx
+++ b/app/components/students/student-import-modal.tsx
@@ -49,6 +49,7 @@ const CONTRIBUTION_LEGEND = [
   { label: 'Goals report', fills: 'students & IEP goals' },
   { label: 'Deliveries', fills: 'schedules' },
   { label: 'Class list', fills: 'teachers' },
+  { label: 'IEP dates', fills: 'review & triennial dates' },
   { label: 'Roster', fills: 'student list' },
 ];
 

--- a/lib/import/classify.ts
+++ b/lib/import/classify.ts
@@ -26,6 +26,8 @@ import {
   ClassListStudent,
 } from '@/lib/parsers/class-list-parser';
 import { DeliveryRecord } from '@/lib/parsers/deliveries-parser';
+import { IepDatesRecord } from '@/lib/parsers/iep-dates-parser';
+import type { IepDatesPreview } from '@/lib/types/student-import';
 import { buildStudentDedupKey } from '@/lib/utils/student-dedup-key';
 import { classifyRosterChange } from '@/lib/import/roster-preview';
 import { resolveClassListTeacher } from '@/lib/import/enrich';
@@ -125,6 +127,39 @@ export interface StudentDetailRow {
   first_name: string | null;
   last_name: string | null;
   iep_goals: string[] | null;
+  /** Stored IEP compliance dates (ISO YYYY-MM-DD) for IEP Dates change detection (SPE-303). */
+  upcoming_iep_date?: string | null;
+  upcoming_triennial_date?: string | null;
+}
+
+/**
+ * Build the review-facing IEP Dates payload for a matched student (SPE-303).
+ * Each date is present only when the file supplied a parseable value; `changed`
+ * is `value !== stored`. Returns null when the file carried no usable date, so
+ * an empty enrichment doesn't fabricate an update. `changed` on the aggregate is
+ * true iff any present date differs from what's stored (drives insert/update/skip).
+ */
+export function buildIepDatesPreview(
+  record: Pick<IepDatesRecord, 'upcomingIepDate' | 'upcomingTriennialDate'>,
+  existingIepDate: string | null,
+  existingTriennialDate: string | null,
+): { iepDates: IepDatesPreview; changed: boolean } | null {
+  const iepDates: IepDatesPreview = {};
+  let changed = false;
+
+  if (record.upcomingIepDate !== undefined) {
+    const isChanged = record.upcomingIepDate !== existingIepDate;
+    iepDates.upcomingIepDate = { value: record.upcomingIepDate, old: existingIepDate, changed: isChanged };
+    changed = changed || isChanged;
+  }
+  if (record.upcomingTriennialDate !== undefined) {
+    const isChanged = record.upcomingTriennialDate !== existingTriennialDate;
+    iepDates.upcomingTriennialDate = { value: record.upcomingTriennialDate, old: existingTriennialDate, changed: isChanged };
+    changed = changed || isChanged;
+  }
+
+  if (!iepDates.upcomingIepDate && !iepDates.upcomingTriennialDate) return null;
+  return { iepDates, changed };
 }
 
 /**
@@ -149,6 +184,9 @@ export function toDatabaseStudents(
         sessions_per_week: student.sessions_per_week || undefined,
         minutes_per_session: student.minutes_per_session || undefined,
         teacher_id: student.teacher_id || undefined,
+        // Stored IEP dates, for IEP Dates change detection (SPE-303).
+        upcoming_iep_date: details?.upcoming_iep_date ?? null,
+        upcoming_triennial_date: details?.upcoming_triennial_date ?? null,
       } as DatabaseStudent;
     }) || []
   );
@@ -158,6 +196,7 @@ export interface MainPreviewResult {
   studentPreviews: StudentPreview[];
   matchedDeliveryNames: Set<string>;
   matchedClassListNames: Set<string>;
+  matchedIepDatesNames: Set<string>;
 }
 
 /**
@@ -169,6 +208,7 @@ export function buildStudentPreviews(params: {
   databaseStudents: DatabaseStudent[];
   deliveriesData: Map<string, DeliveryRecord> | null;
   classListData: Map<string, ClassListStudent> | null;
+  iepDatesData?: Map<string, IepDatesRecord> | null;
   dbTeachers: DbTeacherRow[];
   /**
    * Opt into the SPE-284 initials-enrichment fallback. Safe only when the caller
@@ -183,15 +223,17 @@ export function buildStudentPreviews(params: {
     databaseStudents,
     deliveriesData,
     classListData,
+    iepDatesData = null,
     dbTeachers,
     enrichNoNameByInitials = false,
   } = params;
 
   const matchResult = matchStudents(parsedStudents, databaseStudents, { enrichNoNameByInitials });
 
-  // Track which students from deliveries/classList were matched
+  // Track which students from deliveries/classList/iepDates were matched
   const matchedDeliveryNames = new Set<string>();
   const matchedClassListNames = new Set<string>();
+  const matchedIepDatesNames = new Set<string>();
 
   // Process each student: prepare preview data (goals flow through verbatim).
   const studentPreviews: StudentPreview[] = [];
@@ -232,6 +274,23 @@ export function buildStudentPreviews(params: {
       if (classListStudent) {
         matchedClassListNames.add(normalizedKey);
         teacherMatchResult = resolveClassListTeacher(classListStudent.teacher, dbTeachers);
+      }
+    }
+
+    // Match with IEP Dates data (SPE-303). File wins: a present date overwrites
+    // the stored one; a row whose dates equal what's stored is not a change. For
+    // an insert there is no matchedStudent, so old is null (any present date is
+    // shown against a blank).
+    let iepDatesResult: { iepDates: IepDatesPreview; changed: boolean } | null = null;
+    if (iepDatesData) {
+      const iepRecord = iepDatesData.get(normalizedKey);
+      if (iepRecord) {
+        matchedIepDatesNames.add(normalizedKey);
+        iepDatesResult = buildIepDatesPreview(
+          iepRecord,
+          matchedStudent?.upcoming_iep_date ?? null,
+          matchedStudent?.upcoming_triennial_date ?? null,
+        );
       }
     }
 
@@ -276,12 +335,16 @@ export function buildStudentPreviews(params: {
       const incomingHasName = !!(student.firstName?.trim() && student.lastName?.trim());
       const existingHasAnyName = !!(matchedStudent.first_name?.trim() || matchedStudent.last_name?.trim());
       const hasNameChange = incomingHasName && !existingHasAnyName;
+      // An IEP Dates match with a date that differs from what's stored makes the
+      // row an update even if nothing else changed; identical dates stay a skip.
+      const hasIepDateChange = iepDatesResult?.changed ?? false;
       const anyChanges =
         changeCheck.hasGoalChanges ||
         changeCheck.hasScheduleChanges ||
         changeCheck.hasTeacherChanges ||
         hasUnresolvedTeacher ||
-        hasNameChange;
+        hasNameChange ||
+        hasIepDateChange;
 
       if (anyChanges) {
         action = 'update';
@@ -370,10 +433,17 @@ export function buildStudentPreviews(params: {
       preview.teacher = teacherMatchResult;
     }
 
+    // Add IEP Dates data to preview (SPE-303). Carried for insert and update rows
+    // alike so the confirm write picks up the new dates and the review row can
+    // show old → new.
+    if (iepDatesResult) {
+      preview.iepDates = iepDatesResult.iepDates;
+    }
+
     studentPreviews.push(preview);
   }
 
-  return { studentPreviews, matchedDeliveryNames, matchedClassListNames };
+  return { studentPreviews, matchedDeliveryNames, matchedClassListNames, matchedIepDatesNames };
 }
 
 /**
@@ -398,25 +468,30 @@ export interface UpdatePreviewResult {
   studentUpdates: StudentUpdate[];
   matchedDeliveryNames: Set<string>;
   matchedClassListNames: Set<string>;
+  matchedIepDatesNames: Set<string>;
   unmatchedStudents: UnmatchedStudent[];
 }
 
 /**
- * Deliveries/class-list "update-only" path: the students file is absent, so
- * preview rows fall out of matching existing students by name against the
- * enrichment files. Every matched row is an 'update'. Verbatim.
+ * Deliveries/class-list/IEP-dates "update-only" path: the students file is
+ * absent, so preview rows fall out of matching existing students by name against
+ * the enrichment files. Deliveries/class-list matches are always an 'update'; an
+ * IEP Dates match is an 'update' only when a date differs from what's stored, and
+ * a 'skip' when its dates already match (SPE-303 — no phantom updates).
  */
 export function buildUpdatePreviews(params: {
   studentsByName: Map<string, JoinedExistingStudent>;
   deliveriesData: Map<string, DeliveryRecord> | null;
   classListData: Map<string, ClassListStudent> | null;
+  iepDatesData?: Map<string, IepDatesRecord> | null;
   dbTeachers: DbTeacherRow[];
 }): UpdatePreviewResult {
-  const { studentsByName, deliveriesData, classListData, dbTeachers } = params;
+  const { studentsByName, deliveriesData, classListData, iepDatesData = null, dbTeachers } = params;
 
   const studentUpdates: StudentUpdate[] = [];
   const matchedDeliveryNames = new Set<string>();
   const matchedClassListNames = new Set<string>();
+  const matchedIepDatesNames = new Set<string>();
   const unmatchedStudents: UnmatchedStudent[] = [];
 
   // Match deliveries to existing students
@@ -496,7 +571,64 @@ export function buildUpdatePreviews(params: {
     }
   }
 
-  return { studentUpdates, matchedDeliveryNames, matchedClassListNames, unmatchedStudents };
+  // Match IEP Dates to existing students (SPE-303). File wins: a present date
+  // overwrites the stored one. A row whose dates already match is left as a skip
+  // below (no phantom update).
+  if (iepDatesData) {
+    for (const [normalizedName, record] of iepDatesData) {
+      const existingStudent = studentsByName.get(normalizedName);
+      if (!existingStudent) {
+        unmatchedStudents.push({
+          name: `${record.firstName} ${record.lastName}`.trim() || record.normalizedName,
+          source: 'iepDates',
+        });
+        continue;
+      }
+      matchedIepDatesNames.add(normalizedName);
+      const details = existingStudent.student_details as unknown as {
+        first_name: string;
+        last_name: string;
+        upcoming_iep_date?: string | null;
+        upcoming_triennial_date?: string | null;
+      };
+      const iepDatesResult = buildIepDatesPreview(
+        record,
+        details.upcoming_iep_date ?? null,
+        details.upcoming_triennial_date ?? null,
+      );
+      // Matched but the file carried no usable date for this student — nothing to
+      // enrich, and no row unless another file already made one.
+      if (!iepDatesResult) continue;
+
+      let update = studentUpdates.find(u => u.studentId === existingStudent.id);
+      if (!update) {
+        update = {
+          studentId: existingStudent.id,
+          initials: existingStudent.initials || '',
+          firstName: details.first_name,
+          lastName: details.last_name,
+          gradeLevel: existingStudent.grade_level,
+          action: 'update',
+        };
+        studentUpdates.push(update);
+      }
+      update.iepDates = iepDatesResult.iepDates;
+    }
+  }
+
+  // Resolve each row's action. Deliveries/class-list contributions are always a
+  // change; an IEP Dates contribution is a change only when a date differs from
+  // what's stored. A row with nothing changed (an IEP-dates-only match whose
+  // dates already match) becomes a skip so it isn't a phantom update (SPE-303).
+  for (const update of studentUpdates) {
+    const iepChanged = !!(
+      update.iepDates?.upcomingIepDate?.changed || update.iepDates?.upcomingTriennialDate?.changed
+    );
+    const hasWork = !!update.schedule || !!update.teacher || iepChanged;
+    update.action = hasWork ? 'update' : 'skip';
+  }
+
+  return { studentUpdates, matchedDeliveryNames, matchedClassListNames, matchedIepDatesNames, unmatchedStudents };
 }
 
 /** Roster-template existing-student row shape (initials+grade dedup). */

--- a/lib/import/detect-import-file.ts
+++ b/lib/import/detect-import-file.ts
@@ -13,11 +13,12 @@ export type DetectedImportType =
   | 'seis-report' // SEIS Student/Goals report (xlsx/xls/csv) -> creates students + goals
   | 'deliveries' // SEIS Deliveries CSV -> schedule requirements
   | 'class-list' // Aeries Special Ed class list (txt) -> teacher assignment
+  | 'iep-dates' // SEIS "IEP Dates" report CSV -> review & triennial dates (SPE-303)
   | 'roster-template' // Initials/Grade/Teacher roster CSV
   | 'unknown';
 
 /** The `/api/import-students` multipart form key a type submits under. */
-export type ImportFormKey = 'studentsFile' | 'deliveriesFile' | 'classListFile';
+export type ImportFormKey = 'studentsFile' | 'deliveriesFile' | 'classListFile' | 'iepDatesFile';
 
 export interface ImportTypeMeta {
   /** Form key for server submission, or null if this type isn't server-backed here. */
@@ -32,6 +33,7 @@ export const IMPORT_TYPE_META: Record<DetectedImportType, ImportTypeMeta> = {
   'seis-report': { formKey: 'studentsFile', label: 'Student & goals report', contribution: 'students & goals' },
   deliveries: { formKey: 'deliveriesFile', label: 'Deliveries', contribution: 'schedules' },
   'class-list': { formKey: 'classListFile', label: 'Class list', contribution: 'teachers' },
+  'iep-dates': { formKey: 'iepDatesFile', label: 'IEP dates', contribution: 'review & triennial dates' },
   // Roster template now flows through the server preview/confirm pipeline as the
   // students file (SPE-225), same as a SEIS report.
   'roster-template': { formKey: 'studentsFile', label: 'Roster template', contribution: 'student list' },
@@ -77,6 +79,8 @@ export function normalizeHeaderCells(headerLine: string): string[] {
  * - `.xlsx` / `.xls` -> SEIS report
  * - `.csv` with a "Sessions / Frequency" column -> Deliveries
  * - `.csv` with Initials + Grade + Teacher columns -> roster template
+ * - `.csv` with a "Date of Next Annual Plan Review"/"Date of Next Reevaluation"
+ *   column -> SEIS IEP Dates report (SPE-303)
  * - any other `.csv` -> SEIS Student/Goals report
  * - anything else -> unknown
  */
@@ -92,6 +96,10 @@ export function classifyImportFile(fileName: string, csvHeaderLine?: string): De
 
     if (has('sessions / frequency')) return 'deliveries';
     if (has('initials') && has('grade') && has('teacher')) return 'roster-template';
+    // SEIS "IEP Dates" report (SPE-303): recognized by either compliance-date
+    // column, checked before the goals-report fallback. Verified unique — the
+    // Goals report, Deliveries, and roster template headers contain neither.
+    if (has('date of next annual plan review') || has('date of next reevaluation')) return 'iep-dates';
     return 'seis-report';
   }
 

--- a/lib/import/enrich.ts
+++ b/lib/import/enrich.ts
@@ -71,7 +71,7 @@ export async function loadStudentDetails(
   if (!dbStudents || dbStudents.length === 0) return { data: null, error: null };
   const { data, error } = await supabase
     .from('student_details')
-    .select('student_id, first_name, last_name, iep_goals')
+    .select('student_id, first_name, last_name, iep_goals, upcoming_iep_date, upcoming_triennial_date')
     .in('student_id', dbStudents.map(s => s.id));
   return { data: (data as unknown as StudentDetailRow[] | null), error };
 }
@@ -89,7 +89,7 @@ export async function loadJoinedStudents(
       grade_level,
       school_site,
       school_id,
-      student_details!inner(first_name, last_name)
+      student_details!inner(first_name, last_name, upcoming_iep_date, upcoming_triennial_date)
     `)
     .eq('provider_id', userId);
   return { data: (data as unknown as JoinedExistingStudent[] | null), error };

--- a/lib/import/parse-files.ts
+++ b/lib/import/parse-files.ts
@@ -11,6 +11,7 @@ import { parseSEISReport, ParseResult as SEISParseResult } from '@/lib/parsers/s
 import { parseCSVReport, ParseResult as CSVParseResult } from '@/lib/parsers/csv-parser';
 import { parseDeliveriesCSV, DeliveryRecord } from '@/lib/parsers/deliveries-parser';
 import { parseClassListTXT, ClassListStudent } from '@/lib/parsers/class-list-parser';
+import { parseIepDatesCSV, IepDatesRecord } from '@/lib/parsers/iep-dates-parser';
 import { normalizeSchoolName } from '@/lib/import/normalize-school-name';
 import { MAX_FILE_SIZE_MB } from '@/lib/import/detect-import-file';
 
@@ -18,6 +19,7 @@ export interface ImportForm {
   studentsFile: File | null;
   deliveriesFile: File | null;
   classListFile: File | null;
+  iepDatesFile: File | null;
   currentSchoolId: string | null;
   currentSchoolSite: string | null;
 }
@@ -29,6 +31,7 @@ export async function readImportForm(request: Request): Promise<ImportForm> {
     studentsFile: formData.get('studentsFile') as File | null,
     deliveriesFile: formData.get('deliveriesFile') as File | null,
     classListFile: formData.get('classListFile') as File | null,
+    iepDatesFile: formData.get('iepDatesFile') as File | null,
     currentSchoolId: formData.get('currentSchoolId') as string | null,
     currentSchoolSite: formData.get('currentSchoolSite') as string | null,
   };
@@ -44,9 +47,9 @@ export async function readImportForm(request: Request): Promise<ImportForm> {
  */
 export const MAX_UPLOAD_FILE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
 
-/** Ceiling for the whole multipart body: the 3 optional files at the per-file
+/** Ceiling for the whole multipart body: the 4 optional files at the per-file
  *  cap, plus ~1 MB for multipart framing. */
-export const MAX_TOTAL_UPLOAD_BYTES = MAX_UPLOAD_FILE_BYTES * 3 + 1024 * 1024;
+export const MAX_TOTAL_UPLOAD_BYTES = MAX_UPLOAD_FILE_BYTES * 4 + 1024 * 1024;
 
 /** True when the request's Content-Length exceeds the total-body ceiling. */
 export function exceedsTotalUploadSize(request: Request): boolean {
@@ -57,7 +60,7 @@ export function exceedsTotalUploadSize(request: Request): boolean {
 
 /** The first present file over the per-file cap, or null if all are within it. */
 export function findOversizedFile(form: ImportForm): File | null {
-  for (const file of [form.studentsFile, form.deliveriesFile, form.classListFile]) {
+  for (const file of [form.studentsFile, form.deliveriesFile, form.classListFile, form.iepDatesFile]) {
     if (file && typeof file.size === 'number' && file.size > MAX_UPLOAD_FILE_BYTES) {
       return file;
     }
@@ -129,6 +132,23 @@ export async function parseClassListFile(file: File): Promise<ParsedClassList> {
   return {
     students: result.students,
     read: result.metadata.totalStudents,
+    warnings: result.warnings,
+  };
+}
+
+export interface ParsedIepDates {
+  records: Map<string, IepDatesRecord>;
+  read: number;
+  warnings: Array<{ row: number; message: string }>;
+}
+
+/** Parse a SEIS IEP Dates CSV (SPE-303). Throws on hard parse failure. */
+export async function parseIepDatesFile(file: File): Promise<ParsedIepDates> {
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const result = await parseIepDatesCSV(buffer);
+  return {
+    records: result.records,
+    read: result.metadata.uniqueStudents,
     warnings: result.warnings,
   };
 }

--- a/lib/import/parse-files.ts
+++ b/lib/import/parse-files.ts
@@ -137,20 +137,63 @@ export async function parseClassListFile(file: File): Promise<ParsedClassList> {
 }
 
 export interface ParsedIepDates {
-  records: Map<string, IepDatesRecord>;
+  /** All parsed rows in file order (deduped later, after school scoping). */
+  records: IepDatesRecord[];
   read: number;
   warnings: Array<{ row: number; message: string }>;
 }
 
-/** Parse a SEIS IEP Dates CSV (SPE-303). Throws on hard parse failure. */
+/**
+ * Parse a SEIS IEP Dates CSV (SPE-303). Throws on a wholly-invalid file — a
+ * wrong-shape or empty file yields zero rows plus a structural error, and the
+ * parser records (rather than throws) those, so the wrapper propagates them here
+ * instead of reporting a silent successful-but-empty parse. The caller surfaces
+ * the throw as a 400 (update-only mode) or a warning (main path), the same way a
+ * hard parse failure is handled. Any residual per-row errors ride along as
+ * warnings so they aren't dropped either.
+ */
 export async function parseIepDatesFile(file: File): Promise<ParsedIepDates> {
   const buffer = Buffer.from(await file.arrayBuffer());
   const result = await parseIepDatesCSV(buffer);
+  if (result.records.length === 0 && result.errors.length > 0) {
+    throw new Error(result.errors.map((e) => e.message).join('; '));
+  }
   return {
     records: result.records,
     read: result.metadata.uniqueStudents,
-    warnings: result.warnings,
+    warnings: [...result.warnings, ...result.errors],
   };
+}
+
+/**
+ * Scope IEP Dates rows to the selected school, then dedupe by normalized name
+ * (SPE-303). Order matters: school scoping runs FIRST (via applySchoolFilter,
+ * the same helper the goals file uses — rows with a blank School of Attendance
+ * are kept), so a same-name student at another school can't shadow the
+ * current-school student. Only after filtering do we collapse to one row per
+ * name (first-wins), flagging a genuine same-school name collision as a warning
+ * rather than silently dropping the loser. Returns the name-keyed map the
+ * enrichment lookup uses plus any collision warnings.
+ */
+export function scopeIepDatesToSchool(
+  records: IepDatesRecord[],
+  currentSchoolSite: string | null,
+  worksAtMultipleSchools: boolean | null | undefined,
+): { records: Map<string, IepDatesRecord>; warnings: Array<{ row: number; message: string }> } {
+  const { students } = applySchoolFilter(records, currentSchoolSite, worksAtMultipleSchools);
+  const map = new Map<string, IepDatesRecord>();
+  const warnings: Array<{ row: number; message: string }> = [];
+  for (const record of students) {
+    if (map.has(record.normalizedName)) {
+      warnings.push({
+        row: 0,
+        message: `Duplicate student "${`${record.firstName} ${record.lastName}`.trim()}" at this school — kept the first row's dates`,
+      });
+      continue;
+    }
+    map.set(record.normalizedName, record);
+  }
+  return { records: map, warnings };
 }
 
 export interface SchoolFilterResult<T> {

--- a/lib/import/pipeline.ts
+++ b/lib/import/pipeline.ts
@@ -22,6 +22,7 @@ import {
   parseDeliveriesFile,
   parseClassListFile,
   parseIepDatesFile,
+  scopeIepDatesToSchool,
   applySchoolFilter,
 } from '@/lib/import/parse-files';
 import type { IepDatesRecord } from '@/lib/parsers/iep-dates-parser';
@@ -60,23 +61,6 @@ interface PipelineContext {
 }
 
 const errorMessage = (error: unknown) => (error instanceof Error ? error.message : 'Unknown error');
-
-/**
- * Scope IEP Dates records to the current school before matching (SPE-303).
- * The report can include other-school / other-case-manager students; dropping
- * the other-school rows up front (via applySchoolFilter, the same helper the
- * goals file uses) keeps them out of the "needs review" unmatched list — mirroring
- * the SPE-268 suppression. Records with a blank School of Attendance are kept.
- * Re-keys the kept records by normalized name for the enrichment lookup.
- */
-function scopeIepDatesToSchool(
-  records: Map<string, IepDatesRecord>,
-  currentSchoolSite: string | null,
-  worksAtMultipleSchools: boolean | null | undefined,
-): Map<string, IepDatesRecord> {
-  const { students } = applySchoolFilter(Array.from(records.values()), currentSchoolSite, worksAtMultipleSchools);
-  return new Map(students.map((r) => [r.normalizedName, r]));
-}
 
 /**
  * Deliveries/class-list "update-only" mode: no students file, so preview rows
@@ -148,7 +132,9 @@ export async function runUpdateOnlyPreview(ctx: PipelineContext): Promise<NextRe
   if (iepDatesFile) {
     try {
       iepDates = await parseIepDatesFile(iepDatesFile);
-      iepDatesInScope = scopeIepDatesToSchool(iepDates.records, currentSchoolSite, profile?.works_at_multiple_schools);
+      const scoped = scopeIepDatesToSchool(iepDates.records, currentSchoolSite, profile?.works_at_multiple_schools);
+      iepDatesInScope = scoped.records;
+      iepDates.warnings.push(...scoped.warnings);
     } catch (error) {
       log.error('Failed to parse IEP dates file', error instanceof Error ? error : null, { userId });
       perf.end({ success: false });
@@ -324,7 +310,9 @@ export async function runStudentsPreview(ctx: PipelineContext, file: File): Prom
     try {
       iepDates = await parseIepDatesFile(iepDatesFile);
       iepDatesWarnings.push(...iepDates.warnings);
-      iepDatesInScope = scopeIepDatesToSchool(iepDates.records, currentSchoolSite, profile?.works_at_multiple_schools);
+      const scoped = scopeIepDatesToSchool(iepDates.records, currentSchoolSite, profile?.works_at_multiple_schools);
+      iepDatesInScope = scoped.records;
+      iepDatesWarnings.push(...scoped.warnings);
     } catch (error) {
       log.error('Failed to parse IEP dates file', error instanceof Error ? error : null, { userId });
       iepDatesWarnings.push({ row: 0, message: `Failed to parse IEP dates file: ${errorMessage(error)}` });

--- a/lib/import/pipeline.ts
+++ b/lib/import/pipeline.ts
@@ -21,8 +21,10 @@ import {
   parseStudentsFile,
   parseDeliveriesFile,
   parseClassListFile,
+  parseIepDatesFile,
   applySchoolFilter,
 } from '@/lib/import/parse-files';
+import type { IepDatesRecord } from '@/lib/parsers/iep-dates-parser';
 import {
   loadProfile,
   loadExistingStudents,
@@ -60,18 +62,36 @@ interface PipelineContext {
 const errorMessage = (error: unknown) => (error instanceof Error ? error.message : 'Unknown error');
 
 /**
+ * Scope IEP Dates records to the current school before matching (SPE-303).
+ * The report can include other-school / other-case-manager students; dropping
+ * the other-school rows up front (via applySchoolFilter, the same helper the
+ * goals file uses) keeps them out of the "needs review" unmatched list — mirroring
+ * the SPE-268 suppression. Records with a blank School of Attendance are kept.
+ * Re-keys the kept records by normalized name for the enrichment lookup.
+ */
+function scopeIepDatesToSchool(
+  records: Map<string, IepDatesRecord>,
+  currentSchoolSite: string | null,
+  worksAtMultipleSchools: boolean | null | undefined,
+): Map<string, IepDatesRecord> {
+  const { students } = applySchoolFilter(Array.from(records.values()), currentSchoolSite, worksAtMultipleSchools);
+  return new Map(students.map((r) => [r.normalizedName, r]));
+}
+
+/**
  * Deliveries/class-list "update-only" mode: no students file, so preview rows
  * are updates that fall out of matching existing students against the
  * enrichment files.
  */
 export async function runUpdateOnlyPreview(ctx: PipelineContext): Promise<NextResponse> {
   const { supabase, userId, form, perf } = ctx;
-  const { deliveriesFile, classListFile, currentSchoolId } = form;
+  const { deliveriesFile, classListFile, iepDatesFile, currentSchoolId, currentSchoolSite } = form;
 
-  log.info('Processing deliveries/classList only mode', {
+  log.info('Processing deliveries/classList/iepDates only mode', {
     userId,
     hasDeliveries: !!deliveriesFile,
     hasClassList: !!classListFile,
+    hasIepDates: !!iepDatesFile,
   });
 
   const profile = await loadProfile(supabase, userId);
@@ -123,24 +143,43 @@ export async function runUpdateOnlyPreview(ctx: PipelineContext): Promise<NextRe
       return NextResponse.json({ error: `Failed to parse class list file: ${errorMessage(error)}` }, { status: 400 });
     }
   }
+  let iepDates: Awaited<ReturnType<typeof parseIepDatesFile>> | null = null;
+  let iepDatesInScope: Map<string, IepDatesRecord> | null = null;
+  if (iepDatesFile) {
+    try {
+      iepDates = await parseIepDatesFile(iepDatesFile);
+      iepDatesInScope = scopeIepDatesToSchool(iepDates.records, currentSchoolSite, profile?.works_at_multiple_schools);
+    } catch (error) {
+      log.error('Failed to parse IEP dates file', error instanceof Error ? error : null, { userId });
+      perf.end({ success: false });
+      return NextResponse.json({ error: `Failed to parse IEP dates file: ${errorMessage(error)}` }, { status: 400 });
+    }
+  }
 
   const dbTeachers = classList && classList.students.size > 0 ? await fetchTeachers(supabase, currentSchoolId) : [];
 
-  const { studentUpdates, matchedDeliveryNames, matchedClassListNames, unmatchedStudents } = buildUpdatePreviews({
-    studentsByName,
-    deliveriesData: deliveries?.deliveries ?? null,
-    classListData: classList?.students ?? null,
-    dbTeachers,
-  });
+  const { studentUpdates, matchedDeliveryNames, matchedClassListNames, matchedIepDatesNames, unmatchedStudents } =
+    buildUpdatePreviews({
+      studentsByName,
+      deliveriesData: deliveries?.deliveries ?? null,
+      classListData: classList?.students ?? null,
+      iepDatesData: iepDatesInScope,
+      dbTeachers,
+    });
 
   track.event('student_update_preview_generated', {
     userId,
-    totalUpdates: studentUpdates.length,
+    totalUpdates: studentUpdates.filter(s => s.action === 'update').length,
     withSchedule: studentUpdates.filter(s => s.schedule).length,
     withTeacher: studentUpdates.filter(s => s.teacher).length,
+    // Count only rows that actually apply a date change (an unchanged-date match
+    // is an action:'skip' row that still carries iepDates) so this stays
+    // consistent with totalUpdates.
+    withIepDates: studentUpdates.filter(s => s.action === 'update' && s.iepDates).length,
     unmatchedCount: unmatchedStudents.length,
     hasDeliveriesFile: !!deliveriesFile,
     hasClassListFile: !!classListFile,
+    hasIepDatesFile: !!iepDatesFile,
   });
 
   perf.end({ success: true });
@@ -154,6 +193,9 @@ export async function runUpdateOnlyPreview(ctx: PipelineContext): Promise<NextRe
     classList: classListFile && classList
       ? { fileName: classListFile.name, read: classList.read, matched: matchedClassListNames.size, warnings: classList.warnings }
       : null,
+    iepDates: iepDatesFile && iepDates
+      ? { fileName: iepDatesFile.name, read: iepDates.read, matched: matchedIepDatesNames.size, warnings: iepDates.warnings }
+      : null,
   });
 
   return NextResponse.json({ success: true, mode: 'update', data });
@@ -166,7 +208,7 @@ export async function runUpdateOnlyPreview(ctx: PipelineContext): Promise<NextRe
  */
 export async function runStudentsPreview(ctx: PipelineContext, file: File): Promise<NextResponse> {
   const { supabase, userId, form, perf } = ctx;
-  const { deliveriesFile, classListFile, currentSchoolId, currentSchoolSite } = form;
+  const { deliveriesFile, classListFile, iepDatesFile, currentSchoolId, currentSchoolSite } = form;
 
   const { isExcel, isCSV } = classifyStudentsFileType(file);
   if (!isExcel && !isCSV) {
@@ -275,6 +317,19 @@ export async function runStudentsPreview(ctx: PipelineContext, file: File): Prom
       classListWarnings.push({ row: 0, message: `Failed to parse class list file: ${errorMessage(error)}` });
     }
   }
+  let iepDates: Awaited<ReturnType<typeof parseIepDatesFile>> | null = null;
+  let iepDatesInScope: Map<string, IepDatesRecord> | null = null;
+  const iepDatesWarnings: Note[] = [];
+  if (iepDatesFile) {
+    try {
+      iepDates = await parseIepDatesFile(iepDatesFile);
+      iepDatesWarnings.push(...iepDates.warnings);
+      iepDatesInScope = scopeIepDatesToSchool(iepDates.records, currentSchoolSite, profile?.works_at_multiple_schools);
+    } catch (error) {
+      log.error('Failed to parse IEP dates file', error instanceof Error ? error : null, { userId });
+      iepDatesWarnings.push({ row: 0, message: `Failed to parse IEP dates file: ${errorMessage(error)}` });
+    }
+  }
 
   const dbTeachers = classList && classList.students.size > 0 ? await fetchTeachers(supabase, currentSchoolId) : [];
 
@@ -302,11 +357,12 @@ export async function runStudentsPreview(ctx: PipelineContext, file: File): Prom
   }
   const databaseStudents = toDatabaseStudents(dbStudentsInSchool, studentDetails);
 
-  const { studentPreviews, matchedDeliveryNames, matchedClassListNames } = buildStudentPreviews({
+  const { studentPreviews, matchedDeliveryNames, matchedClassListNames, matchedIepDatesNames } = buildStudentPreviews({
     parsedStudents: filteredStudents,
     databaseStudents,
     deliveriesData: deliveries?.deliveries ?? null,
     classListData: classList?.students ?? null,
+    iepDatesData: iepDatesInScope,
     dbTeachers,
     // Only enrich no-name rows by initials+grade when details actually loaded
     // (otherwise a merely-unloaded name would look blank and could be overwritten).
@@ -328,6 +384,8 @@ export async function runStudentsPreview(ctx: PipelineContext, file: File): Prom
     matchedDeliveryNames,
     matchedClassListNames,
     filteredOutNames,
+    iepDatesInScope,
+    matchedIepDatesNames,
   );
 
   const counts = summarizePreviews(studentPreviews);
@@ -342,6 +400,7 @@ export async function runStudentsPreview(ctx: PipelineContext, file: File): Prom
     withTeacher: counts.withTeacher,
     hasDeliveriesFile: !!deliveriesFile,
     hasClassListFile: !!classListFile,
+    hasIepDatesFile: !!iepDatesFile,
   });
 
   perf.end({ success: true });
@@ -359,6 +418,9 @@ export async function runStudentsPreview(ctx: PipelineContext, file: File): Prom
       : null,
     classList: classListFile
       ? { fileName: classListFile.name, read: classList?.read ?? 0, matched: matchedClassListNames.size, warnings: classListWarnings }
+      : null,
+    iepDates: iepDatesFile
+      ? { fileName: iepDatesFile.name, read: iepDates?.read ?? 0, matched: matchedIepDatesNames.size, warnings: iepDatesWarnings }
       : null,
     unmatchedStudents,
   });

--- a/lib/import/preview-types.ts
+++ b/lib/import/preview-types.ts
@@ -8,6 +8,7 @@
  * consumed by the review UI).
  */
 import type { DatabaseStudent } from '@/lib/utils/student-matcher';
+import type { IepDatesPreview } from '@/lib/types/student-import';
 
 /** Awaited server Supabase client type, without a runtime import of the module. */
 export type ImportSupabaseClient = Awaited<
@@ -75,6 +76,8 @@ export interface StudentPreview {
   schedule?: ScheduleData;
   // New fields from Class List file
   teacher?: TeacherMatch;
+  // New fields from the SEIS IEP Dates report (SPE-303)
+  iepDates?: IepDatesPreview;
 }
 
 /**
@@ -88,7 +91,10 @@ export interface StudentUpdate {
   firstName: string;
   lastName: string;
   gradeLevel: string | null;
-  action: 'update'; // Always 'update' for Deliveries/ClassList-only mode
+  // 'update' when the file(s) change something; 'skip' when an IEP Dates match
+  // carries only dates identical to what's stored (SPE-303). Deliveries/class-list
+  // matches are always 'update' (they carry no change detection of their own).
+  action: 'update' | 'skip';
   schedule?: {
     sessionsPerWeek: number;
     minutesPerSession: number;
@@ -101,11 +107,13 @@ export interface StudentUpdate {
     confidence: 'high' | 'medium' | 'low' | 'none';
     reason: string;
   };
+  // From the SEIS IEP Dates report (SPE-303).
+  iepDates?: IepDatesPreview;
 }
 
 export interface UnmatchedStudent {
   name: string;
-  source: 'deliveries' | 'classList';
+  source: 'deliveries' | 'classList' | 'iepDates';
 }
 
 /**

--- a/lib/import/respond.ts
+++ b/lib/import/respond.ts
@@ -10,6 +10,7 @@
 import type { BulkPreviewData, BulkFileReceipt } from '@/lib/types/student-import';
 import type { ClassListStudent } from '@/lib/parsers/class-list-parser';
 import type { DeliveryRecord } from '@/lib/parsers/deliveries-parser';
+import type { IepDatesRecord } from '@/lib/parsers/iep-dates-parser';
 import type { StudentPreview, StudentUpdate, UnmatchedStudent } from '@/lib/import/preview-types';
 
 type Note = { row: number; message: string };
@@ -59,9 +60,15 @@ export function collectUnmatched(
   // suppress it instead of flagging it (SPE-268). The Deliveries/Class List files
   // carry no school column, so this is the only way to tell an other-school
   // student apart from one genuinely missing at the selected school.
-  filteredOutNames?: Set<string>
+  filteredOutNames?: Set<string>,
+  // SPE-303: the IEP Dates file, matched like the two above. Its own rows are
+  // school-scoped upstream (applySchoolFilter drops other-school rows before
+  // matching), so a leftover here is a genuine same-school non-match.
+  iepDatesData?: Map<string, IepDatesRecord> | null,
+  matchedIepDatesNames?: Set<string>,
 ): UnmatchedStudent[] {
   const suppressed = filteredOutNames ?? new Set<string>();
+  const matchedIep = matchedIepDatesNames ?? new Set<string>();
   const unmatchedStudents: UnmatchedStudent[] = [];
 
   if (deliveriesData) {
@@ -76,6 +83,17 @@ export function collectUnmatched(
     for (const [normalizedName, student] of classListData) {
       if (!matchedClassListNames.has(normalizedName) && !suppressed.has(normalizedName)) {
         unmatchedStudents.push({ name: student.name, source: 'classList' });
+      }
+    }
+  }
+
+  if (iepDatesData) {
+    for (const [normalizedName, record] of iepDatesData) {
+      if (!matchedIep.has(normalizedName) && !suppressed.has(normalizedName)) {
+        unmatchedStudents.push({
+          name: `${record.firstName} ${record.lastName}`.trim() || normalizedName,
+          source: 'iepDates',
+        });
       }
     }
   }
@@ -105,6 +123,17 @@ function classListReceipt(input: EnrichmentFileInput): BulkFileReceipt {
   };
 }
 
+function iepDatesReceipt(input: EnrichmentFileInput): BulkFileReceipt {
+  return {
+    fileKey: 'iepDatesFile',
+    fileName: input.fileName,
+    read: input.read,
+    matched: input.matched,
+    filtered: Math.max(0, input.read - input.matched),
+    notes: input.warnings,
+  };
+}
+
 /** Build the `data` payload for the main SEIS/CSV goals path. */
 export function buildMainPreviewData(params: {
   studentPreviews: StudentPreview[];
@@ -116,11 +145,12 @@ export function buildMainPreviewData(params: {
   filteredOutSchools: string[];
   deliveries: EnrichmentFileInput | null;
   classList: EnrichmentFileInput | null;
+  iepDates: EnrichmentFileInput | null;
   unmatchedStudents: UnmatchedStudent[];
 }): BulkPreviewData {
   const {
     studentPreviews, studentsFileName, parsedStudentCount, parseWarnings, parseErrors,
-    filteredOutCount, filteredOutSchools, deliveries, classList, unmatchedStudents,
+    filteredOutCount, filteredOutSchools, deliveries, classList, iepDates, unmatchedStudents,
   } = params;
 
   const counts = summarizePreviews(studentPreviews);
@@ -130,6 +160,7 @@ export function buildMainPreviewData(params: {
     ...parseWarnings,
     ...(deliveries?.warnings || []).map(w => ({ ...w, source: 'deliveries' as const })),
     ...(classList?.warnings || []).map(w => ({ ...w, source: 'classList' as const })),
+    ...(iepDates?.warnings || []).map(w => ({ ...w, source: 'iepDates' as const })),
   ];
 
   // SPE-227: per-file receipts. The student goals file is always present; the
@@ -146,6 +177,7 @@ export function buildMainPreviewData(params: {
   });
   if (deliveries) files.push(deliveriesReceipt(deliveries));
   if (classList) files.push(classListReceipt(classList));
+  if (iepDates) files.push(iepDatesReceipt(iepDates));
 
   return {
     students: studentPreviews,
@@ -167,25 +199,33 @@ export function buildMainPreviewData(params: {
   };
 }
 
-/** Build the `data` payload for the deliveries/class-list update-only path. */
+/** Build the `data` payload for the deliveries/class-list/IEP-dates update-only path. */
 export function buildUpdatePreviewData(params: {
   studentUpdates: StudentUpdate[];
   unmatchedStudents: UnmatchedStudent[];
   deliveries: EnrichmentFileInput | null;
   classList: EnrichmentFileInput | null;
+  iepDates: EnrichmentFileInput | null;
 }): BulkPreviewData {
-  const { studentUpdates, unmatchedStudents, deliveries, classList } = params;
+  const { studentUpdates, unmatchedStudents, deliveries, classList, iepDates } = params;
 
   const allWarnings = [
     ...(deliveries?.warnings || []).map(w => ({ ...w, source: 'deliveries' as const })),
     ...(classList?.warnings || []).map(w => ({ ...w, source: 'classList' as const })),
+    ...(iepDates?.warnings || []).map(w => ({ ...w, source: 'iepDates' as const })),
   ];
 
-  // SPE-227: per-file receipts. Only deliveries and/or class list apply here —
-  // there is no student goals file in this mode.
+  // SPE-227: per-file receipts. Only the enrichment files apply here — there is
+  // no student goals file in this mode.
   const files: BulkFileReceipt[] = [];
   if (deliveries) files.push(deliveriesReceipt(deliveries));
   if (classList) files.push(classListReceipt(classList));
+  if (iepDates) files.push(iepDatesReceipt(iepDates));
+
+  // SPE-303: an IEP-dates match whose dates already match is a skip, so this mode
+  // is no longer all-updates — derive the counts from the resolved action.
+  const updates = studentUpdates.filter(s => s.action === 'update').length;
+  const skips = studentUpdates.filter(s => s.action === 'skip').length;
 
   return {
     // SPE-227: mirror the top-level `mode` inside `data` so the client keeps it.
@@ -195,8 +235,8 @@ export function buildUpdatePreviewData(params: {
     summary: {
       total: studentUpdates.length,
       inserts: 0,
-      updates: studentUpdates.length,
-      skips: 0,
+      updates,
+      skips,
       withSchedule: studentUpdates.filter(s => s.schedule).length,
       withTeacher: studentUpdates.filter(s => s.teacher).length,
     },

--- a/lib/import/review-model.ts
+++ b/lib/import/review-model.ts
@@ -16,6 +16,7 @@ import type {
   BulkStudentPreview,
   BulkPreviewData,
   TargetPreviewData,
+  IepDatesPreview,
 } from '@/lib/types/student-import';
 
 // The preview/confirm wire contract lives in one shared module (SPE-236) so the
@@ -61,6 +62,9 @@ export interface ReviewRow {
   gradeLevel: string | null;
   schedule?: { sessionsPerWeek: number; minutesPerSession: number };
   teacher?: ReviewTeacher;
+  /** Incoming IEP compliance dates from the SEIS IEP Dates report (SPE-303),
+   *  with old → new for display and the value carried through to confirm. */
+  iepDates?: IepDatesPreview;
   /** Incoming goals being imported (selectable). */
   goals: ReviewGoal[];
   /** Existing goals dropped by an update's replace — shown struck-through + in the exceptions queue. */
@@ -89,7 +93,7 @@ export interface ReviewFileReceipt {
 }
 
 export type ReviewException =
-  | { kind: 'unmatched-student'; name: string; source: 'deliveries' | 'classList'; reason?: string }
+  | { kind: 'unmatched-student'; name: string; source: 'deliveries' | 'classList' | 'iepDates'; reason?: string }
   | { kind: 'low-confidence-teacher'; rowId: string; studentLabel: string; suggestion: ReviewTeacher }
   | { kind: 'goals-removed'; rowId: string; studentLabel: string; goals: string[] };
 
@@ -121,6 +125,7 @@ const FILE_RECEIPT_META: Record<PreviewFileKey, { label: string; fills: string }
   studentsFile: { label: 'Student & goals report', fills: 'students & IEP goals' },
   deliveriesFile: { label: 'Deliveries', fills: 'schedules' },
   classListFile: { label: 'Class list', fills: 'teachers' },
+  iepDatesFile: { label: 'IEP dates', fills: 'review & triennial dates' },
 };
 
 const normalizeGoal = (s: string) => s.trim().toLowerCase();
@@ -182,6 +187,7 @@ function toReviewRow(student: BulkStudentPreview, srcIndex: number): ReviewRow {
         }
       : undefined,
     teacher,
+    iepDates: student.iepDates,
     goals,
     goalsRemoved,
     targetStudentId,

--- a/lib/parsers/iep-dates-parser.ts
+++ b/lib/parsers/iep-dates-parser.ts
@@ -107,22 +107,30 @@ export async function parseIepDatesCSV(buffer: Buffer): Promise<IepDatesParseRes
     skip_empty_lines: true,
   };
 
-  // Choose the encoding from the raw bytes (mirrors csv-parser): if the buffer is
-  // not valid UTF-8, decode as latin1 so a Windows-1252 re-save (e.g. "Muñoz"
-  // stored as byte 0xF1) maps to the intended characters instead of U+FFFD.
-  let encoding: BufferEncoding = 'utf-8';
-  try {
-    new TextDecoder('utf-8', { fatal: true }).decode(buffer);
-  } catch {
-    encoding = 'latin1';
-  }
+  // Choose the encoding from the raw bytes: valid UTF-8 stays UTF-8; otherwise the
+  // file is a Windows-1252 export (what SEIS/Windows tools ship), decoded via
+  // TextDecoder so bytes in 0x80–0x9F resolve to the intended punctuation — most
+  // importantly 0x92 → "’" (U+2019). Plain latin1 would map 0x92 to a C1 control
+  // char, corrupting names like "O’Connor" into a different normalized match key
+  // that would silently miss the student (0xF1 → ñ agrees in both encodings, so
+  // it doesn't exercise this difference).
+  const isUtf8 = (() => {
+    try {
+      new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+      return true;
+    } catch {
+      return false;
+    }
+  })();
 
   let allRecords: string[][];
   try {
-    allRecords = parse(buffer, { encoding, ...parseOptions });
+    allRecords = isUtf8
+      ? parse(buffer, { encoding: 'utf-8', ...parseOptions })
+      : parse(new TextDecoder('windows-1252').decode(buffer), parseOptions);
   } catch {
     // Last-resort fallback for any other hard parse/decoding error.
-    allRecords = parse(buffer, { encoding: 'latin1', ...parseOptions });
+    allRecords = parse(new TextDecoder('windows-1252').decode(buffer), parseOptions);
   }
 
   // Drop whitespace-only lines (which parse to a single blank field) so row

--- a/lib/parsers/iep-dates-parser.ts
+++ b/lib/parsers/iep-dates-parser.ts
@@ -33,7 +33,11 @@ export interface IepDatesRecord {
 }
 
 export interface IepDatesParseResult {
-  records: Map<string, IepDatesRecord>; // Keyed by normalized name
+  // All parsed rows in file order — deliberately NOT deduped by name here.
+  // Name-collision handling is deferred to the pipeline, which dedupes only
+  // AFTER scoping to the selected school, so a same-name student at another
+  // school can't drop the current-school student's dates (SPE-303 review).
+  records: IepDatesRecord[];
   errors: Array<{ row: number; message: string }>;
   warnings: Array<{ row: number; message: string }>;
   metadata: {
@@ -92,7 +96,7 @@ const COL = {
  * (callers render only `warnings`, so swallowing it would enrich nothing silently).
  */
 export async function parseIepDatesCSV(buffer: Buffer): Promise<IepDatesParseResult> {
-  const records = new Map<string, IepDatesRecord>();
+  const records: IepDatesRecord[] = [];
   const errors: Array<{ row: number; message: string }> = [];
   const warnings: Array<{ row: number; message: string }> = [];
 
@@ -198,19 +202,12 @@ export async function parseIepDatesCSV(buffer: Buffer): Promise<IepDatesParseRes
         }
       }
 
-      // First-wins on a duplicate normalized name: two rows keying to the same
-      // name are a genuine identity collision (two different students share a
-      // normalized full name). Keep the first and flag the second so the user
-      // knows its dates were not applied, rather than silently overwriting.
-      if (records.has(normalizedName)) {
-        warnings.push({
-          row: rowNum,
-          message: `Duplicate student "${`${firstName} ${lastName}`.trim()}" — kept the first row's dates`,
-        });
-        continue;
-      }
-
-      records.set(normalizedName, {
+      // Keep every named row (no name-dedup here). Two rows with the same
+      // normalized name can be different students at different schools; deduping
+      // now, before the pipeline scopes to the selected school, could drop the
+      // current-school student in favor of an other-school one. The pipeline
+      // dedupes AFTER school scoping instead (SPE-303 review).
+      records.push({
         normalizedName,
         firstName,
         lastName,
@@ -231,7 +228,7 @@ export async function parseIepDatesCSV(buffer: Buffer): Promise<IepDatesParseRes
     warnings,
     metadata: {
       totalRows,
-      uniqueStudents: records.size,
+      uniqueStudents: new Set(records.map((r) => r.normalizedName)).size,
     },
   };
 }

--- a/lib/parsers/iep-dates-parser.ts
+++ b/lib/parsers/iep-dates-parser.ts
@@ -68,6 +68,36 @@ function parseIepDate(raw: string): string | undefined {
   return valid ? iso : undefined;
 }
 
+// Windows-1252 differs from latin1 (ISO-8859-1) only in 0x80–0x9F, where it maps
+// most bytes to printable punctuation/letters rather than C1 control chars
+// (notably 0x92 → "’" U+2019). We decode manually — latin1 (always available on
+// Buffer) plus this remap — instead of TextDecoder('windows-1252'), which is NOT
+// reliably available in every runtime: small-ICU Node builds throw on it, and the
+// jsdom test environment's TextDecoder decodes it incorrectly. Undefined
+// Windows-1252 slots (0x81, 0x8D, 0x8F, 0x90, 0x9D) fall through unchanged.
+const WINDOWS_1252_C1: Record<number, string> = {
+  0x80: '€', 0x82: '‚', 0x83: 'ƒ', 0x84: '„', 0x85: '…',
+  0x86: '†', 0x87: '‡', 0x88: 'ˆ', 0x89: '‰', 0x8a: 'Š',
+  0x8b: '‹', 0x8c: 'Œ', 0x8e: 'Ž', 0x91: '‘', 0x92: '’',
+  0x93: '“', 0x94: '”', 0x95: '•', 0x96: '–', 0x97: '—',
+  0x98: '˜', 0x99: '™', 0x9a: 'š', 0x9b: '›', 0x9c: 'œ',
+  0x9e: 'ž', 0x9f: 'Ÿ',
+};
+
+function decodeWindows1252(buffer: Buffer): string {
+  // latin1 maps each byte to U+00XX, so the C1 range (0x80-0x9F) is the only
+  // place we diverge from Windows-1252. Walk the bytes and remap that range.
+  const chars: string[] = [];
+  for (const byte of buffer) {
+    chars.push(
+      byte >= 0x80 && byte <= 0x9f
+        ? WINDOWS_1252_C1[byte] ?? String.fromCharCode(byte)
+        : String.fromCharCode(byte),
+    );
+  }
+  return chars.join('');
+}
+
 /** Normalize an already-split header cell: strip quotes, collapse whitespace, lowercase. */
 function normalizeHeader(cell: string): string {
   return cell
@@ -109,11 +139,11 @@ export async function parseIepDatesCSV(buffer: Buffer): Promise<IepDatesParseRes
 
   // Choose the encoding from the raw bytes: valid UTF-8 stays UTF-8; otherwise the
   // file is a Windows-1252 export (what SEIS/Windows tools ship), decoded via
-  // TextDecoder so bytes in 0x80–0x9F resolve to the intended punctuation — most
-  // importantly 0x92 → "’" (U+2019). Plain latin1 would map 0x92 to a C1 control
-  // char, corrupting names like "O’Connor" into a different normalized match key
-  // that would silently miss the student (0xF1 → ñ agrees in both encodings, so
-  // it doesn't exercise this difference).
+  // decodeWindows1252 so bytes in 0x80–0x9F resolve to the intended punctuation —
+  // most importantly 0x92 → "’" (U+2019). Plain latin1 would map 0x92 to a C1
+  // control char, corrupting names like "O’Connor" into a different normalized
+  // match key that would silently miss the student (0xF1 → ñ agrees in both
+  // encodings, so it doesn't exercise this difference).
   const isUtf8 = (() => {
     try {
       new TextDecoder('utf-8', { fatal: true }).decode(buffer);
@@ -127,10 +157,10 @@ export async function parseIepDatesCSV(buffer: Buffer): Promise<IepDatesParseRes
   try {
     allRecords = isUtf8
       ? parse(buffer, { encoding: 'utf-8', ...parseOptions })
-      : parse(new TextDecoder('windows-1252').decode(buffer), parseOptions);
+      : parse(decodeWindows1252(buffer), parseOptions);
   } catch {
     // Last-resort fallback for any other hard parse/decoding error.
-    allRecords = parse(new TextDecoder('windows-1252').decode(buffer), parseOptions);
+    allRecords = parse(decodeWindows1252(buffer), parseOptions);
   }
 
   // Drop whitespace-only lines (which parse to a single blank field) so row

--- a/lib/parsers/iep-dates-parser.ts
+++ b/lib/parsers/iep-dates-parser.ts
@@ -1,0 +1,237 @@
+/**
+ * SEIS "IEP Dates" Report Parser (SPE-303)
+ *
+ * Parses the SEIS "IEP Dates" report — one CSV row per student carrying the two
+ * compliance dates providers track all year: Date of Next Annual Plan Review
+ * (the upcoming IEP review) and Date of Next Reevaluation (the triennial). Like
+ * Deliveries and the Aeries Class List, this is an ENRICHMENT file: it never
+ * creates students, it only fills in dates for students matched by normalized
+ * full name.
+ *
+ * Column lookup is header-based (not fixed positions) so a re-ordered export
+ * still parses. Both dates run through the shared `parseDate` helper, which
+ * emits ISO `YYYY-MM-DD`; an unparseable-but-present date is a per-row warning.
+ */
+
+import { parse } from 'csv-parse/sync';
+import { createNormalizedKey } from './name-utils';
+import { parseDate } from '@/lib/utils/iep-date-utils';
+
+export interface IepDatesRecord {
+  /** createNormalizedKey(firstName, lastName) — the cross-file match key. */
+  normalizedName: string;
+  firstName: string;
+  lastName: string;
+  /** Carried for display/debugging; matching is name-only (like Deliveries). */
+  gradeLevel: string;
+  /** Feeds the school scoping in the pipeline (applySchoolFilter). */
+  schoolOfAttendance: string;
+  /** ISO YYYY-MM-DD, present only when the "Date of Next Annual Plan Review" cell parsed. */
+  upcomingIepDate?: string;
+  /** ISO YYYY-MM-DD, present only when the "Date of Next Reevaluation" cell parsed. */
+  upcomingTriennialDate?: string;
+}
+
+export interface IepDatesParseResult {
+  records: Map<string, IepDatesRecord>; // Keyed by normalized name
+  errors: Array<{ row: number; message: string }>;
+  warnings: Array<{ row: number; message: string }>;
+  metadata: {
+    totalRows: number;
+    uniqueStudents: number;
+  };
+}
+
+/**
+ * Parse one date cell to a real calendar date in ISO form, or undefined.
+ *
+ * The shared `parseDate` handles the MM/DD/YYYY → ISO conversion but does NOT
+ * range-check its output (it string-formats, so "13/45/2026" becomes the
+ * impossible "2026-13-45"). Since these dates flow into a Postgres `date` column
+ * — whose cast would reject an out-of-range value and error the student's whole
+ * write — validate the calendar date here so a bad value surfaces as a review
+ * warning instead.
+ */
+function parseIepDate(raw: string): string | undefined {
+  const iso = parseDate(raw);
+  if (!iso) return undefined;
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  if (!m) return undefined;
+  const [year, month, day] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  const dt = new Date(Date.UTC(year, month - 1, day));
+  const valid =
+    dt.getUTCFullYear() === year && dt.getUTCMonth() === month - 1 && dt.getUTCDate() === day;
+  return valid ? iso : undefined;
+}
+
+/** Normalize an already-split header cell: strip quotes, collapse whitespace, lowercase. */
+function normalizeHeader(cell: string): string {
+  return cell
+    .trim()
+    .replace(/^["']|["']$/g, '')
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+}
+
+// Header signatures (normalized). Names carry the cross-file match key; school
+// feeds school scoping; the two date columns are the payload.
+const COL = {
+  firstName: 'first name',
+  lastName: 'last name',
+  gradeLevel: 'grade level',
+  school: 'school of attendance',
+  iepDate: 'date of next annual plan review',
+  triennial: 'date of next reevaluation',
+} as const;
+
+/**
+ * Parse a SEIS "IEP Dates" CSV buffer into a normalized-name → dates map.
+ * A HARD parse failure (e.g. an unterminated quote running to EOF) propagates to
+ * the caller, matching the deliveries parser — the caller surfaces it as an error
+ * (callers render only `warnings`, so swallowing it would enrich nothing silently).
+ */
+export async function parseIepDatesCSV(buffer: Buffer): Promise<IepDatesParseResult> {
+  const records = new Map<string, IepDatesRecord>();
+  const errors: Array<{ row: number; message: string }> = [];
+  const warnings: Array<{ row: number; message: string }> = [];
+
+  const parseOptions = {
+    bom: true,
+    relax_column_count: true,
+    relax_quotes: true,
+    skip_empty_lines: true,
+  };
+
+  // Choose the encoding from the raw bytes (mirrors csv-parser): if the buffer is
+  // not valid UTF-8, decode as latin1 so a Windows-1252 re-save (e.g. "Muñoz"
+  // stored as byte 0xF1) maps to the intended characters instead of U+FFFD.
+  let encoding: BufferEncoding = 'utf-8';
+  try {
+    new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+  } catch {
+    encoding = 'latin1';
+  }
+
+  let allRecords: string[][];
+  try {
+    allRecords = parse(buffer, { encoding, ...parseOptions });
+  } catch {
+    // Last-resort fallback for any other hard parse/decoding error.
+    allRecords = parse(buffer, { encoding: 'latin1', ...parseOptions });
+  }
+
+  // Drop whitespace-only lines (which parse to a single blank field) so row
+  // numbers stay aligned, matching the deliveries parser.
+  const rows = allRecords.filter((r) => !(r.length === 1 && !r[0].trim()));
+
+  if (rows.length === 0) {
+    errors.push({ row: 0, message: 'IEP Dates file is empty' });
+    return { records, errors, warnings, metadata: { totalRows: 0, uniqueStudents: 0 } };
+  }
+
+  // Build a header → column-index lookup from the first row.
+  const header = rows[0].map(normalizeHeader);
+  const indexOf = (name: string) => header.indexOf(name);
+  const firstNameIdx = indexOf(COL.firstName);
+  const lastNameIdx = indexOf(COL.lastName);
+  const gradeIdx = indexOf(COL.gradeLevel);
+  const schoolIdx = indexOf(COL.school);
+  const iepDateIdx = indexOf(COL.iepDate);
+  const triennialIdx = indexOf(COL.triennial);
+
+  if (firstNameIdx === -1 || lastNameIdx === -1) {
+    errors.push({
+      row: 0,
+      message: 'Could not detect First Name / Last Name columns in the IEP Dates file',
+    });
+    return { records, errors, warnings, metadata: { totalRows: 0, uniqueStudents: 0 } };
+  }
+  if (iepDateIdx === -1 && triennialIdx === -1) {
+    errors.push({
+      row: 0,
+      message:
+        'Could not detect a "Date of Next Annual Plan Review" or "Date of Next Reevaluation" column',
+    });
+    return { records, errors, warnings, metadata: { totalRows: 0, uniqueStudents: 0 } };
+  }
+
+  const cell = (fields: string[], idx: number) => (idx >= 0 ? (fields[idx] ?? '').trim() : '');
+
+  let totalRows = 0;
+
+  for (let i = 1; i < rows.length; i++) {
+    const fields = rows[i];
+    const rowNum = i + 1;
+    totalRows++;
+
+    try {
+      const firstName = cell(fields, firstNameIdx);
+      const lastName = cell(fields, lastNameIdx);
+
+      const normalizedName = createNormalizedKey(firstName, lastName);
+      // createNormalizedKey returns "_" (just the separator) when both names are
+      // blank — treat that as "no name" and skip, so a blank row can't collide.
+      if (!firstName && !lastName) {
+        warnings.push({ row: rowNum, message: 'Row has no student name — skipped' });
+        continue;
+      }
+
+      // Parse each date only when its cell is non-empty; warn on a present-but-
+      // unparseable value so it isn't silently dropped.
+      const iepDateRaw = cell(fields, iepDateIdx);
+      const triennialRaw = cell(fields, triennialIdx);
+
+      let upcomingIepDate: string | undefined;
+      if (iepDateRaw) {
+        upcomingIepDate = parseIepDate(iepDateRaw);
+        if (!upcomingIepDate) {
+          warnings.push({ row: rowNum, message: `Invalid IEP review date: ${iepDateRaw}` });
+        }
+      }
+
+      let upcomingTriennialDate: string | undefined;
+      if (triennialRaw) {
+        upcomingTriennialDate = parseIepDate(triennialRaw);
+        if (!upcomingTriennialDate) {
+          warnings.push({ row: rowNum, message: `Invalid triennial date: ${triennialRaw}` });
+        }
+      }
+
+      // First-wins on a duplicate normalized name: two rows keying to the same
+      // name are a genuine identity collision (two different students share a
+      // normalized full name). Keep the first and flag the second so the user
+      // knows its dates were not applied, rather than silently overwriting.
+      if (records.has(normalizedName)) {
+        warnings.push({
+          row: rowNum,
+          message: `Duplicate student "${`${firstName} ${lastName}`.trim()}" — kept the first row's dates`,
+        });
+        continue;
+      }
+
+      records.set(normalizedName, {
+        normalizedName,
+        firstName,
+        lastName,
+        gradeLevel: cell(fields, gradeIdx),
+        schoolOfAttendance: cell(fields, schoolIdx),
+        upcomingIepDate,
+        upcomingTriennialDate,
+      });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      errors.push({ row: rowNum, message: `Error parsing row: ${message}` });
+    }
+  }
+
+  return {
+    records,
+    errors,
+    warnings,
+    metadata: {
+      totalRows,
+      uniqueStudents: records.size,
+    },
+  };
+}

--- a/lib/types/student-import.ts
+++ b/lib/types/student-import.ts
@@ -18,7 +18,7 @@
 export type RowAction = 'insert' | 'update' | 'skip';
 
 /** Multipart form key each uploaded file submits under (also the receipt key). */
-export type PreviewFileKey = 'studentsFile' | 'deliveriesFile' | 'classListFile';
+export type PreviewFileKey = 'studentsFile' | 'deliveriesFile' | 'classListFile' | 'iepDatesFile';
 
 export interface BulkGoal {
   text: string;
@@ -28,6 +28,28 @@ export interface BulkGoalChange {
   added: string[];
   removed: string[];
   unchanged: string[];
+}
+
+/**
+ * One IEP date coming from the SEIS "IEP Dates" report (SPE-303). `value` is the
+ * new date being written (ISO YYYY-MM-DD, file wins); `old` is the stored date
+ * being replaced (or null when none), so the review row can show old → new;
+ * `changed` is `value !== old`. A field is present only when the file supplied a
+ * parseable date for it, so the confirm write can be presence-keyed (an absent
+ * date never nulls an existing one).
+ */
+export interface BulkIepDateChange {
+  value: string;
+  old: string | null;
+  changed: boolean;
+}
+
+/** The two compliance dates the IEP Dates report fills in for a matched student. */
+export interface IepDatesPreview {
+  /** Date of Next Annual Plan Review → student_details.upcoming_iep_date. */
+  upcomingIepDate?: BulkIepDateChange;
+  /** Date of Next Reevaluation → student_details.upcoming_triennial_date. */
+  upcomingTriennialDate?: BulkIepDateChange;
 }
 
 /**
@@ -59,6 +81,8 @@ export interface BulkStudentPreview {
     confidence: 'high' | 'medium' | 'low' | 'none';
     reason: string;
   };
+  /** Present when the IEP Dates report (SPE-303) matched this student. */
+  iepDates?: IepDatesPreview;
 }
 
 export interface BulkFileReceipt {
@@ -86,7 +110,7 @@ export interface BulkImportSummary {
 export interface BulkPreviewData {
   students: BulkStudentPreview[];
   summary: BulkImportSummary;
-  unmatchedStudents?: Array<{ name: string; source: 'deliveries' | 'classList' }>;
+  unmatchedStudents?: Array<{ name: string; source: 'deliveries' | 'classList' | 'iepDates' }>;
   parseErrors?: Array<{ row: number; message: string }>;
   parseWarnings?: Array<{ row: number; message: string; source?: string }>;
   files?: BulkFileReceipt[];
@@ -129,6 +153,14 @@ export interface StudentToImport {
   teacherId?: string;
   /** For updating the deprecated teacher_name column. */
   teacherName?: string;
+  /**
+   * IEP compliance dates from the SEIS "IEP Dates" report (SPE-303), ISO
+   * YYYY-MM-DD. Presence-keyed: sent only when the file supplied a parseable
+   * date, so the confirm RPC overwrites the stored value (file wins) on presence
+   * and leaves it untouched on absence.
+   */
+  upcomingIepDate?: string;
+  upcomingTriennialDate?: string;
   /** Defaults to 'insert' server-side for backward compatibility. */
   action?: RowAction;
   /** Required for the 'update' action. */

--- a/lib/utils/student-matcher.ts
+++ b/lib/utils/student-matcher.ts
@@ -17,6 +17,9 @@ export interface DatabaseStudent {
   sessions_per_week?: number;
   minutes_per_session?: number;
   teacher_id?: string;
+  // Stored IEP compliance dates (ISO YYYY-MM-DD), for IEP Dates change detection (SPE-303).
+  upcoming_iep_date?: string | null;
+  upcoming_triennial_date?: string | null;
 }
 
 export interface StudentMatch {

--- a/supabase/migrations/20260722_upsert_students_iep_dates.sql
+++ b/supabase/migrations/20260722_upsert_students_iep_dates.sql
@@ -1,0 +1,291 @@
+-- SPE-303: make bulk-import write the SEIS "IEP Dates" report's two compliance
+-- dates into student_details (upcoming_iep_date, upcoming_triennial_date).
+--
+-- Background: the unified import now accepts a 4th file type — the SEIS "IEP
+-- Dates" report — which fills in each matched student's Upcoming IEP Date (Date
+-- of Next Annual Plan Review) and Upcoming Triennial IEP Date (Date of Next
+-- Reevaluation). The confirm route carries the two dates on each student row,
+-- ISO YYYY-MM-DD, presence-keyed: a date field is present only when the file
+-- supplied a parseable value.
+--
+-- Fix: write both columns in the insert branch (a new student created from the
+-- goals file may also match the IEP Dates file) and, presence-keyed like the
+-- teacher columns, in the update branch's student_details upsert. "File wins":
+-- when a date IS present it overwrites the stored value; when absent, the stored
+-- value is left untouched, so an import WITHOUT this file never nulls a date.
+--
+-- Both columns already exist on public.student_details (type date, nullable), so
+-- this is a function replacement only — no schema change. Everything else in this
+-- function is reproduced verbatim from the current live definition (SPE-284
+-- student_details upsert, post-SPE-261 auth binding, post-SPE-251 teacher_name,
+-- and the SPE-289 `pg_temp`-last search_path pin — preserved here since this
+-- CREATE OR REPLACE runs after that ALTER and would otherwise silently drop it).
+
+CREATE OR REPLACE FUNCTION public.upsert_students_atomic(
+  p_provider_id uuid,
+  p_students jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_student jsonb;
+  v_action text;
+  v_student_id uuid;
+  v_new_student_id uuid;
+  v_results jsonb := '[]'::jsonb;
+  v_result jsonb;
+  v_inserted integer := 0;
+  v_updated integer := 0;
+  v_skipped integer := 0;
+  v_errors integer := 0;
+  v_new_sessions_per_week integer;
+  v_provider_role text;
+BEGIN
+  -- Defense-in-depth (SPE-261): this SECURITY DEFINER function bypasses RLS, so
+  -- bind it to the caller — reject any p_provider_id that isn't the authenticated
+  -- user, and fail closed when there is no JWT. The confirm route (the only
+  -- caller) passes the authenticated user's id via the JWT-authenticated client,
+  -- so legitimate calls are unaffected; this stops a signed-in client from
+  -- calling the RPC directly with someone else's provider id.
+  IF auth.uid() IS NULL OR p_provider_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Unauthorized' USING ERRCODE = '42501';
+  END IF;
+
+  -- Look up the provider's role to use as service_type
+  SELECT role INTO v_provider_role
+  FROM public.profiles
+  WHERE id = p_provider_id;
+
+  -- Default to 'resource' if role not found
+  v_provider_role := COALESCE(v_provider_role, 'resource');
+
+  -- Loop through each student in the array
+  FOR v_student IN SELECT * FROM jsonb_array_elements(p_students)
+  LOOP
+    v_action := v_student->>'action';
+    v_student_id := (v_student->>'studentId')::uuid;
+
+    BEGIN
+      CASE v_action
+        WHEN 'insert' THEN
+          -- Insert new student record
+          INSERT INTO public.students (
+            provider_id,
+            initials,
+            grade_level,
+            school_site,
+            school_id,
+            district_id,
+            state_id,
+            sessions_per_week,
+            minutes_per_session,
+            teacher_id,
+            teacher_name
+          )
+          VALUES (
+            p_provider_id,
+            v_student->>'initials',
+            v_student->>'gradeLevel',
+            v_student->>'schoolSite',
+            v_student->>'schoolId',
+            v_student->>'districtId',
+            v_student->>'stateId',
+            (v_student->>'sessionsPerWeek')::integer,
+            (v_student->>'minutesPerSession')::integer,
+            (v_student->>'teacherId')::uuid,
+            v_student->>'teacherName'
+          )
+          RETURNING id INTO v_new_student_id;
+
+          -- Insert student_details record (SPE-303: carry the IEP Dates report's
+          -- two dates when the new student also matched that file; NULL otherwise).
+          INSERT INTO public.student_details (
+            student_id,
+            first_name,
+            last_name,
+            iep_goals,
+            upcoming_iep_date,
+            upcoming_triennial_date
+          )
+          VALUES (
+            v_new_student_id,
+            v_student->>'firstName',
+            v_student->>'lastName',
+            ARRAY(SELECT jsonb_array_elements_text(v_student->'goals')),
+            (v_student->>'upcomingIepDate')::date,
+            (v_student->>'upcomingTriennialDate')::date
+          );
+
+          -- Create unscheduled sessions for NEW students only
+          v_new_sessions_per_week := (v_student->>'sessionsPerWeek')::integer;
+
+          IF v_new_sessions_per_week IS NOT NULL AND v_new_sessions_per_week > 0 THEN
+            INSERT INTO public.schedule_sessions (
+              student_id,
+              provider_id,
+              day_of_week,
+              start_time,
+              end_time,
+              service_type,
+              status,
+              delivered_by
+            )
+            SELECT
+              v_new_student_id,
+              p_provider_id,
+              NULL,
+              NULL,
+              NULL,
+              v_provider_role,  -- Use provider's role instead of hardcoded value
+              'active',
+              'provider'
+            FROM generate_series(1, v_new_sessions_per_week);
+          END IF;
+
+          v_inserted := v_inserted + 1;
+          v_result := jsonb_build_object(
+            'action', 'inserted',
+            'studentId', v_new_student_id,
+            'initials', v_student->>'initials',
+            'success', true
+          );
+
+        WHEN 'update' THEN
+          -- Ownership: only the caller's own students may be updated. p_provider_id
+          -- is bound to auth.uid() at the top of this function (SPE-261), so this
+          -- also confirms the row belongs to the authenticated caller.
+          IF NOT EXISTS (
+            SELECT 1 FROM public.students
+            WHERE id = v_student_id AND provider_id = p_provider_id
+          ) THEN
+            RAISE EXCEPTION 'Student % not found or not owned by provider', v_student_id;
+          END IF;
+
+          -- Update students table (only non-null fields from the request)
+          -- NOTE: Session syncing is handled by updateExistingSessionsForStudent in the API
+          UPDATE public.students
+          SET
+            grade_level = COALESCE(v_student->>'gradeLevel', grade_level),
+            sessions_per_week = COALESCE((v_student->>'sessionsPerWeek')::integer, sessions_per_week),
+            minutes_per_session = COALESCE((v_student->>'minutesPerSession')::integer, minutes_per_session),
+            teacher_id = CASE
+              WHEN v_student ? 'teacherId' THEN (v_student->>'teacherId')::uuid
+              ELSE teacher_id
+            END,
+            teacher_name = CASE
+              WHEN v_student ? 'teacherName' THEN v_student->>'teacherName'
+              ELSE teacher_name
+            END,
+            updated_at = now()
+          WHERE id = v_student_id;
+
+          -- Upsert student_details (SPE-284). A plain UPDATE dropped the incoming
+          -- name for any student with no details row yet (pre-existing rows, plus
+          -- roster-template / manual-add students). INSERT ... ON CONFLICT ensures
+          -- the row exists so enrichment names persist. Name COALESCE and the
+          -- goals-only-when-provided rule are unchanged; a fresh insert with no
+          -- goals defaults to an empty array (matching the insert branch).
+          --
+          -- SPE-303: the IEP Dates report's two dates are presence-keyed like the
+          -- teacher columns above — a present date overwrites (file wins); an
+          -- absent one preserves the stored value. On the fresh-insert side of the
+          -- conflict, an absent key resolves to NULL, matching the insert branch.
+          INSERT INTO public.student_details (
+            student_id,
+            first_name,
+            last_name,
+            iep_goals,
+            upcoming_iep_date,
+            upcoming_triennial_date
+          )
+          VALUES (
+            v_student_id,
+            v_student->>'firstName',
+            v_student->>'lastName',
+            CASE
+              WHEN v_student ? 'goals' AND jsonb_array_length(v_student->'goals') > 0
+              THEN ARRAY(SELECT jsonb_array_elements_text(v_student->'goals'))
+              ELSE '{}'::text[]
+            END,
+            (v_student->>'upcomingIepDate')::date,
+            (v_student->>'upcomingTriennialDate')::date
+          )
+          ON CONFLICT (student_id) DO UPDATE
+          SET
+            first_name = COALESCE(EXCLUDED.first_name, student_details.first_name),
+            last_name = COALESCE(EXCLUDED.last_name, student_details.last_name),
+            iep_goals = CASE
+              WHEN v_student ? 'goals' AND jsonb_array_length(v_student->'goals') > 0
+              THEN EXCLUDED.iep_goals
+              ELSE student_details.iep_goals
+            END,
+            upcoming_iep_date = CASE
+              WHEN v_student ? 'upcomingIepDate' THEN (v_student->>'upcomingIepDate')::date
+              ELSE student_details.upcoming_iep_date
+            END,
+            upcoming_triennial_date = CASE
+              WHEN v_student ? 'upcomingTriennialDate' THEN (v_student->>'upcomingTriennialDate')::date
+              ELSE student_details.upcoming_triennial_date
+            END,
+            updated_at = now();
+
+          v_updated := v_updated + 1;
+          v_result := jsonb_build_object(
+            'action', 'updated',
+            'studentId', v_student_id,
+            'initials', v_student->>'initials',
+            'success', true
+          );
+
+        WHEN 'skip' THEN
+          v_skipped := v_skipped + 1;
+          v_result := jsonb_build_object(
+            'action', 'skipped',
+            'studentId', v_student_id,
+            'initials', v_student->>'initials',
+            'success', true
+          );
+
+        ELSE
+          RAISE EXCEPTION 'Unknown action: %', v_action;
+      END CASE;
+
+    EXCEPTION
+      WHEN OTHERS THEN
+        v_errors := v_errors + 1;
+        v_result := jsonb_build_object(
+          'action', v_action,
+          'studentId', COALESCE(v_student_id, v_new_student_id),
+          'initials', v_student->>'initials',
+          'success', false,
+          'error', SQLERRM
+        );
+    END;
+
+    v_results := v_results || v_result;
+  END LOOP;
+
+  -- Return summary with detailed results
+  RETURN jsonb_build_object(
+    'inserted', v_inserted,
+    'updated', v_updated,
+    'skipped', v_skipped,
+    'errors', v_errors,
+    'results', v_results
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.upsert_students_atomic(uuid, jsonb) IS
+  'Atomically processes an array of student upsert operations (insert, update, or skip).
+   Each student object should have an "action" field and appropriate data fields.
+   Update upserts student_details so an added name persists even when the row had
+   none (SPE-284). Insert and update now also write the SEIS IEP Dates report''s
+   upcoming_iep_date / upcoming_triennial_date, presence-keyed so an import without
+   that file never nulls them (SPE-303). Returns summary counts and detailed
+   results for each student.';
+
+GRANT EXECUTE ON FUNCTION public.upsert_students_atomic(uuid, jsonb) TO authenticated;


### PR DESCRIPTION
## What & why

Adds the SEIS **"IEP Dates" report** to the unified Import Students flow as a 4th recognized file type. Dropping it fills in each matched student's **Upcoming IEP Date** (Date of Next Annual Plan Review) and **Upcoming Triennial IEP Date** (Date of Next Reevaluation) — the same two `student_details` fields providers hand-enter one student at a time today. Those fields also feed the teacher portal and the IEP-meeting scheduling roadmap, so one file drop can populate due dates for a whole caseload.

Today, dropping this file gets rejected ("Could not detect IEP goal columns"); this teaches the importer to recognize and route it.

Closes SPE-303.

## How it works

It plugs into the existing **enrichment-file** slot (same shape as Deliveries → schedules and Class list → teachers), matching students by normalized full name.

- **Detection** (`detect-import-file.ts`): new `iep-dates` type + `iepDatesFile` form key, recognized by the `Date of Next Annual Plan Review` / `Date of Next Reevaluation` header columns (verified unique vs. the goals/deliveries/roster headers).
- **Parser** (`lib/parsers/iep-dates-parser.ts`): header-based column lookup (order-independent), BOM + latin1 tolerance, and **calendar-validated** dates (an out-of-range date like `13/45/2026` becomes a per-row warning instead of corrupting the DB write).
- **Pipeline**: enriches matched rows in the main goals path **and** in update-only mode (drop just this file to refresh a whole caseload). Other-school rows are school-scoped out of the "needs review" list (mirrors SPE-268).
- **File wins** (confirmed by Blair): a present date overwrites the stored one, shown as **old → new** on the review screen; a row whose dates already match stays a **skip** (no phantom update). The write is **presence-keyed**, so an import *without* this file never nulls an existing date.
- **Review screen**: a conditional "IEP / Triennial" column with old → new, a file receipt, and unmatched-source handling.
- **DB**: `upsert_students_atomic` function replacement only — both date columns already exist, so **no schema change**. Presence-keyed writes in both the insert and update branches. (The replacement preserves the SPE-289 `pg_temp` search_path pin.)

## Testing

- **Unit**: detection (signature + precedence), parser (dates/BOM/latin1/bad-dates/dupes/no-name), classify change-detection (main + update-only, skip vs. overwrite), collect-unmatched, review-model, and the shared wire contract. `npm test` fully green.
- **E2E (sim district)**: walked a provider through Import Students, dropped an IEP Dates CSV, confirmed the review screen shows old → new / unchanged / unmatched / skip correctly, then verified underneath the UI that `student_details.upcoming_iep_date` / `upcoming_triennial_date` were written exactly as designed (overwrite where changed, preserved where unchanged, untouched for the skip row). `sim:verify` stayed green (no new tables). 12/12 walk checks pass.
- Ran a deep adversarial self-review over the diff; its two confirmed findings (a dropped `pg_temp` pin in the migration, and a telemetry over-count) are fixed in this branch.

## Not auto-deployable

User-facing (new file type + review column) and includes a DB function migration — normal PR flow, **merge held for your call**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCpAwdGQTpogUAo4eKfYjR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing **IEP Dates** CSV files (SPE-303).
  * Import preview and review screens now display **upcoming IEP** and **upcoming triennial** dates, including old→new change indicators and “Not set” when absent.
  * Confirmation and import APIs now carry presence-keyed IEP date fields: new inserts populate provided values; updates only overwrite when dates are included.

* **Bug Fixes**
  * Update-only imports no longer trigger phantom changes when IEP Dates already match stored values.
  * Unmatched-record receipts and review exceptions now correctly label entries as **IEP dates**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->