### PR TITLE
SPE-335: let teachers actually create their own special activities

### DIFF
--- a/__tests__/unit/lib/supabase/queries/teacher-portal-create-activity.test.ts
+++ b/__tests__/unit/lib/supabase/queries/teacher-portal-create-activity.test.ts
@@ -1,0 +1,86 @@
+/**
+ * SPE-335: the teacher create path must stamp the CURRENT school year.
+ *
+ * `special_activities.school_year` is NOT NULL with a hardcoded default of
+ * '2025-2026'. The provider Special Activities page filters on
+ * getCurrentSchoolYear(), so a row that falls back to that default disappears
+ * from the provider's view the moment the year rolls over on August 1 — the
+ * teacher sees their activity, the resource specialist scheduling around it
+ * does not.
+ *
+ * This is a mock-level test on purpose: it pins the shape of the insert
+ * payload, which is the part RLS cannot tell us anything about. Whether the
+ * database accepts the write at all is covered by the sim-district walk.
+ */
+import { createSpecialActivity } from '@/lib/supabase/queries/teacher-portal';
+import { getCurrentSchoolYear } from '@/lib/school-year';
+
+const insert = jest.fn();
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      getUser: async () => ({ data: { user: { id: 'user-1' } }, error: null }),
+    },
+    from: (table: string) => {
+      if (table === 'teachers') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({
+                data: { id: 'teacher-1', school_id: 'SCH-1' },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return {
+        insert: (rows: unknown) => {
+          insert(rows);
+          return {
+            select: () => ({
+              single: async () => ({ data: { id: 'activity-1' }, error: null }),
+            }),
+          };
+        },
+      };
+    },
+  }),
+}));
+
+jest.mock('@/lib/monitoring/performance-alerts', () => ({
+  measurePerformanceWithAlerts: () => ({ end: () => {} }),
+}));
+
+const activityInput = {
+  teacher_name: 'Nora Ellison',
+  day_of_week: 1,
+  start_time: '09:15',
+  end_time: '09:45',
+  activity_name: 'Library',
+  school_id: 'SCH-1',
+};
+
+describe('createSpecialActivity', () => {
+  beforeEach(() => insert.mockClear());
+
+  it('stamps the current school year rather than falling back to the column default', async () => {
+    await createSpecialActivity(activityInput);
+
+    const [[rows]] = insert.mock.calls;
+    expect(rows[0].school_year).toBe(getCurrentSchoolYear());
+  });
+
+  it('writes the teacher ownership columns the RLS policy requires', async () => {
+    await createSpecialActivity(activityInput);
+
+    const [[rows]] = insert.mock.calls;
+    expect(rows[0]).toMatchObject({
+      teacher_id: 'teacher-1',
+      created_by_role: 'teacher',
+      created_by_id: 'user-1',
+      provider_id: null,
+    });
+  });
+});

--- a/lib/supabase/queries/teacher-portal.ts
+++ b/lib/supabase/queries/teacher-portal.ts
@@ -2,6 +2,7 @@ import { createClient } from '@/lib/supabase/client';
 import { safeQuery } from '@/lib/supabase/safe-query';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
 import { requireNonNull } from '@/lib/types/utils';
+import { getCurrentSchoolYear } from '@/lib/school-year';
 import type { Database } from '../../../src/types/database';
 
 type Student = Database['public']['Tables']['students']['Row'];
@@ -300,6 +301,11 @@ export async function createSpecialActivity(activityData: {
           created_by_role: 'teacher',
           created_by_id: user.id,
           provider_id: null,  // School-wide, not owned by specific provider
+          // Without this the row takes the column default, which is the
+          // hardcoded '2025-2026'. The provider Special Activities page filters
+          // on getCurrentSchoolYear(), so a defaulted row silently vanishes from
+          // it the moment the school year rolls over on August 1.
+          school_year: getCurrentSchoolYear(),
         }])
         .select()
         .single();

