### PR TITLE
SPE-141 §1: fail closed on scheduling filters & cross-provider conflict checks

### DIFF
--- a/__tests__/unit/lib/scheduling/conflict-resolver-fail-closed.test.ts
+++ b/__tests__/unit/lib/scheduling/conflict-resolver-fail-closed.test.ts
@@ -1,0 +1,98 @@
+// Aliased with a `mock` prefix so the jest.mock factory (hoisted above imports
+// by babel-plugin-jest-hoist) may reference it.
+import { createMockSupabaseClient as mockCreateSupabaseClient } from '@/test-utils/supabase-test-helpers';
+
+// ConflictResolver builds a Supabase client in its constructor; stub the module
+// so construction is harmless. Each test then overrides `resolver.supabase`.
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockCreateSupabaseClient(),
+}));
+
+import { ConflictResolver } from '@/lib/scheduling/conflict-resolver';
+
+type QueryResponse = { data: any[] | null; error: any };
+
+// Build a resolver whose cross-provider query resolves to `response`. The chain
+// (.select().eq().eq().neq()) ends on `.neq()`, so every method returns the same
+// thenable builder.
+function resolverReturning(response: QueryResponse): ConflictResolver {
+  const builder: any = {
+    select: () => builder,
+    eq: () => builder,
+    neq: () => builder,
+    then: (resolve: (r: QueryResponse) => unknown) => resolve(response),
+  };
+  const resolver = new ConflictResolver('provider-1') as any;
+  resolver.supabase = { from: () => builder };
+  return resolver as ConflictResolver;
+}
+
+// A resolver whose query throws synchronously, exercising the catch block.
+function resolverThatThrows(): ConflictResolver {
+  const resolver = new ConflictResolver('provider-1') as any;
+  resolver.supabase = {
+    from: () => {
+      throw new Error('network down');
+    },
+  };
+  return resolver as ConflictResolver;
+}
+
+const overlapping = {
+  id: 'other-session',
+  start_time: '09:00:00',
+  end_time: '09:30:00',
+  service_type: 'Speech',
+  profiles: { full_name: 'Dr. Other', role: 'speech' },
+};
+
+// checkCrossProviderConflicts(studentId, schoolSite, dayOfWeek, start, end)
+const args = ['student-1', 'Willow', 1, '09:15', '09:45'] as const;
+
+describe('ConflictResolver.checkCrossProviderConflicts fails closed (SPE-141)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('treats a query error as a conflict rather than silently allowing a double-booking', async () => {
+    const resolver = resolverReturning({ data: null, error: { message: 'boom' } });
+    const result = await resolver.checkCrossProviderConflicts(...args);
+
+    expect(result.hasConflict).toBe(true);
+    expect(result.conflictDetails).toMatch(/could not verify/i);
+  });
+
+  it('treats a thrown error as a conflict (catch block fails closed)', async () => {
+    const resolver = resolverThatThrows();
+    const result = await resolver.checkCrossProviderConflicts(...args);
+
+    expect(result.hasConflict).toBe(true);
+    expect(result.conflictDetails).toMatch(/could not verify/i);
+  });
+
+  it('reports no conflict when the lookup succeeds with no overlapping session', async () => {
+    const resolver = resolverReturning({ data: [], error: null });
+    const result = await resolver.checkCrossProviderConflicts(...args);
+
+    expect(result.hasConflict).toBe(false);
+  });
+
+  it('still reports a genuine overlap as a conflict', async () => {
+    const resolver = resolverReturning({ data: [overlapping], error: null });
+    const result = await resolver.checkCrossProviderConflicts(...args);
+
+    expect(result.hasConflict).toBe(true);
+    expect(result.conflictDetails).toContain('Dr. Other');
+  });
+
+  it('reports the overlap without crashing when the provider profile is missing', async () => {
+    // A deleted provider leaves `profiles` null on the joined row; the overlap
+    // is still real, so it must surface as a conflict, not throw into the catch.
+    const resolver = resolverReturning({
+      data: [{ ...overlapping, profiles: null }],
+      error: null,
+    });
+    const result = await resolver.checkCrossProviderConflicts(...args);
+
+    expect(result.hasConflict).toBe(true);
+    expect(result.conflictDetails).toContain('another provider');
+  });
+});

