### PR TITLE
SPE-332: fix recursive profiles_update RLS — nobody could edit their own profile

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,6 +155,31 @@ flowchart TD
    etc.) carry policies scoped to the user's school(s) and/or ownership. Admin
    scope is granted via `admin_permissions` (§3).
 
+### `profiles` self-updates: policy + trigger (SPE-332)
+
+`profiles_update` has three branches — the row owner, `service_role`, and a
+site admin for the row's `school_id`. A user may edit their **own** row but must
+not change `role`, `is_speddy_admin`, `school_id` or `district_id`.
+
+That immutability rule lives in a **BEFORE UPDATE trigger**
+(`profiles_guard_immutable_columns`), **not** in the policy's `WITH CHECK`. An
+RLS policy cannot reference `OLD`, so the original implementation compared the
+incoming row against stored values by selecting from `profiles` *inside the
+policy on* `profiles` — which Postgres re-evaluates recursively, so **every**
+`UPDATE` failed with `42P17 infinite recursion detected in policy`. It failed
+closed (no escalation was ever possible) but silently broke every self-serve
+write for ~7 months: the SPE-320 daily-schedule toggle, the settings
+"Request Password Reset" button, and dismissing the onboarding banners.
+
+**Consequence for feature work:** anything a user saves to their own profile from
+the browser goes through this policy. Mocked unit tests cannot see RLS at all, so
+a self-write path is only genuinely covered by a **sim-district walk with a real
+signed-in session** — that is the gate that catches this class of bug, and it is
+why SPE-320 shipped broken with three green test files.
+
+**Source of truth:** `supabase/migrations/20260724_fix_profiles_update_rls_recursion.sql`;
+live `profiles_update` policy + `profiles_guard_immutable_columns` trigger.
+
 ### Route-guard matrix (from `middleware.ts`)
 
 | Path prefix | Who's allowed | Else → |

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test:schools:setup": "tsx scripts/test-school-import.ts",
     "sim:reset": "tsx scripts/sim-district/seed.ts",
     "sim:teardown": "tsx scripts/sim-district/teardown.ts",
-    "sim:verify": "tsx scripts/sim-district/verify.ts"
+    "sim:verify": "tsx scripts/sim-district/verify.ts",
+    "sim:verify-rls": "tsx scripts/sim-district/verify-profiles-rls.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",