--- a/supabase/migrations/20260727_fix_special_activities_teacher_write_rls.sql
+++ b/supabase/migrations/20260727_fix_special_activities_teacher_write_rls.sql
@@ -1,0 +1,144 @@
+-- SPE-335: teachers have never been able to create a special activity.
+--
+-- `special_activities` originally identified the owning classroom teacher by
+-- stuffing the teacher's id into `provider_id`. The INSERT/UPDATE/DELETE
+-- policies were written against that convention:
+--
+--     provider_id IN (SELECT id FROM teachers WHERE account_id = auth.uid())
+--     OR provider_id = auth.uid()
+--     OR <site admin for the row's school>
+--
+-- `20251112_migrate_special_activities_to_teacher_id.sql` moved the app to a
+-- dedicated `teacher_id` column, and the teacher portal has written
+-- `{ teacher_id, created_by_role: 'teacher', provider_id: null }` ever since
+-- (lib/supabase/queries/teacher-portal.ts). The write policies never followed.
+-- With `provider_id = NULL` no branch can pass, so every teacher INSERT was
+-- rejected — 0 of the 206 production rows have `created_by_role = 'teacher'`
+-- (verified 2026-07-25). Soft-delete (an UPDATE setting `deleted_at`) was
+-- rejected for the same reason.
+--
+-- SELECT was never affected — it has its own school-scoped branches — which is
+-- why the page loads fine and only writes fail.
+--
+-- Fix: add a teacher branch to the three write policies. Existing
+-- provider/site-admin branches are carried over verbatim.
+--
+-- The teacher branch requires all three of:
+--   * the row's `teacher_id` is one of the caller's own teacher records, and
+--   * `created_by_id` is the caller, and
+--   * `created_by_role = 'teacher'`
+--
+-- `teacher_id` alone would be too wide: it marks WHOSE CLASS the activity
+-- belongs to, not who created it, so a provider-created activity for Ms. Lee's
+-- class carries `teacher_id = <Ms. Lee>`. The teacher portal already treats
+-- those as read-only ("Only activities you created can be deleted",
+-- app/(dashboard)/dashboard/teacher/special-activities/page.tsx), and the query
+-- layer filters on `created_by_id`/`created_by_role` for every teacher write.
+-- Matching the policy to that contract fixes creation without granting teachers
+-- anything the UI does not already offer them.
+--
+-- On UPDATE the same predicate is used for USING and WITH CHECK, so a teacher
+-- can edit or soft-delete their own row but cannot re-point `teacher_id` at a
+-- colleague or launder the row by rewriting `created_by_id`/`created_by_role`.
+
+drop policy if exists special_activities_insert on public.special_activities;
+
+create policy special_activities_insert on public.special_activities
+  for insert
+  to authenticated
+  with check (
+    provider_id in (
+      select teachers.id from public.teachers
+      where teachers.account_id = (select auth.uid())
+    )
+    or provider_id = (select auth.uid())
+    or (
+      created_by_role = 'teacher'
+      and created_by_id = (select auth.uid())
+      and teacher_id in (
+        select teachers.id from public.teachers
+        where teachers.account_id = (select auth.uid())
+      )
+    )
+    or exists (
+      select 1 from public.admin_permissions ap
+      where ap.admin_id = (select auth.uid())
+        and ap.role = 'site_admin'
+        and (ap.school_id)::text = (special_activities.school_id)::text
+    )
+  );
+
+drop policy if exists special_activities_update on public.special_activities;
+
+create policy special_activities_update on public.special_activities
+  for update
+  to authenticated
+  using (
+    provider_id in (
+      select teachers.id from public.teachers
+      where teachers.account_id = (select auth.uid())
+    )
+    or provider_id = (select auth.uid())
+    or (
+      created_by_role = 'teacher'
+      and created_by_id = (select auth.uid())
+      and teacher_id in (
+        select teachers.id from public.teachers
+        where teachers.account_id = (select auth.uid())
+      )
+    )
+    or exists (
+      select 1 from public.admin_permissions ap
+      where ap.admin_id = (select auth.uid())
+        and ap.role = 'site_admin'
+        and (ap.school_id)::text = (special_activities.school_id)::text
+    )
+  )
+  with check (
+    provider_id in (
+      select teachers.id from public.teachers
+      where teachers.account_id = (select auth.uid())
+    )
+    or provider_id = (select auth.uid())
+    or (
+      created_by_role = 'teacher'
+      and created_by_id = (select auth.uid())
+      and teacher_id in (
+        select teachers.id from public.teachers
+        where teachers.account_id = (select auth.uid())
+      )
+    )
+    or exists (
+      select 1 from public.admin_permissions ap
+      where ap.admin_id = (select auth.uid())
+        and ap.role = 'site_admin'
+        and (ap.school_id)::text = (special_activities.school_id)::text
+    )
+  );
+
+drop policy if exists special_activities_delete on public.special_activities;
+
+create policy special_activities_delete on public.special_activities
+  for delete
+  to authenticated
+  using (
+    provider_id in (
+      select teachers.id from public.teachers
+      where teachers.account_id = (select auth.uid())
+    )
+    or provider_id = (select auth.uid())
+    or (
+      created_by_role = 'teacher'
+      and created_by_id = (select auth.uid())
+      and teacher_id in (
+        select teachers.id from public.teachers
+        where teachers.account_id = (select auth.uid())
+      )
+    )
+    or exists (
+      select 1 from public.admin_permissions ap
+      where ap.admin_id = (select auth.uid())
+        and ap.role = 'site_admin'
+        and (ap.school_id)::text = (special_activities.school_id)::text
+    )
+  );

