### PR TITLE
SPE-294: keep session instances in sync on move / unschedule / archive

### DIFF
--- a/lib/services/session-instance-generator.ts
+++ b/lib/services/session-instance-generator.ts
@@ -148,16 +148,19 @@ export async function createInstancesFromTemplate(
       week++;
     }
 
-    // Check which instances already exist
+    // Check which instances already exist. Key this on the DB uniqueness
+    // (student_id, session_date, start_time) — NOT the full template signature.
+    // A row already occupying a (date, start_time) slot with a different end_time
+    // (e.g. today's completed / attendance-marked instance that SPE-294's prune
+    // deliberately preserved across a duration change) must be treated as
+    // existing, or the batch insert below trips unique_session_per_date and every
+    // new row — the whole future series — silently fails. (Concurrency-race
+    // tolerance for the insert itself is tracked separately in SPE-293.)
     const { data: existingInstances, error: checkError } = await supabase
       .from('schedule_sessions')
       .select('session_date')
       .eq('student_id', templateSession.student_id)
-      .eq('provider_id', templateSession.provider_id)
-      .eq('service_type', templateSession.service_type)
-      .eq('day_of_week', templateSession.day_of_week)
       .eq('start_time', templateSession.start_time)
-      .eq('end_time', templateSession.end_time)
       .in('session_date', datesToCreate)
       .not('session_date', 'is', null);
 

--- a/lib/services/session-update-service.ts
+++ b/lib/services/session-update-service.ts
@@ -2,8 +2,8 @@ import { createClient } from '@/lib/supabase/client';
 import { ScheduleSession, BellSchedule, SpecialActivity } from '@/src/types';
 import { DEFAULT_SCHEDULING_CONFIG } from '@/lib/scheduling/scheduling-config';
 import { requireNonNull } from '@/lib/types/utils';
-import { formatDateLocal } from '@/lib/utils/date-helpers';
 import { formatRoleLabel } from '@/lib/utils/role-utils';
+import { deleteFutureTemplateInstances } from '@/lib/supabase/queries/schedule-sessions';
 
 // Helper functions for time conversion
 const timeToMinutes = (time: string): number => {
@@ -288,63 +288,44 @@ export class SessionUpdateService {
         }
       }
 