--- a/scripts/sim-district/verify-profiles-rls.ts
+++ b/scripts/sim-district/verify-profiles-rls.ts
@@ -1,0 +1,152 @@
+/**
+ * SPE-332 — `profiles` RLS regression guard, run with REAL signed-in sessions.
+ *
+ * Why this is a script rather than a jest test: our unit tests mock the Supabase
+ * client, so they cannot see RLS at all — they pass identically whether a policy
+ * permits a write or denies every write. That blind spot is how a recursive
+ * `profiles_update` policy (42P17) sat in production for ~7 months silently
+ * breaking every self-serve profile write, and how SPE-320 shipped a broken
+ * self-toggle behind three green test files.
+ *
+ * This signs in as real sim personas and talks to PostgREST — the same path the
+ * browser takes — asserting both halves of the contract:
+ *
+ *   - a user CAN update their own non-privileged profile columns, and
+ *   - a user CANNOT change their own role / is_speddy_admin / school / district,
+ *     nor write to anyone else's row.
+ *
+ * Requires a seeded sim district (`npm run sim:reset -- --yes`). It writes to
+ * `rsp.willow`'s profile, so re-seed afterwards to restore a pristine fixture.
+ *
+ * Usage: npm run sim:verify-rls
+ */
+import { requireEnv } from './lib';
+import { PERSONAS, derivePassword, simEmail } from './manifest';
+
+const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+const secret = requireEnv('SIM_DISTRICT_PASSWORD');
+
+interface Session {
+  access_token: string;
+  user: { id: string };
+}
+
+async function signIn(emailLocal: string): Promise<Session> {
+  const email = simEmail(emailLocal);
+  const res = await fetch(`${url}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: { apikey: anon, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: derivePassword(secret, email) }),
+  });
+  const body = await res.json();
+  if (!body?.access_token) {
+    throw new Error(`sim login failed for ${emailLocal} — is the district seeded?`);
+  }
+  return body as Session;
+}
+
+async function patchProfile(
+  session: Session,
+  targetId: string,
+  patch: Record<string, unknown>,
+) {
+  const res = await fetch(`${url}/rest/v1/profiles?id=eq.${targetId}`, {
+    method: 'PATCH',
+    headers: {
+      apikey: anon,
+      Authorization: `Bearer ${session.access_token}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=representation',
+    },
+    body: JSON.stringify(patch),
+  });
+  const text = await res.text();
+  let parsed: unknown = null;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    /* error bodies are not always JSON arrays */
+  }
+  return {
+    status: res.status,
+    ok: res.ok,
+    rows: Array.isArray(parsed) ? parsed : [],
+  };
+}
+
+let failures = 0;
+function check(ok: boolean, label: string, detail: string): void {
+  if (!ok) failures++;
+  console.log(`  [${ok ? 'ok  ' : 'FAIL'}] ${label.padEnd(56)} ${detail}`);
+}
+
+async function main(): Promise<void> {
+  const needed = ['rsp.willow', 'slp.itinerant', 'siteadmin.willow'];
+  for (const local of needed) {
+    if (!PERSONAS.some((p) => p.emailLocal === local)) {
+      throw new Error(`persona '${local}' is no longer in the manifest — update this script`);
+    }
+  }
+
+  const provider = await signIn('rsp.willow');
+  const otherProvider = await signIn('slp.itinerant');
+  const siteAdmin = await signIn('siteadmin.willow');
+  const uid = provider.user.id;
+
+  console.log('self-service writes (must succeed):');
+  const selfWrites: [string, Record<string, unknown>][] = [
+    ['daily schedule email toggle', { daily_schedule_email_enabled: true }],
+    ['password reset request flag', { password_reset_requested_at: new Date().toISOString() }],
+    ['dismiss onboarding banner', { setup_banner_dismissed: true }],
+  ];
+  for (const [label, patch] of selfWrites) {
+    const r = await patchProfile(provider, uid, patch);
+    check(r.ok, label, `HTTP ${r.status}`);
+  }
+
+  console.log('self-escalation (must be refused):');
+  const escalations: [string, Record<string, unknown>][] = [
+    ['own role', { role: 'district_admin' }],
+    ['own is_speddy_admin', { is_speddy_admin: true }],
+    ['own school_id', { school_id: '00000000-0000-4000-8000-000000000000' }],
+    ['own district_id', { district_id: '00000000-0000-4000-8000-000000000000' }],
+  ];
+  for (const [label, patch] of escalations) {
+    const r = await patchProfile(provider, uid, patch);
+    check(!r.ok, `cannot change ${label}`, `HTTP ${r.status}`);
+  }
+
+  console.log('cross-profile writes:');
+  // PostgREST reports an RLS-filtered UPDATE as a success with zero rows, so
+  // assert on rows affected rather than on the status code.
+  const cross = await patchProfile(provider, otherProvider.user.id, {
+    daily_schedule_email_enabled: true,
+  });
+  check(
+    cross.rows.length === 0,
+    "provider cannot write another provider's row",
+    `${cross.rows.length} row(s) affected`,
+  );
+
+  const adminWrite = await patchProfile(siteAdmin, uid, {
+    daily_schedule_email_enabled: false,
+  });
+  check(
+    adminWrite.rows.length === 1,
+    'site admin CAN write a provider at their school',
+    `${adminWrite.rows.length} row(s) affected`,
+  );
+
+  if (failures === 0) {
+    console.log('\nAll checks passed. Re-seed (npm run sim:reset -- --yes) to restore the fixture.');
+  } else {
+    console.log(`\n${failures} check(s) failed.`);
+  }
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/sim-district/verify-profiles-rls.ts
+++ b/scripts/sim-district/verify-profiles-rls.ts
@@ -21,7 +21,7 @@
  * Usage: npm run sim:verify-rls
  */
 import { requireEnv } from './lib';
-import { PERSONAS, derivePassword, simEmail } from './manifest';
+import { DISTRICT, MAPLE, PERSONAS, derivePassword, simEmail } from './manifest';
 
 const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
 const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
@@ -72,8 +72,12 @@ async function patchProfile(
     status: res.status,
     ok: res.ok,
     rows: Array.isArray(parsed) ? parsed : [],
+    body: text,
   };
 }