--- a/supabase/migrations/20260727_fix_special_activities_teacher_write_rls.sql
+++ b/supabase/migrations/20260727_fix_special_activities_teacher_write_rls.sql
@@ -23,10 +23,10 @@
 -- Fix: add a teacher branch to the three write policies. Existing
 -- provider/site-admin branches are carried over verbatim.
 --
--- The teacher branch requires all three of:
+-- The teacher branch requires all of:
+--   * `created_by_role = 'teacher'` and `created_by_id` is the caller, and
 --   * the row's `teacher_id` is one of the caller's own teacher records, and
---   * `created_by_id` is the caller, and
---   * `created_by_role = 'teacher'`
+--   * that teacher record is at the row's school.
 --
 -- `teacher_id` alone would be too wide: it marks WHOSE CLASS the activity
 -- belongs to, not who created it, so a provider-created activity for Ms. Lee's
@@ -37,9 +37,24 @@
 -- Matching the policy to that contract fixes creation without granting teachers
 -- anything the UI does not already offer them.
 --
--- On UPDATE the same predicate is used for USING and WITH CHECK, so a teacher
--- can edit or soft-delete their own row but cannot re-point `teacher_id` at a
--- colleague or launder the row by rewriting `created_by_id`/`created_by_role`.
+-- The school correlation matters because nothing else in this branch pins the
+-- row to a site: without it a teacher could file an activity into another
+-- school's schedule using their own teacher record. The site-admin branch
+-- beside it is already school-scoped; this keeps the teacher branch consistent.
+-- Every login-linked `teachers` row in production carries a `school_id`
+-- (59/59, verified 2026-07-27), so this refuses nothing that works today.
+--
+-- Not addressed here, and NOT introduced here: `WITH CHECK` is a disjunction,
+-- so any caller who sets `provider_id` to their own uid in the same statement
+-- satisfies the second branch and can then rewrite the row's other columns —
+-- including `teacher_id` and the `created_by_*` authorship pair. That is
+-- pre-existing behaviour of the `provider_id = auth.uid()` branch and is
+-- reachable today by every provider for their own rows; this migration extends
+-- the same looseness to teacher-authored rows. Closing it needs a BEFORE UPDATE
+-- trigger (RLS gates rows, not columns — see the SPE-332 precedent in
+-- 20260724_fix_profiles_update_rls_recursion.sql) and is tracked separately, so
+-- that it lands as one deliberate change across all writers rather than as a
+-- silent asymmetry between them.
 
 drop policy if exists special_activities_insert on public.special_activities;
 
