### PR TITLE
Disable educational onboarding banners on dashboard

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -9,7 +9,6 @@ import { Card, CardHeader, CardTitle, CardBody } from '../../components/ui/card'
 import { Button } from '../../components/ui/button';
 import { TodoWidget } from '../../components/todo-widget';
 import { WeeklyView } from '../../components/weekly-view';
-import { OnboardingNotifications } from '../../components/onboarding/onboarding-notifications';
 import { AttendanceWidget } from '../../components/dashboard/attendance-widget';
 import { ToastProvider } from '../../contexts/toast-context';
 import { useSchool } from '../../components/providers/school-context';
@@ -82,11 +81,7 @@ export default function DashboardPage() {
           <div className="mb-8">
             <h1 className="text-3xl font-bold text-gray-900 mb-2">Dashboard</h1>
           </div>
-          
-          {/* Onboarding Notifications */}
-          <OnboardingNotifications />
 
-          
           {/* Main Content Area */}
           <div className="space-y-4">
             {/* Scheduling & attendance views don't apply on secondary (middle/high) sites */}


### PR DESCRIPTION
## What & why

The dashboard showed dismissible "new user" education banners (the "Welcome to Speddy! To get started, please add your Students, Bell Schedule, and Special Activities…" banner and the multi-school work-schedule banner). They were buggy and not helpful, so this PR turns them off.

## Change

- Remove the `OnboardingNotifications` import and its render from `app/(dashboard)/dashboard/page.tsx`. That component was the only thing mounting both onboarding banners, so removing it disables all of them.

## Deliberately left in place (disable, not delete)

- The `OnboardingNotifications` / `OnboardingBanner` components and the `setup_banner_dismissed` / `multi_school_banner_dismissed` profile columns are untouched, so the banners can be re-enabled later (after the bugs are fixed) without a schema change or rebuild of the feature.
- The teacher portal's static "About the Teacher Portal" info card is **not** touched — it's permanent, non-dismissible page content, not a new-user onboarding banner.

## Verification

- `tsc --noEmit --skipLibCheck` — clean
- `next lint` on the changed file — no warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iL5CP5UqBUvtBoMUYmVj3

---
_Generated by [Claude Code](https://claude.ai/code/session_011iL5CP5UqBUvtBoMUYmVj3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed onboarding notifications from the dashboard display.
  * Preserved existing dashboard content, loading behavior, role checks, and widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->