--- a/__tests__/unit/lib/utils/session-filters-fail-closed.test.ts
+++ b/__tests__/unit/lib/utils/session-filters-fail-closed.test.ts
@@ -1,0 +1,105 @@
+import { filterSessionsBySchool, type Session, type SchoolContext } from '@/lib/utils/session-filters';
+
+// Assert on the logged error path so an empty result is proven to come from the
+// fail-closed branch, not from a successful-but-empty query.
+jest.mock('@/lib/monitoring/logger', () => ({
+  log: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}));
+import { log } from '@/lib/monitoring/logger';
+
+type QueryResponse = { data: any[] | null; error: any };
+
+/**
+ * A thenable Supabase query stub: every chainable method returns the same
+ * builder, and awaiting it resolves to a fixed response — so it works no matter
+ * which method (`.in()`, trailing `.eq()`) ends the chain in each branch.
+ */
+function makeSupabase(response: QueryResponse) {
+  const builder: any = {
+    select: () => builder,
+    eq: () => builder,
+    in: () => builder,
+    then: (resolve: (r: QueryResponse) => unknown) => resolve(response),
+  };
+  return { from: jest.fn(() => builder) } as any;
+}
+
+const sessions: Session[] = [
+  { student_id: 'student-in-school' },
+  { student_id: 'student-other-school' },
+];
+
+const dbError = { message: 'connection reset', code: 'PGRST000' };
+
+describe('filterSessionsBySchool fails closed on lookup error (SPE-141)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns [] (not the unfiltered input) when the school_id lookup errors', async () => {
+    const supabase = makeSupabase({ data: null, error: dbError });
+    const result = await filterSessionsBySchool(supabase, sessions, {
+      school_id: 'school-1',
+    } as SchoolContext);
+
+    expect(result).toEqual([]);
+    expect(log.error).toHaveBeenCalledWith(
+      'Failed to filter sessions by school_id',
+      dbError,
+      expect.any(Object),
+    );
+  });
+
+  it('returns [] when the district_id lookup errors', async () => {
+    const supabase = makeSupabase({ data: null, error: dbError });
+    const result = await filterSessionsBySchool(supabase, sessions, {
+      district_id: 'district-1',
+      school_site: 'Willow',
+    } as SchoolContext);
+
+    expect(result).toEqual([]);
+    expect(log.error).toHaveBeenCalledWith(
+      'Failed to filter sessions by district_id',
+      dbError,
+      expect.any(Object),
+    );
+  });
+
+  it('returns [] when the legacy school_site lookup errors', async () => {
+    const supabase = makeSupabase({ data: null, error: dbError });
+    const result = await filterSessionsBySchool(supabase, sessions, {
+      school_site: 'Willow',
+      school_district: 'Metro',
+    } as SchoolContext);
+
+    expect(result).toEqual([]);
+    expect(log.error).toHaveBeenCalledWith(
+      'Failed to filter sessions by school_site',
+      dbError,
+      expect.any(Object),
+    );
+  });
+
+  it('still filters normally when the lookup succeeds (fail-closed does not over-block)', async () => {
+    const supabase = makeSupabase({
+      data: [{ id: 'student-in-school' }],
+      error: null,
+    });
+    const result = await filterSessionsBySchool(supabase, sessions, {
+      school_id: 'school-1',
+    } as SchoolContext);
+
+    expect(result).toEqual([{ student_id: 'student-in-school' }]);
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it('returns [] on a successful lookup with null data (no error) — never the unfiltered input', async () => {
+    // { data: null, error: null } is a non-error empty result. It must resolve
+    // to [] (no students matched), not fall back to the unfiltered `sessions`.
+    const supabase = makeSupabase({ data: null, error: null });
+    const result = await filterSessionsBySchool(supabase, sessions, {
+      school_id: 'school-1',
+    } as SchoolContext);
+
+    expect(result).toEqual([]);
+    expect(log.error).not.toHaveBeenCalled();
+  });
+});

