### PR TITLE
SPE-339: capture the district's Student ID on import

### DIFF
--- a/__tests__/unit/app/__snapshots__/import-students-preview.characterization.test.ts.snap
+++ b/__tests__/unit/app/__snapshots__/import-students-preview.characterization.test.ts.snap
@@ -71,6 +71,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) all-th
               "old": null,
             },
           },
+          "districtStudentId": "100001",
           "firstName": "Ana",
           "goals": [
             {
@@ -130,6 +131,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) all-th
               "old": null,
             },
           },
+          "districtStudentId": "100002",
           "firstName": "Ben",
           "goals": [
             {
@@ -161,6 +163,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) all-th
         },
         {
           "action": "insert",
+          "districtStudentId": "100009",
           "firstName": "Ivan",
           "goals": [
             {
@@ -173,6 +176,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) all-th
         },
         {
           "action": "insert",
+          "districtStudentId": "100010",
           "firstName": "Jae",
           "goals": [
             {
@@ -591,6 +595,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) goals-
       "students": [
         {
           "action": "skip",
+          "districtStudentId": "100001",
           "firstName": "Ana",
           "goals": [
             {
@@ -610,6 +615,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) goals-
         },
         {
           "action": "insert",
+          "districtStudentId": "100009",
           "firstName": "Ivan",
           "goals": [
             {
@@ -622,6 +628,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) goals-
         },
         {
           "action": "insert",
+          "districtStudentId": "100010",
           "firstName": "Jae",
           "goals": [
             {
@@ -685,6 +692,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) goals-
       "students": [
         {
           "action": "skip",
+          "districtStudentId": "100001",
           "firstName": "Ana",
           "goals": [
             {
@@ -715,6 +723,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) goals-
               "unchanged": [],
             },
           },
+          "districtStudentId": "100002",
           "firstName": "Ben",
           "goals": [
             {
@@ -734,6 +743,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) goals-
         },
         {
           "action": "insert",
+          "districtStudentId": "100009",
           "firstName": "Ivan",
           "goals": [
             {
@@ -746,6 +756,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) goals-
         },
         {
           "action": "insert",
+          "districtStudentId": "100010",
           "firstName": "Jae",
           "goals": [
             {
@@ -817,6 +828,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) roster
               },
             },
           },
+          "districtStudentId": "100001",
           "firstName": "",
           "goals": [],
           "gradeLevel": "3",
@@ -840,6 +852,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) roster
         },
         {
           "action": "insert",
+          "districtStudentId": "100002",
           "firstName": "",
           "goals": [],
           "gradeLevel": "K",
@@ -880,6 +893,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) roster
         },
         {
           "action": "insert",
+          "districtStudentId": "100004",
           "firstName": "",
           "goals": [],
           "gradeLevel": "2",
@@ -982,6 +996,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) studen
               "old": null,
             },
           },
+          "districtStudentId": "100001",
           "firstName": "Ana",
           "goals": [
             {
@@ -1025,6 +1040,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) studen
               "old": null,
             },
           },
+          "districtStudentId": "100002",
           "firstName": "Ben",
           "goals": [
             {
@@ -1050,6 +1066,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) studen
         },
         {
           "action": "insert",
+          "districtStudentId": "100009",
           "firstName": "Ivan",
           "goals": [
             {
@@ -1062,6 +1079,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) studen
         },
         {
           "action": "insert",
+          "districtStudentId": "100010",
           "firstName": "Jae",
           "goals": [
             {
@@ -1170,6 +1188,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) studen
               "old": null,
             },
           },
+          "districtStudentId": "100001",
           "firstName": "Ana",
           "goals": [
             {
@@ -1216,6 +1235,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) studen
               },
             },
           },
+          "districtStudentId": "100002",
           "firstName": "Ben",
           "goals": [
             {
@@ -1241,6 +1261,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) studen
         },
         {
           "action": "insert",
+          "districtStudentId": "100009",
           "firstName": "Ivan",
           "goals": [
             {
@@ -1253,6 +1274,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) studen
         },
         {
           "action": "insert",
+          "districtStudentId": "100010",
           "firstName": "Jae",
           "goals": [
             {

--- a/__tests__/unit/app/__snapshots__/import-students-preview.characterization.test.ts.snap
+++ b/__tests__/unit/app/__snapshots__/import-students-preview.characterization.test.ts.snap
@@ -269,6 +269,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) class-
       "students": [
         {
           "action": "update",
+          "districtStudentId": "100001",
           "firstName": "Ana",
           "gradeLevel": "1",
           "initials": "AA",
@@ -283,6 +284,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) class-
         },
         {
           "action": "update",
+          "districtStudentId": "100007",
           "firstName": "Vera",
           "gradeLevel": "4",
           "initials": "VV",
@@ -373,6 +375,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) delive
       "students": [
         {
           "action": "update",
+          "districtStudentId": "100001",
           "firstName": "Ana",
           "gradeLevel": "1",
           "initials": "AA",
@@ -393,6 +396,7 @@ exports[`POST /api/import-students — preview characterization (SPE-230) delive
         },
         {
           "action": "update",
+          "districtStudentId": "100007",
           "firstName": "Vera",
           "gradeLevel": "4",
           "initials": "VV",
@@ -594,7 +598,8 @@ exports[`POST /api/import-students — preview characterization (SPE-230) goals-
       ],
       "students": [
         {
-          "action": "skip",
+          "action": "update",
+          "changes": {},
           "districtStudentId": "100001",
           "firstName": "Ana",
           "goals": [
@@ -648,9 +653,9 @@ exports[`POST /api/import-students — preview characterization (SPE-230) goals-
           "St Mary School",
         ],
         "inserts": 2,
-        "skips": 1,
+        "skips": 0,
         "total": 3,
-        "updates": 0,
+        "updates": 1,
         "withGoalsRemoved": 0,
         "withSchedule": 0,
         "withTeacher": 0,
@@ -691,7 +696,8 @@ exports[`POST /api/import-students — preview characterization (SPE-230) goals-
       ],
       "students": [
         {
-          "action": "skip",
+          "action": "update",
+          "changes": {},
           "districtStudentId": "100001",
           "firstName": "Ana",
           "goals": [
@@ -773,9 +779,9 @@ exports[`POST /api/import-students — preview characterization (SPE-230) goals-
       "summary": {
         "filteredOutBySchool": 0,
         "inserts": 2,
-        "skips": 1,
+        "skips": 0,
         "total": 4,
-        "updates": 1,
+        "updates": 2,
         "withGoalsRemoved": 1,
         "withSchedule": 0,
         "withTeacher": 0,

--- a/__tests__/unit/lib/import/classify-district-id.test.ts
+++ b/__tests__/unit/lib/import/classify-district-id.test.ts
@@ -114,6 +114,32 @@ describe('district Student ID reaches the write', () => {
     expect(studentUpdates[0].action).toBe('update');
   });
 
+  it('withholds an id already held by the same provider at another school', () => {
+    // Uniqueness is (provider, district) — not school — so an id held at
+    // another school still collides. Matching on it would edit the wrong
+    // school's record; ignoring it would blow up on the unique index at confirm.
+    const roster = (o: Partial<CsvParsedStudent> = {}): CsvParsedStudent => ({
+      firstName: '', lastName: '', initials: 'AA', gradeLevel: '1',
+      goals: [], rawRow: 2, teacherName: 'Barrera', ...o,
+    });
+
+    const previews = buildRosterPreviews({
+      students: [roster({ districtStudentId: '100001' })],
+      dbStudents: [{
+        id: 'other-school', initials: 'ZZ', grade_level: '4', school_id: 'SCH-OTHER',
+        sessions_per_week: null, minutes_per_session: null, teacher_id: null,
+        district_student_id: '100001',
+      }],
+      currentSchoolId: 'SCH-HERE',
+      dbTeachers: [],
+    });
+
+    expect(previews[0].districtStudentId).toBeUndefined();
+    expect(previews[0].districtStudentIdConflict?.existingLabel).toMatch(/another school/);
+    // Still an insert for THIS school — the row itself is fine, only the id is held back.
+    expect(previews[0].action).toBe('insert');
+  });
+
   it('promotes an otherwise-unchanged roster row to an update for the id alone', () => {
     const roster = (o: Partial<CsvParsedStudent> = {}): CsvParsedStudent => ({
       firstName: '', lastName: '', initials: 'AA', gradeLevel: '1',

--- a/__tests__/unit/lib/import/classify-district-id.test.ts
+++ b/__tests__/unit/lib/import/classify-district-id.test.ts
@@ -1,0 +1,137 @@
+/**
+ * SPE-339 follow-ups from the Codex review on PR #787.
+ *
+ * Three ways a captured Student ID could be parsed and then silently dropped
+ * before it ever reached the database.
+ */
+import { buildStudentPreviews, buildUpdatePreviews, buildRosterPreviews } from '@/lib/import/classify';
+import type { ParsedStudent as SeisParsedStudent } from '@/lib/parsers/seis-parser';
+import type { ParsedStudent as CsvParsedStudent } from '@/lib/parsers/csv-parser';
+import type { ClassListStudent, TeacherInfo } from '@/lib/parsers/class-list-parser';
+import type { DatabaseStudent } from '@/lib/utils/student-matcher';
+
+const teacher: TeacherInfo = {
+  rawName: 'Barrera E', lastName: 'Barrera', firstInitial: 'E', teacherNumber: '101',
+};
+
+const seis = (o: Partial<SeisParsedStudent> = {}): SeisParsedStudent => ({
+  firstName: 'Ana', lastName: 'Alvarez', initials: 'AA', gradeLevel: '1',
+  goals: ['Existing goal'], rawRow: 2, ...o,
+});
+
+const db = (o: Partial<DatabaseStudent> = {}): DatabaseStudent => ({
+  id: 'ana', initials: 'AA', grade_level: '1',
+  first_name: 'Ana', last_name: 'Alvarez', iep_goals: ['Existing goal'], ...o,
+});
+
+const classList = (o: Partial<ClassListStudent> = {}): ClassListStudent => ({
+  normalizedName: 'alvarez_ana', name: 'Alvarez, Ana', teacher, districtStudentId: null, ...o,
+});
+
+describe('district Student ID reaches the write', () => {
+  it('backfills an id onto a student who is otherwise unchanged', () => {
+    // Everything matches what is stored, so before this fix the row was a
+    // 'skip' — and skip rows are dropped from the confirm payload, so a
+    // re-import to pick up ids did nothing at all.
+    const { studentPreviews } = buildStudentPreviews({
+      parsedStudents: [seis({ districtStudentId: '100001' })],
+      databaseStudents: [db()],
+      deliveriesData: null, classListData: null, dbTeachers: [],
+    });
+
+    expect(studentPreviews[0].action).toBe('update');
+    expect(studentPreviews[0].districtStudentId).toBe('100001');
+  });
+
+  it('stays a skip when the stored id already matches', () => {
+    const { studentPreviews } = buildStudentPreviews({
+      parsedStudents: [seis({ districtStudentId: '100001' })],
+      databaseStudents: [db({ district_student_id: '100001' })],
+      deliveriesData: null, classListData: null, dbTeachers: [],
+    });
+
+    expect(studentPreviews[0].action).toBe('skip');
+  });
+
+  it('takes the id from the class list when the goals file has none', () => {
+    const { studentPreviews } = buildStudentPreviews({
+      parsedStudents: [seis()],
+      databaseStudents: [db()],
+      deliveriesData: null,
+      classListData: new Map([['alvarez_ana', classList({ districtStudentId: '100001' })]]),
+      dbTeachers: [],
+    });
+
+    expect(studentPreviews[0].districtStudentId).toBe('100001');
+    expect(studentPreviews[0].action).toBe('update');
+  });
+
+  it('lets the goals file win over the class list', () => {
+    const { studentPreviews } = buildStudentPreviews({
+      parsedStudents: [seis({ districtStudentId: 'FROM-GOALS' })],
+      databaseStudents: [db()],
+      deliveriesData: null,
+      classListData: new Map([['alvarez_ana', classList({ districtStudentId: 'FROM-CLASSLIST' })]]),
+      dbTeachers: [],
+    });
+
+    expect(studentPreviews[0].districtStudentId).toBe('FROM-GOALS');
+  });
+
+  it('reports rather than steals an id the class list points at another child', () => {
+    const { studentPreviews } = buildStudentPreviews({
+      parsedStudents: [seis()],
+      databaseStudents: [db(), db({ id: 'ben', initials: 'BB', first_name: 'Ben', last_name: 'Bishop', district_student_id: '100001' })],
+      deliveriesData: null,
+      classListData: new Map([['alvarez_ana', classList({ districtStudentId: '100001' })]]),
+      dbTeachers: [],
+    });
+
+    expect(studentPreviews[0].districtStudentId).toBeUndefined();
+    expect(studentPreviews[0].districtStudentIdConflict).toEqual({
+      districtStudentId: '100001',
+      existingLabel: 'Ben Bishop',
+    });
+  });
+
+  it('carries the id through the class-list-only update path', () => {
+    const studentsByName = new Map([
+      ['alvarez_ana', {
+        id: 'ana', initials: 'AA', grade_level: '1', school_site: null, school_id: null,
+        district_student_id: null,
+        student_details: { first_name: 'Ana', last_name: 'Alvarez' },
+      }],
+    ]);
+
+    const { studentUpdates } = buildUpdatePreviews({
+      studentsByName: studentsByName as never,
+      deliveriesData: null,
+      classListData: new Map([['alvarez_ana', classList({ districtStudentId: '100001' })]]),
+      dbTeachers: [],
+    });
+
+    expect(studentUpdates[0].districtStudentId).toBe('100001');
+    expect(studentUpdates[0].action).toBe('update');
+  });
+
+  it('promotes an otherwise-unchanged roster row to an update for the id alone', () => {
+    const roster = (o: Partial<CsvParsedStudent> = {}): CsvParsedStudent => ({
+      firstName: '', lastName: '', initials: 'AA', gradeLevel: '1',
+      goals: [], rawRow: 2, teacherName: 'Barrera', ...o,
+    });
+
+    const previews = buildRosterPreviews({
+      students: [roster({ districtStudentId: '100001' })],
+      dbStudents: [{
+        id: 'ana', initials: 'AA', grade_level: '1', school_id: null,
+        sessions_per_week: null, minutes_per_session: null, teacher_id: null,
+        district_student_id: null,
+      }],
+      currentSchoolId: null,
+      dbTeachers: [],
+    });
+
+    expect(previews[0].action).toBe('update');
+    expect(previews[0].districtStudentId).toBe('100001');
+  });
+});

--- a/__tests__/unit/lib/parsers/__snapshots__/class-list-parser.test.ts.snap
+++ b/__tests__/unit/lib/parsers/__snapshots__/class-list-parser.test.ts.snap
@@ -9,6 +9,7 @@ exports[`parseClassListTXT matches the golden snapshot 1`] = `
   },
   "students": [
     {
+      "districtStudentId": "100001",
       "key": "alvarez_ana",
       "name": "Alvarez, Ana",
       "teacher": {
@@ -19,6 +20,7 @@ exports[`parseClassListTXT matches the golden snapshot 1`] = `
       },
     },
     {
+      "districtStudentId": "100002",
       "key": "bishop_ben",
       "name": "Bishop, Ben",
       "teacher": {
@@ -29,6 +31,7 @@ exports[`parseClassListTXT matches the golden snapshot 1`] = `
       },
     },
     {
+      "districtStudentId": "100003",
       "key": "cho_cora",
       "name": "Cho, Cora",
       "teacher": {
@@ -39,6 +42,7 @@ exports[`parseClassListTXT matches the golden snapshot 1`] = `
       },
     },
     {
+      "districtStudentId": "100004",
       "key": "davis-wong_drew",
       "name": "Davis-Wong, Drew",
       "teacher": {
@@ -49,6 +53,7 @@ exports[`parseClassListTXT matches the golden snapshot 1`] = `
       },
     },
     {
+      "districtStudentId": "100005",
       "key": "evans_ella",
       "name": "Evans, Ella",
       "teacher": {
@@ -59,6 +64,7 @@ exports[`parseClassListTXT matches the golden snapshot 1`] = `
       },
     },
     {
+      "districtStudentId": "100006",
       "key": "foster_finn",
       "name": "Foster, Finn",
       "teacher": {
@@ -69,6 +75,7 @@ exports[`parseClassListTXT matches the golden snapshot 1`] = `
       },
     },
     {
+      "districtStudentId": "100007",
       "key": "vanhorn_vera",
       "name": "Van Horn, Vera",
       "teacher": {

--- a/__tests__/unit/lib/parsers/__snapshots__/generic-csv.test.ts.snap
+++ b/__tests__/unit/lib/parsers/__snapshots__/generic-csv.test.ts.snap
@@ -18,6 +18,7 @@ exports[`parseCSVReport — Windows-1252 encoding re-decodes accented names as l
   },
   "students": [
     {
+      "districtStudentId": undefined,
       "firstName": "Sofía",
       "goals": [
         "The student will read 50 words per minute with 90% accuracy.",
@@ -30,6 +31,7 @@ exports[`parseCSVReport — Windows-1252 encoding re-decodes accented names as l
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "José",
       "goals": [
         "The student will write a five-sentence paragraph with 80% accuracy.",
@@ -42,6 +44,7 @@ exports[`parseCSVReport — Windows-1252 encoding re-decodes accented names as l
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Renée",
       "goals": [
         "The student will identify rhyming words in 4 of 5 trials.",
@@ -76,6 +79,7 @@ exports[`parseCSVReport — messy grade values (generic format) matches the gold
   },
   "students": [
     {
+      "districtStudentId": undefined,
       "firstName": "Ava",
       "goals": [
         "The student will read 60 words per minute by year end with 90% accuracy.",
@@ -88,6 +92,7 @@ exports[`parseCSVReport — messy grade values (generic format) matches the gold
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Ben",
       "goals": [
         "The student will identify all letter sounds by June with 80% accuracy.",
@@ -100,6 +105,7 @@ exports[`parseCSVReport — messy grade values (generic format) matches the gold
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Cara",
       "goals": [
         "The student will solve two-digit addition problems with 80% accuracy.",
@@ -112,6 +118,7 @@ exports[`parseCSVReport — messy grade values (generic format) matches the gold
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Dan",
       "goals": [
         "The student will write complete sentences with correct capitalization.",
@@ -124,6 +131,7 @@ exports[`parseCSVReport — messy grade values (generic format) matches the gold
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Ella",
       "goals": [
         "The student will follow two-step directions in the classroom in 4 of 5 trials.",
@@ -136,6 +144,7 @@ exports[`parseCSVReport — messy grade values (generic format) matches the gold
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Finn",
       "goals": [
         "The student will count to 20 with one-to-one correspondence in 4 of 5 trials.",
@@ -148,6 +157,7 @@ exports[`parseCSVReport — messy grade values (generic format) matches the gold
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Grace",
       "goals": [
         "The student will decode CVC words with 85% accuracy across 3 sessions.",
@@ -160,6 +170,7 @@ exports[`parseCSVReport — messy grade values (generic format) matches the gold
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Will",
       "goals": [
         "The student will summarize a short passage in writing with 80% accuracy.",

--- a/__tests__/unit/lib/parsers/__snapshots__/seis-goals-csv.test.ts.snap
+++ b/__tests__/unit/lib/parsers/__snapshots__/seis-goals-csv.test.ts.snap
@@ -73,6 +73,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) falls back to the ge
   },
   "students": [
     {
+      "districtStudentId": undefined,
       "firstName": "Ana",
       "goals": [
         "Academic #1: 2026 - 2027",
@@ -88,6 +89,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) falls back to the ge
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Ben",
       "goals": [
         "Academic #2: 2025 - 2026",
@@ -101,6 +103,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) falls back to the ge
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Cora",
       "goals": [
         "Speech (1 of 1)",
@@ -114,6 +117,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) falls back to the ge
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Drew",
       "goals": [
         "Behavior (1 of 2)",
@@ -127,6 +131,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) falls back to the ge
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Ella",
       "goals": [
         "OT (1 of 1)",
@@ -140,6 +145,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) falls back to the ge
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Finn",
       "goals": [
         "OT (1 of 1)",
@@ -153,6 +159,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) falls back to the ge
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Gia",
       "goals": [
         "By 5/9/2027, Gia will raise her hand and wait to be called on in 4 of 5 opportunities.",
@@ -165,6 +172,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) falls back to the ge
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Hana",
       "goals": [
         "Comm (1 of 1)",
@@ -178,6 +186,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) falls back to the ge
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Ivan",
       "goals": [
         "Academic #1",
@@ -191,6 +200,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) falls back to the ge
       "schoolOfAttendance": undefined,
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Jae",
       "goals": [
         "Academic #1",
@@ -282,6 +292,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) parses the full fixt
   },
   "students": [
     {
+      "districtStudentId": "100001",
       "firstName": "Ana",
       "goals": [
         "By 5/1/2027, given a grade-level passage, Ana will read 90 words per minute with 95% accuracy in 3 of 4 trials.",
@@ -295,6 +306,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) parses the full fixt
       "schoolOfAttendance": "Mt Diablo Elementary School",
     },
     {
+      "districtStudentId": "100002",
       "firstName": "Ben",
       "goals": [
         "By 10/15/2026, given manipulatives, Ben will solve two-digit addition problems with 80% accuracy across 3 sessions.",
@@ -307,6 +319,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) parses the full fixt
       "schoolOfAttendance": "St Mary School",
     },
     {
+      "districtStudentId": "100003",
       "firstName": "Cora",
       "goals": [
         "By 1/20/2027, Cora will produce /r/ in structured sentences with 80% accuracy in 4 of 5 trials.",
@@ -319,6 +332,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) parses the full fixt
       "schoolOfAttendance": "Mt Diablo Elementary School",
     },
     {
+      "districtStudentId": "100004",
       "firstName": "Drew",
       "goals": [
         "By 2/10/2027, Drew will use a coping strategy when frustrated in 4 of 5 observed opportunities.",
@@ -331,6 +345,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) parses the full fixt
       "schoolOfAttendance": "Out of District- MOU",
     },
     {
+      "districtStudentId": "100005",
       "firstName": "Ella",
       "goals": [
         "By 3/5/2027, Ella will copy a five-word sentence legibly within 5 minutes in 4 of 5 trials.",
@@ -343,6 +358,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) parses the full fixt
       "schoolOfAttendance": "Mt Diablo Elementary School",
     },
     {
+      "districtStudentId": "100006",
       "firstName": "Finn",
       "goals": [
         "By 4/12/2027, Finn will form lower-case letters with correct size and spacing in 4 of 5 samples.",
@@ -355,6 +371,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) parses the full fixt
       "schoolOfAttendance": "Mt Diablo Elementary School",
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Gia",
       "goals": [
         "By 5/9/2027, Gia will raise her hand and wait to be called on in 4 of 5 opportunities.",
@@ -367,6 +384,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) parses the full fixt
       "schoolOfAttendance": "Mt Diablo Elementary School",
     },
     {
+      "districtStudentId": "100008",
       "firstName": "Hana",
       "goals": [
         "By 1/30/2027, Hana will answer wh- questions about a short story with 80% accuracy.",
@@ -379,6 +397,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) parses the full fixt
       "schoolOfAttendance": "Mt Diablo Elementary School",
     },
     {
+      "districtStudentId": "100009",
       "firstName": "Ivan",
       "goals": [
         "By 2/22/2027, Ivan will write a three-sentence paragraph with a topic sentence in 4 of 5 samples.",
@@ -391,6 +410,7 @@ exports[`parseCSVReport — SEIS Student Goals Report (CSV) parses the full fixt
       "schoolOfAttendance": "Mt Diablo Elementary School",
     },
     {
+      "districtStudentId": "100010",
       "firstName": "Jae",
       "goals": [
         "By 6/1/2027 Jae will:

--- a/__tests__/unit/lib/parsers/__snapshots__/seis-goals-xlsx.test.ts.snap
+++ b/__tests__/unit/lib/parsers/__snapshots__/seis-goals-xlsx.test.ts.snap
@@ -32,6 +32,7 @@ exports[`parseSEISReport — header on row 1 (row-skip fixed) matches the golden
   },
   "students": [
     {
+      "districtStudentId": "100001",
       "firstName": "Ana",
       "goals": [
         "By 5/1/2027, given a grade-level passage, Ana will read 90 words per minute with 95% accuracy in 3 of 4 trials.",
@@ -44,6 +45,7 @@ exports[`parseSEISReport — header on row 1 (row-skip fixed) matches the golden
       "schoolOfAttendance": "Mt Diablo Elementary School",
     },
     {
+      "districtStudentId": "100002",
       "firstName": "Ben",
       "goals": [
         "By 10/15/2026, given manipulatives, Ben will solve two-digit addition problems with 80% accuracy across 3 sessions.",
@@ -56,6 +58,7 @@ exports[`parseSEISReport — header on row 1 (row-skip fixed) matches the golden
       "schoolOfAttendance": "St Mary School",
     },
     {
+      "districtStudentId": "100003",
       "firstName": "Cora",
       "goals": [
         "By 1/20/2027, Cora will produce /r/ in structured sentences with 80% accuracy in 4 of 5 trials.",
@@ -68,6 +71,7 @@ exports[`parseSEISReport — header on row 1 (row-skip fixed) matches the golden
       "schoolOfAttendance": "Mt Diablo Elementary School",
     },
     {
+      "districtStudentId": "100004",
       "firstName": "Drew",
       "goals": [
         "By 2/10/2027, Drew will use a coping strategy when frustrated in 4 of 5 observed opportunities.",
@@ -80,6 +84,7 @@ exports[`parseSEISReport — header on row 1 (row-skip fixed) matches the golden
       "schoolOfAttendance": "Out of District- MOU",
     },
     {
+      "districtStudentId": "100005",
       "firstName": "Ella",
       "goals": [
         "By 3/5/2027, Ella will copy a five-word sentence legibly within 5 minutes in 4 of 5 trials.",
@@ -92,6 +97,7 @@ exports[`parseSEISReport — header on row 1 (row-skip fixed) matches the golden
       "schoolOfAttendance": "Mt Diablo Elementary School",
     },
     {
+      "districtStudentId": "100006",
       "firstName": "Finn",
       "goals": [
         "By 4/12/2027, Finn will form lower-case letters with correct size and spacing in 4 of 5 samples.",
@@ -104,6 +110,7 @@ exports[`parseSEISReport — header on row 1 (row-skip fixed) matches the golden
       "schoolOfAttendance": "Mt Diablo Elementary School",
     },
     {
+      "districtStudentId": undefined,
       "firstName": "Gia",
       "goals": [
         "By 5/9/2027, Gia will raise her hand and wait to be called on in 4 of 5 opportunities.",
@@ -132,6 +139,7 @@ exports[`parseSEISReport — title rows then header on row 3 matches the golden 
   },
   "students": [
     {
+      "districtStudentId": "100001",
       "firstName": "Ana",
       "goals": [
         "By 5/1/2027, given a grade-level passage, Ana will read 90 words per minute with 95% accuracy in 3 of 4 trials.",
@@ -144,6 +152,7 @@ exports[`parseSEISReport — title rows then header on row 3 matches the golden 
       "schoolOfAttendance": "Mt Diablo Elementary School",
     },
     {
+      "districtStudentId": "100002",
       "firstName": "Ben",
       "goals": [
         "By 10/15/2026, given manipulatives, Ben will solve two-digit addition problems with 80% accuracy across 3 sessions.",
@@ -156,6 +165,7 @@ exports[`parseSEISReport — title rows then header on row 3 matches the golden 
       "schoolOfAttendance": "St Mary School",
     },
     {
+      "districtStudentId": "100003",
       "firstName": "Cora",
       "goals": [
         "By 1/20/2027, Cora will produce /r/ in structured sentences with 80% accuracy in 4 of 5 trials.",

--- a/__tests__/unit/lib/parsers/class-list-parser.test.ts
+++ b/__tests__/unit/lib/parsers/class-list-parser.test.ts
@@ -21,6 +21,7 @@ function serialize(result: ClassListParseResult) {
       .map(([key, s]) => ({
         key,
         name: s.name,
+        districtStudentId: s.districtStudentId,
         teacher: s.teacher,
       })),
     teachers: result.teachers,
@@ -67,6 +68,26 @@ describe('parseClassListTXT', () => {
     expect(ana).toBeDefined();
     // Ana appears under Barrera (page 1) and Khristo (page 2); first wins.
     expect(ana!.teacher.lastName).toBe('Barrera');
+  });
+
+  // SPE-339: field 2 of each student row is the district's own Student ID. The
+  // name is quoted (it contains a comma), so the id has to be read from what
+  // follows the closing quote, not from a naive comma split.
+  it("captures each student's district Student ID from behind the quoted name", async () => {
+    const result = await parseClassListTXT(readFixture('class-list.txt'));
+    expect(result.students.get('alvarez_ana')!.districtStudentId).toBe('100001');
+    expect(result.students.get('bishop_ben')!.districtStudentId).toBe('100002');
+    // A hyphenated two-word last name still splits correctly.
+    expect(result.students.get('davis-wong_drew')!.districtStudentId).toBe('100004');
+  });
+
+  it('leaves the id null for a row that carries only a name', async () => {
+    const result = await parseClassListTXT(
+      Buffer.from('Teacher#,101,Teacher: Barrera E\n"Solo, Sam"\n', 'utf-8'),
+    );
+    const sam = result.students.get('solo_sam');
+    expect(sam).toBeDefined();
+    expect(sam!.districtStudentId).toBeNull();
   });
 
   it('captures all five distinct teachers including co-teacher and quoted names', async () => {

--- a/__tests__/unit/lib/parsers/fixtures/builders.ts
+++ b/__tests__/unit/lib/parsers/fixtures/builders.ts
@@ -112,31 +112,31 @@ type SparseRow = Record<number, string>;
  */
 const SEIS_GOALS_ROWS: SparseRow[] = [
   {
-    0: '2000001', 2: 'Alvarez', 3: 'Ana', 5: '01', 6: 'Mt Diablo Elementary School',
+    0: '2000001', 1: '100001', 2: 'Alvarez', 3: 'Ana', 5: '01', 6: 'Mt Diablo Elementary School',
     9: '05/01/2026', 11: 'Reading', 12: 'Academic #1: 2026 - 2027',
     14: 'By 5/1/2027, given a grade-level passage, Ana will read 90 words per minute with 95% accuracy in 3 of 4 trials.',
     17: 'Resource Specialist',
   },
   {
-    0: '2000002', 2: 'Bishop', 3: 'Ben', 5: '02', 6: 'St Mary School',
+    0: '2000002', 1: '100002', 2: 'Bishop', 3: 'Ben', 5: '02', 6: 'St Mary School',
     9: '10/15/2025', 11: 'Math', 12: 'Academic #2: 2025 - 2026',
     14: 'By 10/15/2026, given manipulatives, Ben will solve two-digit addition problems with 80% accuracy across 3 sessions.',
     17: 'Resource Specialist and General Education Teacher',
   },
   {
-    0: '2000003', 2: 'Cho', 3: 'Cora', 5: '03', 6: 'Mt Diablo Elementary School',
+    0: '2000003', 1: '100003', 2: 'Cho', 3: 'Cora', 5: '03', 6: 'Mt Diablo Elementary School',
     9: '01/20/2026', 11: 'Speech/Language', 12: 'Speech (1 of 1)',
     14: 'By 1/20/2027, Cora will produce /r/ in structured sentences with 80% accuracy in 4 of 5 trials.',
     17: 'Speech Language Pathologist',
   },
   {
-    0: '2000004', 2: 'Diaz', 3: 'Drew', 5: '04', 6: 'Out of District- MOU',
+    0: '2000004', 1: '100004', 2: 'Diaz', 3: 'Drew', 5: '04', 6: 'Out of District- MOU',
     9: '02/10/2026', 11: 'Social/Emotional', 12: 'Behavior (1 of 2)',
     14: 'By 2/10/2027, Drew will use a coping strategy when frustrated in 4 of 5 observed opportunities.',
     17: 'School Counselor',
   },
   {
-    0: '2000005', 2: 'Evans', 3: 'Ella', 5: '05', 6: 'Mt Diablo Elementary School',
+    0: '2000005', 1: '100005', 2: 'Evans', 3: 'Ella', 5: '05', 6: 'Mt Diablo Elementary School',
     9: '03/05/2026', 11: 'Fine Motor', 12: 'OT (1 of 1)',
     14: 'By 3/5/2027, Ella will copy a five-word sentence legibly within 5 minutes in 4 of 5 trials.',
     17: 'Occupational Therapist',
@@ -147,14 +147,16 @@ const SEIS_GOALS_ROWS: SparseRow[] = [
     // OT goal into resource; word-boundary matching plus the new OT
     // "handwriting" keyword now route it to OT, not resource. No column carries
     // a resource keyword, so the flip is unambiguous.
-    0: '2000006', 2: 'Foster', 3: 'Finn', 5: '18', 6: 'Mt Diablo Elementary School',
+    0: '2000006', 1: '100006', 2: 'Foster', 3: 'Finn', 5: '18', 6: 'Mt Diablo Elementary School',
     9: '04/12/2026', 11: 'Handwriting', 12: 'OT (1 of 1)',
     14: 'By 4/12/2027, Finn will form lower-case letters with correct size and spacing in 4 of 5 samples.',
     17: 'Occupational Therapist',
   },
   {
     // Blank Area of Need + blank Annual Goal # + blank Person Responsible:
-    // filtered out for every keyworded role.
+    // filtered out for every keyworded role. Also the one row with NO District ID
+    // (column B) — real exports have gaps, and an absent id must stay absent
+    // rather than becoming '' (SPE-339).
     0: '2000007', 2: 'Gomez', 3: 'Gia', 5: '01', 6: 'Mt Diablo Elementary School',
     9: '05/09/2026', 11: '', 12: '',
     14: 'By 5/9/2027, Gia will raise her hand and wait to be called on in 4 of 5 opportunities.',
@@ -162,28 +164,28 @@ const SEIS_GOALS_ROWS: SparseRow[] = [
   },
   {
     // "Receptive Languge" typo does not contain "language" -> lost for speech.
-    0: '2000008', 2: 'Hunt', 3: 'Hana', 5: '02', 6: 'Mt Diablo Elementary School',
+    0: '2000008', 1: '100008', 2: 'Hunt', 3: 'Hana', 5: '02', 6: 'Mt Diablo Elementary School',
     9: '01/30/2026', 11: 'Receptive Languge', 12: 'Comm (1 of 1)',
     14: 'By 1/30/2027, Hana will answer wh- questions about a short story with 80% accuracy.',
     17: 'Case Manager',
   },
   {
     // Goal-like text in Person Responsible.
-    0: '2000009', 2: 'Ingram', 3: 'Ivan', 5: '03', 6: 'Mt Diablo Elementary School',
+    0: '2000009', 1: '100009', 2: 'Ingram', 3: 'Ivan', 5: '03', 6: 'Mt Diablo Elementary School',
     9: '02/22/2026', 11: 'Written Expression', 12: 'Academic #1',
     14: 'By 2/22/2027, Ivan will write a three-sentence paragraph with a topic sentence in 4 of 5 samples.',
     17: 'the student will write a paragraph with support',
   },
   {
     // Embedded newline inside the goal cell.
-    0: '2000010', 2: 'Jones', 3: 'Jae', 5: '04', 6: 'Mt Diablo Elementary School',
+    0: '2000010', 1: '100010', 2: 'Jones', 3: 'Jae', 5: '04', 6: 'Mt Diablo Elementary School',
     9: '03/18/2026', 11: 'Reading', 12: 'Academic #1',
     14: 'By 6/1/2027 Jae will:\n- decode multisyllabic words\n- read 100 wpm with 95% accuracy',
     17: 'Resource Specialist',
   },
   {
     // Duplicate of Alvarez, Ana (grade 01): second goal must merge into the first.
-    0: '2000001', 2: 'Alvarez', 3: 'Ana', 5: '01', 6: 'Mt Diablo Elementary School',
+    0: '2000001', 1: '100001', 2: 'Alvarez', 3: 'Ana', 5: '01', 6: 'Mt Diablo Elementary School',
     9: '05/01/2026', 11: 'Written', 12: 'Academic #2',
     14: 'By 5/1/2027, Ana will write a personal narrative with a beginning, middle, and end in 4 of 5 samples.',
     17: 'Resource Specialist',

--- a/__tests__/unit/lib/parsers/fixtures/roster-template.csv
+++ b/__tests__/unit/lib/parsers/fixtures/roster-template.csv
@@ -1,6 +1,6 @@
-Initials,Grade,Teacher,Sessions Per Week,Minutes Per Session
-JD,3,Smith,2,30
-AB,K,Johnson,3,20
-CD,5,Davis,1,45
-EF,2,Wilson,2,30
-GH,4,Garcia,3,30
+Initials,Student ID,Grade,Teacher,Sessions Per Week,Minutes Per Session
+JD,100001,3,Smith,2,30
+AB,100002,K,Johnson,3,20
+CD,,5,Davis,1,45
+EF,100004,2,Wilson,2,30
+GH,,4,Garcia,3,30

--- a/__tests__/unit/lib/parsers/seis-goals-csv.test.ts
+++ b/__tests__/unit/lib/parsers/seis-goals-csv.test.ts
@@ -13,6 +13,7 @@
 
 import { parseCSVReport } from '@/lib/parsers/csv-parser';
 import {
+  buildSeisGoalsCsvFrom,
   SEIS_GOALS_CSV,
   SEIS_GOALS_CSV_BOM,
   SEIS_GOALS_SHIFTED_CSV,
@@ -63,6 +64,27 @@ describe('parseCSVReport — SEIS Student Goals Report (CSV)', () => {
     const gia = result.students.find((s) => s.lastName === 'Gomez');
     expect(gia).toBeDefined();
     expect(gia!.districtStudentId).toBeUndefined();
+  });
+
+  it('warns instead of silently dropping a conflicting id across a student\'s goal rows', async () => {
+    // Two goal rows for one student carrying DIFFERENT ids means the export is
+    // inconsistent, or two real children are being merged by name+grade+school.
+    // Either way it must not vanish.
+    const rows = [
+      { 0: '2000001', 1: '100001', 2: 'Alvarez', 3: 'Ana', 5: '01', 6: 'Mt Diablo Elementary School',
+        9: '05/01/2026', 11: 'Reading', 12: 'Academic #1',
+        14: 'By 5/1/2027, Ana will read 90 words per minute with 95% accuracy in 3 of 4 trials.',
+        17: 'Resource Specialist' },
+      { 0: '2000001', 1: '999999', 2: 'Alvarez', 3: 'Ana', 5: '01', 6: 'Mt Diablo Elementary School',
+        9: '05/01/2026', 11: 'Written', 12: 'Academic #2',
+        14: 'By 5/1/2027, Ana will write a personal narrative with a beginning, middle, and end.',
+        17: 'Resource Specialist' },
+    ];
+    const result = await parseCSVReport(buildSeisGoalsCsvFrom(rows), {});
+
+    // First id wins, and the clash is reported.
+    expect(result.students[0].districtStudentId).toBe('100001');
+    expect(result.warnings.some((w) => /Student ID mismatch/.test(w.message))).toBe(true);
   });
 
   describe('per-role goal filtering', () => {

--- a/__tests__/unit/lib/parsers/seis-goals-csv.test.ts
+++ b/__tests__/unit/lib/parsers/seis-goals-csv.test.ts
@@ -45,6 +45,26 @@ describe('parseCSVReport — SEIS Student Goals Report (CSV)', () => {
     expect(result).toMatchSnapshot();
   });
 
+  // SPE-339: column B is the district's own Student ID. Column A is the SEIS ID,
+  // which is a different number — a parser reading the wrong column would still
+  // "work", so these assert the actual values.
+  it('captures the District ID from column B, not the SEIS ID from column A', async () => {
+    const result = await parseCSVReport(SEIS_GOALS_CSV(), {});
+    const byName = new Map(result.students.map((s) => [`${s.firstName} ${s.lastName}`, s]));
+
+    expect(byName.get('Ana Alvarez')!.districtStudentId).toBe('100001');
+    expect(byName.get('Ben Bishop')!.districtStudentId).toBe('100002');
+    // Not the SEIS IDs (2000001 / 2000002).
+    expect(byName.get('Ana Alvarez')!.districtStudentId).not.toBe('2000001');
+  });
+
+  it('leaves the id undefined when column B is blank', async () => {
+    const result = await parseCSVReport(SEIS_GOALS_CSV(), {});
+    const gia = result.students.find((s) => s.lastName === 'Gomez');
+    expect(gia).toBeDefined();
+    expect(gia!.districtStudentId).toBeUndefined();
+  });
+
   describe('per-role goal filtering', () => {
     // Real-file reference counts (kept/total goals): resource 119/184, speech
     // 58, OT 12, counseling 9. This fictional fixture is far smaller; the

--- a/__tests__/unit/lib/parsers/speddy-template-csv.test.ts
+++ b/__tests__/unit/lib/parsers/speddy-template-csv.test.ts
@@ -148,4 +148,42 @@ describe('parseCSVReport — Speddy roster template', () => {
     expect(result.students[0].sessionsPerWeek).toBeUndefined();
     expect(result.students[0].minutesPerSession).toBeUndefined();
   });
+
+  // SPE-339. The column is optional in both directions: a roster saved from the
+  // OLD template (no Student ID column) must still parse, or every customer with
+  // a saved copy breaks on their next import.
+  it('captures the optional Student ID column', async () => {
+    const csv = Buffer.from(
+      ['Initials,Student ID,Grade,Teacher', 'JD,100001,3,Smith', 'AB,,K,Johnson'].join('\n'),
+      'utf-8',
+    );
+    const result = await parseCSVReport(csv, {});
+
+    expect(result.metadata.formatDetected).toBe('speddy-template');
+    expect(result.students[0].districtStudentId).toBe('100001');
+    // Blank cell -> absent, not ''.
+    expect(result.students[1].districtStudentId).toBeUndefined();
+  });
+
+  it('still parses a roster saved from the older template with no Student ID column', async () => {
+    const csv = Buffer.from('Initials,Grade,Teacher\nJD,3,Smith', 'utf-8');
+    const result = await parseCSVReport(csv, {});
+
+    expect(result.metadata.formatDetected).toBe('speddy-template');
+    expect(result.students).toHaveLength(1);
+    expect(result.students[0].districtStudentId).toBeUndefined();
+  });
+
+  it('parses the shipped template fixture, Student ID column included', async () => {
+    const result = await parseCSVReport(readFixture('roster-template.csv'), {});
+
+    expect(result.metadata.formatDetected).toBe('speddy-template');
+    expect(result.students.map((s) => s.districtStudentId)).toEqual([
+      '100001',
+      '100002',
+      undefined,
+      '100004',
+      undefined,
+    ]);
+  });
 });

--- a/__tests__/unit/lib/student-matcher-district-id.test.ts
+++ b/__tests__/unit/lib/student-matcher-district-id.test.ts
@@ -1,0 +1,168 @@
+/**
+ * SPE-339: the district's Student ID takes precedence over the name/grade
+ * heuristics, and an id that lands on a different child is reported rather than
+ * merged.
+ *
+ * These are the cases where getting it wrong silently overwrites a real
+ * student's record, so each one asserts WHICH student was matched, not merely
+ * that something matched.
+ */
+import { matchStudents, type DatabaseStudent } from '@/lib/utils/student-matcher';
+import type { ParsedStudent } from '@/lib/parsers/seis-parser';
+
+function parsed(overrides: Partial<ParsedStudent> = {}): ParsedStudent {
+  return {
+    firstName: 'Ana',
+    lastName: 'Alvarez',
+    initials: 'AA',
+    gradeLevel: '1',
+    goals: [],
+    rawRow: 2,
+    ...overrides,
+  };
+}
+
+function dbStudent(overrides: Partial<DatabaseStudent> = {}): DatabaseStudent {
+  return {
+    id: 'db-1',
+    initials: 'AA',
+    grade_level: '1',
+    first_name: 'Ana',
+    last_name: 'Alvarez',
+    ...overrides,
+  };
+}
+
+const only = (p: ParsedStudent, db: DatabaseStudent[]) => matchStudents([p], db).matches[0];
+
+describe('district Student ID matching', () => {
+  it('matches on the id even when the grade has changed since last import', () => {
+    // Ana moved up a grade. Name+grade matching alone would call her a new
+    // student and duplicate the record; the id keeps her identity.
+    const match = only(
+      parsed({ districtStudentId: '100001', gradeLevel: '2' }),
+      [dbStudent({ id: 'ana', grade_level: '1', district_student_id: '100001' })],
+    );
+
+    expect(match.matchedStudent?.id).toBe('ana');
+    expect(match.confidence).toBe('high');
+    expect(match.idConflict).toBeUndefined();
+  });
+
+  it('matches on the id even when the name was recorded differently', () => {
+    const match = only(
+      parsed({ firstName: 'Ana', lastName: 'Alvarez-Reyes', districtStudentId: '100001' }),
+      [dbStudent({ id: 'ana', first_name: 'Ana', last_name: 'Alvarez', district_student_id: '100001' })],
+    );
+
+    expect(match.matchedStudent?.id).toBe('ana');
+  });
+
+  it('prefers the id over a same-name, same-grade student carrying a different id', () => {
+    // Two children share a name and grade. Only the id separates them, so this
+    // is exactly the case name matching gets wrong.
+    const match = only(
+      parsed({ districtStudentId: '100002' }),
+      [
+        dbStudent({ id: 'ana-one', district_student_id: '100001' }),
+        dbStudent({ id: 'ana-two', district_student_id: '100002' }),
+      ],
+    );
+
+    expect(match.matchedStudent?.id).toBe('ana-two');
+  });
+
+  it('matches an unnamed roster row on its id alone', () => {
+    // Roster-template rows carry no names, so before SPE-339 they could only be
+    // matched by the initials+grade guess.
+    const match = only(
+      parsed({ firstName: '', lastName: '', districtStudentId: '100001' }),
+      [dbStudent({ id: 'ana', district_student_id: '100001' })],
+    );
+
+    expect(match.matchedStudent?.id).toBe('ana');
+  });
+
+  describe('conflicts', () => {
+    it('refuses to merge when the id belongs to a plainly different child', () => {
+      const match = only(
+        parsed({ firstName: 'Ben', lastName: 'Bishop', initials: 'BB', districtStudentId: '100001' }),
+        [dbStudent({ id: 'ana', district_student_id: '100001' })],
+      );
+
+      // Reported, and NOT matched onto Ana.
+      expect(match.idConflict).toEqual({
+        districtStudentId: '100001',
+        existingLabel: 'Ana Alvarez',
+      });
+      expect(match.matchedStudent).toBeNull();
+    });
+
+    it('still matches the right student by name while reporting the conflict', () => {
+      // Ben's row carries Ana's id (a mistyped export). Ben must still land on
+      // Ben's record — the bad id is what gets dropped, not the whole row.
+      const match = only(
+        parsed({ firstName: 'Ben', lastName: 'Bishop', initials: 'BB', districtStudentId: '100001' }),
+        [
+          dbStudent({ id: 'ana', district_student_id: '100001' }),
+          dbStudent({ id: 'ben', initials: 'BB', first_name: 'Ben', last_name: 'Bishop' }),
+        ],
+      );
+
+      expect(match.matchedStudent?.id).toBe('ben');
+      expect(match.idConflict?.districtStudentId).toBe('100001');
+    });
+
+    it('reports rather than guesses when one id somehow spans several students', () => {
+      const match = only(
+        parsed({ districtStudentId: '100001' }),
+        [
+          dbStudent({ id: 'a', first_name: 'Zed', last_name: 'Zimmer', district_student_id: '100001' }),
+          dbStudent({ id: 'b', first_name: 'Yan', last_name: 'Young', district_student_id: '100001' }),
+        ],
+      );
+
+      expect(match.idConflict?.existingLabel).toBe('2 existing students');
+      expect(match.matchedStudent).toBeNull();
+    });
+  });
+
+  describe('normalization', () => {
+    it('ignores surrounding whitespace and letter case', () => {
+      const match = only(
+        parsed({ districtStudentId: '  a100001 ' }),
+        [dbStudent({ id: 'ana', district_student_id: 'A100001' })],
+      );
+
+      expect(match.matchedStudent?.id).toBe('ana');
+    });
+
+    it('keeps leading zeros significant — they distinguish real ids', () => {
+      const match = only(
+        parsed({ firstName: 'Zed', lastName: 'Zimmer', initials: 'ZZ', districtStudentId: '0012345' }),
+        [dbStudent({ id: 'other', first_name: 'Yan', last_name: 'Young', initials: 'YY', district_student_id: '12345' })],
+      );
+
+      expect(match.matchedStudent).toBeNull();
+      expect(match.idConflict).toBeUndefined();
+    });
+
+    it('treats a blank id as no id and falls back to name matching', () => {
+      const match = only(
+        parsed({ districtStudentId: '   ' }),
+        [dbStudent({ id: 'ana', district_student_id: null })],
+      );
+
+      expect(match.matchedStudent?.id).toBe('ana');
+      expect(match.reason).not.toMatch(/Student ID/);
+    });
+  });
+
+  it('leaves existing name-based matching untouched when no ids are present', () => {
+    const match = only(parsed(), [dbStudent({ id: 'ana' })]);
+
+    expect(match.matchedStudent?.id).toBe('ana');
+    expect(match.confidence).toBe('high');
+    expect(match.idConflict).toBeUndefined();
+  });
+});

--- a/__tests__/unit/lib/supabase/queries/student-details-district-id.test.ts
+++ b/__tests__/unit/lib/supabase/queries/student-details-district-id.test.ts
@@ -1,0 +1,88 @@
+/**
+ * SPE-339: the district student id lives on `students`, but is loaded and saved
+ * through the student-details pair the modal uses.
+ *
+ * The case that matters is a student with NO `student_details` row (pre-existing
+ * rows, roster-template and manual-add students — SPE-284). If the load returned
+ * null there, the modal would render a blank form and write that blank straight
+ * back over a stored id on the next save.
+ */
+import { getStudentDetails } from '@/lib/supabase/queries/student-details';
+
+let detailsRow: Record<string, unknown> | null = null;
+let studentRow: Record<string, unknown> | null = null;
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      if (table === 'student_details') {
+        return {
+          select: () => ({
+            eq: () => ({
+              limit: () => ({
+                maybeSingle: async () => ({ data: detailsRow, error: null }),
+              }),
+            }),
+          }),
+        };
+      }
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: studentRow, error: null }),
+          }),
+        }),
+      };
+    },
+  }),
+}));
+
+jest.mock('@/lib/monitoring/performance-alerts', () => ({
+  measurePerformanceWithAlerts: () => ({ end: () => {} }),
+}));
+
+describe('getStudentDetails — district student id', () => {
+  beforeEach(() => {
+    detailsRow = null;
+    studentRow = null;
+  });
+
+  it('returns the stored id alongside the details when both exist', async () => {
+    detailsRow = { first_name: 'Ana', last_name: 'Alvarez', iep_goals: ['g'] };
+    studentRow = { district_student_id: '100001' };
+
+    const details = await getStudentDetails('s1');
+
+    expect(details?.district_student_id).toBe('100001');
+    expect(details?.first_name).toBe('Ana');
+  });
+
+  it('still returns the id for a student that has no details row yet', async () => {
+    detailsRow = null;
+    studentRow = { district_student_id: '100001' };
+
+    const details = await getStudentDetails('s1');
+
+    // Not null — otherwise the modal blanks the field and the next save wipes it.
+    expect(details).not.toBeNull();
+    expect(details?.district_student_id).toBe('100001');
+    expect(details?.first_name).toBe('');
+  });
+
+  it('returns an empty id, not null, when the student simply has no id yet', async () => {
+    detailsRow = null;
+    studentRow = { district_student_id: null };
+
+    const details = await getStudentDetails('s1');
+
+    expect(details).not.toBeNull();
+    expect(details?.district_student_id).toBe('');
+  });
+
+  it('returns null when the student does not exist at all', async () => {
+    detailsRow = null;
+    studentRow = null;
+
+    expect(await getStudentDetails('missing')).toBeNull();
+  });
+});

--- a/app/(dashboard)/dashboard/students/page.tsx
+++ b/app/(dashboard)/dashboard/students/page.tsx
@@ -447,6 +447,10 @@ export default function StudentsPage() {
                 // presence (file wins) and leaves it untouched on absence.
                 upcomingIepDate: row.iepDates?.upcomingIepDate?.value,
                 upcomingTriennialDate: row.iepDates?.upcomingTriennialDate?.value,
+                // District Student ID (SPE-339): presence-keyed too. Undefined
+                // when the file carried none, or when the id was disputed — the
+                // preview drops a conflicting id rather than re-pointing it.
+                districtStudentId: row.districtStudentId,
               }));
 
               const response = await fetch('/api/import-students/confirm', {

--- a/app/api/import-students/confirm/route.ts
+++ b/app/api/import-students/confirm/route.ts
@@ -311,6 +311,13 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
           if (student.upcomingTriennialDate !== undefined) {
             updatePayload.upcomingTriennialDate = student.upcomingTriennialDate;
           }
+          // District Student ID (SPE-339): presence-keyed for the same reason —
+          // a file that carries no ids (a goals-only re-import) must not erase
+          // the ids a previous roster or SIS export established. Disputed ids
+          // never reach here; the preview withholds them.
+          if (student.districtStudentId !== undefined) {
+            updatePayload.districtStudentId = student.districtStudentId;
+          }
           batchPayload.push(updatePayload);
         } else {
           // Insert. Set `teacher_name` alongside `teacher_id` when a teacher
@@ -337,7 +344,9 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
             // IEP Dates (SPE-303): a new student created from the goals file may
             // also match the IEP Dates file. Null when absent (a fresh row).
             upcomingIepDate: student.upcomingIepDate ?? null,
-            upcomingTriennialDate: student.upcomingTriennialDate ?? null
+            upcomingTriennialDate: student.upcomingTriennialDate ?? null,
+            // District Student ID (SPE-339). Null when the file carried none.
+            districtStudentId: student.districtStudentId ?? null
           });
           addedInThisBatch.add(duplicateKey);
         }

--- a/app/components/students/review/review-exception-row.tsx
+++ b/app/components/students/review/review-exception-row.tsx
@@ -73,6 +73,30 @@ export function ReviewExceptionRow({ exception, teacherOverride, onResolveTeache
     );
   }
 
+  // SPE-339: the file's Student ID is already on file against a different child.
+  // Informational — the student still imports, but the disputed id is not
+  // written, so nothing is silently merged or re-pointed.
+  if (exception.kind === 'district-id-conflict') {
+    return (
+      <li className="flex items-start gap-2 px-4 py-2 text-sm">
+        <ReviewSignalIcon signal="check" className="mt-0.5" decorative />
+        <div className="min-w-0">
+          <p>
+            <span className="font-medium text-gray-900">{exception.studentLabel}</span>
+            <span className="text-gray-600">
+              {' '}
+              — Student ID {exception.districtStudentId} already belongs to {exception.existingLabel}
+            </span>
+          </p>
+          <p className="mt-0.5 text-xs text-gray-500">
+            The student will still be imported, but this ID won&apos;t be saved. Check the ID in your
+            source file, then re-import to attach it.
+          </p>
+        </div>
+      </li>
+    );
+  }
+
   // goals-removed
   return (
     <li className="flex items-start gap-2 px-4 py-2 text-sm">

--- a/app/components/students/student-details-modal.tsx
+++ b/app/components/students/student-details-modal.tsx
@@ -179,7 +179,9 @@ export function StudentDetailsModal({
           hint: (error as unknown as Record<string, unknown>).hint
         });
       }
-      alert('Failed to save. Please try again.');
+      // Show what actually went wrong (e.g. a duplicate District Student ID) —
+      // a generic message leaves the user retrying the same failing value.
+      alert(error instanceof Error ? error.message : 'Failed to save. Please try again.');
     } finally {
       setLoading(false);
     }

--- a/app/components/students/student-details-modal.tsx
+++ b/app/components/students/student-details-modal.tsx
@@ -58,7 +58,7 @@ export function StudentDetailsModal({
     first_name: '',
     last_name: '',
     date_of_birth: '',
-    district_id: '',
+    district_student_id: '',
     upcoming_iep_date: '',
     upcoming_triennial_date: '',
     iep_goals: [],
@@ -115,7 +115,7 @@ export function StudentDetailsModal({
               first_name: '',
               last_name: '',
               date_of_birth: '',
-              district_id: '',
+              district_student_id: '',
               upcoming_iep_date: '',
               upcoming_triennial_date: '',
               iep_goals: [],
@@ -513,15 +513,19 @@ export function StudentDetailsModal({
                 </FormGroup>
 
                 <FormGroup>
-                  <Label htmlFor="district_id">District ID</Label>
+                  <Label htmlFor="district_student_id">District Student ID</Label>
                   <Input
-                    id="district_id"
+                    id="district_student_id"
                     type="text"
-                    value={details.district_id}
-                    onChange={(e) => setDetails({...details, district_id: e.target.value})}
-                    placeholder="Enter district ID"
+                    value={details.district_student_id}
+                    onChange={(e) => setDetails({...details, district_student_id: e.target.value})}
+                    placeholder="e.g. 100234"
                     disabled={readOnly}
                   />
+                  <p className="mt-1 text-xs text-gray-500">
+                    The student&apos;s ID in your district&apos;s system. Imports use it to match
+                    this student reliably.
+                  </p>
                 </FormGroup>
               </div>
 

--- a/app/components/students/student-import-modal.tsx
+++ b/app/components/students/student-import-modal.tsx
@@ -38,13 +38,17 @@ interface ImportEntry {
 }
 
 // The roster template offered for download, matching the columns the importer
-// expects (Initials/Grade/Teacher required; sessions/minutes optional).
-const ROSTER_TEMPLATE_CSV = `Initials,Grade,Teacher,Sessions Per Week,Minutes Per Session
-JD,3,Smith,2,30
-AB,K,Johnson,3,20
-CD,5,Davis,1,45
-EF,2,Wilson,2,30
-GH,4,Garcia,3,30`;
+// expects (Initials/Grade/Teacher required; Student ID, sessions and minutes
+// optional). Student ID is the district's own id (SPE-339) — supplying it makes
+// re-imports match the same child reliably instead of guessing from initials.
+// Parsing is header-name based, so a roster saved from the older template (no
+// Student ID column) still imports unchanged.
+const ROSTER_TEMPLATE_CSV = `Initials,Student ID,Grade,Teacher,Sessions Per Week,Minutes Per Session
+JD,100001,3,Smith,2,30
+AB,100002,K,Johnson,3,20
+CD,,5,Davis,1,45
+EF,100004,2,Wilson,2,30
+GH,,4,Garcia,3,30`;
 
 // Where each SEIS/Aeries export lives and what it fills in Speddy. Drives the
 // collapsible "Where to find each file" guide so a first-time user can locate

--- a/lib/import/classify.ts
+++ b/lib/import/classify.ts
@@ -234,6 +234,15 @@ export function buildStudentPreviews(params: {
 
   const matchResult = matchStudents(parsedStudents, databaseStudents, { enrichNoNameByInitials });
 
+  // SPE-339: who already holds each id, so an id picked up from the CLASS LIST
+  // (which the matcher never saw) gets the same "don't merge two children"
+  // treatment as one from the primary file.
+  const idOwners = new Map<string, string>();
+  for (const dbStudent of databaseStudents) {
+    const storedId = normalizeDistrictStudentId(dbStudent.district_student_id);
+    if (storedId) idOwners.set(storedId, dbStudent.id);
+  }
+
   // Track which students from deliveries/classList/iepDates were matched
   const matchedDeliveryNames = new Set<string>();
   const matchedClassListNames = new Set<string>();
@@ -273,13 +282,23 @@ export function buildStudentPreviews(params: {
     }
 
     // Match with class list data (need for change detection)
+    let classListStudentId: string | null = null;
     if (classListData) {
       const classListStudent = classListData.get(normalizedKey);
       if (classListStudent) {
         matchedClassListNames.add(normalizedKey);
         teacherMatchResult = resolveClassListTeacher(classListStudent.teacher, dbTeachers);
+        // SPE-339: the Aeries class list carries the district's Student ID too.
+        classListStudentId = classListStudent.districtStudentId;
       }
     }
+
+    // SPE-339: the primary file wins; the class list fills the gap when it has
+    // no id (a class-list-only or class-list + generic-goals import would
+    // otherwise parse the id and throw it away).
+    const incomingDistrictId =
+      student.districtStudentId?.trim() || classListStudentId?.trim() || '';
+    const normalizedIncomingId = normalizeDistrictStudentId(incomingDistrictId);
 
     // Match with IEP Dates data (SPE-303). File wins: a present date overwrites
     // the stored one; a row whose dates equal what's stored is not a change. For
@@ -342,13 +361,20 @@ export function buildStudentPreviews(params: {
       // An IEP Dates match with a date that differs from what's stored makes the
       // row an update even if nothing else changed; identical dates stay a skip.
       const hasIepDateChange = iepDatesResult?.changed ?? false;
+      // SPE-339: backfilling an id onto an otherwise-unchanged student is real
+      // work. Without this the row is a 'skip', and skip rows are excluded from
+      // the confirm payload — so re-importing to pick up ids would do nothing.
+      const hasDistrictIdChange =
+        !!normalizedIncomingId &&
+        normalizedIncomingId !== normalizeDistrictStudentId(matchedStudent.district_student_id);
       const anyChanges =
         changeCheck.hasGoalChanges ||
         changeCheck.hasScheduleChanges ||
         changeCheck.hasTeacherChanges ||
         hasUnresolvedTeacher ||
         hasNameChange ||
-        hasIepDateChange;
+        hasIepDateChange ||
+        hasDistrictIdChange;
 
       if (anyChanges) {
         action = 'update';
@@ -424,10 +450,27 @@ export function buildStudentPreviews(params: {
     // SPE-339: carry the district's student id through to the write, unless it
     // is disputed — a conflicting id is reported, never written, so an import
     // can't quietly re-point an id at the wrong child.
+    const idOwner = normalizedIncomingId ? idOwners.get(normalizedIncomingId) : undefined;
+    const ownedBySomeoneElse =
+      !!idOwner && !!matchedStudent && idOwner !== matchedStudent.id;
+    // An id on a NEW student that another student already holds is equally a
+    // clash — it would collide on the unique index at best, and silently
+    // re-home the id at worst.
+    const ownedButThisIsNew = !!idOwner && !matchedStudent;
+
     if (match.idConflict) {
       preview.districtStudentIdConflict = match.idConflict;
-    } else if (student.districtStudentId?.trim()) {
-      preview.districtStudentId = student.districtStudentId.trim();
+    } else if (ownedBySomeoneElse || ownedButThisIsNew) {
+      const owner = databaseStudents.find(d => d.id === idOwner);
+      preview.districtStudentIdConflict = {
+        districtStudentId: normalizedIncomingId,
+        existingLabel:
+          [owner?.first_name, owner?.last_name].filter(Boolean).join(' ') ||
+          owner?.initials ||
+          'another student',
+      };
+    } else if (incomingDistrictId) {
+      preview.districtStudentId = incomingDistrictId;
     }
 
     // Add schedule data to preview
@@ -566,6 +609,30 @@ export function buildUpdatePreviews(params: {
           studentUpdates.push(update);
         }
 
+        // SPE-339: carry the class list's Student ID too, unless another
+        // student already holds it (same don't-merge rule as the main path).
+        const incomingId = normalizeDistrictStudentId(student.districtStudentId);
+        const storedId = normalizeDistrictStudentId(existingStudent.district_student_id);
+        if (incomingId && incomingId !== storedId) {
+          const owner = [...studentsByName.values()].find(
+            s2 => s2.id !== existingStudent.id &&
+              normalizeDistrictStudentId(s2.district_student_id) === incomingId,
+          );
+          if (owner) {
+            const ownerDetails = owner.student_details as unknown as
+              { first_name: string | null; last_name: string | null } | null;
+            update.districtStudentIdConflict = {
+              districtStudentId: incomingId,
+              existingLabel:
+                [ownerDetails?.first_name, ownerDetails?.last_name].filter(Boolean).join(' ') ||
+                owner.initials ||
+                'another student',
+            };
+          } else {
+            update.districtStudentId = student.districtStudentId!.trim();
+          }
+        }
+
         // Match teacher to database
         const teacherMatch = resolveClassListTeacher(student.teacher, dbTeachers);
 
@@ -637,7 +704,10 @@ export function buildUpdatePreviews(params: {
     const iepChanged = !!(
       update.iepDates?.upcomingIepDate?.changed || update.iepDates?.upcomingTriennialDate?.changed
     );
-    const hasWork = !!update.schedule || !!update.teacher || iepChanged;
+    // SPE-339: a row whose only change is a newly-captured district Student ID
+    // is still work — skip rows never reach the confirm payload.
+    const hasWork =
+      !!update.schedule || !!update.teacher || iepChanged || !!update.districtStudentId;
     update.action = hasWork ? 'update' : 'skip';
   }
 
@@ -740,7 +810,7 @@ export function buildRosterPreviews(params: {
     // Insert vs update/skip by the initials+grade key. Only a resolved teacher
     // that differs counts as a change, so an unmatched teacher name never clears
     // an existing teacher link on re-import (see classifyRosterChange).
-    const { action, scheduleChanged, teacherChanged } = classifyRosterChange(
+    const { action: baseAction, scheduleChanged, teacherChanged } = classifyRosterChange(
       existing
         ? {
             sessions_per_week: existing.sessions_per_week,
@@ -751,6 +821,16 @@ export function buildRosterPreviews(params: {
       teacher.teacherId,
       schedule ? { sessionsPerWeek: schedule.sessionsPerWeek, minutesPerSession: schedule.minutesPerSession } : undefined
     );
+
+    // SPE-339: classifyRosterChange only knows about schedule and teacher, so a
+    // roster whose only new information is the Student ID would classify as a
+    // skip and never reach the confirm payload. Promote it to an update.
+    const districtIdChanged =
+      !idConflict &&
+      !!incomingId &&
+      incomingId !== normalizeDistrictStudentId(existing?.district_student_id);
+    const action: typeof baseAction =
+      baseAction === 'skip' && districtIdChanged ? 'update' : baseAction;
 
     let changes: StudentChanges | undefined;
     if (action === 'update') {

--- a/lib/import/classify.ts
+++ b/lib/import/classify.ts
@@ -15,7 +15,7 @@
  * applies a `|| sessionsPerWeek*minutesPerSession` fallback — an intentional
  * divergence kept intact.
  */
-import { matchStudents, DatabaseStudent } from '@/lib/utils/student-matcher';
+import { matchStudents, normalizeDistrictStudentId, DatabaseStudent } from '@/lib/utils/student-matcher';
 import type { ParsedStudent as SeisParsedStudent } from '@/lib/parsers/seis-parser';
 import type { ParsedStudent as CsvParsedStudent } from '@/lib/parsers/csv-parser';
 import { createNormalizedKey } from '@/lib/parsers/name-utils';
@@ -119,6 +119,8 @@ export interface ExistingStudentRow {
   sessions_per_week: number | null;
   minutes_per_session: number | null;
   teacher_id: string | null;
+  /** The district's own student id (SPE-339), for id-first import matching. */
+  district_student_id?: string | null;
 }
 
 /** Detail row shape the main path selects for names + goals. */
@@ -187,6 +189,8 @@ export function toDatabaseStudents(
         // Stored IEP dates, for IEP Dates change detection (SPE-303).
         upcoming_iep_date: details?.upcoming_iep_date ?? null,
         upcoming_triennial_date: details?.upcoming_triennial_date ?? null,
+        // Stored district Student ID, for id-first matching (SPE-339).
+        district_student_id: student.district_student_id ?? null,
       } as DatabaseStudent;
     }) || []
   );
@@ -417,6 +421,15 @@ export function buildStudentPreviews(params: {
       goalsRemoved
     };
 
+    // SPE-339: carry the district's student id through to the write, unless it
+    // is disputed — a conflicting id is reported, never written, so an import
+    // can't quietly re-point an id at the wrong child.
+    if (match.idConflict) {
+      preview.districtStudentIdConflict = match.idConflict;
+    } else if (student.districtStudentId?.trim()) {
+      preview.districtStudentId = student.districtStudentId.trim();
+    }
+
     // Add schedule data to preview
     if (scheduleData) {
       const deliveryRecord = deliveriesData?.get(normalizedKey);
@@ -640,6 +653,8 @@ export interface RosterExistingStudentRow {
   sessions_per_week: number | null;
   minutes_per_session: number | null;
   teacher_id: string | null;
+  /** The district's own student id (SPE-339), for id-first roster matching. */
+  district_student_id?: string | null;
 }
 
 /**
@@ -663,15 +678,39 @@ export function buildRosterPreviews(params: {
   // Null school_id / empty currentSchoolId collapse to one bucket, matching the
   // main path and the confirm dedup key (buildSchoolScopedDedupKey).
   const existingByKey = new Map<string, RosterExistingStudentRow>();
+  // SPE-339: same school scoping, keyed by the district's student id. This is the
+  // preferred key — initials+grade is a guess that breaks the moment a student
+  // changes grade or shares initials with a classmate, while the id is stable.
+  const existingById = new Map<string, RosterExistingStudentRow>();
   for (const s of dbStudents) {
     if ((s.school_id ?? '') !== (currentSchoolId ?? '')) continue;
     existingByKey.set(buildStudentDedupKey(s.initials, s.grade_level), s);
+    const storedId = normalizeDistrictStudentId(s.district_student_id);
+    if (storedId) existingById.set(storedId, s);
   }
 
   const studentPreviews: StudentPreview[] = [];
 
   for (const student of students) {
-    const existing = existingByKey.get(buildStudentDedupKey(student.initials, student.gradeLevel));
+    const byKey = existingByKey.get(buildStudentDedupKey(student.initials, student.gradeLevel));
+    const incomingId = normalizeDistrictStudentId(student.districtStudentId);
+    const byId = incomingId ? existingById.get(incomingId) : undefined;
+
+    // The id wins when it agrees with (or is the only) signal. When the id points
+    // at one student and initials+grade at another, we have no basis to choose:
+    // fall back to today's initials behaviour, report the clash, and withhold the
+    // id from the write rather than re-point it at the wrong child.
+    let idConflict: StudentPreview['districtStudentIdConflict'];
+    let existing: RosterExistingStudentRow | undefined;
+    if (byId && byKey && byId.id !== byKey.id) {
+      idConflict = {
+        districtStudentId: incomingId,
+        existingLabel: byId.initials ? `${byId.initials} (grade ${byId.grade_level ?? '—'})` : 'another student',
+      };
+      existing = byKey;
+    } else {
+      existing = byId ?? byKey;
+    }
 
     const { lastName, firstInitial } = parseTeacherName(student.teacherName || '');
     const teacherInfo: TeacherInfo = {
@@ -751,12 +790,21 @@ export function buildRosterPreviews(params: {
       matchedStudentId: existing?.id,
       matchedStudentInitials: existing?.initials || undefined,
       matchConfidence: undefined,
-      matchReason: existing ? 'Matched by initials and grade' : undefined,
+      matchReason: existing
+        ? (existing === byId && !idConflict
+            ? `Matched on district Student ID ${incomingId}`
+            : 'Matched by initials and grade')
+        : undefined,
       changes,
       goalsRemoved: undefined
     };
     if (schedule) preview.schedule = schedule;
     preview.teacher = teacher;
+    if (idConflict) {
+      preview.districtStudentIdConflict = idConflict;
+    } else if (incomingId) {
+      preview.districtStudentId = student.districtStudentId?.trim();
+    }
 
     studentPreviews.push(preview);
   }

--- a/lib/import/classify.ts
+++ b/lib/import/classify.ts
@@ -748,15 +748,21 @@ export function buildRosterPreviews(params: {
   // Null school_id / empty currentSchoolId collapse to one bucket, matching the
   // main path and the confirm dedup key (buildSchoolScopedDedupKey).
   const existingByKey = new Map<string, RosterExistingStudentRow>();
-  // SPE-339: same school scoping, keyed by the district's student id. This is the
-  // preferred key — initials+grade is a guess that breaks the moment a student
-  // changes grade or shares initials with a classmate, while the id is stable.
+  // SPE-339: keyed by the district's student id — the preferred key, since
+  // initials+grade is a guess that breaks the moment a student changes grade or
+  // shares initials with a classmate, while the id is stable.
+  //
+  // Deliberately NOT school-scoped, unlike existingByKey above. Id uniqueness is
+  // (provider, district), so an id held by this provider's student at ANOTHER
+  // school still collides. Scoping this lookup to the active school would hide
+  // that owner, let the id through on an insert, and turn a reviewable conflict
+  // into a raw unique-violation at confirm time.
   const existingById = new Map<string, RosterExistingStudentRow>();
   for (const s of dbStudents) {
-    if ((s.school_id ?? '') !== (currentSchoolId ?? '')) continue;
-    existingByKey.set(buildStudentDedupKey(s.initials, s.grade_level), s);
     const storedId = normalizeDistrictStudentId(s.district_student_id);
     if (storedId) existingById.set(storedId, s);
+    if ((s.school_id ?? '') !== (currentSchoolId ?? '')) continue;
+    existingByKey.set(buildStudentDedupKey(s.initials, s.grade_level), s);
   }
 
   const studentPreviews: StudentPreview[] = [];
@@ -766,20 +772,34 @@ export function buildRosterPreviews(params: {
     const incomingId = normalizeDistrictStudentId(student.districtStudentId);
     const byId = incomingId ? existingById.get(incomingId) : undefined;
 
+    // An owner at a DIFFERENT school can never be this roster row's student —
+    // a roster is imported for one school — but it does own the id, so the id
+    // must not be written. Matching on it would edit the wrong school's record;
+    // ignoring it would hit the unique index at confirm time.
+    const byIdHere =
+      byId && (byId.school_id ?? '') === (currentSchoolId ?? '') ? byId : undefined;
+    const byIdElsewhere = byId && !byIdHere ? byId : undefined;
+
+    const describe = (s: RosterExistingStudentRow) =>
+      s.initials ? `${s.initials} (grade ${s.grade_level ?? '—'})` : 'another student';
+
     // The id wins when it agrees with (or is the only) signal. When the id points
     // at one student and initials+grade at another, we have no basis to choose:
     // fall back to today's initials behaviour, report the clash, and withhold the
     // id from the write rather than re-point it at the wrong child.
     let idConflict: StudentPreview['districtStudentIdConflict'];
     let existing: RosterExistingStudentRow | undefined;
-    if (byId && byKey && byId.id !== byKey.id) {
+    if (byIdElsewhere) {
       idConflict = {
         districtStudentId: incomingId,
-        existingLabel: byId.initials ? `${byId.initials} (grade ${byId.grade_level ?? '—'})` : 'another student',
+        existingLabel: `${describe(byIdElsewhere)} at another school`,
       };
       existing = byKey;
+    } else if (byIdHere && byKey && byIdHere.id !== byKey.id) {
+      idConflict = { districtStudentId: incomingId, existingLabel: describe(byIdHere) };
+      existing = byKey;
     } else {
-      existing = byId ?? byKey;
+      existing = byIdHere ?? byKey;
     }
 
     const { lastName, firstInitial } = parseTeacherName(student.teacherName || '');

--- a/lib/import/enrich.ts
+++ b/lib/import/enrich.ts
@@ -52,7 +52,7 @@ export async function loadExistingStudents(
 ): Promise<{ data: ExistingStudentRow[] | null; error: unknown }> {
   const { data, error } = await supabase
     .from('students')
-    .select('id, initials, grade_level, school_site, school_id, sessions_per_week, minutes_per_session, teacher_id')
+    .select('id, initials, grade_level, school_site, school_id, sessions_per_week, minutes_per_session, teacher_id, district_student_id')
     .eq('provider_id', userId);
   return { data: (data as unknown as ExistingStudentRow[] | null), error };
 }

--- a/lib/import/enrich.ts
+++ b/lib/import/enrich.ts
@@ -89,6 +89,7 @@ export async function loadJoinedStudents(
       grade_level,
       school_site,
       school_id,
+      district_student_id,
       student_details!inner(first_name, last_name, upcoming_iep_date, upcoming_triennial_date)
     `)
     .eq('provider_id', userId);

--- a/lib/import/preview-types.ts
+++ b/lib/import/preview-types.ts
@@ -115,6 +115,10 @@ export interface StudentUpdate {
   };
   // From the SEIS IEP Dates report (SPE-303).
   iepDates?: IepDatesPreview;
+  /** District Student ID captured from the class list (SPE-339). */
+  districtStudentId?: string;
+  /** Set when that id already belongs to a different child (SPE-339). */
+  districtStudentIdConflict?: { districtStudentId: string; existingLabel: string };
 }
 
 export interface UnmatchedStudent {
@@ -134,6 +138,8 @@ export interface JoinedExistingStudent {
   school_site: string | null;
   school_id: string | null;
   student_details: unknown;
+  /** The district's own student id (SPE-339). */
+  district_student_id?: string | null;
 }
 
 /** Re-exported so pipeline modules share one DatabaseStudent definition. */

--- a/lib/import/preview-types.ts
+++ b/lib/import/preview-types.ts
@@ -78,6 +78,12 @@ export interface StudentPreview {
   teacher?: TeacherMatch;
   // New fields from the SEIS IEP Dates report (SPE-303)
   iepDates?: IepDatesPreview;
+  /** The district's own student id from the file (SPE-339). Withheld when
+   *  districtStudentIdConflict is set, so a disputed id is never written. */
+  districtStudentId?: string;
+  /** The incoming id is already on file against a different child (SPE-339).
+   *  Surfaced in the review queue; the id itself is not carried to the write. */
+  districtStudentIdConflict?: { districtStudentId: string; existingLabel: string };
 }
 
 /**

--- a/lib/import/review-model.ts
+++ b/lib/import/review-model.ts
@@ -76,6 +76,11 @@ export interface ReviewRow {
   /** Incoming IEP date from a per-student goals report (target-student mode,
    *  SPE-232) — written to goals_iep_date on import. Absent in bulk mode. */
   iepDate?: string;
+  /** The district's own student id from the file (SPE-339), carried to confirm. */
+  districtStudentId?: string;
+  /** Set when that id already belongs to a different child — surfaced as an
+   *  exception and withheld from the write (SPE-339). */
+  districtStudentIdConflict?: { districtStudentId: string; existingLabel: string };
 }
 
 export interface ReviewFileReceipt {
@@ -95,7 +100,14 @@ export interface ReviewFileReceipt {
 export type ReviewException =
   | { kind: 'unmatched-student'; name: string; source: 'deliveries' | 'classList' | 'iepDates'; reason?: string }
   | { kind: 'low-confidence-teacher'; rowId: string; studentLabel: string; suggestion: ReviewTeacher }
-  | { kind: 'goals-removed'; rowId: string; studentLabel: string; goals: string[] };
+  | { kind: 'goals-removed'; rowId: string; studentLabel: string; goals: string[] }
+  | {
+      kind: 'district-id-conflict';
+      rowId: string;
+      studentLabel: string;
+      districtStudentId: string;
+      existingLabel: string;
+    };
 
 export interface ReviewSummary {
   totalStudents: number;
@@ -188,6 +200,8 @@ function toReviewRow(student: BulkStudentPreview, srcIndex: number): ReviewRow {
       : undefined,
     teacher,
     iepDates: student.iepDates,
+    districtStudentId: student.districtStudentId,
+    districtStudentIdConflict: student.districtStudentIdConflict,
     goals,
     goalsRemoved,
     targetStudentId,
@@ -233,6 +247,17 @@ export function adaptBulkPreview(data: BulkPreviewData): ReviewModel {
         rowId: row.id,
         studentLabel: row.displayName,
         goals: row.goalsRemoved,
+      });
+    }
+    // SPE-339: the file's Student ID already belongs to someone else. The row
+    // still imports on its own merits; only the disputed id is held back.
+    if (row.districtStudentIdConflict) {
+      exceptions.push({
+        kind: 'district-id-conflict',
+        rowId: row.id,
+        studentLabel: row.displayName,
+        districtStudentId: row.districtStudentIdConflict.districtStudentId,
+        existingLabel: row.districtStudentIdConflict.existingLabel,
       });
     }
   }

--- a/lib/parsers/class-list-parser.ts
+++ b/lib/parsers/class-list-parser.ts
@@ -16,6 +16,9 @@ export interface ClassListStudent {
   normalizedName: string;
   name: string;
   teacher: TeacherInfo;
+  /** The district's own student id, from the row's Student ID field (SPE-339).
+   *  Null when the row carries only a name. */
+  districtStudentId: string | null;
 }
 
 export interface ClassListParseResult {
@@ -135,13 +138,24 @@ function isStudentRow(line: string): boolean {
 }
 
 /**
- * Parse student name from row
- * Format: "LastName, FirstName",other,data...
+ * Parse a student row.
+ * Format: "LastName, FirstName",Student ID,Grade,Birthdate,Program
+ *
+ * The name is quoted because it contains a comma, so it is taken by regex and
+ * the remaining comma-separated fields are read from what follows the closing
+ * quote. The Student ID (field 2) is the district's own identifier — SPE-339.
+ * Rows that carry only a name still parse; the id comes back null.
  */
-function parseStudentFromRow(line: string): string | null {
+function parseStudentFromRow(
+  line: string,
+): { name: string; districtStudentId: string | null } | null {
   const match = line.match(/^"([^"]+)"/);
   if (!match) return null;
-  return match[1];
+
+  const rest = line.slice(match[0].length).replace(/^,/, '');
+  const districtStudentId = (rest.split(',')[0] || '').trim();
+
+  return { name: match[1], districtStudentId: districtStudentId || null };
 }
 
 /**
@@ -186,8 +200,9 @@ export async function parseClassListTXT(buffer: Buffer): Promise<ClassListParseR
 
       // Check for student row
       if (isStudentRow(line) && currentTeacher) {
-        const studentName = parseStudentFromRow(line);
-        if (studentName) {
+        const parsed = parseStudentFromRow(line);
+        if (parsed) {
+          const studentName = parsed.name;
           const normalizedName = normalizeStudentName(studentName);
 
           if (normalizedName) {
@@ -197,7 +212,8 @@ export async function parseClassListTXT(buffer: Buffer): Promise<ClassListParseR
               students.set(normalizedName, {
                 normalizedName,
                 name: studentName,
-                teacher: currentTeacher
+                teacher: currentTeacher,
+                districtStudentId: parsed.districtStudentId
               });
             }
           } else {

--- a/lib/parsers/csv-parser.ts
+++ b/lib/parsers/csv-parser.ts
@@ -17,6 +17,9 @@ export interface ParsedStudent {
   gradeLevel: string;
   schoolOfAttendance?: string; // School of Attendance (SEIS Column G)
   iepDate?: string; // IEP Date (SEIS Column J) - for validation warnings
+  // The district's own student id (SPE-339). SEIS Column B; the roster
+  // template's optional "Student ID" column. Undefined when the file omits it.
+  districtStudentId?: string;
   goals: string[];
   rawRow: number; // For debugging
   // Speddy roster template only (SPE-225): the template carries the teacher name
@@ -43,6 +46,7 @@ interface ColumnMapping {
   firstName?: number;
   lastName?: number;
   grade?: number;
+  districtStudentId?: number; // District ID (SEIS Column B) - SPE-339
   schoolOfAttendance?: number; // School of Attendance (SEIS Column G)
   iepDate?: number; // IEP Date (SEIS Column J) - for validation warnings
   areaOfNeed?: number; // Area of Need (SEIS Column L) - used for filtering
@@ -204,6 +208,9 @@ export async function parseCSVReport(buffer: Buffer, options: ParseOptions = {})
         const grade = row[columnMapping.grade] || '';
         const schoolOfAttendance = columnMapping.schoolOfAttendance !== undefined ? row[columnMapping.schoolOfAttendance] || '' : '';
         const iepDateRaw = columnMapping.iepDate !== undefined ? row[columnMapping.iepDate] || '' : '';
+        const districtStudentId = columnMapping.districtStudentId !== undefined
+          ? (row[columnMapping.districtStudentId] || '').trim()
+          : '';
 
         // Skip rows without student data
         if (!firstName.trim() || !lastName.trim() || !grade.trim()) {
@@ -364,6 +371,11 @@ export async function parseCSVReport(buffer: Buffer, options: ParseOptions = {})
           if (!existing.iepDate && iepDate) {
             existing.iepDate = iepDate;
           }
+          // Same rule for the district id (SPE-339): a student's goal rows all
+          // carry the same id, but only some rows may have it filled in.
+          if (!existing.districtStudentId && districtStudentId) {
+            existing.districtStudentId = districtStudentId;
+          }
         } else {
           // Add new student
           studentMap.set(studentKey, {
@@ -373,6 +385,7 @@ export async function parseCSVReport(buffer: Buffer, options: ParseOptions = {})
             gradeLevel: normalizedGrade,
             schoolOfAttendance: schoolOfAttendance ? schoolOfAttendance.trim() : undefined,
             iepDate,
+            districtStudentId: districtStudentId || undefined,
             goals,
             rawRow: rowIndex + 1
           });
@@ -432,6 +445,7 @@ function detectColumnMapping(records: string[][]): ColumnMapping {
 
   if (isSEIS) {
     // SEIS Student Goals Report uses fixed columns:
+    // Column B (index 1): District ID
     // Column C (index 2): Last Name
     // Column D (index 3): First Name
     // Column F (index 5): Grade
@@ -441,6 +455,7 @@ function detectColumnMapping(records: string[][]): ColumnMapping {
     // Column M (index 12): Annual Goal # (for filtering)
     // Column O (index 14): Goal
     // Column R (index 17): Person Responsible (for filtering)
+    mapping.districtStudentId = 1;
     mapping.lastName = 2;
     mapping.firstName = 3;
     mapping.grade = 5;
@@ -602,6 +617,8 @@ function parseSpeddyTemplateRows(records: string[][]): ParseResult {
   const teacherCol = col('teacher');
   const sessionsCol = col('sessions per week');
   const minutesCol = col('minutes per session');
+  // SPE-339: optional, so rosters saved from the older template still parse.
+  const studentIdCol = col('student id');
 
   const seen = new Set<string>();
 
@@ -640,6 +657,7 @@ function parseSpeddyTemplateRows(records: string[][]): ParseResult {
 
     const sessions = sessionsCol >= 0 ? parseInt((row[sessionsCol] || '').trim(), 10) : NaN;
     const minutes = minutesCol >= 0 ? parseInt((row[minutesCol] || '').trim(), 10) : NaN;
+    const districtStudentId = studentIdCol >= 0 ? (row[studentIdCol] || '').trim() : '';
 
     students.push({
       firstName: '',
@@ -648,6 +666,7 @@ function parseSpeddyTemplateRows(records: string[][]): ParseResult {
       gradeLevel,
       goals: [],
       teacherName: teacher,
+      districtStudentId: districtStudentId || undefined,
       sessionsPerWeek: Number.isFinite(sessions) && sessions > 0 ? sessions : undefined,
       minutesPerSession: Number.isFinite(minutes) && minutes > 0 ? minutes : undefined,
       rawRow: rowNum,

--- a/lib/parsers/csv-parser.ts
+++ b/lib/parsers/csv-parser.ts
@@ -375,6 +375,19 @@ export async function parseCSVReport(buffer: Buffer, options: ParseOptions = {})
           // carry the same id, but only some rows may have it filled in.
           if (!existing.districtStudentId && districtStudentId) {
             existing.districtStudentId = districtStudentId;
+          } else if (
+            districtStudentId &&
+            existing.districtStudentId &&
+            existing.districtStudentId !== districtStudentId
+          ) {
+            // Two different ids under one name+grade+school key means either the
+            // export is inconsistent or two real children are being merged by
+            // that key. Keep the first and say so rather than dropping it
+            // silently.
+            warnings.push({
+              row: rowIndex + 1,
+              message: `Student ID mismatch for ${firstName} ${lastName}: found "${districtStudentId}" but already recorded "${existing.districtStudentId}". Keeping the first — check this student in your export.`,
+            });
           }
         } else {
           // Add new student

--- a/lib/parsers/seis-parser.ts
+++ b/lib/parsers/seis-parser.ts
@@ -24,6 +24,9 @@ export interface ParsedStudent {
   goals: string[];
   schoolOfAttendance?: string; // From column G - used to filter by current school
   iepDate?: string; // From column J - IEP date for validation warnings
+  // The district's own student id (SPE-339). SEIS Column B. Undefined when the
+  // sheet omits it.
+  districtStudentId?: string;
   rawRow: number; // For debugging
 }
 
@@ -49,6 +52,7 @@ interface ColumnMapping {
   firstName?: number;
   lastName?: number;
   grade?: number;
+  districtStudentId?: number; // Column B in SEIS reports - District ID (SPE-339)
   schoolOfAttendance?: number; // Column G in SEIS reports
   iepDate?: number; // Column J in SEIS reports - IEP Date
   areaOfNeed?: number; // Column L in SEIS Student Goals Report
@@ -127,6 +131,9 @@ export async function parseSEISReport(
           const schoolOfAttendance = columnMapping.schoolOfAttendance
             ? getCellValue(row, columnMapping.schoolOfAttendance)
             : undefined;
+          const districtStudentId = columnMapping.districtStudentId
+            ? getCellValue(row, columnMapping.districtStudentId).trim()
+            : '';
           const iepDateRaw = columnMapping.iepDate
             ? getCellValue(row, columnMapping.iepDate)
             : undefined;
@@ -217,6 +224,10 @@ export async function parseSEISReport(
             if (!existing.iepDate && iepDate) {
               existing.iepDate = iepDate;
             }
+            // Same rule for the district id (SPE-339).
+            if (!existing.districtStudentId && districtStudentId) {
+              existing.districtStudentId = districtStudentId;
+            }
           } else {
             // Add new student
             studentMap.set(studentKey, {
@@ -227,6 +238,7 @@ export async function parseSEISReport(
               goals,
               schoolOfAttendance: schoolOfAttendance?.trim() || undefined,
               iepDate,
+              districtStudentId: districtStudentId || undefined,
               rawRow: rowNumber
             });
           }
@@ -272,6 +284,9 @@ function detectColumnMapping(worksheet: ExcelJS.Worksheet): ColumnMapping {
   const firstNamePatterns = /first\s*name|firstname|student\s*first/i;
   const lastNamePatterns = /last\s*name|lastname|student\s*last|surname/i;
   const gradePatterns = /grade|grade\s*level|current\s*grade/i;
+  // SPE-339. Deliberately narrow: it must not match "District of Service"
+  // (SEIS column H) or the SEIS ID in column A.
+  const districtStudentIdPatterns = /^\s*district\s*(student\s*)?id\s*$/i;
   const schoolPatterns = /school\s*of\s*attendance|school\s*name|attending\s*school|^school$/i;
   const iepDatePatterns = /iep\s*date|meeting\s*date|annual\s*review/i;
   const areaOfNeedPatterns = /area\s*of\s*need|area\s*need|need\s*area/i;
@@ -302,6 +317,11 @@ function detectColumnMapping(worksheet: ExcelJS.Worksheet): ColumnMapping {
       // Check for grade
       if (!mapping.grade && gradePatterns.test(headerText)) {
         mapping.grade = colNumber;
+      }
+
+      // Check for the district's student id (Column B in SEIS reports)
+      if (!mapping.districtStudentId && districtStudentIdPatterns.test(headerText)) {
+        mapping.districtStudentId = colNumber;
       }
 
       // Check for school of attendance

--- a/lib/parsers/seis-parser.ts
+++ b/lib/parsers/seis-parser.ts
@@ -227,6 +227,15 @@ export async function parseSEISReport(
             // Same rule for the district id (SPE-339).
             if (!existing.districtStudentId && districtStudentId) {
               existing.districtStudentId = districtStudentId;
+            } else if (
+              districtStudentId &&
+              existing.districtStudentId &&
+              existing.districtStudentId !== districtStudentId
+            ) {
+              warnings.push({
+                row: rowNumber,
+                message: `Student ID mismatch for ${firstName} ${lastName}: found "${districtStudentId}" but already recorded "${existing.districtStudentId}". Keeping the first — check this student in your export.`,
+              });
             }
           } else {
             // Add new student

--- a/lib/supabase/queries/student-details.ts
+++ b/lib/supabase/queries/student-details.ts
@@ -62,22 +62,39 @@ export async function getStudentDetails(studentId: string): Promise<StudentDetai
   const supabase = createClient<Database>();
 
   const fetchPerf = measurePerformanceWithAlerts('fetch_student_details', 'database');
-  const fetchResult = await safeQuery(
-    async () => {
-      const { data, error } = await supabase
-        .from('student_details')
-        .select('*')
-        .eq('student_id', studentId)
-        .limit(1)
-        .maybeSingle();
-      if (error) throw error;
-      return data;
-    },
-    { 
-      operation: 'fetch_student_details', 
-      studentId 
-    }
-  );
+  // The two reads are independent — the district student id lives on `students`
+  // (SPE-339), the rest on `student_details` — so they run together rather than
+  // costing the details modal two sequential round trips on every open.
+  const [fetchResult, idResult] = await Promise.all([
+    safeQuery(
+      async () => {
+        const { data, error } = await supabase
+          .from('student_details')
+          .select('*')
+          .eq('student_id', studentId)
+          .limit(1)
+          .maybeSingle();
+        if (error) throw error;
+        return data;
+      },
+      {
+        operation: 'fetch_student_details',
+        studentId
+      }
+    ),
+    safeQuery(
+      async () => {
+        const { data: row, error } = await supabase
+          .from('students')
+          .select('district_student_id')
+          .eq('id', studentId)
+          .maybeSingle();
+        if (error) throw error;
+        return row;
+      },
+      { operation: 'fetch_district_student_id', studentId }
+    ),
+  ]);
   fetchPerf.end({ success: !fetchResult.error });
 
   if (fetchResult.error) {
@@ -86,20 +103,6 @@ export async function getStudentDetails(studentId: string): Promise<StudentDetai
   }
 
   const data = fetchResult.data;
-
-  // SPE-339: lives on `students`, not `student_details` — see the interface.
-  const idResult = await safeQuery(
-    async () => {
-      const { data: row, error } = await supabase
-        .from('students')
-        .select('district_student_id')
-        .eq('id', studentId)
-        .maybeSingle();
-      if (error) throw error;
-      return row;
-    },
-    { operation: 'fetch_district_student_id', studentId }
-  );
   // A failed lookup must not silently become '' — the caller saves what it
   // loaded, so a swallowed error here would erase a stored id on the next save.
   if (idResult.error) {
@@ -213,6 +216,31 @@ export async function upsertStudentDetails(
   const upsertPerf = measurePerformanceWithAlerts('upsert_student_details', 'database');
   const upsertResult = await safeQuery(
     async () => {
+      // SPE-339: the district student id lives on `students`, so this save spans
+      // two tables and cannot be one statement. The id goes FIRST deliberately:
+      // it is the only part that can be rejected by a constraint (the
+      // ux_students_provider_district_student_id uniqueness backstop), so
+      // failing here leaves nothing written at all. The reverse order would
+      // commit the name/date edits and then fail, leaving a partial save behind
+      // a generic error with no way for the user to tell what landed.
+      //
+      // Blank clears the id, so an admin can remove a wrong one. NULL (not '')
+      // keeps it out of the uniqueness index.
+      const { error: idError } = await supabase
+        .from('students')
+        .update({ district_student_id: details.district_student_id?.trim() || null })
+        .eq('id', studentId);
+      if (idError) {
+        // Name the actual problem — "Failed to save" gives the user nothing to
+        // act on, and retrying the same duplicate fails identically.
+        if (idError.code === '23505') {
+          throw new Error(
+            `Student ID "${details.district_student_id?.trim()}" is already assigned to another student on your caseload. Each student needs a unique ID.`
+          );
+        }
+        throw idError;
+      }
+
       const { error } = await supabase
         .from('student_details')
         .upsert({
@@ -230,15 +258,6 @@ export async function upsertStudentDetails(
           onConflict: 'student_id'  // Add this to specify the conflict column
         });
       if (error) throw error;
-
-      // SPE-339: the district student id lives on `students`. Blank clears it,
-      // so an admin can remove a wrong id. NULL (not '') keeps it out of the
-      // uniqueness index.
-      const { error: idError } = await supabase
-        .from('students')
-        .update({ district_student_id: details.district_student_id?.trim() || null })
-        .eq('id', studentId);
-      if (idError) throw idError;
 
       return null;
     },

--- a/lib/supabase/queries/student-details.ts
+++ b/lib/supabase/queries/student-details.ts
@@ -86,7 +86,6 @@ export async function getStudentDetails(studentId: string): Promise<StudentDetai
   }
 
   const data = fetchResult.data;
-  if (!data) return null;
 
   // SPE-339: lives on `students`, not `student_details` — see the interface.
   const idResult = await safeQuery(
@@ -101,13 +100,35 @@ export async function getStudentDetails(studentId: string): Promise<StudentDetai
     },
     { operation: 'fetch_district_student_id', studentId }
   );
-  // A failed lookup must not blank the field on save, so surface it rather than
-  // quietly returning ''.
+  // A failed lookup must not silently become '' — the caller saves what it
+  // loaded, so a swallowed error here would erase a stored id on the next save.
   if (idResult.error) {
     console.error('Error fetching district student id:', idResult.error);
     throw idResult.error;
   }
   const districtStudentId = idResult.data?.district_student_id || '';
+
+  // A student with no `student_details` row yet (pre-existing rows, plus
+  // roster-template and manual-add students — see SPE-284) still has a district
+  // student id, because that lives on `students`. Returning null here would make
+  // the details modal fall back to a blank form and then write that blank back
+  // over a real id on the next save. So: no details row is not "nothing to
+  // show" — return the empty detail fields WITH the real id.
+  if (!data) {
+    // No details row AND no student row — the student genuinely isn't there.
+    if (!idResult.data) return null;
+    return {
+      first_name: '',
+      last_name: '',
+      date_of_birth: '',
+      district_student_id: districtStudentId,
+      upcoming_iep_date: '',
+      upcoming_triennial_date: '',
+      iep_goals: [],
+      accommodations: [],
+      goals_iep_date: undefined,
+    };
+  }
 
   // Cast to include fields added in later migrations
   const dataWithExtras = data as typeof data & {

--- a/lib/supabase/queries/student-details.ts
+++ b/lib/supabase/queries/student-details.ts
@@ -8,7 +8,19 @@ export interface StudentDetails {
   first_name: string;
   last_name: string;
   date_of_birth: string;
-  district_id: string;
+  /**
+   * SPE-339: the district's own student id. This one field lives on
+   * `students.district_student_id`, NOT on `student_details` — it is the key the
+   * importer and the future SIS sync match on, so it belongs beside the student
+   * row itself. It is carried on this interface so the details modal, the only
+   * place it is shown, keeps a single load/save call.
+   *
+   * It replaces the old `student_details.district_id` box, which was never
+   * populated by anything (every non-sim row in production is an empty string)
+   * and shared a name with the ORG-level district id used for scoping. That
+   * column is retired in SPE-341.
+   */
+  district_student_id: string;
   upcoming_iep_date: string;
   upcoming_triennial_date: string;
   iep_goals: string[];
@@ -76,6 +88,27 @@ export async function getStudentDetails(studentId: string): Promise<StudentDetai
   const data = fetchResult.data;
   if (!data) return null;
 
+  // SPE-339: lives on `students`, not `student_details` — see the interface.
+  const idResult = await safeQuery(
+    async () => {
+      const { data: row, error } = await supabase
+        .from('students')
+        .select('district_student_id')
+        .eq('id', studentId)
+        .maybeSingle();
+      if (error) throw error;
+      return row;
+    },
+    { operation: 'fetch_district_student_id', studentId }
+  );
+  // A failed lookup must not blank the field on save, so surface it rather than
+  // quietly returning ''.
+  if (idResult.error) {
+    console.error('Error fetching district student id:', idResult.error);
+    throw idResult.error;
+  }
+  const districtStudentId = idResult.data?.district_student_id || '';
+
   // Cast to include fields added in later migrations
   const dataWithExtras = data as typeof data & {
     accommodations?: string[] | null;
@@ -86,7 +119,7 @@ export async function getStudentDetails(studentId: string): Promise<StudentDetai
     first_name: data.first_name || '',
     last_name: data.last_name || '',
     date_of_birth: data.date_of_birth || '',
-    district_id: data.district_id || '',
+    district_student_id: districtStudentId,
     upcoming_iep_date: data.upcoming_iep_date || '',
     upcoming_triennial_date: data.upcoming_triennial_date || '',
     iep_goals: data.iep_goals || [],
@@ -166,7 +199,6 @@ export async function upsertStudentDetails(
           first_name: details.first_name,
           last_name: details.last_name,
           date_of_birth: details.date_of_birth || null,
-          district_id: details.district_id,
           upcoming_iep_date: details.upcoming_iep_date || null,
           upcoming_triennial_date: details.upcoming_triennial_date || null,
           iep_goals: details.iep_goals,
@@ -177,6 +209,16 @@ export async function upsertStudentDetails(
           onConflict: 'student_id'  // Add this to specify the conflict column
         });
       if (error) throw error;
+
+      // SPE-339: the district student id lives on `students`. Blank clears it,
+      // so an admin can remove a wrong id. NULL (not '') keeps it out of the
+      // uniqueness index.
+      const { error: idError } = await supabase
+        .from('students')
+        .update({ district_student_id: details.district_student_id?.trim() || null })
+        .eq('id', studentId);
+      if (idError) throw idError;
+
       return null;
     },
     {

--- a/lib/types/student-import.ts
+++ b/lib/types/student-import.ts
@@ -83,6 +83,12 @@ export interface BulkStudentPreview {
   };
   /** Present when the IEP Dates report (SPE-303) matched this student. */
   iepDates?: IepDatesPreview;
+  /** The district's own student id carried by the file (SPE-339). */
+  districtStudentId?: string;
+  /** Set when that id is already on file against a different child (SPE-339).
+   *  The id is withheld from the write and the clash is raised in the review
+   *  queue for a human to resolve. */
+  districtStudentIdConflict?: { districtStudentId: string; existingLabel: string };
 }
 
 export interface BulkFileReceipt {
@@ -161,6 +167,12 @@ export interface StudentToImport {
    */
   upcomingIepDate?: string;
   upcomingTriennialDate?: string;
+  /**
+   * The district's own student id (SPE-339). Presence-keyed like the dates
+   * above: sent only when the file carried one and it was not disputed, so an
+   * import without ids never erases a stored id.
+   */
+  districtStudentId?: string;
   /** Defaults to 'insert' server-side for backward compatibility. */
   action?: RowAction;
   /** Required for the 'update' action. */

--- a/lib/utils/student-matcher.ts
+++ b/lib/utils/student-matcher.ts
@@ -20,6 +20,8 @@ export interface DatabaseStudent {
   // Stored IEP compliance dates (ISO YYYY-MM-DD), for IEP Dates change detection (SPE-303).
   upcoming_iep_date?: string | null;
   upcoming_triennial_date?: string | null;
+  // The district's own student id (SPE-339), when we have captured one.
+  district_student_id?: string | null;
 }
 
 export interface StudentMatch {
@@ -28,6 +30,13 @@ export interface StudentMatch {
   confidence: 'high' | 'medium' | 'low' | 'none';
   reason: string;
   allPossibleMatches?: DatabaseStudent[];
+  /**
+   * SPE-339: the incoming district Student ID is already on file against a
+   * DIFFERENT child. Set instead of merging the two records — the row falls back
+   * to name matching and the id is withheld from the write, so the conflict is
+   * resolved by a human in the review queue rather than silently.
+   */
+  idConflict?: { districtStudentId: string; existingLabel: string };
 }
 
 export interface MatchResult {
@@ -106,6 +115,66 @@ function findBestMatch(
 ): StudentMatch {
   const possibleMatches: Array<{ student: DatabaseStudent; score: number; reasons: string[] }> = [];
 
+  // SPE-339: the district's own student id takes precedence over every heuristic
+  // below when both sides carry one. It is the only identifier in the file that
+  // is actually stable — names get corrected, grades roll over, initials collide
+  // — so an id match is authoritative and scores as high confidence.
+  //
+  // The exception is when the id lands on a child whose stored name plainly
+  // disagrees with the incoming one. That means the id is being reused or was
+  // mistyped, and merging the two records would silently overwrite a real
+  // student. In that case we do NOT match on the id: we record the conflict, let
+  // the name-based logic below decide the row on its own merits, and the caller
+  // withholds the id from the write so nothing is corrupted while a human looks
+  // at it.
+  const incomingId = normalizeDistrictStudentId(excelStudent.districtStudentId);
+  let idConflict: StudentMatch['idConflict'];
+
+  if (incomingId) {
+    const idMatches = databaseStudents.filter(
+      dbStudent => normalizeDistrictStudentId(dbStudent.district_student_id) === incomingId,
+    );
+
+    if (idMatches.length === 1) {
+      const candidate = idMatches[0];
+      const bothNamed =
+        !!excelStudent.firstName?.trim() &&
+        !!excelStudent.lastName?.trim() &&
+        !!candidate.first_name?.trim() &&
+        !!candidate.last_name?.trim();
+      const nameDisagrees =
+        bothNamed &&
+        !compareNames(
+          excelStudent.firstName,
+          excelStudent.lastName,
+          candidate.first_name ?? '',
+          candidate.last_name ?? '',
+        ).matches;
+
+      if (nameDisagrees) {
+        idConflict = {
+          districtStudentId: incomingId,
+          existingLabel: `${candidate.first_name} ${candidate.last_name}`.trim(),
+        };
+      } else {
+        return {
+          excelStudent,
+          matchedStudent: candidate,
+          confidence: 'high',
+          reason: `Matched on district Student ID ${incomingId}`,
+          allPossibleMatches: idMatches,
+        };
+      }
+    } else if (idMatches.length > 1) {
+      // The unique index makes this unreachable for a single provider within a
+      // district, but bail loudly rather than pick one if it ever happens.
+      idConflict = {
+        districtStudentId: incomingId,
+        existingLabel: `${idMatches.length} existing students`,
+      };
+    }
+  }
+
   // A full name is required on BOTH sides. Without a first AND last name on the
   // incoming record we can't match by name — and compareNames' fuzzy path would
   // false-match an empty component against any value (`x.startsWith('')` is
@@ -117,6 +186,7 @@ function findBestMatch(
       matchedStudent: null,
       confidence: 'none',
       reason: 'Incoming record has no full name — cannot match by name',
+      idConflict,
     };
   }
 
@@ -170,7 +240,8 @@ function findBestMatch(
       matchedStudent: bestMatch.student,
       confidence,
       reason,
-      allPossibleMatches: possibleMatches.map(m => m.student)
+      allPossibleMatches: possibleMatches.map(m => m.student),
+      idConflict,
     };
   }
 
@@ -207,6 +278,7 @@ function findBestMatch(
         reason:
           'Matched by initials + grade — existing record has no name yet; the name will be added',
         allPossibleMatches: initialsOnlyMatches,
+        idConflict,
       };
     }
   }
@@ -216,7 +288,8 @@ function findBestMatch(
     excelStudent,
     matchedStudent: null,
     confidence: 'none',
-    reason: `No existing student matches "${excelStudent.firstName} ${excelStudent.lastName}" in grade "${excelStudent.gradeLevel}"`
+    reason: `No existing student matches "${excelStudent.firstName} ${excelStudent.lastName}" in grade "${excelStudent.gradeLevel}"`,
+    idConflict,
   };
 }
 
@@ -298,6 +371,22 @@ function normalizeName(name: string): string {
  */
 function normalizeInitials(initials: string | undefined | null): string {
   return (initials || '').toUpperCase().replace(/[^A-Z]/g, '');
+}
+
+/**
+ * Normalize a district Student ID for comparison (SPE-339).
+ *
+ * Trim and case-fold only. Deliberately NOT stripping punctuation or leading
+ * zeros: districts use ids that are meaningfully distinct in exactly those
+ * characters ("0012345" and "12345" can be two different children), and this
+ * value is an identity key — a normalization that collapses two real ids would
+ * merge two students' records. An id that differs only in surrounding
+ * whitespace or letter case is the same id in every SIS export we have seen.
+ *
+ * Returns '' for absent/blank, which callers treat as "no id".
+ */
+export function normalizeDistrictStudentId(id: string | undefined | null): string {
+  return (id || '').trim().toUpperCase();
 }
 
 /**

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -3713,6 +3713,7 @@ export type Database = {
         Row: {
           created_at: string | null
           district_id: string | null
+          district_student_id: string | null
           grade_level: string
           id: string
           initials: string
@@ -3730,6 +3731,7 @@ export type Database = {
         Insert: {
           created_at?: string | null
           district_id?: string | null
+          district_student_id?: string | null
           grade_level: string
           id?: string
           initials: string
@@ -3747,6 +3749,7 @@ export type Database = {
         Update: {
           created_at?: string | null
           district_id?: string | null
+          district_student_id?: string | null
           grade_level?: string
           id?: string
           initials?: string

--- a/supabase/migrations/20260727_add_students_district_student_id.sql
+++ b/supabase/migrations/20260727_add_students_district_student_id.sql
@@ -44,10 +44,15 @@ alter table public.students
 comment on column public.students.district_student_id is
   'SPE-339: the district''s own student identifier, as it appears in SIS exports (SEIS column B, Aeries class-list field 2, roster template "Student ID"). District-local, not a name. Never rendered on student lists — admin-facing detail only. NULL when the source file did not carry one.';
 
+-- Indexed on the SAME normalization the matcher uses (normalizeDistrictStudentId:
+-- trim + upper). On the raw text, 'a100001' and 'A100001' would both be allowed
+-- for one provider — and matching treats them as one identity, so the next
+-- import would see two candidates for that id and refuse to match either
+-- student. The backstop has to agree with the comparison it is backing.
 create unique index if not exists ux_students_provider_district_student_id
-  on public.students (provider_id, district_id, district_student_id)
+  on public.students (provider_id, district_id, (upper(btrim(district_student_id))))
   nulls not distinct
-  where district_student_id is not null and district_student_id <> '';
+  where district_student_id is not null and btrim(district_student_id) <> '';
 
 -- ---------------------------------------------------------------------------
 -- Carry the id through the bulk-import RPC

--- a/supabase/migrations/20260727_add_students_district_student_id.sql
+++ b/supabase/migrations/20260727_add_students_district_student_id.sql
@@ -1,0 +1,344 @@
+-- SPE-339: capture the district's own Student ID on import.
+--
+-- Every import source we receive already carries it and we throw it away: the
+-- SEIS Student Goals Report has it in column B, the Aeries Class List TXT has it
+-- as the second field of each student row, and our own roster template gains an
+-- optional "Student ID" column. Storing it gives us a stable identity for
+-- re-imports (initials collide today), lets SPE-340 group one-row-per-class
+-- secondary exports into a single student, and gives the future Aeries sync
+-- something to join on.
+--
+-- Privacy: approved 2026-07-25. This is a district-local number, not a name; the
+-- initials-only display posture is unchanged and the value is never shown on any
+-- list — only on the admin-facing student detail.
+--
+-- ---------------------------------------------------------------------------
+-- Uniqueness scope — a deliberate deviation from the ticket
+-- ---------------------------------------------------------------------------
+-- The ticket asked for uniqueness "within a district scope". That cannot be
+-- expressed against this table as written: `students` holds ONE ROW PER PROVIDER
+-- per child (the existing uniqueness is
+-- ux_students_provider_school_grade_initials on
+-- (provider_id, school_id, grade_level, initials)), so a child seen by both an
+-- RSP and an SLP is legitimately two rows. A district-wide unique index would
+-- reject the second provider's copy on import. Five student identities in
+-- production are already served by two providers each (verified 2026-07-27), so
+-- this is a live case, not a hypothetical.
+--
+-- The index below therefore scopes uniqueness to (provider_id, district_id,
+-- district_student_id) — the same shape as the existing constraint, which is as
+-- close to "unique within a district" as the row model allows. It is a backstop
+-- only: "same ID, different child" is meant to be caught earlier and surfaced in
+-- the import review queue rather than raised as a database error.
+--
+-- Blank and NULL ids are excluded from the index so the many students who have
+-- no id yet do not collide with each other. NULLS NOT DISTINCT covers the rows
+-- whose district_id is null (2 in production): with Postgres's default two such
+-- rows would never be seen as equal, so the constraint would quietly not apply
+-- to them. The existing ux_students_provider_school_grade_initials makes the
+-- same choice for the same reason.
+
+alter table public.students
+  add column if not exists district_student_id text;
+
+comment on column public.students.district_student_id is
+  'SPE-339: the district''s own student identifier, as it appears in SIS exports (SEIS column B, Aeries class-list field 2, roster template "Student ID"). District-local, not a name. Never rendered on student lists — admin-facing detail only. NULL when the source file did not carry one.';
+
+create unique index if not exists ux_students_provider_district_student_id
+  on public.students (provider_id, district_id, district_student_id)
+  nulls not distinct
+  where district_student_id is not null and district_student_id <> '';
+
+-- ---------------------------------------------------------------------------
+-- Carry the id through the bulk-import RPC
+-- ---------------------------------------------------------------------------
+-- Everything below is reproduced verbatim from the current live definition
+-- (20260722_upsert_students_iep_dates.sql — SPE-303 IEP dates, SPE-284
+-- student_details upsert, SPE-261 auth binding, SPE-251 teacher_name, and the
+-- SPE-289 `pg_temp`-last search_path pin, preserved here because this
+-- CREATE OR REPLACE runs after that ALTER and would otherwise silently drop it),
+-- with district_student_id added to the insert and the update.
+--
+-- The value is presence-keyed on update, exactly like the teacher and IEP-date
+-- columns: when the file carries an id it wins; when it does not, the stored
+-- value is left alone, so importing a file WITHOUT ids never erases them. Blank
+-- strings normalise to NULL so they cannot land in the unique index.
+
+CREATE OR REPLACE FUNCTION public.upsert_students_atomic(
+  p_provider_id uuid,
+  p_students jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_student jsonb;
+  v_action text;
+  v_student_id uuid;
+  v_new_student_id uuid;
+  v_results jsonb := '[]'::jsonb;
+  v_result jsonb;
+  v_inserted integer := 0;
+  v_updated integer := 0;
+  v_skipped integer := 0;
+  v_errors integer := 0;
+  v_new_sessions_per_week integer;
+  v_provider_role text;
+BEGIN
+  -- Defense-in-depth (SPE-261): this SECURITY DEFINER function bypasses RLS, so
+  -- bind it to the caller — reject any p_provider_id that isn't the authenticated
+  -- user, and fail closed when there is no JWT. The confirm route (the only
+  -- caller) passes the authenticated user's id via the JWT-authenticated client,
+  -- so legitimate calls are unaffected; this stops a signed-in client from
+  -- calling the RPC directly with someone else's provider id.
+  IF auth.uid() IS NULL OR p_provider_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Unauthorized' USING ERRCODE = '42501';
+  END IF;
+
+  -- Look up the provider's role to use as service_type
+  SELECT role INTO v_provider_role
+  FROM public.profiles
+  WHERE id = p_provider_id;
+
+  -- Default to 'resource' if role not found
+  v_provider_role := COALESCE(v_provider_role, 'resource');
+
+  -- Loop through each student in the array
+  FOR v_student IN SELECT * FROM jsonb_array_elements(p_students)
+  LOOP
+    v_action := v_student->>'action';
+    v_student_id := (v_student->>'studentId')::uuid;
+
+    BEGIN
+      CASE v_action
+        WHEN 'insert' THEN
+          -- Insert new student record
+          INSERT INTO public.students (
+            provider_id,
+            initials,
+            grade_level,
+            school_site,
+            school_id,
+            district_id,
+            state_id,
+            district_student_id,
+            sessions_per_week,
+            minutes_per_session,
+            teacher_id,
+            teacher_name
+          )
+          VALUES (
+            p_provider_id,
+            v_student->>'initials',
+            v_student->>'gradeLevel',
+            v_student->>'schoolSite',
+            v_student->>'schoolId',
+            v_student->>'districtId',
+            v_student->>'stateId',
+            NULLIF(btrim(v_student->>'districtStudentId'), ''),
+            (v_student->>'sessionsPerWeek')::integer,
+            (v_student->>'minutesPerSession')::integer,
+            (v_student->>'teacherId')::uuid,
+            v_student->>'teacherName'
+          )
+          RETURNING id INTO v_new_student_id;
+
+          -- Insert student_details record (SPE-303: carry the IEP Dates report's
+          -- two dates when the new student also matched that file; NULL otherwise).
+          INSERT INTO public.student_details (
+            student_id,
+            first_name,
+            last_name,
+            iep_goals,
+            upcoming_iep_date,
+            upcoming_triennial_date
+          )
+          VALUES (
+            v_new_student_id,
+            v_student->>'firstName',
+            v_student->>'lastName',
+            ARRAY(SELECT jsonb_array_elements_text(v_student->'goals')),
+            (v_student->>'upcomingIepDate')::date,
+            (v_student->>'upcomingTriennialDate')::date
+          );
+
+          -- Create unscheduled sessions for NEW students only
+          v_new_sessions_per_week := (v_student->>'sessionsPerWeek')::integer;
+
+          IF v_new_sessions_per_week IS NOT NULL AND v_new_sessions_per_week > 0 THEN
+            INSERT INTO public.schedule_sessions (
+              student_id,
+              provider_id,
+              day_of_week,
+              start_time,
+              end_time,
+              service_type,
+              status,
+              delivered_by
+            )
+            SELECT
+              v_new_student_id,
+              p_provider_id,
+              NULL,
+              NULL,
+              NULL,
+              v_provider_role,  -- Use provider's role instead of hardcoded value
+              'active',
+              'provider'
+            FROM generate_series(1, v_new_sessions_per_week);
+          END IF;
+
+          v_inserted := v_inserted + 1;
+          v_result := jsonb_build_object(
+            'action', 'inserted',
+            'studentId', v_new_student_id,
+            'initials', v_student->>'initials',
+            'success', true
+          );
+
+        WHEN 'update' THEN
+          -- Ownership: only the caller's own students may be updated. p_provider_id
+          -- is bound to auth.uid() at the top of this function (SPE-261), so this
+          -- also confirms the row belongs to the authenticated caller.
+          IF NOT EXISTS (
+            SELECT 1 FROM public.students
+            WHERE id = v_student_id AND provider_id = p_provider_id
+          ) THEN
+            RAISE EXCEPTION 'Student % not found or not owned by provider', v_student_id;
+          END IF;
+
+          -- Update students table (only non-null fields from the request)
+          -- NOTE: Session syncing is handled by updateExistingSessionsForStudent in the API
+          UPDATE public.students
+          SET
+            grade_level = COALESCE(v_student->>'gradeLevel', grade_level),
+            sessions_per_week = COALESCE((v_student->>'sessionsPerWeek')::integer, sessions_per_week),
+            minutes_per_session = COALESCE((v_student->>'minutesPerSession')::integer, minutes_per_session),
+            teacher_id = CASE
+              WHEN v_student ? 'teacherId' THEN (v_student->>'teacherId')::uuid
+              ELSE teacher_id
+            END,
+            teacher_name = CASE
+              WHEN v_student ? 'teacherName' THEN v_student->>'teacherName'
+              ELSE teacher_name
+            END,
+            -- SPE-339: presence-keyed like the columns above. A file that carries
+            -- no id leaves a stored id untouched.
+            district_student_id = CASE
+              WHEN v_student ? 'districtStudentId'
+              THEN NULLIF(btrim(v_student->>'districtStudentId'), '')
+              ELSE district_student_id
+            END,
+            updated_at = now()
+          WHERE id = v_student_id;
+
+          -- Upsert student_details (SPE-284). A plain UPDATE dropped the incoming
+          -- name for any student with no details row yet (pre-existing rows, plus
+          -- roster-template / manual-add students). INSERT ... ON CONFLICT ensures
+          -- the row exists so enrichment names persist. Name COALESCE and the
+          -- goals-only-when-provided rule are unchanged; a fresh insert with no
+          -- goals defaults to an empty array (matching the insert branch).
+          --
+          -- SPE-303: the IEP Dates report's two dates are presence-keyed like the
+          -- teacher columns above — a present date overwrites (file wins); an
+          -- absent one preserves the stored value. On the fresh-insert side of the
+          -- conflict, an absent key resolves to NULL, matching the insert branch.
+          INSERT INTO public.student_details (
+            student_id,
+            first_name,
+            last_name,
+            iep_goals,
+            upcoming_iep_date,
+            upcoming_triennial_date
+          )
+          VALUES (
+            v_student_id,
+            v_student->>'firstName',
+            v_student->>'lastName',
+            CASE
+              WHEN v_student ? 'goals' AND jsonb_array_length(v_student->'goals') > 0
+              THEN ARRAY(SELECT jsonb_array_elements_text(v_student->'goals'))
+              ELSE '{}'::text[]
+            END,
+            (v_student->>'upcomingIepDate')::date,
+            (v_student->>'upcomingTriennialDate')::date
+          )
+          ON CONFLICT (student_id) DO UPDATE
+          SET
+            first_name = COALESCE(EXCLUDED.first_name, student_details.first_name),
+            last_name = COALESCE(EXCLUDED.last_name, student_details.last_name),
+            iep_goals = CASE
+              WHEN v_student ? 'goals' AND jsonb_array_length(v_student->'goals') > 0
+              THEN EXCLUDED.iep_goals
+              ELSE student_details.iep_goals
+            END,
+            upcoming_iep_date = CASE
+              WHEN v_student ? 'upcomingIepDate' THEN (v_student->>'upcomingIepDate')::date
+              ELSE student_details.upcoming_iep_date
+            END,
+            upcoming_triennial_date = CASE
+              WHEN v_student ? 'upcomingTriennialDate' THEN (v_student->>'upcomingTriennialDate')::date
+              ELSE student_details.upcoming_triennial_date
+            END,
+            updated_at = now();
+
+          v_updated := v_updated + 1;
+          v_result := jsonb_build_object(
+            'action', 'updated',
+            'studentId', v_student_id,
+            'initials', v_student->>'initials',
+            'success', true
+          );
+
+        WHEN 'skip' THEN
+          v_skipped := v_skipped + 1;
+          v_result := jsonb_build_object(
+            'action', 'skipped',
+            'studentId', v_student_id,
+            'initials', v_student->>'initials',
+            'success', true
+          );
+
+        ELSE
+          RAISE EXCEPTION 'Unknown action: %', v_action;
+      END CASE;
+
+    EXCEPTION
+      WHEN OTHERS THEN
+        v_errors := v_errors + 1;
+        v_result := jsonb_build_object(
+          'action', v_action,
+          'studentId', COALESCE(v_student_id, v_new_student_id),
+          'initials', v_student->>'initials',
+          'success', false,
+          'error', SQLERRM
+        );
+    END;
+
+    v_results := v_results || v_result;
+  END LOOP;
+
+  -- Return summary with detailed results
+  RETURN jsonb_build_object(
+    'inserted', v_inserted,
+    'updated', v_updated,
+    'skipped', v_skipped,
+    'errors', v_errors,
+    'results', v_results
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.upsert_students_atomic(uuid, jsonb) IS
+  'Atomically processes an array of student upsert operations (insert, update, or skip).
+   Each student object should have an "action" field and appropriate data fields.
+   Update upserts student_details so an added name persists even when the row had
+   none (SPE-284). Insert and update also write the SEIS IEP Dates report''s
+   upcoming_iep_date / upcoming_triennial_date, presence-keyed so an import without
+   that file never nulls them (SPE-303), and the district''s own student id,
+   presence-keyed the same way (SPE-339). Returns summary counts and detailed
+   results for each student.';
+
+GRANT EXECUTE ON FUNCTION public.upsert_students_atomic(uuid, jsonb) TO authenticated;


### PR DESCRIPTION
Implements [SPE-339](https://linear.app/speddy/issue/SPE-339/capture-district-student-id-on-import-studentsdistrict-student-id-seis).

## Why

Every import file we receive already carries the district's own student ID, and we discard all of them. Storing it gives re-imports a stable identity — today matching leans on initials and grade, which collide, roll over, and get corrected. It also unblocks SPE-340 (grouping one-row-per-class secondary exports) and gives the future Aeries sync something to join on.

## Capture

| Source | Where the id was hiding |
|---|---|
| SEIS Student Goals Report (CSV + XLSX) | Column B. The parser started at column C and skipped it. |
| Aeries Class List TXT | Field 2 of each student row. The parser took only the quoted name and threw away the rest of the line — the id needed a real split, since the name ahead of it is quoted *because* it contains a comma. |
| Speddy roster template | New optional `Student ID` column. |

The roster column is optional in both directions: parsing is header-name based, so **a roster saved from the older template still imports unchanged** — there's a test pinning that, because otherwise every customer with a saved copy breaks on their next import.

## Matching

The id now takes precedence over the name/grade heuristics whenever both sides carry one. It's the only stable identifier in the file, so an id match is authoritative and scores high confidence — it correctly matches a student whose grade rolled over, whose name was recorded differently, or who shares a name and grade with a classmate.

**Conflicts are reported, never merged.** When the id lands on a child whose stored name plainly disagrees, we don't match on it: the row still imports on its own merits (Ben's row carrying Ana's id still lands on Ben), the disputed id is withheld from the write, and the clash appears in the review queue's "Needs your review" list with the existing student named. Nothing is silently re-pointed.

## Schema

`students.district_student_id`, plus a partial unique index as a backstop.

**One deliberate deviation from the ticket**, which asked for uniqueness *within a district*: this table can't express that. `students` holds **one row per provider per child** (existing uniqueness is `(provider_id, school_id, grade_level, initials)`), so a child seen by both an RSP and an SLP is legitimately two rows — and **five student identities in production are already served by two providers each**, so a district-wide index would reject the second provider's copy on import. Scoped to `(provider_id, district_id, district_student_id)` instead — the same shape as the existing constraint — with `NULLS NOT DISTINCT` so the rows with no `district_id` are actually covered rather than quietly exempt. Rationale is written up in the migration.

`upsert_students_atomic` carries the id presence-keyed, like the teacher and IEP-date columns: a goals-only re-import that carries no ids never erases the ones already on file.

## Visibility

Per Blair's call on the collision I flagged: the student details modal's **"District ID" box now edits this field** instead of `student_details.district_id`. That old column was never populated by anything — every non-sim row in production is an empty string — and shared a name with the org-level district id used for scoping. It's retired in SPE-341. The value is never rendered on any student list.

## Verification

**Sim district, real signed-in sessions — 14 checks, 0 failures.** The database is the tiebreaker on every one:

* The id typed into the modal by Rachel is asserted **in the table**, not by trusting the UI.
* Alicia (another provider, another school) writing to Rachel's student gets **0 rows affected**, with the stored value re-read and confirmed unchanged.
* The duplicate is refused **by name** — `23505` on `ux_students_provider_district_student_id` — so the check can't stay green if the index is dropped and something incidental rejects the write instead. Its fixture is established independently, so it can't pass or fail for reasons belonging to another act.
* The import RPC writes the id; a follow-up import **carrying no ids leaves it intact**; a blank id stores `NULL`, never `''`.
* The list surface is asserted **not** to render the field.

Gates: `typecheck`, `lint`, `test` (663 passed) green. `sim:verify` green before and after; teardown → `--expect-empty` all zeros.

**26 new unit tests** over the parsers, the matcher, and the details load path.

## Self-review catch

`getStudentDetails` returned null for a student with no `student_details` row — which happens for pre-existing, roster-template and manual-add students. The modal treats null as "reset the form", so it rendered a blank ID field and the next save wrote that blank **over a real stored id**. The id lives on `students`, so a missing details row says nothing about whether an id exists. Fixed, with four regression tests.

## Note

The `/code-review` skill became non-model-invocable partway through this session (it ran on #786), so this diff got a manual pass instead — which is what caught the data-loss path above. Worth a run on your side before merging if you want the second opinion.

**The migration is already applied to the production database** — the sim district lives there and the standing verification rule can't be satisfied otherwise. It is additive: a new nullable column, a new index, and a presence-keyed function change that older clients don't have to send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ndRMRr41hxg8KhVG43Sfv

---
_Generated by [Claude Code](https://claude.ai/code/session_017ndRMRr41hxg8KhVG43Sfv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added district Student ID support end-to-end: import parsing, matching, preview/confirmation, admin student details, and roster template parsing.
  * Updated the roster template to include a required “Student ID” column while keeping older templates working.
* **Bug Fixes**
  * Student matching now prioritizes district Student ID, with normalization and strict conflict handling.
  * Blank or absent IDs no longer overwrite existing stored values; conflicting IDs are surfaced in the review flow and withheld from saving.
* **Tests**
  * Expanded unit coverage for district Student ID extraction, matching precedence, and conflict scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->