-      // ORPHAN CLEANUP: When a template's time/day changes, delete future orphaned instances
-      // This prevents old instances from showing up in Day view/Today's Schedule
-      if (session.session_date === null) {
-        const timeChanged = session.start_time !== newStartTime || session.day_of_week !== newDay;
+      // SPE-294: keep a template's dated instances in sync with its slot on every
+      // change. A scheduled template carries up to 12 weeks of pre-materialized
+      // future instances (the SPE-291 top-up), so when the slot changes we must
+      // (1) delete the future, not-yet-completed instances at the OLD slot and
+      // (2) (re)generate at the NEW slot. Without (2), a MOVE previously left the
+      // new slot with no persisted instances until the daily top-up next ran;
+      // keying both steps on the same slot-changed condition also keeps an
+      // end-time-only change from colliding on unique(student_id, session_date,
+      // start_time).
+      if (updatedSession.session_date === null) {
+        const wasUnscheduled = session.day_of_week === null ||
+                               session.start_time === null ||
+                               session.end_time === null;
+        const nowScheduled = updatedSession.day_of_week !== null &&
+                             updatedSession.start_time !== null &&
+                             updatedSession.end_time !== null;
+        const slotChanged = session.day_of_week !== updatedSession.day_of_week ||
+                            session.start_time !== updatedSession.start_time ||
+                            session.end_time !== updatedSession.end_time;
 
-        if (timeChanged && session.start_time && session.day_of_week !== null) {
-          const today = formatDateLocal(new Date());
-
-          console.log('Cleaning up orphaned instances:', {
-            studentId: session.student_id,
-            oldDay: session.day_of_week,
-            oldStartTime: session.start_time,
-            newDay,
-            newStartTime
-          });
-
-          // Delete future non-completed instances at the OLD time
-          const { error: cleanupError, count } = await this.supabase
-            .from('schedule_sessions')
-            .delete()
-            .eq('student_id', session.student_id)
-            .eq('provider_id', session.provider_id)
-            .eq('day_of_week', session.day_of_week)
-            .eq('start_time', session.start_time)
-            .gte('session_date', today)
-            .is('completed_at', null);
-
-          if (cleanupError) {
-            console.error('Error cleaning up orphaned instances:', cleanupError);
+        // (1) Prune the template's now-stale future instances — after the update
+        // they sit at the OLD slot. The shared helper preserves attendance-marked
+        // and completed rows (same guarantee as archive/unschedule), so a move made
+        // after today's session was marked can't destroy that attendance record.
+        if (!wasUnscheduled && slotChanged) {
+          const { deleted, error: pruneError } = await deleteFutureTemplateInstances(this.supabase, sessionId);
+          if (pruneError) {
+            console.error('Error pruning old-slot instances on move:', pruneError);
           } else {
-            console.log(`Deleted ${count || 0} orphaned instances`);
+            console.log(`Pruned ${deleted} old-slot instances on move`);
           }
         }
-      }
 
-      // Generate instances if this is a template session being scheduled
-      // Only create instances if:
-      // 1. Session has no session_date (it's a template)
-      // 2. Session now has valid schedule (day_of_week, start_time, end_time)
-      // 3. Session wasn't already scheduled (changed from unscheduled to scheduled)
-      if (updatedSession.session_date === null &&
-          updatedSession.day_of_week !== null &&
-          updatedSession.start_time !== null &&
-          updatedSession.end_time !== null) {
-
-        // Check if this session was previously unscheduled
-        const wasUnscheduled = session.day_of_week === null ||
-                              session.start_time === null ||
-                              session.end_time === null;
-
-        if (wasUnscheduled) {
-          // This is a newly scheduled session - create instances via API
-          // Instances are generated through school year end (June 30) by default
-          console.log('Creating instances for newly scheduled template through school year end:', sessionId);
-
-          // Create instances asynchronously (don't block the response)
-          // Pass useSchoolYearEnd: true to generate through June 30
+        // (2) (Re)generate instances at the NEW slot whenever the template is
+        // scheduled and its slot changed — covers unscheduled->scheduled AND moves.
+        // Fire-and-forget through the API (generation is dedup-safe); don't block.
+        if (nowScheduled && (wasUnscheduled || slotChanged)) {
+          console.log('Generating instances for scheduled template through school year end:', sessionId);
           fetch('/api/sessions/generate-instances', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -1101,6 +1082,14 @@ export class SessionUpdateService {
         );
       }
 
+      // SPE-294: an unscheduled template has no slot, so its future, not-yet-completed
+      // instances (up to 12 weeks from the top-up) would linger as phantom "unmarked"
+      // sessions — prune them. Best-effort: never fail the unschedule over cleanup.
+      const { error: pruneError } = await deleteFutureTemplateInstances(this.supabase, sessionId);
+      if (pruneError) {
+        console.error('Error pruning future instances on unschedule:', pruneError);
+      }
+
       return { success: true, session: updatedSession };
     } catch (error) {
       console.error('Unschedule session error:', error);
@@ -1117,6 +1106,9 @@ export class SessionUpdateService {
     count?: number;
   }> {
     try {
+      // Only TEMPLATES are unscheduled (session_date IS NULL). Dated instances that
+      // share this day_of_week keep it as history and are handled by the prune below;
+      // without this filter the update would null day_of_week on past instances too.
       const { data: updatedSessions, error: updateError } = await this.supabase
         .from('schedule_sessions')
         .update({
@@ -1130,11 +1122,22 @@ export class SessionUpdateService {
         })
         .eq('provider_id', providerId)
         .eq('day_of_week', dayOfWeek)
+        .is('session_date', null)
         .select();
 
       if (updateError) {
         console.error('Error unscheduling day sessions:', updateError);
         return { success: false, error: 'Failed to unschedule sessions' };
+      }
+
+      // SPE-294: prune the now-unscheduled templates' future, not-yet-completed
+      // instances so they don't linger as phantom "unmarked" sessions.
+      const templateIds = (updatedSessions ?? []).map(s => s.id);
+      if (templateIds.length > 0) {
+        const { error: pruneError } = await deleteFutureTemplateInstances(this.supabase, templateIds);
+        if (pruneError) {
+          console.error('Error pruning future instances on unschedule-day:', pruneError);
+        }
       }
 
       console.log(`Unscheduled ${updatedSessions?.length || 0} sessions from day ${dayOfWeek}`);

--- a/lib/supabase/queries/schedule-sessions.ts
+++ b/lib/supabase/queries/schedule-sessions.ts
@@ -1,16 +1,77 @@
 import { createClient } from '@/lib/supabase/client';
 import { safeQuery } from '@/lib/supabase/safe-query';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
+import { formatDateLocal } from '@/lib/utils/date-helpers';
 import type { Database } from '../../../src/types/database';
 import type { SupabaseClient, PostgrestError } from '@supabase/supabase-js';
+
+/**
+ * SPE-294: delete a template's FUTURE, not-yet-completed, UNMARKED dated instances.
+ *
+ * Every active scheduled template carries up to 12 weeks of pre-materialized
+ * future instances (the SPE-291 rolling top-up). Whenever a template stops being
+ * live at its current slot — a move (its old-slot rows), unschedule, archive, or
+ * a per-template caseload decrease — those rows must go, or each becomes a
+ * phantom "unmarked session" in the attendance widget (`/api/attendance/summary`)
+ * once its date passes.
+ *
+ * "Strandable" = `session_date >= today` AND `completed_at IS NULL` AND has NO
+ * row in `attendance`. Attendance lives in a separate table joined by session id
+ * with an ON DELETE CASCADE FK, so deleting a marked instance would destroy its
+ * present/absent record — a compliance record. Those are preserved here, as is
+ * all past and explicitly-completed history. Accepts one template id or many
+ * (e.g. clearing a day). Two-pass because PostgREST can't express the anti-join
+ * inline; RLS scopes both the attendance read and the delete to the caller.
+ */
+export async function deleteFutureTemplateInstances(
+  supabase: SupabaseClient<Database>,
+  templateIds: string | string[]
+): Promise<{ deleted: number; error: PostgrestError | null }> {
+  const ids = Array.isArray(templateIds) ? templateIds : [templateIds];
+  if (ids.length === 0) return { deleted: 0, error: null };
+
+  const today = formatDateLocal(new Date());
+
+  // Candidates: this template's future, not-explicitly-completed instances.
+  const { data: candidates, error: candErr } = await supabase
+    .from('schedule_sessions')
+    .select('id')
+    .in('template_id', ids)
+    .gte('session_date', today)
+    .is('completed_at', null);
+  if (candErr) return { deleted: 0, error: candErr };
+
+  const candidateIds = (candidates ?? []).map((c) => c.id);
+  if (candidateIds.length === 0) return { deleted: 0, error: null };
+
+  // Preserve any candidate that already has recorded attendance — the FK cascade
+  // would otherwise delete that present/absent record along with the instance.
+  const { data: marked, error: attErr } = await supabase
+    .from('attendance')
+    .select('session_id')
+    .in('session_id', candidateIds);
+  if (attErr) return { deleted: 0, error: attErr };
+
+  const markedIds = new Set((marked ?? []).map((m) => m.session_id));
+  const deletableIds = candidateIds.filter((id) => !markedIds.has(id));
+  if (deletableIds.length === 0) return { deleted: 0, error: null };
+
+  const { count, error } = await supabase
+    .from('schedule_sessions')
+    .delete({ count: 'exact' })
+    .in('id', deletableIds);
+
+  return { deleted: count ?? 0, error };
+}
 
 /**
  * Removes a schedule_sessions row while preserving instance history.
  *
  * - A dated instance the user explicitly removed is hard-deleted.
- * - A template that has >=1 dated instance is soft-deleted (deleted_at set), so
- *   those instances keep a valid template_id and completed history survives.
- * - A template with no instances is hard-deleted (nothing to preserve).
+ * - A template's FUTURE, not-yet-completed instances are pruned first (SPE-294),
+ *   so the top-up's future rows don't linger as phantom "unmarked" sessions.
+ * - The template is then soft-deleted (deleted_at set) iff past/completed history
+ *   remains — keeping a valid template_id for it — else hard-deleted.
  *
  * Template reads must filter `.is('deleted_at', null)` so archived templates stay
  * out of the schedule grid, count math, conflict checks, and instance generation.
@@ -34,7 +95,13 @@ export async function deleteOrArchiveTemplate(
     return { archived: false, error };
   }
 
-  // Template: archive only if it has instances worth keeping.
+  // Prune this template's future, not-yet-completed instances (SPE-294) before
+  // deciding archive vs hard-delete, so the archive decision is based on the
+  // history actually worth keeping.
+  const { error: pruneError } = await deleteFutureTemplateInstances(supabase, sessionId);
+  if (pruneError) return { archived: false, error: pruneError };
+
+  // Archive only if past/completed history remains after the prune.
   const { count, error: countError } = await supabase
     .from('schedule_sessions')
     .select('id', { count: 'exact', head: true })

--- a/lib/supabase/queries/schedule-sessions.ts
+++ b/lib/supabase/queries/schedule-sessions.ts
@@ -20,8 +20,10 @@ import type { SupabaseClient, PostgrestError } from '@supabase/supabase-js';
  * with an ON DELETE CASCADE FK, so deleting a marked instance would destroy its
  * present/absent record — a compliance record. Those are preserved here, as is
  * all past and explicitly-completed history. Accepts one template id or many
- * (e.g. clearing a day). Two-pass because PostgREST can't express the anti-join
- * inline; RLS scopes both the attendance read and the delete to the caller.
+ * (e.g. clearing a day). Reads the candidate ids up front (paginated, since
+ * clearing a busy day can exceed PostgREST's 1000-row cap) then deletes in
+ * chunks; PostgREST can't express the attendance anti-join inline. RLS scopes
+ * both the attendance read and the delete to the caller.
  */
 export async function deleteFutureTemplateInstances(
   supabase: SupabaseClient<Database>,
@@ -32,36 +34,55 @@ export async function deleteFutureTemplateInstances(
 
   const today = formatDateLocal(new Date());
 
-  // Candidates: this template's future, not-explicitly-completed instances.
-  const { data: candidates, error: candErr } = await supabase
-    .from('schedule_sessions')
-    .select('id')
-    .in('template_id', ids)
-    .gte('session_date', today)
-    .is('completed_at', null);
-  if (candErr) return { deleted: 0, error: candErr };
-
-  const candidateIds = (candidates ?? []).map((c) => c.id);
+  // Collect candidates: each template's future, not-explicitly-completed
+  // instances. Paginate (PostgREST caps a single response at 1000 rows, and
+  // templates now generate through the school year end) and read every id
+  // before deleting anything, so the scan isn't disturbed mid-pass.
+  const PAGE = 1000;
+  const candidateIds: string[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from('schedule_sessions')
+      .select('id')
+      .in('template_id', ids)
+      .gte('session_date', today)
+      .is('completed_at', null)
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1);
+    if (error) return { deleted: 0, error };
+    const batch = data ?? [];
+    for (const row of batch) candidateIds.push(row.id);
+    if (batch.length < PAGE) break;
+  }
   if (candidateIds.length === 0) return { deleted: 0, error: null };
 
-  // Preserve any candidate that already has recorded attendance — the FK cascade
-  // would otherwise delete that present/absent record along with the instance.
-  const { data: marked, error: attErr } = await supabase
-    .from('attendance')
-    .select('session_id')
-    .in('session_id', candidateIds);
-  if (attErr) return { deleted: 0, error: attErr };
+  // Delete in chunks, preserving any instance that already has recorded
+  // attendance — the ON DELETE CASCADE FK would otherwise destroy that
+  // present/absent record. Chunking also bounds the `.in(...)` URL length.
+  const CHUNK = 200;
+  let deleted = 0;
+  for (let i = 0; i < candidateIds.length; i += CHUNK) {
+    const chunk = candidateIds.slice(i, i + CHUNK);
 
-  const markedIds = new Set((marked ?? []).map((m) => m.session_id));
-  const deletableIds = candidateIds.filter((id) => !markedIds.has(id));
-  if (deletableIds.length === 0) return { deleted: 0, error: null };
+    const { data: marked, error: attErr } = await supabase
+      .from('attendance')
+      .select('session_id')
+      .in('session_id', chunk);
+    if (attErr) return { deleted, error: attErr };
 
-  const { count, error } = await supabase
-    .from('schedule_sessions')
-    .delete({ count: 'exact' })
-    .in('id', deletableIds);
+    const markedIds = new Set((marked ?? []).map((m) => m.session_id));
+    const deletableIds = chunk.filter((id) => !markedIds.has(id));
+    if (deletableIds.length === 0) continue;
 
-  return { deleted: count ?? 0, error };
+    const { count, error } = await supabase
+      .from('schedule_sessions')
+      .delete({ count: 'exact' })
+      .in('id', deletableIds);
+    if (error) return { deleted, error };
+    deleted += count ?? 0;
+  }
+
+  return { deleted, error: null };
 }
 
 /**


### PR DESCRIPTION
## What & why

Since the SPE-291 rolling top-up shipped, **every active scheduled template carries up to 12 weeks of pre-materialized dated instances**. That exposed two asymmetries in how templates stop being live at their slot:

1. **Move gap:** `updateSessionTime` deleted the old-slot instances but only regenerated when the template was *previously unscheduled* — so a **move** left the new slot with no persisted instances until the next nightly top-up.
2. **Strand on unschedule/archive/caseload-decrease:** `deleteOrArchiveTemplate`, `unscheduleSession`, and `unscheduleDaySessions` left the template's future instances live. Each one becomes a phantom **"unmarked session"** in the dashboard attendance widget (`/api/attendance/summary` reads instances with no template-liveness check) once its date passes.

## The fix

New shared helper **`deleteFutureTemplateInstances(supabase, templateIds)`** — deletes a template's **future (`session_date >= today`), not-yet-completed, unmarked** instances, used by all four sites:

- **Move (`updateSessionTime`):** prune the template's now-stale (old-slot) instances **and regenerate at the new slot**. Both steps are keyed on the same slot-changed condition, so an end-time-only change can't collide on `unique(student_id, session_date, start_time)`.
- **`deleteOrArchiveTemplate`:** prune first, then archive iff past/completed history remains (else hard-delete). Caseload decreases flow through here, so they're covered.
- **`unscheduleSession` / `unscheduleDaySessions`:** prune the affected template(s). `unscheduleDaySessions` now scopes its UPDATE to templates (`session_date IS NULL`) so it no longer nulls `day_of_week` on past instances.

### Data-safety guard (caught in self-review)

Attendance lives in a **separate `attendance` table** joined by session id with an **`ON DELETE CASCADE`** FK, and it's *decoupled* from `completed_at` (the dashboard quick-mark writes attendance but leaves `completed_at` NULL). So a naive `completed_at IS NULL` prune of a **today**-dated instance that was already marked present/absent would silently cascade-delete that attendance — a compliance record. The helper therefore **skips any instance that has an `attendance` row** (the ticket's "non-**touched**"), preserving all marked and completed history. RLS scopes the attendance read and the instance delete to the same owner, so the guard can't be bypassed.

## Verification

- **TypeScript** ✅, **lint** ✅, related **unit tests** ✅ (39 passed).
- **Prod data check:** **0** currently-stranded future instances across archived / unscheduled / moved / orphan categories (the top-up only went live yesterday). This fix is **preventive — no data backfill needed**.
- The top-up skips `deleted_at`/unscheduled templates, so pruned rows are not re-created.
- Deep adversarial self-review performed; its one High finding (the attendance cascade above) is fixed in this diff.

**Recommend a Sim District E2E as the final pre-merge gate** — drag a session to a new slot, unschedule it, clear a day, and confirm instances regenerate/prune while marked attendance survives. Happy to run it on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019fTDZKd7JuWiQSYE6How9f)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed lingering future sessions after scheduled templates are moved or unscheduled.
  - Updated day-level unscheduling to affect only template sessions, preventing unintended changes to dated sessions.
  - Preserved completed sessions and attendance history while cleaning up future scheduled instances.
  - Improved template deletion and archiving by removing eligible future instances first, preventing duplicate or outdated schedule entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->