@@ -55,9 +70,11 @@ create policy special_activities_insert on public.special_activities
     or (
       created_by_role = 'teacher'
       and created_by_id = (select auth.uid())
-      and teacher_id in (
-        select teachers.id from public.teachers
-        where teachers.account_id = (select auth.uid())
+      and exists (
+        select 1 from public.teachers t
+        where t.id = special_activities.teacher_id
+          and t.account_id = (select auth.uid())
+          and (t.school_id)::text = (special_activities.school_id)::text
       )
     )
     or exists (
@@ -82,9 +99,11 @@ create policy special_activities_update on public.special_activities
     or (
       created_by_role = 'teacher'
       and created_by_id = (select auth.uid())
-      and teacher_id in (
-        select teachers.id from public.teachers
-        where teachers.account_id = (select auth.uid())
+      and exists (
+        select 1 from public.teachers t
+        where t.id = special_activities.teacher_id
+          and t.account_id = (select auth.uid())
+          and (t.school_id)::text = (special_activities.school_id)::text
       )
     )
     or exists (
@@ -103,9 +122,11 @@ create policy special_activities_update on public.special_activities
     or (
       created_by_role = 'teacher'
       and created_by_id = (select auth.uid())
-      and teacher_id in (
-        select teachers.id from public.teachers
-        where teachers.account_id = (select auth.uid())
+      and exists (
+        select 1 from public.teachers t
+        where t.id = special_activities.teacher_id
+          and t.account_id = (select auth.uid())
+          and (t.school_id)::text = (special_activities.school_id)::text
       )
     )
     or exists (
@@ -130,9 +151,11 @@ create policy special_activities_delete on public.special_activities
     or (
       created_by_role = 'teacher'
       and created_by_id = (select auth.uid())
-      and teacher_id in (
-        select teachers.id from public.teachers
-        where teachers.account_id = (select auth.uid())
+      and exists (
+        select 1 from public.teachers t
+        where t.id = special_activities.teacher_id
+          and t.account_id = (select auth.uid())
+          and (t.school_id)::text = (special_activities.school_id)::text
       )
     )
     or exists (


### PR DESCRIPTION
Fixes [SPE-335](https://linear.app/speddy/issue/SPE-335/teacher-special-activity-creation-is-blocked-by-rls-in-production-zero).

## The bug

No teacher has ever successfully created a special activity. **0 of the 206 rows in production have `created_by_role = 'teacher'`.**

`special_activities` used to identify the owning classroom teacher by stuffing the teacher's id into `provider_id`, and the write policies were built on that. `20251112_migrate_special_activities_to_teacher_id.sql` moved the app onto a dedicated `teacher_id` column, and the teacher portal has written `{ teacher_id, created_by_role: 'teacher', provider_id: null }` ever since — but the INSERT/UPDATE/DELETE policies never followed. With `provider_id = NULL` no branch can pass, so every teacher write was rejected. Soft-delete is an UPDATE, so it failed the same way.

SELECT has its own school-scoped branches and was never affected, which is why the page loads fine and only writes fail.

This is an elementary surface (hidden on secondary via `SECONDARY_HIDDEN_HREFS`), so every elementary teacher hits it.

## The change

**`supabase/migrations/20260727_fix_special_activities_teacher_write_rls.sql`** — adds a teacher branch to the three write policies. Existing provider and site-admin branches are carried over verbatim. The branch requires all of:

* `created_by_role = 'teacher'` and `created_by_id` is the caller, and
* the row's `teacher_id` is one of the caller's own teacher records, and
* that teacher record is at the row's school.

`teacher_id` alone would be too wide: it marks *whose class* an activity is for, not who created it, so a provider-created activity for Ms. Lee's class carries `teacher_id = <Ms. Lee>`. The portal already treats those as read-only ("Only activities you created can be deleted") and the query layer already filters on `created_by_id`/`created_by_role`. Matching the policy to that contract fixes creation without granting teachers anything the UI does not already offer.

The school correlation was added after self-review found a teacher could otherwise file an activity into another school's schedule using their own teacher record. All 59 login-linked `teachers` rows in production carry a `school_id`, so it refuses nothing that works today.

**`lib/supabase/queries/teacher-portal.ts`** — stamp `school_year` on create. It was omitted, so rows took the column default, which is a hardcoded `'2025-2026'`. The provider Special Activities page filters on `getCurrentSchoolYear()`, which rolls over **on August 1 — five days from now**. Without this, every activity a teacher creates would silently disappear from the resource specialist's view on that date.

**`__tests__/unit/lib/supabase/queries/teacher-portal-create-activity.test.ts`** — pins the insert payload (the part RLS can tell us nothing about). Note the school-year assertion is the meaningful coverage for that fix: in the sim walk the stale default and the current year are the same string until August 1.

## Verification

Sim-district walk against a **real signed-in session** per the standing rule — **27 checks, 0 failures**. Full run report in the comment below.

The headline checks, all asserted against the database rather than against HTTP status:

* Nora creates an activity through the real UI and the row is *in the table*, with `created_by_role='teacher'`, her `teacher_id`, `provider_id = null` — the exact shape that was rejected before.
* She soft-deletes it through the UI and `deleted_at` is actually stamped.
* David can **read** her activity (school-wide SELECT is intended) but every write is refused: edit, soft-delete and hard-delete all affect **0 rows** with the values verified unchanged afterwards.
* Every attempt that *should* produce an explicit denial does: impersonating her teacher record, laundering authorship onto her, re-pointing an activity at a colleague, and filing into another school all fail with **42501, the policy itself** — not an incidental type or FK error.
* Positive controls sit beside each refusal (David can write his own; Fatima can write at her own school), so none of the negatives pass for the wrong reason. Negative fixtures are created fresh in the run.
* Provider and site-admin writes still succeed.

Gates: `npm run typecheck`, `npm run lint`, `npm test` (643 passed) all green. `sim:verify` green before and after; teardown → `sim:verify --expect-empty` all zeros, so the run left nothing behind.

**The migration is already applied to the production database** — the sim district lives there and the standing rule cannot be satisfied otherwise. The policy change is additive (it only widens what teachers may write) and this PR is the code record of it.

## Found along the way — filed, not fixed here

* **[SPE-343](https://linear.app/speddy/issue/SPE-343)** (High) — with writes unblocked, the *next* thing a teacher hits: the form is free text but `activity_name` has a 7-value CHECK constraint, so most names produce a raw Postgres error. The placeholder suggests "Art"; the allowlist has `ART`. Screenshot in the run report.
* **[SPE-344](https://linear.app/speddy/issue/SPE-344)** (Medium) — `WITH CHECK` is a disjunction, so setting `provider_id` to your own id lets the other columns through. Pre-existing and reachable by every provider today; this PR extends it to teachers. Needs a trigger (the SPE-332 pattern), applied to all writers at once rather than leaving teachers and providers on different rules. The migration comment now states this limitation instead of overclaiming.
* **[SPE-345](https://linear.app/speddy/issue/SPE-345)** (Medium) — the auto-scheduler doesn't filter `deleted_at`, so a deleted activity keeps blocking scheduling. Pre-existing, newly reachable now that teachers can delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ndRMRr41hxg8KhVG43Sfv

---
_Generated by [Claude Code](https://claude.ai/code/session_017ndRMRr41hxg8KhVG43Sfv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Teachers can now create, update, and delete special activities they own within their school.
  - Existing provider and site administrator access remains supported.

- **Bug Fixes**
  - Newly created teacher activities are now assigned to the current school year, ensuring they remain visible after the school year changes.
  - Improved authorization prevents activities from being created or modified outside the appropriate school context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->