--- a/lib/scheduling/conflict-resolver.ts
+++ b/lib/scheduling/conflict-resolver.ts
@@ -151,7 +151,12 @@ export class ConflictResolver {
   }
 
   /**
-   * Check if a student has sessions with other providers at the same time
+   * Check if a student has sessions with other providers at the same time.
+   *
+   * NOTE: currently uncalled — the live cross-provider gate is
+   * `session-update-service.ts#interpretCrossProviderStaleCheck` (already
+   * fail-closed, SPE-255). Kept fail-closed here too so a future revival can't
+   * regress to fail-open (SPE-141).
    */
   async checkCrossProviderConflicts(
     studentId: string,
@@ -163,7 +168,7 @@ export class ConflictResolver {
   ): Promise<{ hasConflict: boolean; conflictDetails?: string }> {
     try {
       // Get all sessions for this student from ALL providers at this school
-      const { data: otherSessions } = await this.supabase
+      const { data: otherSessions, error } = await this.supabase
         .from('schedule_sessions')
         .select(`
           *,
@@ -175,6 +180,17 @@ export class ConflictResolver {
         .eq('student_id', studentId)
         .eq('day_of_week', dayOfWeek)
         .neq('provider_id', this.providerId);
+
+      // Fail closed (SPE-141): if we can't verify the student's other-provider
+      // sessions, treat it as a conflict rather than silently allowing a
+      // potential double-booking.
+      if (error) {
+        console.error('Error checking cross-provider conflicts:', error);
+        return {
+          hasConflict: true,
+          conflictDetails: 'Could not verify cross-provider availability — treated as a conflict. Please retry.'
+        };
+      }
 
       if (!otherSessions || otherSessions.length === 0) {
         return { hasConflict: false };
@@ -190,20 +206,31 @@ export class ConflictResolver {
           session.start_time,
           session.end_time
         )) {
+          // The profiles join can be null (e.g. the other provider's profile
+          // row was deleted). We still know there IS a real overlap, so report
+          // the conflict with a generic label rather than dereferencing null.
           const providerInfo = session.profiles;
-          const roleDisplay = this.getRoleDisplayName(providerInfo.role);
+          const providerName = providerInfo?.full_name ?? 'another provider';
+          const roleDisplay = providerInfo?.role
+            ? this.getRoleDisplayName(providerInfo.role)
+            : 'Provider';
 
           return {
             hasConflict: true,
-            conflictDetails: `Student has ${session.service_type} with ${providerInfo.full_name} (${roleDisplay}) at this time`
+            conflictDetails: `Student has ${session.service_type} with ${providerName} (${roleDisplay}) at this time`
           };
         }
       }
 
       return { hasConflict: false };
     } catch (error) {
+      // Fail closed (SPE-141): an unexpected error must not silently allow a
+      // double-booking. Surface it as a conflict so the caller re-checks.
       console.error('Error checking cross-provider conflicts:', error);
-      return { hasConflict: false };
+      return {
+        hasConflict: true,
+        conflictDetails: 'Could not verify cross-provider availability — treated as a conflict. Please retry.'
+      };
     }
   }
 

--- a/lib/utils/session-filters.ts
+++ b/lib/utils/session-filters.ts
@@ -11,12 +11,15 @@ export interface Session {
 }
 
 /**
- * Filters sessions by school context with graceful error handling
+ * Filters sessions by school context. FAILS CLOSED (SPE-141): if the
+ * school-membership lookup errors, returns `[]` rather than the unfiltered
+ * input, so a transient DB error can never leak another school's sessions. The
+ * error is logged; callers render an empty schedule until the next load.
  *
  * @param supabase - Supabase client instance
  * @param sessions - Array of sessions to filter
  * @param currentSchool - Current school context with school_id, district_id, or school_site
- * @returns Filtered array of sessions that belong to the current school, or original sessions on error
+ * @returns Sessions belonging to the current school; `[]` on any lookup error
  */
 export async function filterSessionsBySchool<T extends Session>(
   supabase: SupabaseClient,
@@ -50,13 +53,14 @@ export async function filterSessionsBySchool<T extends Session>(
       .eq('school_id', schoolId)
       .in('id', studentIds);
 
-    // Graceful degradation: return original sessions on error
+    // Fail closed: never return the unfiltered set on error — that would leak
+    // other schools' sessions (SPE-141). Empty is safe; the error is logged.
     if (error) {
       log.error('Failed to filter sessions by school_id', error, {
         schoolId,
         studentCount: studentIds.length
       });
-      return sessions;
+      return [];
     }
 
     // Return filtered sessions if query succeeded
@@ -78,14 +82,14 @@ export async function filterSessionsBySchool<T extends Session>(
 
     const { data: studentsData, error } = await query;
 
-    // Graceful degradation: return original sessions on error
+    // Fail closed (SPE-141): an errored lookup must not leak other schools.
     if (error) {
       log.error('Failed to filter sessions by district_id', error, {
         districtId,
         schoolSite,
         studentCount: studentIds.length
       });
-      return sessions;
+      return [];
     }
 
     // Since school_site filter was pushed to database (if provided),
@@ -117,14 +121,14 @@ export async function filterSessionsBySchool<T extends Session>(
 
     const { data: studentsData, error } = await query;
 
-    // Graceful degradation: return original sessions on error
+    // Fail closed (SPE-141): an errored lookup must not leak other schools.
     if (error) {
       log.error('Failed to filter sessions by school_site', error, {
         schoolSite,
         schoolDistrict,
         studentCount: studentIds.length
       });
-      return sessions;
+      return [];
     }
 
     const schoolStudentIds = new Set(studentsData?.map(s => s.id) || []);


### PR DESCRIPTION
## What & why

Two scheduling-integrity gaps "failed open" — on a database error they returned a **permissive** result instead of a safe one. This closes both.

- **School filter (the live fix).** `filterSessionsBySchool` backs the Week view, weekly view, and plan-page schedule. When its school-membership lookup errored, it returned the **entire unfiltered** session list — leaking other schools' sessions on any transient DB hiccup. All three error branches (`school_id` / `district_id` / `school_site`) now return `[]` and log the error.
- **Cross-provider conflict check (latent-safety).** `checkCrossProviderConflicts` returned "no conflict" on a query error and in its catch block, which would silently allow a double-booking. Both now fail closed (report a conflict + a retry hint). This method is **currently uncalled** — the live gate is `interpretCrossProviderStaleCheck`, already fail-closed under SPE-255 — so this is hardening against a future revival, documented in a docstring, plus a null-safe provider read so a revival can't crash on a deleted profile.

This is **§1 of [SPE-141](https://linear.app/speddy/issue/SPE-141)**. The ticket's prescribed fix for §1 is *"fail closed (or surface the error)"* — this takes the fail-closed path. §2 (DB slot-capacity constraint), §3 (wire special activities / real school hours into batch scheduling), and §4 (batch the writes) are larger, separate changes and remain open.

## Tests

New regression suites lock in the fail-closed behavior:
- `session-filters-fail-closed.test.ts` — every error branch returns `[]` (not the input) and logs; success path still filters normally; a null-data success returns `[]`.
- `conflict-resolver-fail-closed.test.ts` — query error and thrown error both report a conflict; a genuine overlap still reports; a missing provider profile reports without crashing.

Full gate green locally: typecheck, lint, and `jest __tests__ lib` (64 suites / 573 passing).

## Self-review

Ran `/code-review` at high effort on the diff. It confirmed the change is well-scoped (all three `filterSessionsBySchool` callers use the result for display only — no destructive reconciliation keys off it) and surfaced 5 findings. Two were fixed here (the null-profile deref in the conflict-resolver; a test-coverage gap for the null-data success case). The other three are **pre-existing, non-error paths outside §1's scope and are behavior/UX-sensitive** — flagged below rather than changed unilaterally.

## ⚠️ Your call, Blair — three related items I did **not** change

These are real, but each is a behavior/UX decision I didn't want to make silently inside a fail-closed bug fix:

1. **District context with no specific school selected** still returns *all* students across the district (by design today — it logs a warning). Not an error path, so §1 didn't touch it. Tightening it changes what multi-school district users see before they pick a site.
2. **A school context with no identifiers at all** still returns the unfiltered list (same fail-open shape, reached without a DB error). Closing it could blank the schedule for minimal-context accounts.
3. **The fail-closed empty result looks identical to a genuinely empty week** at every caller — a transient DB blip now shows an empty schedule with no error banner. The ticket explicitly allows this ("fail closed *or surface the error*"); the nicer-UX alternative is to show a "couldn't load — retry" state, which is caller-side UX work across three components.

My recommendation: merge §1 as-is (it strictly removes a cross-school data leak), and I'll log items 1–3 as a follow-up so we can decide together whether to surface load errors in the UI. **Holding this for your merge call** — it's integrity/permissions-adjacent and item 3 is a (ticket-sanctioned) behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuaWPzsJjZidvoW6FnBCgn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling conflict checks to treat verification errors and unexpected failures as conflicts, preventing unsafe approvals.
  * Improved conflict messages when provider details are unavailable.
  * Updated session filtering to return no sessions when school-lookup requests fail, preventing unfiltered results from being shown.

* **Tests**
  * Added coverage for failed lookups, unexpected errors, missing provider details, valid overlaps, and successful session filtering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->