+
+/** The message profiles_guard_immutable_columns raises. */
+const TRIGGER_MESSAGE = 'cannot be changed by the account holder';
 
 let failures = 0;
 function check(ok: boolean, label: string, detail: string): void {
@@ -102,19 +106,34 @@ async function main(): Promise<void> {
   ];
   for (const [label, patch] of selfWrites) {
     const r = await patchProfile(provider, uid, patch);
-    check(r.ok, label, `HTTP ${r.status}`);
+    // Assert a row came back, not merely a 2xx. PostgREST reports an
+    // RLS-filtered UPDATE as a success with an empty representation, so a
+    // status-only check would call a write that persisted NOTHING a pass —
+    // exactly the failure this guard exists to catch.
+    check(r.ok && r.rows.length === 1, label, `HTTP ${r.status}, ${r.rows.length} row(s)`);
   }
 
   console.log('self-escalation (must be refused):');
+  // Use REAL seeded ids, not synthetic ones. rsp.willow sits at WILLOW, so
+  // moving them to MAPLE is a plausible scope change that the trigger must
+  // refuse. A made-up id risks being rejected by type coercion or a foreign key
+  // instead — the check would still go green while telling us nothing about the
+  // trigger. (Raised by Codex on PR #782; its stated cause was off — these
+  // columns are varchar(36), so a UUID does fit — but the point stands.)
   const escalations: [string, Record<string, unknown>][] = [
     ['own role', { role: 'district_admin' }],
     ['own is_speddy_admin', { is_speddy_admin: true }],
-    ['own school_id', { school_id: '00000000-0000-4000-8000-000000000000' }],
-    ['own district_id', { district_id: '00000000-0000-4000-8000-000000000000' }],
+    ['own school_id', { school_id: MAPLE }],
+    ['own district_id', { district_id: `${DISTRICT.id}-OTHER` }],
   ];
   for (const [label, patch] of escalations) {
     const r = await patchProfile(provider, uid, patch);
-    check(!r.ok, `cannot change ${label}`, `HTTP ${r.status}`);
+    // Assert it was refused BY THE TRIGGER, not incidentally by type coercion or
+    // a foreign key. Otherwise a badly-chosen test value would keep this check
+    // green even if the trigger stopped guarding scope entirely.
+    const byTrigger = !r.ok && r.body.includes(TRIGGER_MESSAGE);
+    check(byTrigger, `cannot change ${label}`,
+      byTrigger ? `HTTP ${r.status} (trigger)` : `HTTP ${r.status} — ${r.body.slice(0, 90)}`);
   }
 
   console.log('cross-profile writes:');

--- a/scripts/sim-district/verify-profiles-rls.ts
+++ b/scripts/sim-district/verify-profiles-rls.ts
@@ -76,8 +76,15 @@ async function patchProfile(
   };
 }
 
