### PR TITLE
docs(ndpa): fix sheet for JSUSD interim DPA draft; record Vercel Pro upgrade

### DIFF
--- a/docs/data-inventory.md
+++ b/docs/data-inventory.md
@@ -34,7 +34,7 @@ California Student Privacy Alliance (see SPE-59), and the companion to
 | **Communications** | Limited | Optional | Provider session/progress notes (free text) | `schedule_sessions.session_notes`, `manual_goal_progress.notes`, `care_meeting_notes` |
 | **Student Identifiers (local/state)** | **Yes (extension)** | Derived | Speddy student UUID (backend). **SEIS ID (SSID) is _not_ stored in the backend DB, but the Chrome extension persists it — with student name, grade, and school — in the provider's local browser storage (`chrome.storage.local`) when passive discrepancy detection runs.** | `students.id`; extension `chrome.storage.local` |
 | **Parent/Guardian Name** | Limited | Optional | Requesting parent/guardian's name + relationship on Lane B (parent-written-request) CARE referrals | `care_referrals.requested_by` |
-| **Parent/Guardian Contact** | **No** | — | No parent/guardian address / email / phone | — |
+| **Parent/Guardian Contact** | **No** | — | No dedicated address / email / phone fields (none collected by design; free-text fields such as `requested_by` are not validated against incidentally entered contact details) | — |
 | **Student Contact Info** | **No** | — | No student email / phone / address | — |
 | **Student Survey Responses** | **No** | — | — | — |
 | **Transcript / official grades** | **No** | — | Grade level only; no transcript/GPA | — |

--- a/docs/data-inventory.md
+++ b/docs/data-inventory.md
@@ -7,6 +7,11 @@ California Student Privacy Alliance (see SPE-59), and the companion to
 
 > Grounded in the live database schema (project `qkcruccytmmdajfavpgb`), verified
 > 2026-06-12. Keep current as the schema changes.