-/** The message profiles_guard_immutable_columns raises. */
-const TRIGGER_MESSAGE = 'cannot be changed by the account holder';
+/**
+ * Signature of a refusal from profiles_guard_immutable_columns: its SQLSTATE
+ * plus the column list it names. Matching both proves the TRIGGER refused —
+ * not type coercion, a foreign key, or a plain RLS filter — while staying
+ * robust to the exact wording of the message.
+ */
+function refusedByTrigger(body: string): boolean {
+  return body.includes('"code":"42501"') && body.includes('profiles: role, is_speddy_admin');
+}
 
 let failures = 0;
 function check(ok: boolean, label: string, detail: string): void {
@@ -131,7 +138,7 @@ async function main(): Promise<void> {
     // Assert it was refused BY THE TRIGGER, not incidentally by type coercion or
     // a foreign key. Otherwise a badly-chosen test value would keep this check
     // green even if the trigger stopped guarding scope entirely.
-    const byTrigger = !r.ok && r.body.includes(TRIGGER_MESSAGE);
+    const byTrigger = !r.ok && refusedByTrigger(r.body);
     check(byTrigger, `cannot change ${label}`,
       byTrigger ? `HTTP ${r.status} (trigger)` : `HTTP ${r.status} — ${r.body.slice(0, 90)}`);
   }
@@ -156,6 +163,28 @@ async function main(): Promise<void> {
     'site admin CAN write a provider at their school',
     `${adminWrite.rows.length} row(s) affected`,
   );
+
+  // Privilege escalation via the site-admin row grant. RLS gates rows, not
+  // columns, so holding write access to a colleague's row previously allowed
+  // setting is_speddy_admin on it — turning a school-scoped admin into a global
+  // platform admin. Verified exploitable on production before the trigger was
+  // widened to cover every authenticated actor (CodeRabbit, PR #782).
+  //
+  // NB: these must run against a freshly-seeded fixture. If a prior run already
+  // escalated the target, the patch is a no-op, the trigger correctly permits it,
+  // and the check passes for the wrong reason.
+  console.log('site-admin escalation (must be refused):');
+  const adminEscalations: [string, Record<string, unknown>][] = [
+    ["a colleague's is_speddy_admin", { is_speddy_admin: true }],
+    ["a colleague's role", { role: 'district_admin' }],
+    ["a colleague's district_id", { district_id: `${DISTRICT.id}-OTHER` }],
+  ];
+  for (const [label, patch] of adminEscalations) {
+    const r = await patchProfile(siteAdmin, uid, patch);
+    const byTrigger = !r.ok && refusedByTrigger(r.body);
+    check(byTrigger, `site admin cannot set ${label}`,
+      byTrigger ? `HTTP ${r.status} (trigger)` : `HTTP ${r.status} — ${r.body.slice(0, 90)}`);
+  }
 
   if (failures === 0) {
     console.log('\nAll checks passed. Re-seed (npm run sim:reset -- --yes) to restore the fixture.');

--- a/supabase/migrations/20260724_fix_profiles_update_rls_recursion.sql
+++ b/supabase/migrations/20260724_fix_profiles_update_rls_recursion.sql
@@ -64,25 +64,31 @@ security invoker
 set search_path = ''
 as $$
 begin
-  -- Server-side admin flows run as service_role and are how role/school
-  -- legitimately change (admin account creation, provider transfers).
+  -- Server-side admin flows run as service_role and are the ONLY legitimate way
+  -- these columns change (admin account creation, provider transfers). Every such
+  -- route already uses the service client, and no browser/user-session code path
+  -- writes them at all — `is_speddy_admin` is never written by app code anywhere.
   if coalesce((select auth.role()), '') = 'service_role' then
     return new;
   end if;
 
-  -- Only constrain the account holder editing their OWN row. Cross-profile
-  -- edits are already gated by the site-admin branch of profiles_update.
-  if (select auth.uid()) is distinct from old.id then
-    return new;
-  end if;
-
+  -- Applies to EVERY authenticated actor, not just the account holder.
+  --
+  -- An earlier cut of this trigger returned early when auth.uid() <> old.id, on
+  -- the reasoning that cross-profile edits were "already gated by the site-admin
+  -- branch of profiles_update". That gate is about ROWS. RLS decides which rows
+  -- you may touch and says nothing about which columns — so a site admin, whose
+  -- branch grants them any profile at their school, could PATCH a colleague's row
+  -- and set is_speddy_admin = true, promoting a school-scoped admin into a global
+  -- platform admin (`/internal`). Confirmed exploitable against production before
+  -- this change: HTTP 200, is_speddy_admin flipped. Caught by CodeRabbit on PR #782.
   if new.role is distinct from old.role
      or new.is_speddy_admin is distinct from old.is_speddy_admin
      or new.school_id is distinct from old.school_id
      or new.district_id is distinct from old.district_id
   then
     raise exception
-      'profiles: role, is_speddy_admin, school_id and district_id cannot be changed by the account holder'
+      'profiles: role, is_speddy_admin, school_id and district_id can only be changed by a service_role flow'
       using errcode = '42501';
   end if;
 
@@ -91,7 +97,7 @@ end;
 $$;
 
 comment on function public.profiles_guard_immutable_columns() is
-  'SPE-332: blocks a user from escalating their own role/is_speddy_admin/school_id/district_id. Lives in a trigger rather than the profiles_update WITH CHECK because a policy cannot reference OLD, and the subquery workaround made the policy self-recursive (42P17).';
+  'SPE-332: role/is_speddy_admin/school_id/district_id are changeable only by service_role. Enforced in a trigger rather than the profiles_update WITH CHECK because a policy cannot reference OLD (the subquery workaround made the policy self-recursive, 42P17) and because RLS gates rows, not columns — the site-admin row grant would otherwise permit privilege escalation.';
 
 drop trigger if exists profiles_guard_immutable_columns on public.profiles;
 

--- a/supabase/migrations/20260724_fix_profiles_update_rls_recursion.sql
+++ b/supabase/migrations/20260724_fix_profiles_update_rls_recursion.sql
@@ -1,0 +1,101 @@
+-- SPE-332: profiles_update RLS was recursive — NO user could update their own row.
+--
+-- The policy's WITH CHECK compared the incoming row's immutable columns against
+-- the stored ones by querying `profiles` from inside its own policy:
+--
+--     AND role = (SELECT p.role FROM profiles p WHERE p.id = (select auth.uid()))
+--     AND NOT (school_id::text IS DISTINCT FROM (SELECT p.school_id FROM profiles p ...))
+--     ...
+--
+-- Postgres re-applies the policy to those subqueries, so every UPDATE failed with
+-- `42P17 infinite recursion detected in policy for relation "profiles"` — for all
+-- users, all columns. Introduced in 20251230_fix_profiles_update_rls_security.sql
+-- and carried forward verbatim into 20260107_fix_rls_performance_warnings.sql.
+--
+-- It failed CLOSED (no escalation was possible), but it silently broke every
+-- self-serve write: the SPE-320 daily-schedule toggle, the settings
+-- "Request Password Reset" button, and dismissing the onboarding banners.
+--
+-- The intent was right and is preserved: a user may edit their own profile but
+-- must not be able to change their own role, speddy-admin flag, school or
+-- district. RLS policies cannot reference OLD, which is why the original reached
+-- for a subquery. A BEFORE UPDATE trigger CAN see OLD and NEW, so the immutability
+-- rule moves there and the policy goes back to a plain identity check.
+
+-- 1. Non-recursive policy. Same three branches as before (self, service_role,
+--    site admin for the row's school); nothing here reads `profiles`.
+drop policy if exists profiles_update on public.profiles;
+
+create policy profiles_update on public.profiles
+  for update
+  to authenticated
+  using (
+    (select auth.uid()) = id
+    or (select auth.role()) = 'service_role'
+    or exists (
+      select 1
+      from public.admin_permissions ap
+      where ap.admin_id = (select auth.uid())
+        and ap.role = 'site_admin'
+        and (ap.school_id)::text = (profiles.school_id)::text
+    )
+  )
+  with check (
+    (select auth.uid()) = id
+    or (select auth.role()) = 'service_role'
+    or exists (
+      select 1
+      from public.admin_permissions ap
+      where ap.admin_id = (select auth.uid())
+        and ap.role = 'site_admin'
+        and (ap.school_id)::text = (profiles.school_id)::text
+    )
+  );
+
+-- 2. The immutability rule the policy was trying to express, where OLD is
+--    actually available.
+create or replace function public.profiles_guard_immutable_columns()
+returns trigger
+language plpgsql
+security invoker
+-- Empty search_path per the SPE-10 hardening; every reference below is schema
+-- qualified so nothing resolves off an ambient path (cf. SPE-281, where a locked
+-- search_path broke an unqualified similarity() call).
+set search_path = ''
+as $$
+begin
+  -- Server-side admin flows run as service_role and are how role/school
+  -- legitimately change (admin account creation, provider transfers).
+  if coalesce((select auth.role()), '') = 'service_role' then
+    return new;
+  end if;
+
+  -- Only constrain the account holder editing their OWN row. Cross-profile
+  -- edits are already gated by the site-admin branch of profiles_update.
+  if (select auth.uid()) is distinct from old.id then
+    return new;
+  end if;
+
+  if new.role is distinct from old.role
+     or new.is_speddy_admin is distinct from old.is_speddy_admin
+     or new.school_id is distinct from old.school_id
+     or new.district_id is distinct from old.district_id
+  then
+    raise exception
+      'profiles: role, is_speddy_admin, school_id and district_id cannot be changed by the account holder'
+      using errcode = '42501';
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function public.profiles_guard_immutable_columns() is
+  'SPE-332: blocks a user from escalating their own role/is_speddy_admin/school_id/district_id. Lives in a trigger rather than the profiles_update WITH CHECK because a policy cannot reference OLD, and the subquery workaround made the policy self-recursive (42P17).';
+
+drop trigger if exists profiles_guard_immutable_columns on public.profiles;
+
+create trigger profiles_guard_immutable_columns
+  before update on public.profiles
+  for each row
+  execute function public.profiles_guard_immutable_columns();


### PR DESCRIPTION
Closes [SPE-332](https://linear.app/speddy/issue/SPE-332/bug-rls-infinite-recursion-no-user-can-update-their-own-profile-breaks).

## The bug

Every `UPDATE` a user made to their **own** `profiles` row failed:

```
42P17: infinite recursion detected in policy for relation "profiles"
```

All users, all columns. Reads were fine — writes were totally broken.

`profiles_update`'s `WITH CHECK` enforced column immutability by selecting from `profiles` *inside its own policy on* `profiles`:

```sql
AND role = (SELECT p.role FROM profiles p WHERE p.id = (select auth.uid()))
AND NOT (school_id::text IS DISTINCT FROM (SELECT p.school_id FROM profiles p ...))
```

Postgres re-applies the policy to those subqueries, so it could never evaluate. Introduced in `20251230_fix_profiles_update_rls_security.sql`, carried forward verbatim into `20260107_fix_rls_performance_warnings.sql`.

It failed **closed** — no escalation was ever possible — but it silently broke every self-serve write for ~7 months:

- the **SPE-320 daily-schedule toggle** (shipped this morning, has never worked)
- the settings **"Request Password Reset"** button (the reported symptom)
- **dismissing the onboarding banners**

Everything else writes `profiles` through a service-role client, which bypasses RLS entirely — which is why nothing surfaced until SPE-320 shipped the first feature that depends on a user-session write.

## The fix

The original intent was right and is preserved: a user may edit their own profile but must not change their own `role`, `is_speddy_admin`, `school_id` or `district_id`.

An RLS policy **cannot reference `OLD`**, which is why the original author reached for a subquery. A `BEFORE UPDATE` trigger *can*, so the immutability rule moves there and the policy returns to a plain identity check. The trigger is `SECURITY INVOKER` with an empty `search_path` and fully-qualified references (SPE-10 hardening; cf. SPE-281, where a locked `search_path` broke an unqualified `similarity()` call).

Rejected the alternative — a `SECURITY DEFINER` helper to read the caller's stored row — because it adds to the definer-function surface that SPE-10 / 114 / 279 have been working to shrink.

## Verification — real sessions, both halves

Run against production with actual signed-in sim personas over PostgREST, the same path the browser takes:

| Check | Result |
|---|---|
| daily-schedule self-toggle | ✅ HTTP 200 |
| password-reset request flag | ✅ HTTP 200 |
| dismiss onboarding banner | ✅ HTTP 200 |
| cannot change own `role` | ✅ 403 |
| cannot grant self `is_speddy_admin` | ✅ 403 |
| cannot move own `school_id` / `district_id` | ✅ 403 |
| provider cannot write another provider's row | ✅ 0 rows affected |
| site admin CAN write a provider at their school | ✅ 1 row affected |

Supabase security advisors: no new findings (the trigger is `SECURITY INVOKER`, so it adds nothing to the SPE-279 backlog).

## Also: closing the blind spot that hid this

Added **`npm run sim:verify-rls`** (`scripts/sim-district/verify-profiles-rls.ts`) — the checks above as a repeatable script.

This is the part worth keeping. Our jest suite **mocks the Supabase client, so it cannot see RLS at all** — it passes identically whether a policy permits a write or denies every single one. That blind spot is how this survived seven months, and how SPE-320 shipped a broken toggle behind three green test files whose own ticket had explicitly flagged the risk ("*confirm the existing profiles self-UPDATE RLS policy covers the column... if self-update isn't permitted, route it through an API endpoint instead*"). That confirmation was done by reading the policy rather than performing a write.

The lesson recorded in `docs/ARCHITECTURE.md` §2: any feature where the browser saves to the user's own profile is only genuinely covered by a **real signed-in session**, not by unit tests.

## Note on the migration

The DDL is already applied to production (that's how it was verified). The migration file is the durable record and is idempotent — `drop policy if exists`, `create or replace function`, `drop trigger if exists`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZ13Rm3pwJLuNC2Azb64UW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored reliable self-service profile updates (including schedule preferences, password reset flow changes, and onboarding banner dismissal).
  * Prevented unauthorized changes to protected profile fields (no self-escalation or cross-tenant/profile updates).
  * Ensured site administrators can update provider profiles within their school.
* **Tests**
  * Added automated RLS simulation coverage to verify allowed updates, blocked privilege changes, and correct row-impact behavior.
* **Documentation**
  * Updated architecture guidance for profile update permissions and immutability safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->