+>
+> **Correction 2026-07-28:** added the Parent/Guardian Name row —
+> `care_referrals.requested_by` (Lane B requester name/relationship, added
+> 2026-05-16) was missed by the June sweep; caught during the JSUSD DPA
+> review (PR #788).
 
 ---
 
@@ -28,7 +33,8 @@ California Student Privacy Alliance (see SPE-59), and the companion to
 | **Conduct / Behavior** | Limited | Optional | Behavior-area IEP goals; CARE referral reason | `student_details.iep_goals`, `care_referrals.referral_reason` |
 | **Communications** | Limited | Optional | Provider session/progress notes (free text) | `schedule_sessions.session_notes`, `manual_goal_progress.notes`, `care_meeting_notes` |
 | **Student Identifiers (local/state)** | **Yes (extension)** | Derived | Speddy student UUID (backend). **SEIS ID (SSID) is _not_ stored in the backend DB, but the Chrome extension persists it — with student name, grade, and school — in the provider's local browser storage (`chrome.storage.local`) when passive discrepancy detection runs.** | `students.id`; extension `chrome.storage.local` |
-| **Parent/Guardian Contact** | **No** | — | — | — |
+| **Parent/Guardian Name** | Limited | Optional | Requesting parent/guardian's name + relationship on Lane B (parent-written-request) CARE referrals | `care_referrals.requested_by` |
+| **Parent/Guardian Contact** | **No** | — | No parent/guardian address / email / phone | — |
 | **Student Contact Info** | **No** | — | No student email / phone / address | — |
 | **Student Survey Responses** | **No** | — | — | — |
 | **Transcript / official grades** | **No** | — | Grade level only; no transcript/GPA | — |
@@ -97,7 +103,7 @@ extension API key (`api_keys`); see [`offboarding-runbook.md`](./offboarding-run
 ## Notable points (for the NDPA / due diligence)
 
 1. **Full student names and date of birth _are_ collected** (`student_details`). This corrects the earlier SPE-59 draft inventory, which said "initials, not full names." Names + DOB must be disclosed on the Schedule of Data.
-2. **The CARE module holds special-education evaluation data** — full student names, referral reasons, and psych/speech/OT testing + eligibility outcomes. This is among the most sensitive data here (special-ed records under FERPA/IDEA) and should be called out explicitly.
+2. **The CARE module holds special-education evaluation data** — full student names, referral reasons, and psych/speech/OT testing + eligibility outcomes; Lane B referrals also record the requesting parent/guardian's name and relationship (`requested_by`). This is among the most sensitive data here (special-ed records under FERPA/IDEA) and should be called out explicitly.
 3. **Student work images** are stored (Supabase Storage, private buckets, served via short-lived signed URLs).
 4. **Minimization wins worth stating:** no SEIS ID (SSID) stored in the backend DB (it is held only in the provider's local browser storage by the Chrome extension — see Section A), no parent/guardian or student contact info, no SSN, no race/ethnicity/gender, no health data beyond special-ed status.
 5. **Provider IP addresses** are logged (`sign_in_logs`, `analytics_events`) — provider PII, not student.

--- a/docs/ndpa/ca-ndpa-execution-packet.md
+++ b/docs/ndpa/ca-ndpa-execution-packet.md
@@ -224,7 +224,7 @@ Source: `subprocessors.md` (last reviewed 2026-06-11).
 | Subprocessor | Function | Student data | Location | Agreement |
 |---|---|---|---|---|
 | Supabase | Database, auth, file storage — system of record | Yes — all categories in Exhibit B | US (us-west-1, N. California) | DPA available; **sign via dashboard → Legal Documents [ACTION]** |
-| Vercel | Application hosting; traffic + runtime logs | Yes — in transit and incidentally in logs | US-configurable | DPA incorporated into ToS (Pro/Enterprise); **confirm plan tier + save copy [ACTION]** |
+| Vercel | Application hosting; traffic + runtime logs | Yes — in transit and incidentally in logs | US-configurable | DPA incorporated into ToS — **on Pro since 2026-07-28**; **save copy [ACTION]** |
 | Sentry | Error monitoring, minimized (no logs/replay, PII scrubbed, `sendDefaultPii: false`) | Incidental only | US ingest | DPA self-serve; **accept in Settings → Legal & Compliance [ACTION]** |
 | Help Scout | Support help desk + chat widget | No by design (provider PII only) | US | DPA v2 via ToS; DPF + SCCs (SPE-170, on file) |
 | OpenAI — **planned, NOT enabled** | AI lesson generation (when enabled) | None today (hard-gated off); initials + IEP goal text when enabled | US | DPA executed 2026-06-12 (SPE-163) |
@@ -262,11 +262,10 @@ only when active); Supabase Auth transactional email.
    - **Supabase**: DPA must be signed — Supabase dashboard → Organization →
      Legal Documents (PandaDoc flow). Save the executed copy.
    - **Vercel**: DPA is incorporated by reference into the Terms of Service
-     (deemed signed) for **Pro/Enterprise** customers. **Confirmed
-     2026-06-12: currently on HOBBY plan → upgrade to Pro required before
-     signing** (Hobby is non-commercial and outside the DPA's scope) —
-     tracked as **SPE-173** (blocks SPE-59). After upgrading, save a copy of
-     vercel.com/legal/dpa for the records file.
+     (deemed signed) for **Pro/Enterprise** customers. ~~Currently on HOBBY
+     plan~~ **Upgraded Hobby → Pro 2026-07-28 (owner-confirmed)** — the DPA
+     now applies. Remaining (SPE-173): save a copy of vercel.com/legal/dpa
+     for the records file; sanity-check the daily crons on Pro.
    - **Sentry**: self-serve click-accept — Sentry → Settings → Legal &
      Compliance (requires Owner/Billing role); DocuSign option if a signed
      copy is preferred. Save the acceptance record.
@@ -312,7 +311,7 @@ only when active); Supabase Auth transactional email.
 5. ☑ AI stance: "No AI used at this time" (decided 2026-06-12; attorney confirms, brief item 3; enablement runbook = SPE-174)
 6. ☑ Framework: NIST CSF 1.1 + mapping memo `docs/security-framework-mapping.md` (done 2026-06-12; attorney confirms, brief item 5)
 7. ☐ Email CITE about Exhibit H (tracked: **SPE-172**)
-8. ☐ Sign Supabase DPA (dashboard) · accept Sentry DPA (Settings → Legal & Compliance) · **upgrade Vercel Hobby → Pro (SPE-173)** + save DPA copy; collate with OpenAI/Anthropic/Help Scout records (Gap 8)
+8. ☐ Sign Supabase DPA (dashboard) · accept Sentry DPA (Settings → Legal & Compliance) · ~~upgrade Vercel Hobby → Pro~~ **done 2026-07-28** — save Vercel DPA copy (SPE-173); collate with OpenAI/Anthropic/Help Scout records (Gap 8)
 9. ☑ Security overview rewritten to current reality, v2.0 (Gap 9 — done 2026-06-12)
 10. ☑ MFA references removed from privacy page (Gap 10 — done 2026-06-12)
 11. ☑ Incident-response plan written: `docs/incident-response-plan.md` (Gap 11 — done 2026-06-12; **[DPO]** review recommended)

--- a/docs/ndpa/ca-ndpa-execution-packet.md
+++ b/docs/ndpa/ca-ndpa-execution-packet.md
@@ -155,7 +155,8 @@ Check exactly these; leave everything else unchecked.
 | Enrollment | Student grade level | ☑ | `students.grade_level` |
 | Enrollment | Specific curriculum programs | ☑ (SPIRE / Reveal Math curriculum tracking) | `curriculum_tracking` |
 | Enrollment | Homeroom / Guidance counselor / Year of graduation / Other | ☐ | — |
-| Parent/Guardian Contact, ID, Name | all | ☐ — not collected | `data-inventory.md` §A |
+| Parent/Guardian Contact, ID | all | ☐ — not collected | `data-inventory.md` §A |
+| Parent/Guardian Name | First and/or last | ☑ (limited: requesting parent/guardian's name + relationship on Lane B CARE referrals — corrected 2026-07-28, was ☐) | `care_referrals.requested_by`; `data-inventory.md` §A |
 | Schedule | Student scheduled courses | ☑ (special-education service sessions: day/time, service type, group) | `schedule_sessions`, `bell_schedules`, `special_activities` |
 | Schedule | Teacher names | ☑ | `students.teacher_name`, `teachers` |
 | Special Indicator | Student disability information | ☑ | `care_cases.eligibility_category/outcome`, `student_details` |

--- a/docs/ndpa/jsusd-dpa-fix-sheet.md
+++ b/docs/ndpa/jsusd-dpa-fix-sheet.md
@@ -64,13 +64,22 @@ All checkboxes below are in the first column ("ALL DPA-COVERED APPS").
 | 11 | Assessment — Observation data | `Check Box60` | **[ATTORNEY]** Decided framing (brief item 4b): leave unchecked; provider notes are disclosed under "Other" (§2c below). |
 | 12 | Demographics — Gender | `Check Box93` | Not collected (no race/ethnicity/gender). |
 | 12 | Demographics — Language information | `Check Box95` | Not collected. |
-| 13 | Parent/Guardian Contact — Address | `Check Box182` | No parent/guardian data collected at all. |
+| 13 | Parent/Guardian Contact — Address | `Check Box182` | No parent/guardian contact information collected. |
 | 13 | Parent/Guardian Contact — Email | `Check Box189` | Same. |
 | 13 | Parent/Guardian Contact — Phone | `Check Box196` | Same. |
-| 13 | Parent/Guardian Name — First and/or last | `Check Box216` | Same. |
 | 13 | Special Indicator — English language learner information | `Check Box231` | Not collected. |
 | 14 | Student Contact Information — Address | `Check Box280` | No student contact info collected. |
 | 14 | Student Identifiers — Local (school district) ID number | `Check Box289` | Not collected. Speddy's UUID is the "Provider/app assigned" row (already checked); the SEIS SSID is the "State ID" row. |
+
+**Keep checked: Parent/Guardian Name (p. 13, `Check Box216`).** The draft
+has this one right — confirmed in code during review: Lane B
+(parent-written-request) CARE referrals collect the requesting
+parent/guardian's **name and relationship**
+(`care_referrals.requested_by`, migration
+`20260516_care_lane_b_compliance.sql`; entered in
+`add-referral-modal.tsx`). The June data-inventory sweep missed this
+column — now corrected in `data-inventory.md`. The CARE specify text in
+§2b discloses it. (Caught by Codex review on PR #788.)
 
 ### 2b. CHECK — elements Speddy does collect that the draft missed
 
@@ -78,7 +87,7 @@ All checkboxes below are in the first column ("ALL DPA-COVERED APPS").
 |---|---|---|---|
 | 11 | Application Technology Meta Data — Other | `Check Box8` | In `Text448`: *"Browser user agent, device type, and product-usage event metadata (event type, timestamps, processing time, error codes)."* |
 | 11 | Assessment — Standardized test scores | `Check Box28` | — (mClass, STAR, WISC-V, BRIEF etc. in `student_assessments`) |
-| 13 | Special Indicator — Other indicator information | `Check Box237` | In `Text476` (top of p. 14): *"Special-education referral and eligibility-process records: referral reason and source; academic/speech/psych/OT testing dates and completion status; eligibility meeting dates and outcomes; SST notes links."* |
+| 13 | Special Indicator — Other indicator information | `Check Box237` | In `Text476` (top of p. 14): *"Special-education referral and eligibility-process records: referral reason and source; academic/speech/psych/OT testing dates and completion status; eligibility meeting dates and outcomes; SST notes links; and, for parent/guardian-initiated (Lane B) referrals, the requesting parent/guardian's name and relationship."* |
 | 15 | Student Work — Student generated content | `Check Box358` | — (scanned worksheet images in Supabase Storage) |
 | 15 | Student Work — Other student work data | `Check Box359` | In `Text483`: *"Documents uploaded by providers that may pertain to students (e.g., rosters, IEP-related documents); generated worksheets/lessons associated with students."* |
 
@@ -264,7 +273,8 @@ Exhibit B rows: IP addresses/cookies, application-use statistics, class
 attendance (not daily), conduct/behavioral (limited), date of birth,
 school enrollment, grade level, curriculum programs, scheduled courses,
 teacher names, disability information, IEP/504 services, provider-assigned
-ID, State ID (with §2c note), student name, in-app performance, "Other data
+ID, State ID (with §2c note), student name, parent/guardian name (limited —
+Lane B CARE requester, see §2a note), in-app performance, "Other data
 collected."
 
 ## 8. Pre-signing checklist (state as of 2026-07-28)

--- a/docs/ndpa/jsusd-dpa-fix-sheet.md
+++ b/docs/ndpa/jsusd-dpa-fix-sheet.md
@@ -49,6 +49,12 @@ only real controls (the SPE-134 principle).
 > documented incident response plan providing 72-hour breach notification to
 > the LEA consistent with Article V §4.
 
+**Prerequisite for this paragraph:** the subprocessor-agreements sentence
+must be true when the corrected PDF leaves the building. OpenAI, Anthropic,
+Help Scout, and Vercel (Pro since 2026-07-28) are in place; the **Supabase
+DPA signing and Sentry DPA acceptance (§8 item 2) must be completed before
+sending** — they are two self-serve click-throughs, not negotiations.
+
 ---
 
 ## 2. Exhibit B — Schedule of Data corrections (pp. 11–16) — **must fix**
@@ -285,6 +291,8 @@ collected."
    records file; sanity-check the two daily crons on Pro.
 2. ☐ Sign the Supabase DPA (dashboard → Organization → Legal Documents);
    accept the Sentry DPA (Settings → Legal & Compliance). ~15 min total.
+   **Prerequisite for the Exhibit F representation in §1 — do before the
+   corrected PDF is sent anywhere.**
 3. ☐ Apply §§1–6 above to the PDF, then send to counsel with
    `attorney-review-brief.md` (its enclosure list) + this fix sheet.
 4. ☐ SPE-172 — CITE Exhibit H question; now more relevant since this draft

--- a/docs/ndpa/jsusd-dpa-fix-sheet.md
+++ b/docs/ndpa/jsusd-dpa-fix-sheet.md
@@ -1,0 +1,289 @@
+# Fix Sheet — JSUSD Interim CA-NDPA Draft (`SpeddyJSUSD_CANDPA_v1.5_DRAFT.pdf`)
+
+Corrections to the Claude-chat-drafted **CA-NDPA Standard v1.5** fill for
+**John Swett Unified School District ↔ Orchestrate LLC** (27-page PDF,
+reviewed 2026-07-28). Cross-checked field-by-field against the repo's legal
+corpus: `ca-ndpa-execution-packet.md` (the source of truth for every fill),
+`data-inventory.md`, `security-framework-mapping.md`,
+`attorney-review-brief.md`, and `docs/pilots/john-swett-unified.md`.
+
+> **Internal doc — do not send to the district.** Not legal advice; items
+> marked **[ATTORNEY]** go to counsel with the attorney review brief.
+>
+> **How to apply:** each fix gives the PDF page (matches the printed footer
+> numbers), the row label as it appears on the form, and the internal
+> AcroForm field name in `code` — usable in any PDF editor, or
+> programmatically, or hand this file + the original PDF back to Claude
+> chat with the instruction: *"Apply the edits in §§1–6 of this fix sheet
+> exactly; change nothing else."*
+
+---
+
+## 1. Exhibit F — replace the security-program paragraph (p. 21, field `Text94`) — **must fix**
+
+The drafted paragraph claims **"multi-factor authentication for
+administrative access"** (Speddy offers no MFA — the claim was deliberately
+removed from the privacy page during NDPA prep, execution packet Gap 10) and
+**"audit logging and monitoring"** (student-data audit logging is not built —
+SPE-169 Backlog; `security-framework-mapping.md` lists it as the most
+material gap). This field is a contractual representation; it must describe
+only real controls (the SPE-134 principle).
+
+**Replace the entire field with:**
+
+> Provider has designated the NIST Cybersecurity Framework (CSF) Version 1.1
+> as its Cybersecurity Framework under Article V §3 and maintains a written
+> self-assessment mapping its controls to the CSF core functions, available
+> to the LEA on request. Implemented safeguards include: administrator-
+> provisioned accounts (no self-registration); role-based, least-privilege
+> access control enforced by PostgreSQL Row-Level Security on every
+> application table; encryption of Student Data in transit (TLS 1.2+) and at
+> rest (AES-256); private storage buckets with short-lived signed URLs for
+> student work images; revocable hashed API keys for Provider's browser
+> extension; automatic inactivity logout; sign-in event logging;
+> PII-minimized error monitoring; enforced data-retention limits with
+> documented deletion and offboarding procedures; automated backups with
+> point-in-time recovery; secure development practices including server-side
+> input validation and dependency auditing; written data-processing
+> agreements with Subprocessors (register available on request); and a
+> documented incident response plan providing 72-hour breach notification to
+> the LEA consistent with Article V §4.
+
+---
+
+## 2. Exhibit B — Schedule of Data corrections (pp. 11–16) — **must fix**
+
+The draft checks data we don't collect and omits sensitive data we do.
+Basis for every line: `data-inventory.md` (verified against the live schema).
+All checkboxes below are in the first column ("ALL DPA-COVERED APPS").
+
+### 2a. UNCHECK — elements Speddy does not collect
+
+| Pg | Row (category — element) | Field | Why |
+|---|---|---|---|
+| 11 | Assessment — Observation data | `Check Box60` | **[ATTORNEY]** Decided framing (brief item 4b): leave unchecked; provider notes are disclosed under "Other" (§2c below). |
+| 12 | Demographics — Gender | `Check Box93` | Not collected (no race/ethnicity/gender). |
+| 12 | Demographics — Language information | `Check Box95` | Not collected. |
+| 13 | Parent/Guardian Contact — Address | `Check Box182` | No parent/guardian data collected at all. |
+| 13 | Parent/Guardian Contact — Email | `Check Box189` | Same. |
+| 13 | Parent/Guardian Contact — Phone | `Check Box196` | Same. |
+| 13 | Parent/Guardian Name — First and/or last | `Check Box216` | Same. |
+| 13 | Special Indicator — English language learner information | `Check Box231` | Not collected. |
+| 14 | Student Contact Information — Address | `Check Box280` | No student contact info collected. |
+| 14 | Student Identifiers — Local (school district) ID number | `Check Box289` | Not collected. Speddy's UUID is the "Provider/app assigned" row (already checked); the SEIS SSID is the "State ID" row. |
+
+### 2b. CHECK — elements Speddy does collect that the draft missed
+
+| Pg | Row (category — element) | Field | Specify text (field) |
+|---|---|---|---|
+| 11 | Application Technology Meta Data — Other | `Check Box8` | In `Text448`: *"Browser user agent, device type, and product-usage event metadata (event type, timestamps, processing time, error codes)."* |
+| 11 | Assessment — Standardized test scores | `Check Box28` | — (mClass, STAR, WISC-V, BRIEF etc. in `student_assessments`) |
+| 13 | Special Indicator — Other indicator information | `Check Box237` | In `Text476` (top of p. 14): *"Special-education referral and eligibility-process records: referral reason and source; academic/speech/psych/OT testing dates and completion status; eligibility meeting dates and outcomes; SST notes links."* |
+| 15 | Student Work — Student generated content | `Check Box358` | — (scanned worksheet images in Supabase Storage) |
+| 15 | Student Work — Other student work data | `Check Box359` | In `Text483`: *"Documents uploaded by providers that may pertain to students (e.g., rosters, IEP-related documents); generated worksheets/lessons associated with students."* |
+
+The CARE/eligibility line (row 3) is the one `data-inventory.md` calls
+"among the most sensitive data here" — it must not be omitted.
+
+### 2c. REVISE — existing text fields
+
+**p. 11, `Text455`** (Assessment — Other, currently only IEP-goal progress).
+Replace with:
+
+> Curriculum-based and informal assessment results (exit tickets, progress
+> checks), IEP-goal progress data (including trial data and percent
+> accuracy), and derived performance metrics (accuracy, error patterns,
+> performance levels).
+
+**p. 16, `Text504`** (Other data collected — currently IEP-records text that
+duplicates rows already checked, and misses what actually belongs here).
+Replace with:
+
+> Provider-authored session/progress notes and CARE meeting notes/action
+> items (free text about students); student absence reasons; derived AI
+> analysis of submitted student work (populated only if AI features are
+> enabled — currently disabled platform-wide). Note re "State ID number"
+> above: the SEIS ID (SSID) is read by Provider's Chrome extension solely
+> for discrepancy detection and cached only in the provider's local browser
+> storage (7-day TTL; cleared on logout or API-key revocation); it is never
+> stored on Provider's servers.
+
+The final sentence carries the SEIS-cache disclosure the attorney brief
+(item 4d) attaches to the checked "State ID number" row (`Check Box290` —
+keep checked).
+
+### 2d. Verify / at execution
+
+- "None — no student data collected" (`Check Box435`, p. 16) stays
+  **unchecked** (it is in the draft — keep it that way).
+- Exhibit A completion checkbox (`Check Box82`, p. 10) is currently
+  unchecked — tick at execution after counsel review.
+
+---
+
+## 3. Exhibit A — replace the services description (p. 10, field `Text80`) — **must fix**
+
+The drafted description covers scheduling, IEP goal tracking, session
+logging, and SEIS sync only — omitting worksheets/grading (student work
+images), assessments and progress checks, curriculum tracking, and the
+entire CARE/eligibility module. Article IV §2 scopes authorized data use to
+the services described here, so under-description narrows our own
+permission. It also says "synchronization … between the Services and …
+SEIS," which reads as two-way; the extension is read-only (writes nothing
+back to SEIS). **Replace the entire field with the decided text (execution
+packet §2):**
+
+> Speddy (speddy.xyz), operated by Orchestrate LLC, is a web-based platform
+> for K-12 special-education service providers (resource specialists,
+> speech-language pathologists, occupational therapists, counselors, and
+> special-education assistants) and school/district administrators. The
+> Services include: caseload management for students receiving
+> special-education services; IEP goal and accommodation tracking; service
+> scheduling (sessions, bell schedules, special activities); session
+> attendance and service documentation; progress monitoring (assessments,
+> exit tickets, progress checks, IEP-goal progress); curriculum tracking;
+> creation, storage, and grading of instructional materials and student
+> worksheets (including scanned images of student work); student support /
+> CARE-team referral and special-education eligibility-process tracking; and
+> school staff/scheduling administration. The Services include a companion
+> Chrome browser extension that, with the provider's authorization, reads
+> student records from the LEA's SEIS (California Special Education
+> Information System) account to detect discrepancies between SEIS and
+> Speddy records; the extension sends data to Speddy and writes nothing back
+> to SEIS. AI-assisted generation features exist in the codebase but are
+> disabled platform-wide as of the Effective Date (see Exhibit G).
+
+Keep `Text81` ("None. All current and future Provider Services are covered
+by this DPA.") as is.
+
+---
+
+## 4. Exhibit G free-text fields (p. 23, fields `Text1`, `Text2`) — recommended **[ATTORNEY]**
+
+The drafted answers are accurate but thinner than the decided versions
+(execution packet §4; attorney brief item 3 already asks counsel to bless
+them). Replace both — and note `Text1`'s parenthetical otherwise repeats
+Exhibit A's too-narrow service list.
+
+**`Text1` — "Describe how Student Data is Used":**
+
+> Student Data is used solely to provide the Services described in Exhibit
+> A: scheduling and documenting special-education services; tracking IEP
+> goals, accommodations, attendance, and student progress; storing and
+> grading student work; and supporting the LEA's special-education referral
+> and eligibility workflows. Student Data is not used for targeted
+> advertising or profiling, is never sold, and is not used to train AI
+> models. As of the Effective Date, no Student Data is processed by any
+> artificial-intelligence system: Speddy's AI-assisted features are disabled
+> platform-wide by a server-side feature gate, and the associated routes are
+> inoperative.
+
+**`Text2` — "Any other information related to Provider's use of AI":**
+
+> Speddy has developed, but has not enabled, optional AI-assisted features
+> (lesson, exit-ticket, and progress-check generation; worksheet-image
+> grading; document parsing) that would use OpenAI and Anthropic as
+> subprocessors. These features are disabled by a platform-level kill switch
+> and currently transmit zero data to either provider. Data-processing
+> agreements with both providers are executed and on file; both prohibit
+> training on customer data. Before enabling any AI feature, Provider will
+> (a) apply prompt de-identification, (b) request zero-data-retention
+> handling from the AI providers, and (c) provide advance notice to the LEA
+> pursuant to Exhibit G § 4.1 and submit an updated AI Schedule of Data
+> pursuant to § 4.2.
+
+If counsel prefers the shorter drafted `Text2` (less affirmative
+commitment), that's a defensible call — but make it consciously, not by
+default.
+
+---
+
+## 5. Exhibit H (p. 27) — keep the interim/supersession concept, with two flags **[ATTORNEY]**
+
+The chat-added Exhibit H (interim bilateral DPA, auto-superseded by the
+CITE/CSPA execution) is a sound idea and mostly well drafted (survival of
+accrued obligations; no data-disposition trigger on supersession; correct
+Art. VII §3 precedence). Two things for counsel:
+
+**(a) General Offer continuity.** Exhibit E binds Provider to Subscribing
+LEAs "for the term of the DPA between the [Originating LEA] and the
+Provider" — and Exhibit H deliberately cuts that term short at supersession.
+Proposed addition to Exhibit H §2 (counsel to approve or redraft):
+
+> (c) any Subscribing LEA that has accepted Provider's General Offer of
+> Privacy Terms (Exhibit "E") under this DPA shall, from the date of
+> supersession, have the benefit of the Successor Agreement's privacy terms
+> (or, at the Subscribing LEA's option, may execute the Successor
+> Agreement's General Offer), so that no Subscribing LEA's protections lapse
+> by reason of the supersession.
+
+**(b) The variance slot.** Article V §3 says cybersecurity-framework
+exclusions/variances "must be detailed in an attachment to Exhibit H" — the
+official v1.5 form has no Exhibit H page (open CITE question, SPE-172), and
+this draft now occupies the slot with interim terms while Exhibit F (§1
+above) previously papered over the gaps. If counsel prefers disclosure over
+silence (attorney brief item 5), attach:
+
+> **Attachment 1 to Exhibit H — Cybersecurity Framework variances (Article V
+> §3).** Provider's designated framework is NIST CSF 1.1. Current variances,
+> tracked to remediation: (1) application-level audit logging of individual
+> student-record access/modification is in development (authentication,
+> row-level security, and sign-in event logging are in place today); (2) no
+> formal third-party penetration test has been performed (infrastructure
+> subprocessors maintain SOC 2 Type II attestations); (3) SSO/MFA is not
+> currently offered for LEA user accounts; accounts are
+> administrator-provisioned with password-complexity and inactivity-timeout
+> controls.
+
+---
+
+## 6. Small items
+
+- **Signer title** appears as "Owner/Managing Member" (pp. 3, 20, 23, 27).
+  Our records use "Owner" (packet decision 2); "Owner/Managing Member" is
+  also accurate for a single-member LLC. Standardize on one everywhere —
+  counsel confirms with brief item 7. Cosmetic.
+- **Phone number** (510) 256-9748 is baked into p. 3. Still-open decision
+  (packet decision 3): a dedicated business line before signing — this
+  number goes to every subscribing district for 3 years.
+- **Cover-page state-law blank** (p. 2, after "applicable state privacy laws
+  and regulations ___") is unfilled. Counsel supplies if the form allows —
+  expected: SOPIPA (Cal. B&P Code §§ 22584–22585) and Cal. Ed. Code
+  § 49073.1 (brief item 6). Exhibit H already recites § 49073.1.
+- **Exhibit E date** (p. 20, "which is dated ___") — fill at execution.
+
+## 7. Correct as drafted — change nothing
+
+Parties, addresses, and JSUSD details; the Standard Clauses (v3.0,
+unmodified); cover-page boxes (Exhibit G incorporation `Check Box76`,
+Exhibit E signed `Check Box77` — both match decided positions); GOPT inbox
+help@speddy.xyz; the AI Addendum (all type/purpose/data tables unchecked,
+"No AI used at this time" marked, final confirmation checked — Decision 5
+exactly); NIST CSF designation; 3-year term; and these correctly checked
+Exhibit B rows: IP addresses/cookies, application-use statistics, class
+attendance (not daily), conduct/behavioral (limited), date of birth,
+school enrollment, grade level, curriculum programs, scheduled courses,
+teacher names, disability information, IEP/504 services, provider-assigned
+ID, State ID (with §2c note), student name, in-app performance, "Other data
+collected."
+
+## 8. Pre-signing checklist (state as of 2026-07-28)
+
+1. ✅ **Vercel Hobby → Pro — upgraded 2026-07-28** (owner-confirmed). The
+   Vercel DPA (incorporated via ToS for Pro) now applies. Remaining
+   housekeeping (SPE-173): save a copy of vercel.com/legal/dpa to the
+   records file; sanity-check the two daily crons on Pro.
+2. ☐ Sign the Supabase DPA (dashboard → Organization → Legal Documents);
+   accept the Sentry DPA (Settings → Legal & Compliance). ~15 min total.
+3. ☐ Apply §§1–6 above to the PDF, then send to counsel with
+   `attorney-review-brief.md` (its enclosure list) + this fix sheet.
+4. ☐ SPE-172 — CITE Exhibit H question; now more relevant since this draft
+   defines an Exhibit H.
+5. ☐ Business-phone-line decision (§6).
+6. ☐ Verify Vercel env `CRON_SECRET` + `CLEANUP_ANALYTICS=true` and first
+   cron runs (packet Gap 12) — the retention TTLs we represent depend on it.
+7. At execution: signatures + dates, Exhibit A completion box
+   (`Check Box82`), Exhibit E date.
+
+_Related: SPE-59 (NDPA master), SPE-169 (audit logging), SPE-172 (Exhibit
+H), SPE-173 (Vercel Pro), SPE-174 (AI-enablement obligations)._

--- a/docs/pilots/john-swett-unified.md
+++ b/docs/pilots/john-swett-unified.md
@@ -19,7 +19,7 @@ Contra Costa County, CA · NCES LEA `0618990` · <https://www.jsusd.org>.
 | 3 | **Terms of Service** | Public terms | speddy.xyz/terms | Live |
 | 4 | **FERPA Notice** | FERPA "school official" posture | speddy.xyz/ferpa | Live |
 | 5 | **Incident Response Plan** | Written IR plan (breach detection, 72-hr LEA notice) | `docs/incident-response-plan.md` | Ready — share on request (quick DPO glance first) |
-| 6 | **CA-NDPA** | The agreement the district signs, via CITE / CSPA | CITE/CSPA fillable form | Draft filled; pre-signing items open (§3) |
+| 6 | **CA-NDPA** | The agreement the district signs, via CITE / CSPA | CITE/CSPA fillable form | Draft filled; **corrections required before sending — see `docs/ndpa/jsusd-dpa-fix-sheet.md`**; pre-signing items open (§3) |
 
 **Available on request** (usually only if their team digs deeper): data inventory
 (`docs/data-inventory.md`), subprocessor register (`docs/subprocessors.md`),
@@ -47,9 +47,9 @@ secondary-school experience; Rodeo Hills gets the full elementary experience.
 
 ## 3. Pre-signing items (close before John Swett *signs* — not before they review)
 
-- **Vercel Hobby → Pro upgrade (SPE-173, open).** The hosting DPA only applies to
-  Pro/Enterprise; a commercial pilot needs Pro. Real blocker for subprocessor
-  flow-down.
+- **Vercel Hobby → Pro upgrade — DONE 2026-07-28** (owner-confirmed; SPE-173).
+  The hosting DPA (incorporated via ToS on Pro) now applies. Remaining
+  housekeeping: save the DPA copy to the records file; sanity-check crons on Pro.
 - **Attorney FERPA/COPPA sign-off.** The attorney review brief is prepared; final
   counsel sign-off should be confirmed on record.
 - **Subprocessor DPA housekeeping.** OpenAI/Anthropic done (SPE-163). Confirm the


### PR DESCRIPTION
## What

Adds `docs/ndpa/jsusd-dpa-fix-sheet.md` — field-by-field corrections to the Claude-chat-drafted **CA-NDPA v1.5** fill for John Swett Unified (`SpeddyJSUSD_CANDPA_v1.5_DRAFT.pdf`), produced by cross-checking every filled form field and checkbox in the PDF against the repo's legal corpus (`ca-ndpa-execution-packet.md`, `data-inventory.md`, `security-framework-mapping.md`, `attorney-review-brief.md`).

Key corrections captured in the sheet (with exact PDF page + AcroForm field names so it can be applied in any PDF editor or handed back to Claude chat):

- **Exhibit F (`Text94`)** — replace the security-program paragraph: the draft claimed MFA and audit logging, which Speddy does not have (SPE-169 is Backlog; MFA claims were deliberately removed during NDPA prep). Replacement text describes only real controls.
- **Exhibit B (pp. 11–16)** — uncheck 9 elements not collected (gender, language, ELL, parent/guardian *contact* rows, student address, local district ID, plus the Observation-data judgment call), check 5 missing elements that are collected (standardized test scores, student-work images, uploaded documents, app-tech metadata, and the CARE referral/eligibility records), and revise the two specify-text fields (including the SEIS-cache disclosure for the State ID row). **Parent/Guardian Name stays checked** — Codex review caught that Lane B CARE referrals store the requester's name/relationship (`care_referrals.requested_by`), which the June data-inventory sweep missed; `data-inventory.md` and the execution packet's Exhibit B map are corrected accordingly.
- **Exhibit A (`Text80`)** — restore the full decided services description (worksheets/grading, assessments, CARE module, one-way SEIS read).
- **Exhibit G (`Text1`/`Text2`)** — swap in the decided free-text answers (attorney-flagged).
- **Exhibit H (new, chat-drafted)** — keep the interim/supersession concept; flags for counsel on GOPT subscriber continuity and the Art. V §3 variance slot, with proposed language for both.

## Also

Records the **Vercel Hobby → Pro upgrade (2026-07-28, owner-confirmed)** in the execution packet (Gap 8, §5 table, checklist item 8) and the John Swett pilot tracker — the hosting DPA now applies; remaining SPE-173 housekeeping (save DPA copy, cron sanity check) noted. The pilot tracker's CA-NDPA row now points at the fix sheet.

Docs-only; no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gag9mFdJdCruVnvvgYMCQ9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a detailed CA-NDPA fix sheet for the John Swett Unified School District execution packet.
  * Updated onboarding guidance to require NDPA corrections before sending.
  * Recorded completion of the Vercel Pro upgrade and remaining follow-up actions.
  * Corrected student-data inventory documentation to include limited, optional parent/guardian names while confirming contact details are not collected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->