### PR TITLE
SPE-347: child-record foundation — `children` table above `students`

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -523,11 +523,17 @@ erDiagram
   holds one row per provider per child. Cross-district recurrence stays legal.
 - **Rows are created by the database, never by a caller.** A `BEFORE INSERT`
   trigger (`trg_students_child_link` → `students_child_link()`, SECURITY DEFINER)
-  links every new `students` row: it **attaches** to the existing child when
-  `district_student_id` already identifies one in that district, otherwise it
-  **creates** one. Manual add, roster import and `upsert_students_atomic` were
-  not modified. Name-and-initials matching with human confirmation is a separate
-  step (**SPE-348**); the trigger only does exact id equality.
+  creates the child for every new `students` row. Manual add, roster import and
+  `upsert_students_atomic` were not modified.
+  **It never attaches to an existing child**, deliberately: an earlier cut did
+  attach when `(district_id, district_student_id)` matched, and because both
+  columns are client-supplied and unconstrained (`students_insert` pins only
+  `provider_id`), any provider could link themselves to any child in any
+  district and read or overwrite its name and DOB — verified exploitable on a
+  replica before merge. When the claimed id is already held in that district,
+  the trigger creates this provider's child **without** it and logs the
+  collision; the caseload row still lands, and the two children stay separate
+  until the human-confirmed create-or-attach step (**SPE-348**) reconciles them.
 - **`child_id` is not the caller's to set.** The same trigger refuses (`42501`)
   any attempt by an end-user session to set or change it. `students_insert`'s
   `WITH CHECK` only constrains `provider_id`, so without that guard a signed-in
@@ -538,16 +544,35 @@ erDiagram
   overwrites** — writes on both tables are routinely partial (the import RPC
   `COALESCE`s almost every column; a PostgREST `PATCH` carries only what the
   caller sent), so an absent value means "not provided", not "cleared".
-  Divergence on a child more than one caseload row points at is `RAISE LOG`ged.
+  `district_student_id` is stricter still: the mirror only ever **fills an empty
+  one**, because it is an identity claim, and overwriting it made the value flap
+  between two merged rows on every write. Divergence on a child more than one
+  caseload row points at is `RAISE LOG`ged.
+- **The mirrors authorize nothing — the source table's policy is the gate.**
+  Both are SECURITY DEFINER. That has one consequence worth knowing:
+  `student_details`'s UPDATE policy has an SEA branch with no column
+  restriction, so an SEA **can** change a child's name/DOB/IEP dates *through
+  `student_details`* even though `children_update` refuses them a direct write.
+  Not a new capability (they can already write those columns) and invisible
+  while nothing reads `children` — but at the cross-provider read switch it
+  would start reaching the co-serving provider's view of the child, so that
+  ticket decides whether to narrow it. Pinned by an assertion in
+  `sim:verify-children-rls`.
 - **RLS.** `children_select` **mirrors every branch of `students_select`**
   through the link — owning provider, the student's teacher, an assigned
   specialist or SEA, an SEA at the school, a site admin for that school — so
   nobody who can see a student is blind to its child. `children_update` is
-  narrower: only a **linked provider**. That edit scope is deliberately coarse
-  (any co-serving provider may edit), matching today's reality where each
-  copy-owner edits freely; case-manager-only tightening is **SPE-201**. There is
-  **no INSERT or DELETE policy, and no INSERT/DELETE grant** — the definer
-  trigger is the only way a row is born, and nothing deletes one.
+  narrower: only a **linked provider**, and the UPDATE **grant is column-scoped**
+  to the identity/compliance fields (name, DOB, initials, grade, IEP + triennial
+  dates, accommodations). The scoping and identifier columns — `district_id`,
+  `school_id`, `state_id`, `district_student_id` — are database-managed: they are
+  mirrored from the caseload row, and letting a provider rewrite one would move a
+  child between districts or re-stamp its district identifier. That edit scope is
+  otherwise deliberately coarse (any co-serving provider may edit), matching
+  today's reality where each copy-owner edits freely; case-manager-only
+  tightening is **SPE-201**. There is **no INSERT or DELETE policy, and no
+  INSERT/DELETE grant** — the definer trigger is the only way a row is born, and
+  nothing deletes one.
   No policy on `students` references `children`, so there is no recursion
   surface (§2, SPE-332).
 - **Retention: children survive provider offboarding.** `students` is
@@ -559,7 +584,8 @@ erDiagram
   caller until something re-links it. Re-attaching orphaned children is part of
   the cross-provider read-switch step, not this one (§7).
 
-**Source of truth:** `supabase/migrations/20260729_spe347_children_foundation.sql`;
+**Source of truth:** `supabase/migrations/20260729_spe347_children_foundation.sql`
++ `20260729_spe347_children_hardening.sql`;
 live `children` table + `children_select` / `children_update` policies;
 `students_child_link()`, `students_mirror_child_facts()`,
 `student_details_mirror_child_facts()`; `scripts/sim-district/manifest.ts`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,6 +65,7 @@
 | Session idle timeout | `lib/config/session-timeout.ts`, `lib/hooks/use-activity-tracker.ts`, `app/components/providers/auth-provider.tsx` |
 | SSO provisioning gate | `app/auth/callback/route.ts` |
 | Admin teacher creation | `app/api/admin/create-teacher-account/route.ts` |
+| Student identity (child vs caseload row) | `children` table + `students.child_id`; `supabase/migrations/20260729_spe347_children_foundation.sql` |
 | Scheduling model | `schedule_sessions` table; `lib/scheduling/` |
 | Retention cron jobs | `app/api/cron/*`, `vercel.json` |
 | CARE module | `supabase/migrations/20251222_create_care_meeting_tables.sql`, `lib/supabase/queries/care-referrals.ts` |
@@ -79,6 +80,7 @@
 4. [Account Creation & Invite Flows](#4-account-creation--invite-flows)
 5. [Auth & Session Lifecycle](#5-auth--session-lifecycle)
 6. [Scheduling / Session Data Model](#6-scheduling--session-data-model)
+   — incl. [Student identity — `children` ↔ caseload rows](#student-identity--children--caseload-rows-spe-347)
 7. [Data Lifecycle & Retention](#7-data-lifecycle--retention)
 8. [CARE / Referrals Model](#8-care--referrals-model)
 9. [Elementary vs Secondary (school-level experience)](#9-elementary-vs-secondary-school-level-experience)
@@ -489,6 +491,82 @@ flowchart TD
 
 ## 6. Scheduling / Session Data Model
 
+### Student identity — `children` ↔ caseload rows (SPE-347)
+
+**One child = one `children` row. A `students` row is one provider's caseload
+entry for that child, not the child.** A pupil served by an RSP and an SLP is
+**one** `children` row and **two** `students` rows, each pointing at it via
+`students.child_id`.
+
+That split is new (SPE-347) and, so far, invisible: nothing in the app reads
+`children` yet. Every surface still reads the `students` row it always read, and
+`students` still carries its own copy of the child facts. Retiring those
+duplicated columns is a separate contract ticket (**SPE-350**) after a bake.
+
+```mermaid
+erDiagram
+    CHILDREN ||--o{ STUDENTS : "child_id (no cascade)"
+    PROFILES ||--o{ STUDENTS : "provider_id (CASCADE)"
+    STUDENTS ||--o| STUDENT_DETAILS : "student_id (CASCADE)"
+    STUDENTS ||--o{ SCHEDULE_SESSIONS : "student_id (CASCADE)"
+```
+
+- **What lives where.** `children` holds the child-level facts — name, DOB,
+  initials, grade, school/district/state, `district_student_id`, IEP + triennial
+  dates, accommodations. `students` keeps the per-provider **service** facts:
+  `provider_id`, `sessions_per_week`, `minutes_per_session`, per-discipline
+  goals. All 18 FK dependents (including 11k+ `schedule_sessions`) still key off
+  `students.id` — nothing was re-keyed.
+- **`district_student_id` is unique per district** on `children`
+  (`ux_children_district_student_id`, normalized `upper(btrim(...))`). On
+  `students` the same column had to be **provider**-scoped, because that table
+  holds one row per provider per child. Cross-district recurrence stays legal.
+- **Rows are created by the database, never by a caller.** A `BEFORE INSERT`
+  trigger (`trg_students_child_link` → `students_child_link()`, SECURITY DEFINER)
+  links every new `students` row: it **attaches** to the existing child when
+  `district_student_id` already identifies one in that district, otherwise it
+  **creates** one. Manual add, roster import and `upsert_students_atomic` were
+  not modified. Name-and-initials matching with human confirmation is a separate
+  step (**SPE-348**); the trigger only does exact id equality.
+- **`child_id` is not the caller's to set.** The same trigger refuses (`42501`)
+  any attempt by an end-user session to set or change it. `students_insert`'s
+  `WITH CHECK` only constrains `provider_id`, so without that guard a signed-in
+  user could insert a throwaway caseload row carrying someone else's `child_id`
+  and inherit that child's read **and write** access.
+- **Dual-write.** `AFTER` triggers mirror child facts from `students` and
+  `student_details` onto the linked child. Last write wins, but **NULL never
+  overwrites** — writes on both tables are routinely partial (the import RPC
+  `COALESCE`s almost every column; a PostgREST `PATCH` carries only what the
+  caller sent), so an absent value means "not provided", not "cleared".
+  Divergence on a child more than one caseload row points at is `RAISE LOG`ged.
+- **RLS.** `children_select` **mirrors every branch of `students_select`**
+  through the link — owning provider, the student's teacher, an assigned
+  specialist or SEA, an SEA at the school, a site admin for that school — so
+  nobody who can see a student is blind to its child. `children_update` is
+  narrower: only a **linked provider**. That edit scope is deliberately coarse
+  (any co-serving provider may edit), matching today's reality where each
+  copy-owner edits freely; case-manager-only tightening is **SPE-201**. There is
+  **no INSERT or DELETE policy, and no INSERT/DELETE grant** — the definer
+  trigger is the only way a row is born, and nothing deletes one.
+  No policy on `students` references `children`, so there is no recursion
+  surface (§2, SPE-332).
+- **Retention: children survive provider offboarding.** `students` is
+  `ON DELETE CASCADE` from `profiles`, so deleting a provider destroys their
+  caseload rows and everything hanging off them. `children` is a *parent* —
+  nothing cascades into it — so the child record outlives that. **Caveat worth
+  knowing:** once its last caseload row is gone the child has no link for RLS to
+  reach it by, so it survives in the data but is invisible to every non-service
+  caller until something re-links it. Re-attaching orphaned children is part of
+  the cross-provider read-switch step, not this one (§7).
+
+**Source of truth:** `supabase/migrations/20260729_spe347_children_foundation.sql`;
+live `children` table + `children_select` / `children_update` policies;
+`students_child_link()`, `students_mirror_child_facts()`,
+`student_details_mirror_child_facts()`; `scripts/sim-district/manifest.ts`
+(`childKey` / `childId` / `TOTAL_CHILDREN`).
+
+### The session tables
+
 `schedule_sessions` is the core table. It uses a **template → instance** pattern:
 a template defines a recurring weekly slot; instances are the dated occurrences.
 
@@ -660,6 +738,13 @@ All cron routes authenticate with a shared `CRON_SECRET` (header
 
 ### Deletion semantics
 - **Soft delete:** `schedule_sessions.deleted_at`, `care_referrals.deleted_at`.
+- **Children are not deleted (SPE-347).** `children` has no DELETE policy and no
+  DELETE grant, and nothing cascades into it — so deleting a provider (which
+  cascades away their `students` rows) no longer destroys the child record.
+  The unfinished half: a child whose last caseload row is gone has no link for
+  RLS to reach it by, so it is retained but invisible to non-service callers,
+  and the admin "delete student" flow above does not yet consider whether the
+  child should go with it. Both are on the cross-provider read-switch step.
 - **Hard delete (admin "delete student"):**
   `app/api/admin/students/[studentId]` runs the row delete under the **admin's
   own RLS session** (keeps the DB authz backstop), cascades FK children, then

--- a/docs/SIM_DISTRICT.md
+++ b/docs/SIM_DISTRICT.md
@@ -272,6 +272,18 @@ Field conventions:
 
 - `initials` only in `students` (as the model intends); fictional full names +
   DOBs live in `student_details` with `-Sim` surnames.
+- **One `children` row per child (SPE-347), 200 for 202 caseload rows.** A
+  `students` row is one provider's caseload entry; the child it serves is the
+  `children` row it points at. The "same child" quirk above is what makes the
+  two numbers differ: Tomás's first two Willow students share Rachel's two
+  children (`childKey()` in the manifest), so the fixture models a co-served
+  child the way the schema now means it. `TOTAL_CHILDREN` derives from the same
+  function the seed uses, so the count cannot drift from the rule.
+  One collision is deliberately **not** shared: Tomás and Hannah each carry a
+  grade-7 `HL` at Cedar with the same teacher, which the SPE-255/290 matcher
+  also calls one child. It is an artifact of the initials generator rather than
+  a designed pair, so it stays two children — negative space for SPE-348's
+  create-or-attach step, which must cope with exactly that shape.
 - Both scoping systems set on every row: legacy text (`school_site`,
   `school_district`) **and** structured FKs (`school_id`, `district_id`,
   `state_id`), plus `teacher_name` text **and** `teacher_id` FK — mirroring

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "sim:reset": "tsx scripts/sim-district/seed.ts",
     "sim:teardown": "tsx scripts/sim-district/teardown.ts",
     "sim:verify": "tsx scripts/sim-district/verify.ts",
-    "sim:verify-rls": "tsx scripts/sim-district/verify-profiles-rls.ts"
+    "sim:verify-rls": "tsx scripts/sim-district/verify-profiles-rls.ts",
+    "sim:verify-children-rls": "tsx scripts/sim-district/verify-children-rls.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -273,6 +273,40 @@ export function studentInitials(providerKey: string, schoolId: string, index: nu
   return String.fromCharCode(65 + (seed[0] % 26)) + String.fromCharCode(65 + (seed[1] % 26));
 }
 
+/**
+ * SPE-347 — the child a caseload row serves.
+ *
+ * `students` rows are per-provider caseload rows; `children` rows are children.
+ * The fixture's "same child on two caseloads" quirk (spec §6) therefore has to
+ * resolve to ONE children row: Tomás's first two Willow students are the same
+ * two kids as Rachel's first two, so they share her child key — the same
+ * mirroring rule studentInitials / studentFullName / studentGrade already use.
+ *
+ * Known non-quirk collision, deliberately NOT shared: Tomás and Hannah each
+ * carry a grade-7 "HL" at Cedar with the same teacher, which the SPE-255/290
+ * matcher also calls one child. That is an artifact of the initials generator,
+ * not a designed pair, so the fixture leaves it as two children — useful
+ * negative space for SPE-348's create-or-attach step, which has to cope with
+ * exactly that shape.
+ */
+export function childKey(providerKey: string, schoolId: string, index: number): string {
+  if (providerKey === 'tomas' && schoolId === WILLOW && index < 2) {
+    return childKey('rachel', WILLOW, index);
+  }
+  return `child:${providerKey}:${schoolId}:${index}`;
+}
+
+export function childId(providerKey: string, schoolId: string, index: number): string {
+  return simUuid(childKey(providerKey, schoolId, index));
+}
+
+/** Distinct children across every caseload — students minus the shared pairs. */
+export const TOTAL_CHILDREN = new Set(
+  CASELOADS.flatMap(rule =>
+    Array.from({ length: rule.count }, (_, i) => childKey(rule.providerKey, rule.schoolId, i)),
+  ),
+).size;
+
 export function studentGrade(rule: CaseloadRule, index: number): string {
   if (rule.providerKey === 'tomas' && rule.schoolId === WILLOW && index < 2) {
     return studentGrade({ providerKey: 'rachel', schoolId: WILLOW, count: 28, serviceType: 'resource' }, index);
@@ -593,7 +627,10 @@ export function careHistoryId(key: string, status: string): string {
 /** Tables seed.ts plants rows in (all rows manifest-keyed). Teardown order = reverse-ish, children first. */
 export const SEEDED_TABLES = [
   'districts', 'schools', 'profiles', 'admin_permissions', 'provider_schools',
-  'user_site_schedules', 'teachers', 'students', 'student_details',
+  // `children` is a PARENT of students (students.child_id), so it seeds before
+  // them and tears down after them — the one entry here whose order is the
+  // reverse of the rest (SPE-347).
+  'user_site_schedules', 'teachers', 'children', 'students', 'student_details',
   'bell_schedules', 'school_hours', 'special_activities',
   'session_groups', 'schedule_sessions',
   'attendance', 'care_referrals', 'care_cases', 'care_meeting_notes',

--- a/scripts/sim-district/seed.ts
+++ b/scripts/sim-district/seed.ts
@@ -41,6 +41,7 @@ import {
   careHistoryId,
   careNoteId,
   careReferralId,
+  childId,
   derivePassword,
   groupAssignmentFor,
   personaEmail,
@@ -254,8 +255,15 @@ async function main() {
   }
   counts['teachers'] = await bulkInsert(admin, 'teachers', teacherRows);
 
-  // ---- Students + details --------------------------------------------------
-  console.log('Step 6/9: students + student_details...');
+  // ---- Children + students + details ---------------------------------------
+  // SPE-347: `children` is the child record, `students` the per-provider
+  // caseload row. Children are inserted FIRST (students.child_id is an FK) and
+  // the two shared pairs resolve to ONE children row each via childKey(), so
+  // the fixture models a co-served child the way the schema now means it.
+  // Setting child_id explicitly also keeps the auto-create trigger out of the
+  // way: it only fires when child_id arrives NULL.
+  console.log('Step 6/9: children + students + student_details...');
+  const childRows = new Map<string, Record<string, unknown>>();
   const studentRows: Record<string, unknown>[] = [];
   const detailRows: Record<string, unknown>[] = [];
   for (const rule of CASELOADS) {
@@ -266,8 +274,34 @@ async function main() {
       const grade = studentGrade(rule, i);
       const mix = sessionMix(i);
       const teacher = studentTeacher(rule, i);
+      const childUuid = childId(rule.providerKey, rule.schoolId, i);
+      const name = studentFullName(rule.providerKey, rule.schoolId, i);
+      const gradeNum = grade === 'K' ? 0 : parseInt(grade, 10);
+      const hasDetails = i < nDetails;
+      // First writer wins for a shared child. CASELOADS lists Rachel before
+      // Tomás, so the canonical (Rachel) row supplies the child's facts; the
+      // mirror rows derive identical values anyway.
+      if (!childRows.has(childUuid)) {
+        childRows.set(childUuid, {
+          id: childUuid,
+          first_name: hasDetails ? name.firstName : null,
+          last_name: hasDetails ? name.lastName : null,
+          date_of_birth: hasDetails ? `${seedDate.getUTCFullYear() - 6 - gradeNum}-0${(i % 9) + 1}-1${i % 9}` : null,
+          initials: studentInitials(rule.providerKey, rule.schoolId, i),
+          grade_level: grade,
+          school_id: school.id,
+          district_id: DISTRICT.id,
+          state_id: DISTRICT.state_id,
+          upcoming_iep_date: hasDetails ? addDays(seedDate, (i * 17) % 300 + 7) : null,
+          upcoming_triennial_date: hasDetails ? addDays(seedDate, (i * 37) % 900 + 30) : null,
+          accommodations: hasDetails
+            ? [ACCOMMODATION_BANK[i % ACCOMMODATION_BANK.length], ACCOMMODATION_BANK[(i + 1) % ACCOMMODATION_BANK.length]]
+            : [],
+        });
+      }
       studentRows.push({
         id,
+        child_id: childUuid,
         provider_id: userIds.get(rule.providerKey)!,
         initials: studentInitials(rule.providerKey, rule.schoolId, i),
         grade_level: grade,
@@ -281,9 +315,7 @@ async function main() {
         district_id: DISTRICT.id,
         school_id: school.id,
       });
-      if (i < nDetails) {
-        const name = studentFullName(rule.providerKey, rule.schoolId, i);
-        const gradeNum = grade === 'K' ? 0 : parseInt(grade, 10);
+      if (hasDetails) {
         detailRows.push({
           id: studentDetailsId(id),
           student_id: id,
@@ -306,6 +338,7 @@ async function main() {
       }
     }
   }
+  counts['children'] = await bulkInsert(admin, 'children', [...childRows.values()]);
   counts['students'] = await bulkInsert(admin, 'students', studentRows);
   counts['student_details'] = await bulkInsert(admin, 'student_details', detailRows);
 

--- a/scripts/sim-district/seed.ts
+++ b/scripts/sim-district/seed.ts
@@ -278,10 +278,14 @@ async function main() {
       const name = studentFullName(rule.providerKey, rule.schoolId, i);
       const gradeNum = grade === 'K' ? 0 : parseInt(grade, 10);
       const hasDetails = i < nDetails;
-      // First writer wins for a shared child. CASELOADS lists Rachel before
-      // Tomás, so the canonical (Rachel) row supplies the child's facts; the
-      // mirror rows derive identical values anyway.
-      if (!childRows.has(childUuid)) {
+      // First writer wins for a shared child — but a writer that HAS details
+      // beats one that doesn't, so the child never ends up with a NULL name just
+      // because CASELOADS happens to list a detail-less caseload first. (Today
+      // Rachel precedes Tomás and her detail window covers the aliased indices,
+      // so the canonical row wins on both counts; this keeps that true if either
+      // fact changes.) The mirror rows derive identical values anyway.
+      const seeded = childRows.get(childUuid);
+      if (!seeded || (hasDetails && !seeded.first_name)) {
         childRows.set(childUuid, {
           id: childUuid,
           first_name: hasDetails ? name.firstName : null,

--- a/scripts/sim-district/teardown.ts
+++ b/scripts/sim-district/teardown.ts
@@ -43,11 +43,16 @@ export async function teardown(admin: Admin): Promise<Record<string, number>> {
     if (error) throw new Error(`student lookup by school failed: ${error.message}`);
     for (const row of data ?? []) { studentIds.add(row.id); if (row.child_id) childIds.add(row.child_id); }
   }
-  {
-    // Also sweep by school, so a child orphaned by a half-failed prior teardown
-    // (its students already gone) is still cleaned up — teardown is idempotent.
-    const { data, error } = await admin.from('children').select('id').in('school_id', SIM_SCHOOL_IDS);
-    if (error) throw new Error(`children lookup by school failed: ${error.message}`);
+  // Also sweep by school AND by district, so a child orphaned by a half-failed
+  // prior teardown (its students already gone) is still cleaned up — teardown is
+  // idempotent. Both keys are needed: `students.school_id` is nullable, so a
+  // child created from such a row carries the district but no school.
+  for (const [column, values] of [
+    ['school_id', SIM_SCHOOL_IDS],
+    ['district_id', [DISTRICT.id]],
+  ] as const) {
+    const { data, error } = await admin.from('children').select('id').in(column, values as string[]);
+    if (error) throw new Error(`children lookup by ${column} failed: ${error.message}`);
     for (const row of data ?? []) childIds.add(row.id);
   }
   const simStudentIds = [...studentIds];

--- a/scripts/sim-district/teardown.ts
+++ b/scripts/sim-district/teardown.ts
@@ -26,19 +26,32 @@ export async function teardown(admin: Admin): Promise<Record<string, number>> {
   const simUsersByEmail = await resolveSimAuthUsers(admin);
   const simUserIds = [...simUsersByEmail.values()];
 
-  // Collect sim student ids (owned by sim providers OR scoped to sim schools).
+  // Collect sim student ids (owned by sim providers OR scoped to sim schools),
+  // and the children they link to (SPE-347). `children` is a PARENT of students
+  // and has no cascade path from profiles/students — that is the point of the
+  // table (a child outlives provider offboarding) — so teardown has to delete
+  // it explicitly, AFTER the students that reference it.
   const studentIds = new Set<string>();
+  const childIds = new Set<string>();
   if (simUserIds.length > 0) {
-    const { data, error } = await admin.from('students').select('id').in('provider_id', simUserIds);
+    const { data, error } = await admin.from('students').select('id, child_id').in('provider_id', simUserIds);
     if (error) throw new Error(`student lookup by provider failed: ${error.message}`);
-    for (const row of data ?? []) studentIds.add(row.id);
+    for (const row of data ?? []) { studentIds.add(row.id); if (row.child_id) childIds.add(row.child_id); }
   }
   {
-    const { data, error } = await admin.from('students').select('id').in('school_id', SIM_SCHOOL_IDS);
+    const { data, error } = await admin.from('students').select('id, child_id').in('school_id', SIM_SCHOOL_IDS);
     if (error) throw new Error(`student lookup by school failed: ${error.message}`);
-    for (const row of data ?? []) studentIds.add(row.id);
+    for (const row of data ?? []) { studentIds.add(row.id); if (row.child_id) childIds.add(row.child_id); }
+  }
+  {
+    // Also sweep by school, so a child orphaned by a half-failed prior teardown
+    // (its students already gone) is still cleaned up — teardown is idempotent.
+    const { data, error } = await admin.from('children').select('id').in('school_id', SIM_SCHOOL_IDS);
+    if (error) throw new Error(`children lookup by school failed: ${error.message}`);
+    for (const row of data ?? []) childIds.add(row.id);
   }
   const simStudentIds = [...studentIds];
+  const simChildIds = [...childIds];
 
   // 1. Leaf data keyed to students/providers.
   deleted['attendance'] = await deleteWhereIn(admin, 'attendance', 'student_id', simStudentIds);
@@ -81,9 +94,10 @@ export async function teardown(admin: Admin): Promise<Record<string, number>> {
     admin, 'care_referrals', 'school_id', SIM_SCHOOL_IDS,
   );
 
-  // 5. Students and their detail rows.
+  // 5. Students and their detail rows, then the children they pointed at.
   deleted['student_details'] = await deleteWhereIn(admin, 'student_details', 'student_id', simStudentIds);
   deleted['students'] = await deleteWhereIn(admin, 'students', 'id', simStudentIds);
+  deleted['children'] = await deleteWhereIn(admin, 'children', 'id', simChildIds);
 
   // 6. Teachers, permissions, school assignments.
   deleted['teachers'] = await deleteWhereIn(admin, 'teachers', 'school_id', SIM_SCHOOL_IDS);

--- a/scripts/sim-district/verify-children-rls.ts
+++ b/scripts/sim-district/verify-children-rls.ts
@@ -1,0 +1,231 @@
+/**
+ * SPE-347 — `children` RLS + child-link guard, run with REAL signed-in sessions.
+ *
+ * Same reason this is a script and not a jest test as its sibling
+ * verify-profiles-rls.ts: our unit tests mock the Supabase client, so they
+ * cannot see RLS at all — they pass identically whether a policy permits a
+ * write or denies every one. A `children` table whose whole point is
+ * cross-provider access is exactly the kind of change that blind spot hides.
+ *
+ * The contract asserted here:
+ *   - a provider with a caseload row reads, and may edit, that child;
+ *   - BOTH providers of a co-served child resolve to the SAME children row;
+ *   - every non-owner who can read the STUDENT can read its CHILD (teacher,
+ *     SEA, site admin) but may NOT write it;
+ *   - an unlinked provider gets 0 rows on SELECT and 0 rows affected on UPDATE;
+ *   - nobody can INSERT or DELETE a children row directly;
+ *   - `students.child_id` cannot be set or moved by an end-user session, while
+ *     an ordinary insert still auto-links and the dual-write still mirrors.
+ *
+ * Three traps this deliberately avoids (CLAUDE.md):
+ *   - assert the write PERSISTED, not the HTTP status — PostgREST reports an
+ *     RLS-filtered UPDATE as a 2xx with an empty body;
+ *   - assert WHY a refusal happened (SQLSTATE / rows affected), so a value
+ *     rejected incidentally cannot keep a negative check green;
+ *   - negative checks use a value the target does NOT already carry, and read
+ *     back with the service client.
+ *
+ * Requires a seeded sim district (`npm run sim:reset -- --yes`). It edits sim
+ * children, so re-seed afterwards to restore a pristine fixture.
+ *
+ * Usage: npm run sim:verify-children-rls
+ */
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createAdmin, requireEnv } from './lib';
+import { CEDAR, WILLOW, derivePassword, personaEmail } from './manifest';
+
+const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+const secret = requireEnv('SIM_DISTRICT_PASSWORD');
+
+const admin = createAdmin();
+
+let failures = 0;
+function check(ok: boolean, label: string, detail = ''): void {
+  if (!ok) failures++;
+  console.log(`  [${ok ? 'ok  ' : 'FAIL'}] ${label.padEnd(58)} ${detail}`);
+}
+
+async function signIn(personaKey: string): Promise<SupabaseClient> {
+  const email = personaEmail(personaKey);
+  const client = createClient(url, anon, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: derivePassword(secret, email),
+  });
+  if (error) throw new Error(`sim login failed for ${email} — is the district seeded? (${error.message})`);
+  return client;
+}
+
+async function profileId(personaKey: string): Promise<string> {
+  const { data, error } = await admin
+    .from('profiles').select('id').eq('email', personaEmail(personaKey)).single();
+  if (error) throw new Error(`profile lookup failed for ${personaKey}: ${error.message}`);
+  return data.id as string;
+}
+
+async function childFirstName(childId: string): Promise<string | null> {
+  const { data, error } = await admin
+    .from('children').select('first_name').eq('id', childId).single();
+  if (error) throw new Error(`child readback failed: ${error.message}`);
+  return data.first_name as string | null;
+}
+
+async function main(): Promise<void> {
+  // The fixture's co-served child: Tomás's first Willow student IS Rachel's
+  // first (manifest childKey()). Resolve it from the data rather than assuming.
+  const rachelId = await profileId('rachel');
+  const tomasId = await profileId('tomas');
+  const { data: rachelRows, error: rErr } = await admin
+    .from('students').select('id, child_id').eq('provider_id', rachelId).eq('school_id', WILLOW);
+  if (rErr) throw new Error(`caseload lookup failed: ${rErr.message}`);
+  const { data: tomasRows } = await admin
+    .from('students').select('child_id').eq('provider_id', tomasId).eq('school_id', WILLOW);
+  const tomasChildren = new Set((tomasRows ?? []).map(r => r.child_id));
+  const shared = (rachelRows ?? []).find(r => tomasChildren.has(r.child_id));
+  if (!shared) throw new Error('no co-served child in the fixture — has the seed changed?');
+  const sharedChildId = shared.child_id as string;
+
+  const { data: cedar } = await admin
+    .from('students').select('child_id').eq('school_id', CEDAR).limit(1).single();
+  const otherChildId = cedar!.child_id as string;
+
+  const rachel = await signIn('rachel');
+  const tomas = await signIn('tomas');
+  const alicia = await signIn('alicia');
+
+  console.log('linked provider (must read + write):');
+  {
+    const { data, error } = await rachel.from('children').select('id');
+    check(!error && (data?.length ?? 0) === (rachelRows ?? []).length,
+      'reads exactly the children of their caseload',
+      `${data?.length} children / ${(rachelRows ?? []).length} caseload rows`);
+
+    const stamp = `spe347-rachel-${Date.now()}`;
+    const { data: rows } = await rachel.from('children')
+      .update({ first_name: stamp }).eq('id', sharedChildId).select('id');
+    // Rows affected AND a readback: a 2xx alone proves nothing.
+    check((rows?.length ?? 0) === 1 && (await childFirstName(sharedChildId)) === stamp,
+      'linked provider EDIT persists', `${rows?.length ?? 0} row(s)`);
+  }
+
+  console.log('co-serving provider (the point of the table):');
+  {
+    const { data } = await tomas.from('children').select('id').eq('id', sharedChildId);
+    check((data?.length ?? 0) === 1, 'both providers resolve to the SAME children row', sharedChildId);
+
+    const stamp = `spe347-tomas-${Date.now()}`;
+    await tomas.from('children').update({ first_name: stamp }).eq('id', sharedChildId);
+    check((await childFirstName(sharedChildId)) === stamp,
+      'co-provider EDIT of the shared child persists');
+  }
+
+  console.log('unlinked provider (must be refused):');
+  {
+    const { count, error } = await alicia.from('children')
+      .select('id', { count: 'exact', head: true }).eq('id', sharedChildId);
+    check(!error && count === 0, 'SELECT returns 0 rows', `count=${count}`);
+
+    // Negative write against a value the row does NOT already carry, so a no-op
+    // patch cannot pass for the wrong reason.
+    const before = await childFirstName(sharedChildId);
+    const forbidden = `spe347-alicia-${Date.now()}`;
+    const { data: rows, status } = await alicia.from('children')
+      .update({ first_name: forbidden }).eq('id', sharedChildId).select('id');
+    const after = await childFirstName(sharedChildId);
+    check((rows?.length ?? 0) === 0, 'UPDATE affects 0 rows', `HTTP ${status}, ${rows?.length ?? 0} row(s)`);
+    check(after === before && after !== forbidden, 'UPDATE did not persist', `stored=${after}`);
+
+    const { error: insErr } = await alicia.from('children')
+      .insert({ initials: 'XX', grade_level: '1' });
+    check(insErr?.code === '42501', 'direct INSERT is refused', `code=${insErr?.code}`);
+
+    const { error: delErr, data: delRows } = await alicia.from('children')
+      .delete().eq('id', sharedChildId).select('id');
+    check(delErr?.code === '42501' || (delRows?.length ?? 0) === 0,
+      'direct DELETE is refused', `code=${delErr?.code ?? 'none'} rows=${delRows?.length ?? 0}`);
+  }
+
+  console.log('non-owner read paths (must read, must not write):');
+  for (const [key, label] of [
+    ['nora', 'teacher of the student'],
+    ['leah', 'SEA at the school'],
+    ['priya', 'site admin for the school'],
+  ] as const) {
+    const client = await signIn(key);
+    const { count: children } = await client.from('children').select('*', { count: 'exact', head: true });
+    const { count: students } = await client.from('students').select('*', { count: 'exact', head: true });
+    // The contract is "nobody who can see a student is blind to its child".
+    // children <= students because co-served students collapse to one child.
+    check((students ?? 0) > 0 && (children ?? 0) > 0 && (children ?? 0) <= (students ?? 0),
+      `${label} can read children`, `children=${children} students=${students}`);
+
+    const before = await childFirstName(sharedChildId);
+    const forbidden = `spe347-${key}-${Date.now()}`;
+    const { data: rows } = await client.from('children')
+      .update({ first_name: forbidden }).eq('id', sharedChildId).select('id');
+    check((rows?.length ?? 0) === 0 && (await childFirstName(sharedChildId)) === before,
+      `${label} cannot write a child`, `${rows?.length ?? 0} row(s)`);
+  }
+
+  console.log('students.child_id is managed by the database:');
+  {
+    const { error } = await rachel.from('students').insert({
+      provider_id: rachelId, initials: 'QZ', grade_level: '3',
+      school_id: WILLOW, district_id: 'SIM-D001', state_id: 'CA',
+      child_id: otherChildId,
+    });
+    check(error?.code === '42501', 'INSERT that sets child_id is refused', `code=${error?.code}`);
+
+    const own = (rachelRows ?? [])[0]!;
+    const { error: updErr } = await rachel.from('students')
+      .update({ child_id: otherChildId }).eq('id', own.id);
+    const { data: still } = await admin.from('students').select('child_id').eq('id', own.id).single();
+    check(updErr?.code === '42501' && still?.child_id === own.child_id,
+      'UPDATE that moves child_id is refused', `code=${updErr?.code}`);
+  }
+
+  console.log('auto-create + dual-write, through a real session:');
+  {
+    const { data: created, error } = await rachel.from('students').insert({
+      provider_id: rachelId, initials: 'QY', grade_level: '3',
+      school_id: WILLOW, district_id: 'SIM-D001', state_id: 'CA',
+    }).select('id, child_id').single();
+    check(!error && !!created?.child_id, 'ordinary INSERT still works and auto-links',
+      error ? error.message : `child=${created?.child_id}`);
+
+    if (created) {
+      await rachel.from('students').update({ grade_level: '4' }).eq('id', created.id);
+      const { data: mirrored } = await admin.from('children')
+        .select('grade_level').eq('id', created.child_id).single();
+      check(mirrored?.grade_level === '4', 'students UPDATE mirrors onto the child',
+        `grade=${mirrored?.grade_level}`);
+
+      await rachel.from('student_details').insert({
+        student_id: created.id, first_name: 'Probe', last_name: 'Child-Sim',
+        date_of_birth: '2017-04-04',
+      });
+      const { data: named } = await admin.from('children')
+        .select('first_name, last_name, date_of_birth').eq('id', created.child_id).single();
+      check(named?.first_name === 'Probe' && named?.date_of_birth === '2017-04-04',
+        'student_details write mirrors onto the child', JSON.stringify(named));
+
+      await admin.from('students').delete().eq('id', created.id);
+      await admin.from('children').delete().eq('id', created.child_id);
+    }
+  }
+
+  if (failures === 0) {
+    console.log('\nAll checks passed. Re-seed (npm run sim:reset -- --yes) to restore the fixture.');
+  } else {
+    console.log(`\n${failures} check(s) failed.`);
+  }
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/sim-district/verify-children-rls.ts
+++ b/scripts/sim-district/verify-children-rls.ts
@@ -170,6 +170,45 @@ async function main(): Promise<void> {
       `${label} cannot write a child`, `${rows?.length ?? 0} row(s)`);
   }
 
+  // Deliberate, documented asymmetry (SPE-347 hardening §5): the mirrors are
+  // SECURITY DEFINER and authorize nothing — the SOURCE table's policy is the
+  // gate. `student_details`'s UPDATE policy has an SEA branch with no column
+  // restriction, so an SEA CAN change a child's name through student_details
+  // even though children_update refuses them a direct write. Not a new
+  // capability (they can already write those columns today) and invisible while
+  // nothing reads `children`, but it becomes user-visible at the cross-provider
+  // read switch. Pinned here so it cannot change unnoticed.
+  console.log('mirror authorization is the SOURCE table\'s, not children_update:');
+  {
+    const leahId = await profileId('leah');
+    const { data: delegated } = await admin
+      .from('schedule_sessions').select('student_id').eq('assigned_to_sea_id', leahId).limit(50);
+    const candidates = [...new Set((delegated ?? []).map(r => r.student_id))];
+    const { data: withDetails } = await admin
+      .from('student_details').select('student_id').in('student_id', candidates.slice(0, 50)).limit(1);
+    const target = withDetails?.[0]?.student_id as string | undefined;
+
+    if (!target) {
+      check(false, 'found an SEA-delegated student with details', 'none in the fixture');
+    } else {
+      const { data: link } = await admin.from('students').select('child_id').eq('id', target).single();
+      const leah = await signIn('leah');
+      const before = await childFirstName(link!.child_id as string);
+      const stamp = `spe347-sea-${Date.now()}`;
+
+      const { data: direct } = await leah.from('children')
+        .update({ first_name: stamp }).eq('id', link!.child_id).select('id');
+      check((direct?.length ?? 0) === 0 && (await childFirstName(link!.child_id as string)) === before,
+        'SEA cannot write the child DIRECTLY', `${direct?.length ?? 0} row(s)`);
+
+      const { data: viaDetails } = await leah.from('student_details')
+        .update({ first_name: stamp }).eq('student_id', target).select('student_id');
+      check((viaDetails?.length ?? 0) === 1 && (await childFirstName(link!.child_id as string)) === stamp,
+        'SEA CAN write it through student_details (known, documented)',
+        `${viaDetails?.length ?? 0} row(s)`);
+    }
+  }
+
   console.log('students.child_id is managed by the database:');
   {
     const { error } = await rachel.from('students').insert({
@@ -185,6 +224,57 @@ async function main(): Promise<void> {
     const { data: still } = await admin.from('students').select('child_id').eq('id', own.id).single();
     check(updErr?.code === '42501' && still?.child_id === own.child_id,
       'UPDATE that moves child_id is refused', `code=${updErr?.code}`);
+  }
+
+  // Regression test for the escalation the deep self-review caught before merge:
+  // the first cut of students_child_link() ATTACHED a new caseload row to an
+  // existing child when (district_id, district_student_id) matched. Both columns
+  // are client-supplied and unconstrained, so any provider could link themselves
+  // to any child in any district and read/overwrite its name and DOB. The
+  // trigger now never attaches — it creates its own child, dropping the
+  // contested id — while the insert that the attach existed to protect still
+  // succeeds.
+  console.log('a claimed district student id cannot borrow another child:');
+  {
+    const aliciaId = await profileId('alicia');
+    const claimedId = `SPE347-PROBE-${Date.now()}`;
+    const { data: victim } = await rachel.from('students').insert({
+      provider_id: rachelId, initials: 'QV', grade_level: '3',
+      school_id: WILLOW, district_id: 'SIM-D001', state_id: 'CA',
+      district_student_id: claimedId,
+    }).select('id, child_id').single();
+
+    const { data: victimChild } = await admin.from('children')
+      .select('district_student_id').eq('id', victim!.child_id).single();
+    check(victimChild?.district_student_id === claimedId,
+      'the first row to claim an id keeps it', `${victimChild?.district_student_id}`);
+
+    // Alicia is at MAPLE and has no relationship to this child.
+    const { data: attacker, error: attackErr } = await alicia.from('students').insert({
+      provider_id: aliciaId, initials: 'QV', grade_level: '3',
+      school_id: 'SIM-S002', district_id: 'SIM-D001', state_id: 'CA',
+      district_student_id: claimedId,
+    }).select('id, child_id').single();
+
+    check(!attackErr && !!attacker?.child_id,
+      'a second provider claiming the same id still imports fine',
+      attackErr ? attackErr.message : 'inserted');
+    check(attacker?.child_id !== victim!.child_id,
+      'it does NOT borrow the first child', `${attacker?.child_id} vs ${victim!.child_id}`);
+
+    const { count: canSee } = await alicia.from('children')
+      .select('*', { count: 'exact', head: true }).eq('id', victim!.child_id);
+    check(canSee === 0, 'and gains no access to it', `count=${canSee}`);
+
+    const { data: theirChild } = await admin.from('children')
+      .select('district_student_id').eq('id', attacker!.child_id).single();
+    check(theirChild?.district_student_id === null,
+      'their own child is created WITHOUT the contested id', `${theirChild?.district_student_id}`);
+
+    for (const row of [victim!, attacker!]) {
+      await admin.from('students').delete().eq('id', row.id);
+      await admin.from('children').delete().eq('id', row.child_id);
+    }
   }
 
   console.log('auto-create + dual-write, through a real session:');

--- a/scripts/sim-district/verify-children-rls.ts
+++ b/scripts/sim-district/verify-children-rls.ts
@@ -81,16 +81,18 @@ async function main(): Promise<void> {
   const { data: rachelRows, error: rErr } = await admin
     .from('students').select('id, child_id').eq('provider_id', rachelId).eq('school_id', WILLOW);
   if (rErr) throw new Error(`caseload lookup failed: ${rErr.message}`);
-  const { data: tomasRows } = await admin
+  const { data: tomasRows, error: tErr } = await admin
     .from('students').select('child_id').eq('provider_id', tomasId).eq('school_id', WILLOW);
+  if (tErr) throw new Error(`Tomás caseload lookup failed: ${tErr.message}`);
   const tomasChildren = new Set((tomasRows ?? []).map(r => r.child_id));
   const shared = (rachelRows ?? []).find(r => tomasChildren.has(r.child_id));
   if (!shared) throw new Error('no co-served child in the fixture — has the seed changed?');
   const sharedChildId = shared.child_id as string;
 
-  const { data: cedar } = await admin
+  const { data: cedar, error: cErr } = await admin
     .from('students').select('child_id').eq('school_id', CEDAR).limit(1).single();
-  const otherChildId = cedar!.child_id as string;
+  if (cErr) throw new Error(`Cedar caseload lookup failed: ${cErr.message}`);
+  const otherChildId = cedar.child_id as string;
 
   const rachel = await signIn('rachel');
   const tomas = await signIn('tomas');
@@ -138,8 +140,11 @@ async function main(): Promise<void> {
     check((rows?.length ?? 0) === 0, 'UPDATE affects 0 rows', `HTTP ${status}, ${rows?.length ?? 0} row(s)`);
     check(after === before && after !== forbidden, 'UPDATE did not persist', `stored=${after}`);
 
+    // Fully-populated row on purpose: if `children` ever gains a NOT NULL, a
+    // sparse insert could fail with 23502 and this check would pass for a reason
+    // that has nothing to do with the grant it is testing.
     const { error: insErr } = await alicia.from('children')
-      .insert({ initials: 'XX', grade_level: '1' });
+      .insert({ initials: 'XX', grade_level: '1', school_id: WILLOW, district_id: 'SIM-D001', state_id: 'CA' });
     check(insErr?.code === '42501', 'direct INSERT is refused', `code=${insErr?.code}`);
 
     const { error: delErr, data: delRows } = await alicia.from('children')
@@ -191,19 +196,21 @@ async function main(): Promise<void> {
     if (!target) {
       check(false, 'found an SEA-delegated student with details', 'none in the fixture');
     } else {
-      const { data: link } = await admin.from('students').select('child_id').eq('id', target).single();
+      const { data: link, error: linkErr } = await admin
+        .from('students').select('child_id').eq('id', target).single();
+      if (linkErr) throw new Error(`child link lookup failed for ${target}: ${linkErr.message}`);
       const leah = await signIn('leah');
-      const before = await childFirstName(link!.child_id as string);
+      const before = await childFirstName(link.child_id as string);
       const stamp = `spe347-sea-${Date.now()}`;
 
       const { data: direct } = await leah.from('children')
-        .update({ first_name: stamp }).eq('id', link!.child_id).select('id');
-      check((direct?.length ?? 0) === 0 && (await childFirstName(link!.child_id as string)) === before,
+        .update({ first_name: stamp }).eq('id', link.child_id).select('id');
+      check((direct?.length ?? 0) === 0 && (await childFirstName(link.child_id as string)) === before,
         'SEA cannot write the child DIRECTLY', `${direct?.length ?? 0} row(s)`);
 
       const { data: viaDetails } = await leah.from('student_details')
         .update({ first_name: stamp }).eq('student_id', target).select('student_id');
-      check((viaDetails?.length ?? 0) === 1 && (await childFirstName(link!.child_id as string)) === stamp,
+      check((viaDetails?.length ?? 0) === 1 && (await childFirstName(link.child_id as string)) === stamp,
         'SEA CAN write it through student_details (known, documented)',
         `${viaDetails?.length ?? 0} row(s)`);
     }
@@ -238,14 +245,15 @@ async function main(): Promise<void> {
   {
     const aliciaId = await profileId('alicia');
     const claimedId = `SPE347-PROBE-${Date.now()}`;
-    const { data: victim } = await rachel.from('students').insert({
+    const { data: victim, error: vErr } = await rachel.from('students').insert({
       provider_id: rachelId, initials: 'QV', grade_level: '3',
       school_id: WILLOW, district_id: 'SIM-D001', state_id: 'CA',
       district_student_id: claimedId,
     }).select('id, child_id').single();
+    if (vErr || !victim) throw new Error(`could not seed the id-claim fixture: ${vErr?.message}`);
 
     const { data: victimChild } = await admin.from('children')
-      .select('district_student_id').eq('id', victim!.child_id).single();
+      .select('district_student_id').eq('id', victim.child_id).single();
     check(victimChild?.district_student_id === claimedId,
       'the first row to claim an id keeps it', `${victimChild?.district_student_id}`);
 
@@ -259,21 +267,21 @@ async function main(): Promise<void> {
     check(!attackErr && !!attacker?.child_id,
       'a second provider claiming the same id still imports fine',
       attackErr ? attackErr.message : 'inserted');
-    check(attacker?.child_id !== victim!.child_id,
-      'it does NOT borrow the first child', `${attacker?.child_id} vs ${victim!.child_id}`);
+    check(attacker?.child_id !== victim.child_id,
+      'it does NOT borrow the first child', `${attacker?.child_id} vs ${victim.child_id}`);
 
     const { count: canSee } = await alicia.from('children')
-      .select('*', { count: 'exact', head: true }).eq('id', victim!.child_id);
+      .select('*', { count: 'exact', head: true }).eq('id', victim.child_id);
     check(canSee === 0, 'and gains no access to it', `count=${canSee}`);
 
     const { data: theirChild } = await admin.from('children')
-      .select('district_student_id').eq('id', attacker!.child_id).single();
+      .select('district_student_id').eq('id', attacker?.child_id).single();
     check(theirChild?.district_student_id === null,
       'their own child is created WITHOUT the contested id', `${theirChild?.district_student_id}`);
 
-    for (const row of [victim!, attacker!]) {
-      await admin.from('students').delete().eq('id', row.id);
-      await admin.from('children').delete().eq('id', row.child_id);
+    for (const row of [victim, attacker].filter(Boolean)) {
+      await admin.from('students').delete().eq('id', row!.id);
+      await admin.from('children').delete().eq('id', row!.child_id);
     }
   }
 

--- a/scripts/sim-district/verify.ts
+++ b/scripts/sim-district/verify.ts
@@ -21,6 +21,7 @@ import {
   SEEDED_TABLES,
   SESSION_GROUPS,
   SWEPT_TABLES,
+  TOTAL_CHILDREN,
   TOTAL_STUDENTS,
   careCaseId,
 } from './manifest';
@@ -59,6 +60,35 @@ async function collectCounts(admin: Admin) {
     for (const row of data ?? []) studentIds.add(row.id);
   }
   const simStudentIds = [...studentIds];
+
+  // SPE-347: the children those caseload rows serve. Collected the same two
+  // ways as students (via the link, and by sim school so an orphan would still
+  // be counted rather than silently ignored by the orphan scan).
+  const childIds = new Set<string>();
+  if (simStudentIds.length > 0) {
+    const { data, error } = await admin.from('students').select('child_id').in('id', simStudentIds);
+    if (error) throw new Error(`child link scan failed: ${error.message}`);
+    for (const row of data ?? []) if (row.child_id) childIds.add(row.child_id);
+  }
+  {
+    const { data, error } = await admin.from('children').select('id').in('school_id', SIM_SCHOOL_IDS);
+    if (error) throw new Error(`children scan by school failed: ${error.message}`);
+    for (const row of data ?? []) childIds.add(row.id);
+  }
+  const simChildIds = [...childIds];
+
+  // Unlinked caseload rows would mean the auto-create trigger did not fire.
+  let unlinkedStudents = 0;
+  if (simStudentIds.length > 0) {
+    const { count, error } = await admin
+      .from('students')
+      .select('*', { count: 'exact', head: true })
+      .in('id', simStudentIds)
+      .is('child_id', null);
+    if (error) throw new Error(`unlinked student scan failed: ${error.message}`);
+    unlinkedStudents = count ?? 0;
+  }
+
   const careCaseIds = CARE_REFERRALS.filter(c => c.withCase).map(c => careCaseId(c.key));
 
   const counts: Record<string, number> = {
@@ -70,6 +100,8 @@ async function collectCounts(admin: Admin) {
     provider_schools: simUserIds.length > 0 ? await countWhereIn(admin, 'provider_schools', 'provider_id', simUserIds) : 0,
     user_site_schedules: simUserIds.length > 0 ? await countWhereIn(admin, 'user_site_schedules', 'user_id', simUserIds) : 0,
     teachers: await countWhereIn(admin, 'teachers', 'school_id', SIM_SCHOOL_IDS),
+    children: simChildIds.length,
+    'students with no child': unlinkedStudents,
     students: simStudentIds.length,
     student_details: simStudentIds.length > 0 ? await countWhereIn(admin, 'student_details', 'student_id', simStudentIds) : 0,
     bell_schedules: await countWhereIn(admin, 'bell_schedules', 'school_id', SIM_SCHOOL_IDS),
@@ -193,6 +225,11 @@ async function main() {
     expect('admin_permissions', n => n === 6, '6');
     expect('teachers', n => n === RECORD_TEACHERS.length + teacherLogins, String(RECORD_TEACHERS.length + teacherLogins));
     expect('students', n => n === TOTAL_STUDENTS, String(TOTAL_STUDENTS));
+    // SPE-347: one children row per child. Fewer children than students is the
+    // whole point — the gap is exactly the fixture's shared pairs (spec §6),
+    // and TOTAL_CHILDREN derives from the same childKey() the seed uses.
+    expect('children', n => n === TOTAL_CHILDREN, String(TOTAL_CHILDREN));
+    expect('students with no child', n => n === 0, '0');
     expect('student_details', n => n > 0, '> 0');
     expect('bell_schedules', n => n > 0, '> 0');
     expect('school_hours', n => n > 0, '> 0');

--- a/scripts/sim-district/verify.ts
+++ b/scripts/sim-district/verify.ts
@@ -48,46 +48,46 @@ async function collectCounts(admin: Admin) {
   const simUsers = await resolveSimAuthUsers(admin);
   const simUserIds = [...simUsers.values()];
 
+  // SPE-347: both student scans also carry child_id, so the child set and the
+  // unlinked count come out of the scans we already run — no extra query, and
+  // nothing passes a 200-element id list to a single `.in()` (the helpers chunk
+  // at 150 for a reason; an unchunked list becomes a 414 as the fixture grows).
   const studentIds = new Set<string>();
+  const childIds = new Set<string>();
+  let unlinkedStudents = 0;
+  const takeStudents = (rows: { id: string; child_id: string | null }[]) => {
+    for (const row of rows) {
+      if (studentIds.has(row.id)) continue;
+      studentIds.add(row.id);
+      if (row.child_id) childIds.add(row.child_id);
+      else unlinkedStudents++;
+    }
+  };
   {
-    const { data, error } = await admin.from('students').select('id').in('school_id', SIM_SCHOOL_IDS);
+    const { data, error } = await admin.from('students').select('id, child_id').in('school_id', SIM_SCHOOL_IDS);
     if (error) throw new Error(`student scan failed: ${error.message}`);
-    for (const row of data ?? []) studentIds.add(row.id);
+    takeStudents(data ?? []);
   }
   if (simUserIds.length > 0) {
-    const { data, error } = await admin.from('students').select('id').in('provider_id', simUserIds);
+    const { data, error } = await admin.from('students').select('id, child_id').in('provider_id', simUserIds);
     if (error) throw new Error(`student scan by provider failed: ${error.message}`);
-    for (const row of data ?? []) studentIds.add(row.id);
+    takeStudents(data ?? []);
   }
   const simStudentIds = [...studentIds];
 
-  // SPE-347: the children those caseload rows serve. Collected the same two
-  // ways as students (via the link, and by sim school so an orphan would still
-  // be counted rather than silently ignored by the orphan scan).
-  const childIds = new Set<string>();
-  if (simStudentIds.length > 0) {
-    const { data, error } = await admin.from('students').select('child_id').in('id', simStudentIds);
-    if (error) throw new Error(`child link scan failed: ${error.message}`);
-    for (const row of data ?? []) if (row.child_id) childIds.add(row.child_id);
-  }
-  {
-    const { data, error } = await admin.from('children').select('id').in('school_id', SIM_SCHOOL_IDS);
-    if (error) throw new Error(`children scan by school failed: ${error.message}`);
+  // Children whose caseload rows are already gone would be invisible to the
+  // scan above, so also sweep by sim school AND sim district — a child with no
+  // school_id still carries the district. Without both, an orphan would sit in
+  // the namespace and `--expect-empty` would report a clean teardown anyway.
+  for (const [column, values] of [
+    ['school_id', SIM_SCHOOL_IDS],
+    ['district_id', [DISTRICT.id]],
+  ] as const) {
+    const { data, error } = await admin.from('children').select('id').in(column, values as string[]);
+    if (error) throw new Error(`children scan by ${column} failed: ${error.message}`);
     for (const row of data ?? []) childIds.add(row.id);
   }
   const simChildIds = [...childIds];
-
-  // Unlinked caseload rows would mean the auto-create trigger did not fire.
-  let unlinkedStudents = 0;
-  if (simStudentIds.length > 0) {
-    const { count, error } = await admin
-      .from('students')
-      .select('*', { count: 'exact', head: true })
-      .in('id', simStudentIds)
-      .is('child_id', null);
-    if (error) throw new Error(`unlinked student scan failed: ${error.message}`);
-    unlinkedStudents = count ?? 0;
-  }
 
   const careCaseIds = CARE_REFERRALS.filter(c => c.withCase).map(c => careCaseId(c.key));
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -935,6 +935,82 @@ export type Database = {
           },
         ]
       }
+      children: {
+        Row: {
+          accommodations: string[]
+          created_at: string
+          date_of_birth: string | null
+          district_id: string | null
+          district_student_id: string | null
+          first_name: string | null
+          grade_level: string
+          id: string
+          initials: string
+          last_name: string | null
+          school_id: string | null
+          state_id: string | null
+          upcoming_iep_date: string | null
+          upcoming_triennial_date: string | null
+          updated_at: string
+        }
+        Insert: {
+          accommodations?: string[]
+          created_at?: string
+          date_of_birth?: string | null
+          district_id?: string | null
+          district_student_id?: string | null
+          first_name?: string | null
+          grade_level: string
+          id?: string
+          initials: string
+          last_name?: string | null
+          school_id?: string | null
+          state_id?: string | null
+          upcoming_iep_date?: string | null
+          upcoming_triennial_date?: string | null
+          updated_at?: string
+        }
+        Update: {
+          accommodations?: string[]
+          created_at?: string
+          date_of_birth?: string | null
+          district_id?: string | null
+          district_student_id?: string | null
+          first_name?: string | null
+          grade_level?: string
+          id?: string
+          initials?: string
+          last_name?: string | null
+          school_id?: string | null
+          state_id?: string | null
+          upcoming_iep_date?: string | null
+          upcoming_triennial_date?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "children_district_id_fkey"
+            columns: ["district_id"]
+            isOneToOne: false
+            referencedRelation: "districts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "children_school_id_fkey"
+            columns: ["school_id"]
+            isOneToOne: false
+            referencedRelation: "schools"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "children_state_id_fkey"
+            columns: ["state_id"]
+            isOneToOne: false
+            referencedRelation: "states"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       conversation_participants: {
         Row: {
           added_at: string
@@ -3711,6 +3787,7 @@ export type Database = {
       }
       students: {
         Row: {
+          child_id: string | null
           created_at: string | null
           district_id: string | null
           district_student_id: string | null
@@ -3729,6 +3806,7 @@ export type Database = {
           updated_at: string | null
         }
         Insert: {
+          child_id?: string | null
           created_at?: string | null
           district_id?: string | null
           district_student_id?: string | null
@@ -3747,6 +3825,7 @@ export type Database = {
           updated_at?: string | null
         }
         Update: {
+          child_id?: string | null
           created_at?: string | null
           district_id?: string | null
           district_student_id?: string | null
@@ -3765,6 +3844,13 @@ export type Database = {
           updated_at?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "students_child_id_fkey"
+            columns: ["child_id"]
+            isOneToOne: false
+            referencedRelation: "children"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "students_district_id_fkey"
             columns: ["district_id"]

--- a/supabase/migrations/20260729_spe347_children_foundation.sql
+++ b/supabase/migrations/20260729_spe347_children_foundation.sql
@@ -668,6 +668,18 @@ CREATE UNIQUE INDEX IF NOT EXISTS ux_children_district_student_id
 -- Names and DOB are not available at this point — student_details is written
 -- after the students row — so they arrive via the student_details mirror below.
 
+-- !! SUPERSEDED — read 20260729_spe347_children_hardening.sql §1 before this !!
+-- The attach-to-existing branch below is a PRIVILEGE ESCALATION and is replaced
+-- by the next migration. Both key columns (district_id, district_student_id) are
+-- client-supplied and unconstrained, so any provider could name someone else's
+-- district and a guessed student id and be handed a link to that child — and
+-- with it the child's SELECT and UPDATE access. The NULL-district match and the
+-- SELECT-then-INSERT race below go with it.
+--
+-- The body is left as-applied rather than rewritten, so the hardening migration
+-- reads as the fix it is. Any database that stops BETWEEN these two migrations
+-- is running the vulnerable definition and must not be used until both have
+-- applied — production has both.
 CREATE OR REPLACE FUNCTION public.students_child_link()
 RETURNS trigger
 LANGUAGE plpgsql

--- a/supabase/migrations/20260729_spe347_children_foundation.sql
+++ b/supabase/migrations/20260729_spe347_children_foundation.sql
@@ -312,12 +312,18 @@ BEGIN
   FOR rec IN
     WITH RECURSIVE
     -- Phase 2 groups: same district + same normalized district student id.
+    -- Both sides must name the SAME, KNOWN district. A district student id is
+    -- meaningless without a district, so two rows that merely agree on "district
+    -- unknown" are not evidence of the same child — treating NULL as a matching
+    -- value would merge unrelated children from different real districts (2
+    -- production rows have no district_id), and a merge is not reversible.
     dsid_edges AS (
       SELECT a.child_id AS x, b.child_id AS y
       FROM public.students a
       JOIN public.students b
         ON b.child_id > a.child_id
-       AND a.district_id IS NOT DISTINCT FROM b.district_id
+       AND a.district_id IS NOT NULL
+       AND a.district_id = b.district_id
        AND upper(btrim(a.district_student_id)) = upper(btrim(b.district_student_id))
       WHERE NULLIF(btrim(a.district_student_id), '') IS NOT NULL
         AND NULLIF(btrim(b.district_student_id), '') IS NOT NULL
@@ -402,6 +408,27 @@ BEGIN
     v_ids := rec.child_ids;
 
     IF rec.held_out THEN
+      -- A hold-out is a judgement call about a MATCHER guess ("are these the
+      -- same kid?"). It cannot override the district's own identifier: leaving
+      -- two children that share a (district, district student id) un-merged
+      -- would make ux_children_district_student_id below fail and roll the whole
+      -- migration back, with an error pointing at the index instead of at the
+      -- real contradiction. Fail here, precisely, instead.
+      IF EXISTS (
+        SELECT 1
+        FROM public.students a
+        JOIN public.students b
+          ON b.id > a.id
+         AND a.district_id IS NOT NULL
+         AND a.district_id = b.district_id
+         AND upper(btrim(a.district_student_id)) = upper(btrim(b.district_student_id))
+        WHERE a.child_id = ANY (v_ids)
+          AND b.child_id = ANY (v_ids)
+          AND NULLIF(btrim(a.district_student_id), '') IS NOT NULL
+      ) THEN
+        RAISE EXCEPTION 'SPE-347: held-out group % shares a district student id, so it cannot stay un-merged (ux_children_district_student_id would reject it). Either merge it or clear the duplicate id first.',
+          rec.label;
+      END IF;
       v_held := v_held + 1;
       RAISE NOTICE 'SPE-347 HELD OUT (awaiting owner confirmation, not merged): % [%] children=%',
         rec.label, rec.providers, v_ids;
@@ -555,16 +582,22 @@ $spe347_backfill$;
 --
 -- Normalization matches the matcher's (trim + upper) so the backstop agrees
 -- with the comparison it backs. Blank/NULL ids are excluded so the many
--- children with no id yet do not collide. NULLS NOT DISTINCT covers rows whose
--- district_id is NULL (2 in production) — with Postgres's default, two such
--- rows would never compare equal and the constraint would quietly not apply.
+-- children with no id yet do not collide.
+--
+-- Rows with NO district are excluded too — a deliberate difference from the
+-- students index, which uses NULLS NOT DISTINCT. "Unique within a district" has
+-- no meaning for a row whose district is unknown, and NULLS NOT DISTINCT would
+-- make two such children (2 production rows have no district_id) collide on a
+-- shared id even though nothing says they are the same child. Excluding them
+-- keeps the constraint saying only what it can actually know.
 --
 -- Created AFTER the backfill on purpose: the merge phase above is what collapses
 -- duplicate ids, so a failure here is a loud, correct signal that it did not.
 CREATE UNIQUE INDEX IF NOT EXISTS ux_children_district_student_id
   ON public.children (district_id, (upper(btrim(district_student_id))))
-  NULLS NOT DISTINCT
-  WHERE district_student_id IS NOT NULL AND btrim(district_student_id) <> '';
+  WHERE district_id IS NOT NULL
+    AND district_student_id IS NOT NULL
+    AND btrim(district_student_id) <> '';
 
 -- ===========================================================================
 -- 6. Auto-create / attach on INSERT, and the child_id write guard

--- a/supabase/migrations/20260729_spe347_children_foundation.sql
+++ b/supabase/migrations/20260729_spe347_children_foundation.sql
@@ -1,0 +1,878 @@
+-- SPE-347: child-record foundation — a `children` table above `students`.
+--
+-- Target model: ONE CHILD = ONE `children` ROW. Existing `students` rows stay
+-- exactly what they are today — the per-provider caseload/service row
+-- (ownership, sessions_per_week, minutes_per_session, per-discipline goals).
+-- A child served by an RSP and an SLP is one `children` row and two `students`
+-- rows pointing at it.
+--
+-- This migration is BEHAVIOR-IDENTICAL. No surface changes what it shows or
+-- accepts: nothing reads `children` yet, no existing policy is modified, no
+-- column is dropped, and no existing write path is altered. It is additive
+-- only.
+--
+-- ---------------------------------------------------------------------------
+-- Why extraction, not collapse
+-- ---------------------------------------------------------------------------
+-- All 18 FK dependents (schedule_sessions with 11k+ rows included) key off
+-- `students.id` and STAY PUT; sessions carry their own provider_id. Write RLS
+-- on `students` (provider_id = auth.uid()) is untouched. The only new policies
+-- live on the new table. No re-keying, no big-bang.
+--
+-- `children` deliberately has NO cascade path from `profiles`. Today `students`
+-- is ON DELETE CASCADE from `profiles`, so deleting a provider destroys their
+-- students' full history. `children` is a PARENT of `students` — nothing
+-- cascades into it — so the child record survives provider offboarding. That is
+-- the first half of the retention fix flagged in the 2026-07-27 audit.
+--
+-- ---------------------------------------------------------------------------
+-- Recursion posture (SPE-332 / SPE-334 doctrine)
+-- ---------------------------------------------------------------------------
+-- The new policies on `children` reference `students`. NO policy on `students`
+-- references `children`, so there is no cycle: children -> students -> (teachers,
+-- schedule_sessions, profiles, admin_permissions), and none of those reference
+-- children. `schedule_sessions`'s own policies reach students only through the
+-- SECURITY DEFINER seam (get_teacher_student_ids), which is why students_select
+-- can already reference schedule_sessions today without recursing.
+--
+-- The one place this migration DOES need the definer seam is writes: the
+-- `children` INSERT path. There is no INSERT policy at all, so the only way a
+-- row is created is the SECURITY DEFINER trigger below.
+
+-- ===========================================================================
+-- 1. The table
+-- ===========================================================================
+
+CREATE TABLE IF NOT EXISTS public.children (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Identity. first/last/DOB live on student_details today; initials and grade
+  -- live on students. The child-level copy folds both together.
+  first_name text,
+  last_name text,
+  date_of_birth date,
+  initials text NOT NULL,
+  grade_level text NOT NULL,
+
+  -- Context. Same shapes and same FK targets as students.school_id /
+  -- district_id / state_id (varchar, not uuid — these are NCES/CDE-style ids).
+  school_id varchar(36) REFERENCES public.schools(id),
+  district_id varchar(36) REFERENCES public.districts(id),
+  state_id varchar(2) REFERENCES public.states(id),
+
+  -- SPE-339's column, at the level it actually belongs to. On `students` it had
+  -- to be provider-scoped (one row per provider per child); here the child IS
+  -- the row, so it can carry the district's real uniqueness rule.
+  district_student_id text,
+
+  -- Compliance: the child-level slice of student_details.
+  upcoming_iep_date date,
+  upcoming_triennial_date date,
+  accommodations text[] NOT NULL DEFAULT '{}'::text[],
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.children IS
+  'SPE-347: one row per child. `students` rows are the per-provider caseload/service rows and point here via students.child_id. Rows are created only by the SECURITY DEFINER trigger on students (there is no INSERT policy) and are never deleted by any policy — children outlive provider offboarding on purpose.';
+
+COMMENT ON COLUMN public.children.district_student_id IS
+  'SPE-339/SPE-347: the district''s own student identifier, unique within a district (ux_children_district_student_id). Cross-district recurrence stays legal.';
+
+CREATE INDEX IF NOT EXISTS idx_children_school_id
+  ON public.children (school_id) WHERE school_id IS NOT NULL;
+
+CREATE TRIGGER trg_children_updated_at
+  BEFORE UPDATE ON public.children
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+-- ===========================================================================
+-- 2. The link column on students
+-- ===========================================================================
+--
+-- NULLable for the moment the column exists and before the backfill below runs;
+-- every row is linked by the end of this migration and the trigger keeps every
+-- future row linked. Left NULLable rather than NOT NULL because the constraint
+-- would have to be validated inside the same transaction that populates it, and
+-- because a future create-or-attach flow may want to stage a row. No cascade:
+-- deleting a child is not something any policy permits.
+
+ALTER TABLE public.students
+  ADD COLUMN IF NOT EXISTS child_id uuid REFERENCES public.children(id);
+
+COMMENT ON COLUMN public.students.child_id IS
+  'SPE-347: the child this caseload row serves. Managed by the database (trg_students_child_link) — an end-user session may not set or change it.';
+
+CREATE INDEX IF NOT EXISTS idx_students_child_id
+  ON public.students (child_id) WHERE child_id IS NOT NULL;
+
+-- ===========================================================================
+-- 3. RLS
+-- ===========================================================================
+--
+-- Grants first, so the table's reachable surface is exactly SELECT + UPDATE for
+-- signed-in users. INSERT and DELETE are not granted at all (belt to the
+-- policies' braces): inserts arrive through the definer trigger, which runs as
+-- the function owner, and nothing deletes.
+
+ALTER TABLE public.children ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON public.children FROM anon, authenticated;
+GRANT SELECT, UPDATE ON public.children TO authenticated;
+GRANT ALL ON public.children TO service_role;
+
+-- SELECT: mirrors every branch of `students_select` (20251224_fix_rls_performance.sql)
+-- through students.child_id, so nobody who can see a student today is blind to
+-- its child. Branches, in the same order as the source policy: owning provider;
+-- the student's teacher; a specialist or SEA assigned to one of the student's
+-- sessions; an SEA at the student's school; a site admin for that school.
+--
+-- Note that `students`'s own RLS ALSO applies to the sub-select below (Postgres
+-- applies RLS inside policy expressions — that is what made profiles_update
+-- recurse in SPE-332). Here that is harmless and fail-closed: it can only
+-- narrow this policy to rows the caller could already select from `students`,
+-- which is precisely the intent. The explicit mirror is kept anyway so the rule
+-- is readable on its face, and so a future change to students_select (SPE-334
+-- rewrites its teacher branch onto student_teachers) shows up as a policy that
+-- needs updating rather than as silent drift.
+CREATE POLICY children_select ON public.children
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.students s
+      WHERE s.child_id = children.id
+        AND (
+          s.provider_id = (SELECT auth.uid())
+          OR s.teacher_id IN (
+            SELECT t.id FROM public.teachers t WHERE t.account_id = (SELECT auth.uid())
+          )
+          OR EXISTS (
+            SELECT 1 FROM public.schedule_sessions ss
+            WHERE ss.student_id = s.id AND ss.assigned_to_specialist_id = (SELECT auth.uid())
+          )
+          OR EXISTS (
+            SELECT 1 FROM public.schedule_sessions ss
+            WHERE ss.student_id = s.id AND ss.assigned_to_sea_id = (SELECT auth.uid())
+          )
+          OR (
+            (s.school_id)::text IN (
+              SELECT p.school_id FROM public.profiles p WHERE p.id = (SELECT auth.uid())
+            )
+            AND (SELECT auth.uid()) IN (
+              SELECT p.id FROM public.profiles p WHERE p.role = 'sea'
+            )
+          )
+          OR EXISTS (
+            SELECT 1 FROM public.admin_permissions ap
+            WHERE ap.admin_id = (SELECT auth.uid())
+              AND ap.role = 'site_admin'
+              AND (ap.school_id)::text = (s.school_id)::text
+          )
+        )
+    )
+  );
+
+-- UPDATE: deliberately COARSE — any provider with a caseload row for this child
+-- may edit the child's facts. That matches today's reality, where each provider
+-- edits their own copy freely and nothing arbitrates. Field-level tightening
+-- (case-manager-only) is SPE-201's amended scope, not this ticket.
+--
+-- Narrower than SELECT on purpose: a teacher / SEA / site admin can READ a child
+-- (they can read the student today) but cannot write one.
+CREATE POLICY children_update ON public.children
+  FOR UPDATE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.students s
+      WHERE s.child_id = children.id AND s.provider_id = (SELECT auth.uid())
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.students s
+      WHERE s.child_id = children.id AND s.provider_id = (SELECT auth.uid())
+    )
+  );
+
+-- No INSERT policy: rows come from the definer trigger only.
+-- No DELETE policy: nobody deletes a child. The admin student-deletion flow
+-- gets its own look at the cross-provider read-switch step.
+
+-- ===========================================================================
+-- 4. Backfill + merge
+-- ===========================================================================
+--
+-- Runs BEFORE the triggers are created, so the backfill is not fighting its own
+-- dual-write, and before the district_student_id unique index is created, so a
+-- pre-existing duplicate id surfaces as a clear index failure after the merge
+-- phase rather than as a mid-insert error.
+--
+-- Phases:
+--   1. one children row per students row;
+--   2. collapse rows that share a (district_id, district_student_id) — the
+--      SPE-339 rule "same district + same district id => same child";
+--   3. collapse rows the SPE-255/SPE-290 cross-provider matcher calls the same
+--      child (school-scoped, full-name-preferred), MINUS an explicit hold-out;
+--   4. assert the invariants.
+--
+-- Field-level merge rule (ticket): prefer non-null, then newest updated_at.
+-- Every conflict — two members carrying different non-null values for a field —
+-- is RAISE NOTICE'd, so it lands in the migration output and the Postgres log.
+
+DO $spe347_backfill$
+DECLARE
+  -- Hold-out: components containing one of these (school_id | grade_level |
+  -- initials) natural keys are DETECTED and REPORTED but NOT merged.
+  --
+  -- '062271002458|2|GB' is the one real-world duplicate pair — Mt. Diablo
+  -- Elementary, an OT and an SLP each carrying a copy of the same 2nd-grader.
+  -- Verified 2026-07-27: the two copies diverge on nothing (same 2x30 service,
+  -- same teacher, no student_details rows on either), so merging them is
+  -- trivial — but merging real children is the owner's call, not the
+  -- migration's. It merges in a follow-up migration on Blair's explicit
+  -- confirmation; until then both copies keep their own child row, which is
+  -- exactly today's behavior.
+  v_holdout_keys text[] := ARRAY['062271002458|2|GB'];
+
+  v_students_before bigint;
+  v_sessions_before bigint;
+  v_details_before bigint;
+  v_created bigint := 0;
+  v_merged bigint := 0;
+  v_held bigint := 0;
+
+  rec record;
+  v_ids uuid[];
+  v_survivor uuid;
+  v_conflicts jsonb;
+
+  v_first_name text;
+  v_last_name text;
+  v_dob date;
+  v_initials text;
+  v_grade text;
+  v_school varchar(36);
+  v_district varchar(36);
+  v_state varchar(2);
+  v_dsid text;
+  v_iep date;
+  v_tri date;
+  v_accom text[];
+BEGIN
+  SELECT count(*) INTO v_students_before FROM public.students;
+  SELECT count(*) INTO v_sessions_before FROM public.schedule_sessions;
+  SELECT count(*) INTO v_details_before FROM public.student_details;
+
+  -- ---- Phase 1: one child per student ------------------------------------
+  -- Mapping table first, so the insert and the link are two plainly-ordered
+  -- statements rather than one clever data-modifying CTE.
+  CREATE TEMP TABLE spe347_new_children ON COMMIT DROP AS
+    SELECT s.id AS student_id, gen_random_uuid() AS child_id
+    FROM public.students s
+    WHERE s.child_id IS NULL;
+
+  INSERT INTO public.children (
+    id, first_name, last_name, date_of_birth, initials, grade_level,
+    school_id, district_id, state_id, district_student_id,
+    upcoming_iep_date, upcoming_triennial_date, accommodations,
+    created_at, updated_at
+  )
+  SELECT
+    m.child_id,
+    d.first_name,
+    d.last_name,
+    d.date_of_birth,
+    s.initials,
+    s.grade_level,
+    s.school_id,
+    s.district_id,
+    s.state_id,
+    NULLIF(btrim(s.district_student_id), ''),
+    d.upcoming_iep_date,
+    d.upcoming_triennial_date,
+    COALESCE(d.accommodations, '{}'::text[]),
+    COALESCE(s.created_at, now()),
+    COALESCE(s.updated_at, now())
+  FROM spe347_new_children m
+  JOIN public.students s ON s.id = m.student_id
+  LEFT JOIN public.student_details d ON d.student_id = s.id;
+  GET DIAGNOSTICS v_created = ROW_COUNT;
+
+  UPDATE public.students s
+     SET child_id = m.child_id
+    FROM spe347_new_children m
+   WHERE s.id = m.student_id;
+
+  RAISE NOTICE 'SPE-347 phase 1: created % children (one per students row)', v_created;
+
+  -- ---- Phases 2 + 3: merge -----------------------------------------------
+  -- Both phases feed the same merge body through a single component list.
+  FOR rec IN
+    WITH RECURSIVE
+    -- Phase 2 groups: same district + same normalized district student id.
+    dsid_edges AS (
+      SELECT a.child_id AS x, b.child_id AS y
+      FROM public.students a
+      JOIN public.students b
+        ON b.child_id > a.child_id
+       AND a.district_id IS NOT DISTINCT FROM b.district_id
+       AND upper(btrim(a.district_student_id)) = upper(btrim(b.district_student_id))
+      WHERE NULLIF(btrim(a.district_student_id), '') IS NOT NULL
+        AND NULLIF(btrim(b.district_student_id), '') IS NOT NULL
+    ),
+    -- Phase 3 groups: the SPE-255/SPE-290 cross-provider matcher, verbatim —
+    -- same school always required; both sides named => normalized names + grade
+    -- must agree (a name is authoritative); otherwise fall back to
+    -- initials + grade + teacher.
+    named AS (
+      SELECT
+        s.id, s.child_id, s.provider_id, s.school_id, s.grade_level, s.initials,
+        s.teacher_id, s.teacher_name,
+        public.norm_student_name(d.first_name, d.last_name) AS nname
+      FROM public.students s
+      LEFT JOIN public.student_details d ON d.student_id = s.id
+    ),
+    match_edges AS (
+      SELECT a.child_id AS x, b.child_id AS y
+      FROM named a
+      JOIN named b
+        ON b.child_id > a.child_id
+       AND a.provider_id IS DISTINCT FROM b.provider_id
+       AND a.school_id IS NOT NULL
+       AND a.school_id = b.school_id
+       AND (
+         (
+           a.nname IS NOT NULL AND b.nname IS NOT NULL
+           AND a.nname = b.nname
+           AND a.grade_level = b.grade_level
+         )
+         OR (
+           (a.nname IS NULL OR b.nname IS NULL)
+           AND lower(a.initials) = lower(b.initials)
+           AND a.grade_level = b.grade_level
+           AND (
+             (a.teacher_id IS NOT NULL AND b.teacher_id IS NOT NULL AND a.teacher_id = b.teacher_id)
+             OR (
+               (a.teacher_id IS NULL OR b.teacher_id IS NULL)
+               AND lower(COALESCE(a.teacher_name, '')) = lower(COALESCE(b.teacher_name, ''))
+               AND COALESCE(a.teacher_name, '') <> ''
+             )
+           )
+         )
+       )
+    ),
+    -- Symmetric edge set + reflexive base, so `min(seed) reachable` is a
+    -- correct connected-component label even if a group ever exceeds a pair.
+    edges AS (
+      SELECT x, y FROM dsid_edges
+      UNION SELECT y, x FROM dsid_edges
+      UNION SELECT x, y FROM match_edges
+      UNION SELECT y, x FROM match_edges
+    ),
+    nodes AS (
+      SELECT x AS id FROM edges UNION SELECT y FROM edges
+    ),
+    reach AS (
+      SELECT id AS node, id AS seed FROM nodes
+      UNION
+      SELECT e.y, r.seed FROM reach r JOIN edges e ON e.x = r.node
+    ),
+    component AS (
+      -- (array_agg ORDER BY)[1] rather than min(): Postgres has no min(uuid).
+      SELECT node, (array_agg(seed ORDER BY seed))[1] AS comp FROM reach GROUP BY node
+    )
+    SELECT
+      c.comp,
+      array_agg(DISTINCT c.node) AS child_ids,
+      bool_or(
+        (s.school_id || '|' || s.grade_level || '|' || s.initials) = ANY (v_holdout_keys)
+      ) AS held_out,
+      string_agg(DISTINCT coalesce(sc.name, s.school_id) || ' / grade ' || s.grade_level || ' / ' || s.initials, ', ') AS label,
+      string_agg(DISTINCT coalesce(p.email, s.provider_id::text), ', ') AS providers
+    FROM component c
+    JOIN public.students s ON s.child_id = c.node
+    LEFT JOIN public.schools sc ON sc.id = s.school_id
+    LEFT JOIN public.profiles p ON p.id = s.provider_id
+    GROUP BY c.comp
+    HAVING count(DISTINCT c.node) > 1
+    ORDER BY c.comp
+  LOOP
+    v_ids := rec.child_ids;
+
+    IF rec.held_out THEN
+      v_held := v_held + 1;
+      RAISE NOTICE 'SPE-347 HELD OUT (awaiting owner confirmation, not merged): % [%] children=%',
+        rec.label, rec.providers, v_ids;
+      CONTINUE;
+    END IF;
+
+    -- Ordering is deliberately anchored on the SOURCE students row, never on the
+    -- children id: child ids are minted fresh by phase 1, so tie-breaking on them
+    -- would make the winner of an exact updated_at tie differ between replays of
+    -- the same migration against the same data. Every child in a component has
+    -- exactly one caseload row at this point (components are disjoint and phase 1
+    -- is 1:1), and even if it did not, "first non-null in this order" stays
+    -- well-defined.
+    SELECT c.id INTO v_survivor
+    FROM public.children c
+    JOIN public.students s ON s.child_id = c.id
+    WHERE c.id = ANY (v_ids)
+    ORDER BY c.created_at ASC NULLS LAST, s.id ASC
+    LIMIT 1;
+
+    -- Winning value per field: first non-null in (updated_at DESC, student id
+    -- DESC) order == "prefer non-null, then newest updated_at".
+    SELECT
+      (array_remove(array_agg(c.first_name ORDER BY c.updated_at DESC, s.id DESC), NULL))[1],
+      (array_remove(array_agg(c.last_name ORDER BY c.updated_at DESC, s.id DESC), NULL))[1],
+      (array_remove(array_agg(c.date_of_birth ORDER BY c.updated_at DESC, s.id DESC), NULL))[1],
+      (array_remove(array_agg(c.initials ORDER BY c.updated_at DESC, s.id DESC), NULL))[1],
+      (array_remove(array_agg(c.grade_level ORDER BY c.updated_at DESC, s.id DESC), NULL))[1],
+      (array_remove(array_agg(c.school_id ORDER BY c.updated_at DESC, s.id DESC), NULL))[1],
+      (array_remove(array_agg(c.district_id ORDER BY c.updated_at DESC, s.id DESC), NULL))[1],
+      (array_remove(array_agg(c.state_id ORDER BY c.updated_at DESC, s.id DESC), NULL))[1],
+      (array_remove(array_agg(c.district_student_id ORDER BY c.updated_at DESC, s.id DESC), NULL))[1],
+      (array_remove(array_agg(c.upcoming_iep_date ORDER BY c.updated_at DESC, s.id DESC), NULL))[1],
+      (array_remove(array_agg(c.upcoming_triennial_date ORDER BY c.updated_at DESC, s.id DESC), NULL))[1]
+    INTO v_first_name, v_last_name, v_dob, v_initials, v_grade, v_school,
+         v_district, v_state, v_dsid, v_iep, v_tri
+    FROM public.children c
+    JOIN public.students s ON s.child_id = c.id
+    WHERE c.id = ANY (v_ids);
+
+    -- accommodations is an array column: "non-null" means "non-empty".
+    SELECT c.accommodations INTO v_accom
+    FROM public.children c
+    JOIN public.students s ON s.child_id = c.id
+    WHERE c.id = ANY (v_ids)
+      AND COALESCE(array_length(c.accommodations, 1), 0) > 0
+    ORDER BY c.updated_at DESC, s.id DESC
+    LIMIT 1;
+
+    -- Conflicts: any field where two members disagree on a non-null value.
+    SELECT NULLIF(jsonb_strip_nulls(jsonb_build_object(
+      'first_name',              CASE WHEN count(DISTINCT first_name) > 1 THEN to_jsonb(array_agg(DISTINCT first_name)) END,
+      'last_name',               CASE WHEN count(DISTINCT last_name) > 1 THEN to_jsonb(array_agg(DISTINCT last_name)) END,
+      'date_of_birth',           CASE WHEN count(DISTINCT date_of_birth) > 1 THEN to_jsonb(array_agg(DISTINCT date_of_birth)) END,
+      'initials',                CASE WHEN count(DISTINCT initials) > 1 THEN to_jsonb(array_agg(DISTINCT initials)) END,
+      'grade_level',             CASE WHEN count(DISTINCT grade_level) > 1 THEN to_jsonb(array_agg(DISTINCT grade_level)) END,
+      'school_id',               CASE WHEN count(DISTINCT school_id) > 1 THEN to_jsonb(array_agg(DISTINCT school_id)) END,
+      'district_id',             CASE WHEN count(DISTINCT district_id) > 1 THEN to_jsonb(array_agg(DISTINCT district_id)) END,
+      'state_id',                CASE WHEN count(DISTINCT state_id) > 1 THEN to_jsonb(array_agg(DISTINCT state_id)) END,
+      'district_student_id',     CASE WHEN count(DISTINCT district_student_id) > 1 THEN to_jsonb(array_agg(DISTINCT district_student_id)) END,
+      'upcoming_iep_date',       CASE WHEN count(DISTINCT upcoming_iep_date) > 1 THEN to_jsonb(array_agg(DISTINCT upcoming_iep_date)) END,
+      'upcoming_triennial_date', CASE WHEN count(DISTINCT upcoming_triennial_date) > 1 THEN to_jsonb(array_agg(DISTINCT upcoming_triennial_date)) END
+    )), '{}'::jsonb)
+    INTO v_conflicts
+    FROM public.children
+    WHERE id = ANY (v_ids);
+
+    UPDATE public.children
+       SET first_name = v_first_name,
+           last_name = v_last_name,
+           date_of_birth = v_dob,
+           initials = v_initials,
+           grade_level = v_grade,
+           school_id = v_school,
+           district_id = v_district,
+           state_id = v_state,
+           district_student_id = v_dsid,
+           upcoming_iep_date = v_iep,
+           upcoming_triennial_date = v_tri,
+           accommodations = COALESCE(v_accom, '{}'::text[])
+     WHERE id = v_survivor;
+
+    UPDATE public.students
+       SET child_id = v_survivor
+     WHERE child_id = ANY (v_ids)
+       AND child_id <> v_survivor;
+
+    DELETE FROM public.children
+     WHERE id = ANY (v_ids)
+       AND id <> v_survivor;
+
+    v_merged := v_merged + (array_length(v_ids, 1) - 1);
+    RAISE NOTICE 'SPE-347 MERGED % rows into child %: % [%]%',
+      array_length(v_ids, 1), v_survivor, rec.label, rec.providers,
+      CASE WHEN v_conflicts IS NULL THEN ' (no field conflicts)'
+           ELSE ' CONFLICTS RESOLVED (prefer non-null, then newest updated_at): ' || v_conflicts::text END;
+  END LOOP;
+
+  RAISE NOTICE 'SPE-347 merge summary: % duplicate row(s) merged away, % group(s) held out for owner confirmation',
+    v_merged, v_held;
+
+  -- ---- Phase 4: assertions -----------------------------------------------
+  IF (SELECT count(*) FROM public.students) <> v_students_before THEN
+    RAISE EXCEPTION 'SPE-347: students count changed (% -> %)',
+      v_students_before, (SELECT count(*) FROM public.students);
+  END IF;
+  IF (SELECT count(*) FROM public.schedule_sessions) <> v_sessions_before THEN
+    RAISE EXCEPTION 'SPE-347: schedule_sessions count changed (% -> %)',
+      v_sessions_before, (SELECT count(*) FROM public.schedule_sessions);
+  END IF;
+  IF (SELECT count(*) FROM public.student_details) <> v_details_before THEN
+    RAISE EXCEPTION 'SPE-347: student_details count changed (% -> %)',
+      v_details_before, (SELECT count(*) FROM public.student_details);
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.students WHERE child_id IS NULL) THEN
+    RAISE EXCEPTION 'SPE-347: % students row(s) left unlinked',
+      (SELECT count(*) FROM public.students WHERE child_id IS NULL);
+  END IF;
+  -- The ticket's headline invariant. Holds because this migration applies
+  -- exactly once (its CREATE POLICY / CREATE TRIGGER statements are not
+  -- IF NOT EXISTS), so `children` starts empty and every row here came from
+  -- phase 1.
+  IF (SELECT count(*) FROM public.children) <> v_students_before - v_merged THEN
+    RAISE EXCEPTION 'SPE-347: children count % <> students count % minus merged %',
+      (SELECT count(*) FROM public.children), v_students_before, v_merged;
+  END IF;
+  IF v_created <> v_students_before THEN
+    RAISE EXCEPTION 'SPE-347: phase 1 created % children for % students — children was not empty',
+      v_created, v_students_before;
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.children c
+    WHERE NOT EXISTS (SELECT 1 FROM public.students s WHERE s.child_id = c.id)
+  ) THEN
+    RAISE EXCEPTION 'SPE-347: orphan children row(s) created';
+  END IF;
+
+  RAISE NOTICE 'SPE-347 backfill complete: % students -> % children (% merged, % held out)',
+    v_students_before, (SELECT count(*) FROM public.children), v_merged, v_held;
+END;
+$spe347_backfill$;
+
+-- ===========================================================================
+-- 5. district_student_id uniqueness, per district
+-- ===========================================================================
+--
+-- The same shape as students' ux_students_provider_district_student_id, minus
+-- the provider scope — which is the whole point of the child row: `students`
+-- needed the provider in the key because it holds one row per provider per
+-- child, `children` does not.
+--
+-- Normalization matches the matcher's (trim + upper) so the backstop agrees
+-- with the comparison it backs. Blank/NULL ids are excluded so the many
+-- children with no id yet do not collide. NULLS NOT DISTINCT covers rows whose
+-- district_id is NULL (2 in production) — with Postgres's default, two such
+-- rows would never compare equal and the constraint would quietly not apply.
+--
+-- Created AFTER the backfill on purpose: the merge phase above is what collapses
+-- duplicate ids, so a failure here is a loud, correct signal that it did not.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_children_district_student_id
+  ON public.children (district_id, (upper(btrim(district_student_id))))
+  NULLS NOT DISTINCT
+  WHERE district_student_id IS NOT NULL AND btrim(district_student_id) <> '';
+
+-- ===========================================================================
+-- 6. Auto-create / attach on INSERT, and the child_id write guard
+-- ===========================================================================
+--
+-- Every existing write path — the manual add form, the roster import, and
+-- upsert_students_atomic — keeps working completely unmodified: they insert a
+-- students row without a child_id, and this trigger fills one in.
+--
+-- Two behaviors, one function so their ordering can never drift:
+--
+-- (a) child_id is not the caller's to set. `students_insert`'s WITH CHECK only
+--     constrains provider_id, so without this guard a signed-in user could
+--     insert a throwaway caseload row carrying someone else's child_id and
+--     inherit that child's SELECT + UPDATE grants — turning "can see this
+--     child" into "can edit this child". No app code writes child_id (the
+--     column did not exist until this migration), so nothing legitimate is
+--     refused. auth.uid() IS NULL means there is no end-user session: the
+--     service client, this migration, and the sim seed, all of which are
+--     trusted to set the link explicitly.
+--
+-- (b) otherwise: attach to an existing child when the district's own student id
+--     already identifies one, else create a fresh child from the row's child
+--     facts. The ID-first attach is the same rule the backfill above applies
+--     and the rule SPE-339 defined for the import path ("same district + same
+--     district student id => same child"). Without it, the SECOND provider to
+--     import a child the district already knows would hit
+--     ux_children_district_student_id and their whole insert would fail — a
+--     visible regression in a path this ticket promises not to touch. This is
+--     NOT the create-or-attach step (SPE-348): there is no name/initials
+--     matching and no human confirmation here, only exact id equality.
+--
+-- Names and DOB are not available at this point — student_details is written
+-- after the students row — so they arrive via the student_details mirror below.
+
+CREATE OR REPLACE FUNCTION public.students_child_link()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_dsid text;
+  v_child_id uuid;
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.child_id IS DISTINCT FROM OLD.child_id AND auth.uid() IS NOT NULL THEN
+      RAISE EXCEPTION 'students.child_id is managed by the database (SPE-347)'
+        USING ERRCODE = '42501';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF NEW.child_id IS NOT NULL THEN
+    IF auth.uid() IS NOT NULL THEN
+      RAISE EXCEPTION 'students.child_id is managed by the database (SPE-347)'
+        USING ERRCODE = '42501';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  v_dsid := NULLIF(btrim(NEW.district_student_id), '');
+
+  IF v_dsid IS NOT NULL THEN
+    SELECT c.id INTO v_child_id
+    FROM public.children c
+    WHERE c.district_id IS NOT DISTINCT FROM NEW.district_id
+      AND upper(btrim(c.district_student_id)) = upper(v_dsid)
+    LIMIT 1;
+  END IF;
+
+  IF v_child_id IS NULL THEN
+    INSERT INTO public.children (
+      initials, grade_level, school_id, district_id, state_id, district_student_id
+    )
+    VALUES (
+      NEW.initials, NEW.grade_level, NEW.school_id, NEW.district_id, NEW.state_id, v_dsid
+    )
+    RETURNING id INTO v_child_id;
+  END IF;
+
+  NEW.child_id := v_child_id;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.students_child_link() IS
+  'SPE-347: BEFORE INSERT OR UPDATE on students. On insert, links the row to a child — attaching to the existing child when the district student id already identifies one, otherwise creating it (SECURITY DEFINER: there is no INSERT policy on children). On update, refuses any attempt by an end-user session to set or change child_id.';
+
+CREATE TRIGGER trg_students_child_link
+  BEFORE INSERT OR UPDATE ON public.students
+  FOR EACH ROW EXECUTE FUNCTION public.students_child_link();
+
+-- ===========================================================================
+-- 7. Dual-write: students / student_details child facts -> children
+-- ===========================================================================
+--
+-- Nothing stops being written to students or student_details here — the child
+-- row is a mirror, and retiring the duplicated columns is its own later
+-- contract ticket (SPE-350).
+--
+-- Rule: last write wins, and a NULL never overwrites a stored value. Writes on
+-- both source tables are routinely partial today (upsert_students_atomic
+-- COALESCEs almost every column, and PostgREST PATCHes carry only the fields
+-- the caller sent), so an absent value means "not provided", not "cleared".
+-- Applying it literally would let one provider's blank details row wipe the
+-- name another provider supplied for the same child. Same reason
+-- `accommodations` mirrors only when non-empty.
+--
+-- Divergence — the mirror overwriting a DIFFERENT non-null value on a child that
+-- more than one caseload row points at — is logged. After the backfill above
+-- there are no shared children left un-merged except the held-out real pair, so
+-- in practice this should stay silent; it is the rule for when create-or-attach
+-- starts producing shared children in volume.
+
+CREATE OR REPLACE FUNCTION public.students_mirror_child_facts()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_dsid text;
+  v_diverged jsonb;
+  v_linked bigint;
+BEGIN
+  v_dsid := NULLIF(btrim(NEW.district_student_id), '');
+
+  -- Never mirror a district student id that another child in the same district
+  -- already owns: ux_children_district_student_id would abort the caller's
+  -- UPDATE, and "same id, different child" is a conflict to surface, never to
+  -- resolve silently (SPE-339's import rule).
+  IF v_dsid IS NOT NULL AND EXISTS (
+    SELECT 1 FROM public.children c
+    WHERE c.id <> NEW.child_id
+      AND c.district_id IS NOT DISTINCT FROM NEW.district_id
+      AND upper(btrim(c.district_student_id)) = upper(v_dsid)
+  ) THEN
+    RAISE LOG 'SPE-347 district_student_id conflict: student % carries id % in district %, already held by another child — not mirrored',
+      NEW.id, v_dsid, NEW.district_id;
+    v_dsid := NULL;
+  END IF;
+
+  SELECT count(*) INTO v_linked FROM public.students s WHERE s.child_id = NEW.child_id;
+  IF v_linked > 1 THEN
+    SELECT NULLIF(jsonb_strip_nulls(jsonb_build_object(
+      'initials',            CASE WHEN c.initials IS DISTINCT FROM NEW.initials THEN to_jsonb(c.initials) END,
+      'grade_level',         CASE WHEN c.grade_level IS DISTINCT FROM NEW.grade_level THEN to_jsonb(c.grade_level) END,
+      'school_id',           CASE WHEN NEW.school_id IS NOT NULL AND c.school_id IS DISTINCT FROM NEW.school_id THEN to_jsonb(c.school_id) END,
+      'district_id',         CASE WHEN NEW.district_id IS NOT NULL AND c.district_id IS DISTINCT FROM NEW.district_id THEN to_jsonb(c.district_id) END,
+      'state_id',            CASE WHEN NEW.state_id IS NOT NULL AND c.state_id IS DISTINCT FROM NEW.state_id THEN to_jsonb(c.state_id) END,
+      'district_student_id', CASE WHEN v_dsid IS NOT NULL AND c.district_student_id IS DISTINCT FROM v_dsid THEN to_jsonb(c.district_student_id) END
+    )), '{}'::jsonb)
+    INTO v_diverged
+    FROM public.children c WHERE c.id = NEW.child_id;
+
+    IF v_diverged IS NOT NULL THEN
+      RAISE LOG 'SPE-347 child-fact divergence on child % (% caseload rows): students row % overwrote %',
+        NEW.child_id, v_linked, NEW.id, v_diverged;
+    END IF;
+  END IF;
+
+  UPDATE public.children c
+     SET initials = NEW.initials,
+         grade_level = NEW.grade_level,
+         school_id = COALESCE(NEW.school_id, c.school_id),
+         district_id = COALESCE(NEW.district_id, c.district_id),
+         state_id = COALESCE(NEW.state_id, c.state_id),
+         district_student_id = COALESCE(v_dsid, c.district_student_id)
+   WHERE c.id = NEW.child_id;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.students_mirror_child_facts() IS
+  'SPE-347: mirrors the child-level facts on a students row into its linked children row. Last write wins; NULL never overwrites; divergence on a shared child is logged.';
+
+CREATE TRIGGER trg_students_mirror_child_facts
+  AFTER UPDATE ON public.students
+  FOR EACH ROW
+  WHEN (
+    NEW.child_id IS NOT NULL
+    AND (
+      OLD.initials IS DISTINCT FROM NEW.initials
+      OR OLD.grade_level IS DISTINCT FROM NEW.grade_level
+      OR OLD.school_id IS DISTINCT FROM NEW.school_id
+      OR OLD.district_id IS DISTINCT FROM NEW.district_id
+      OR OLD.state_id IS DISTINCT FROM NEW.state_id
+      OR OLD.district_student_id IS DISTINCT FROM NEW.district_student_id
+      -- A re-link (service/migration only — an end-user session is refused by
+      -- trg_students_child_link) must carry this row's facts onto the new child.
+      OR OLD.child_id IS DISTINCT FROM NEW.child_id
+    )
+  )
+  EXECUTE FUNCTION public.students_mirror_child_facts();
+
+CREATE OR REPLACE FUNCTION public.student_details_mirror_child_facts()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_child_id uuid;
+  v_diverged jsonb;
+  v_linked bigint;
+BEGIN
+  SELECT s.child_id INTO v_child_id FROM public.students s WHERE s.id = NEW.student_id;
+  IF v_child_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  SELECT count(*) INTO v_linked FROM public.students s WHERE s.child_id = v_child_id;
+  IF v_linked > 1 THEN
+    SELECT NULLIF(jsonb_strip_nulls(jsonb_build_object(
+      'first_name',              CASE WHEN NEW.first_name IS NOT NULL AND c.first_name IS DISTINCT FROM NEW.first_name THEN to_jsonb(c.first_name) END,
+      'last_name',               CASE WHEN NEW.last_name IS NOT NULL AND c.last_name IS DISTINCT FROM NEW.last_name THEN to_jsonb(c.last_name) END,
+      'date_of_birth',           CASE WHEN NEW.date_of_birth IS NOT NULL AND c.date_of_birth IS DISTINCT FROM NEW.date_of_birth THEN to_jsonb(c.date_of_birth) END,
+      'upcoming_iep_date',       CASE WHEN NEW.upcoming_iep_date IS NOT NULL AND c.upcoming_iep_date IS DISTINCT FROM NEW.upcoming_iep_date THEN to_jsonb(c.upcoming_iep_date) END,
+      'upcoming_triennial_date', CASE WHEN NEW.upcoming_triennial_date IS NOT NULL AND c.upcoming_triennial_date IS DISTINCT FROM NEW.upcoming_triennial_date THEN to_jsonb(c.upcoming_triennial_date) END,
+      'accommodations',          CASE WHEN COALESCE(array_length(NEW.accommodations, 1), 0) > 0 AND c.accommodations IS DISTINCT FROM NEW.accommodations THEN to_jsonb(c.accommodations) END
+    )), '{}'::jsonb)
+    INTO v_diverged
+    FROM public.children c WHERE c.id = v_child_id;
+
+    IF v_diverged IS NOT NULL THEN
+      RAISE LOG 'SPE-347 child-fact divergence on child % (% caseload rows): student_details for student % overwrote %',
+        v_child_id, v_linked, NEW.student_id, v_diverged;
+    END IF;
+  END IF;
+
+  UPDATE public.children c
+     SET first_name = COALESCE(NEW.first_name, c.first_name),
+         last_name = COALESCE(NEW.last_name, c.last_name),
+         date_of_birth = COALESCE(NEW.date_of_birth, c.date_of_birth),
+         upcoming_iep_date = COALESCE(NEW.upcoming_iep_date, c.upcoming_iep_date),
+         upcoming_triennial_date = COALESCE(NEW.upcoming_triennial_date, c.upcoming_triennial_date),
+         accommodations = CASE
+           WHEN COALESCE(array_length(NEW.accommodations, 1), 0) > 0 THEN NEW.accommodations
+           ELSE c.accommodations
+         END
+   WHERE c.id = v_child_id;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.student_details_mirror_child_facts() IS
+  'SPE-347: mirrors the child-level facts on a student_details row (name, DOB, IEP/triennial dates, accommodations) into the linked children row. Last write wins; NULL/empty never overwrites; divergence on a shared child is logged.';
+
+CREATE TRIGGER trg_student_details_mirror_child_facts
+  AFTER INSERT OR UPDATE ON public.student_details
+  FOR EACH ROW
+  EXECUTE FUNCTION public.student_details_mirror_child_facts();
+
+-- ===========================================================================
+-- 7b. Shrink the definer surface these three functions add
+-- ===========================================================================
+--
+-- All three are trigger functions: nothing should ever call them over
+-- /rest/v1/rpc. Postgres checks EXECUTE on a trigger function at CREATE TRIGGER
+-- time, not when the trigger fires, so revoking here leaves every trigger above
+-- working while removing them from the exposed API — the same treatment
+-- SPE-10 Tier 1+2 gave the existing trigger functions, and what Supabase's
+-- {anon,authenticated}_security_definer_function_executable advisors ask for.
+REVOKE ALL ON FUNCTION public.students_child_link() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.students_mirror_child_facts() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.student_details_mirror_child_facts() FROM PUBLIC, anon, authenticated;
+
+-- ===========================================================================
+-- 8. Post-wiring assertion
+-- ===========================================================================
+-- Proves the objects this migration promises actually exist, so a partially
+-- applied migration cannot look successful.
+
+DO $spe347_check$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid
+                 WHERE c.relname = 'children' AND p.polname = 'children_select') THEN
+    RAISE EXCEPTION 'SPE-347: children_select policy missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid
+                 WHERE c.relname = 'children' AND p.polname = 'children_update') THEN
+    RAISE EXCEPTION 'SPE-347: children_update policy missing';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid
+             WHERE c.relname = 'children' AND p.polcmd IN ('a', 'd')) THEN
+    RAISE EXCEPTION 'SPE-347: unexpected INSERT/DELETE policy on children';
+  END IF;
+  IF NOT (SELECT relrowsecurity FROM pg_class WHERE oid = 'public.children'::regclass) THEN
+    RAISE EXCEPTION 'SPE-347: RLS not enabled on children';
+  END IF;
+  IF (SELECT count(*) FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid
+      WHERE NOT t.tgisinternal AND c.relname IN ('students', 'student_details')
+        AND t.tgname LIKE 'trg_stud%child%') <> 3 THEN
+    RAISE EXCEPTION 'SPE-347: expected 3 child-link/mirror triggers on students + student_details';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname IN ('students_child_link', 'students_mirror_child_facts',
+                        'student_details_mirror_child_facts')
+      AND (has_function_privilege('anon', p.oid, 'EXECUTE')
+           OR has_function_privilege('authenticated', p.oid, 'EXECUTE'))
+  ) THEN
+    RAISE EXCEPTION 'SPE-347: a trigger function is still EXECUTE-able by anon/authenticated';
+  END IF;
+END;
+$spe347_check$;

--- a/supabase/migrations/20260729_spe347_children_foundation.sql
+++ b/supabase/migrations/20260729_spe347_children_foundation.sql
@@ -242,6 +242,7 @@ DECLARE
   v_created bigint := 0;
   v_merged bigint := 0;
   v_held bigint := 0;
+  v_ambiguous bigint := 0;
 
   rec record;
   v_ids uuid[];
@@ -388,16 +389,43 @@ BEGIN
     component AS (
       -- (array_agg ORDER BY)[1] rather than min(): Postgres has no min(uuid).
       SELECT node, (array_agg(seed ORDER BY seed))[1] AS comp FROM reach GROUP BY node
+    ),
+    -- The matcher is PAIRWISE and says nothing about transitivity, so a
+    -- connected component is not automatically one child. Three rows that share
+    -- initials + grade + teacher, where A is "Alice Smith", C is "Carol Jones"
+    -- and B has no name at all, produce edges A-B and B-C via the fallback path
+    -- while A-C is explicitly REFUSED by the name-authoritative rule. Merging
+    -- the component would fuse two children the matcher just said are
+    -- different — irreversibly, since the losing rows are deleted.
+    --
+    -- So a component is only merged when it is a CLIQUE: every pair in it
+    -- matched. Anything else is ambiguous by construction (B matches two
+    -- differently-named children and nothing here can say which it is) and is
+    -- left for the human-confirmed create-or-attach step. A pair is trivially a
+    -- clique, so this changes nothing for the shape all real duplicates have.
+    component_size AS (
+      SELECT comp, count(*) AS n FROM component GROUP BY comp
+    ),
+    component_edges AS (
+      -- `edges` holds both directions, so each undirected pair is counted twice.
+      SELECT c1.comp, count(*) / 2 AS pairs
+      FROM component c1
+      JOIN edges e ON e.x = c1.node
+      JOIN component c2 ON c2.node = e.y AND c2.comp = c1.comp
+      GROUP BY c1.comp
     )
     SELECT
       c.comp,
       array_agg(DISTINCT c.node) AS child_ids,
+      bool_and(cs.n * (cs.n - 1) / 2 = ce.pairs) AS is_clique,
       bool_or(
         (s.school_id || '|' || s.grade_level || '|' || s.initials) = ANY (v_holdout_keys)
       ) AS held_out,
       string_agg(DISTINCT coalesce(sc.name, s.school_id) || ' / grade ' || s.grade_level || ' / ' || s.initials, ', ') AS label,
       string_agg(DISTINCT coalesce(p.email, s.provider_id::text), ', ') AS providers
     FROM component c
+    JOIN component_size cs ON cs.comp = c.comp
+    JOIN component_edges ce ON ce.comp = c.comp
     JOIN public.students s ON s.child_id = c.node
     LEFT JOIN public.schools sc ON sc.id = s.school_id
     LEFT JOIN public.profiles p ON p.id = s.provider_id
@@ -406,6 +434,13 @@ BEGIN
     ORDER BY c.comp
   LOOP
     v_ids := rec.child_ids;
+
+    IF NOT rec.is_clique THEN
+      v_ambiguous := v_ambiguous + 1;
+      RAISE NOTICE 'SPE-347 AMBIGUOUS (not merged, needs human confirmation): % [%] — the matcher links these % children only transitively, and at least one pair in the group does NOT match. children=%',
+        rec.label, rec.providers, array_length(v_ids, 1), v_ids;
+      CONTINUE;
+    END IF;
 
     IF rec.held_out THEN
       -- A hold-out is a judgement call about a MATCHER guess ("are these the
@@ -527,8 +562,8 @@ BEGIN
            ELSE ' CONFLICTS RESOLVED (prefer non-null, then newest updated_at): ' || v_conflicts::text END;
   END LOOP;
 
-  RAISE NOTICE 'SPE-347 merge summary: % duplicate row(s) merged away, % group(s) held out for owner confirmation',
-    v_merged, v_held;
+  RAISE NOTICE 'SPE-347 merge summary: % duplicate row(s) merged away, % group(s) held out for owner confirmation, % group(s) left un-merged as ambiguous',
+    v_merged, v_held, v_ambiguous;
 
   -- ---- Phase 4: assertions -----------------------------------------------
   IF (SELECT count(*) FROM public.students) <> v_students_before THEN
@@ -566,8 +601,8 @@ BEGIN
     RAISE EXCEPTION 'SPE-347: orphan children row(s) created';
   END IF;
 
-  RAISE NOTICE 'SPE-347 backfill complete: % students -> % children (% merged, % held out)',
-    v_students_before, (SELECT count(*) FROM public.children), v_merged, v_held;
+  RAISE NOTICE 'SPE-347 backfill complete: % students -> % children (% merged, % held out, % ambiguous)',
+    v_students_before, (SELECT count(*) FROM public.children), v_merged, v_held, v_ambiguous;
 END;
 $spe347_backfill$;
 

--- a/supabase/migrations/20260729_spe347_children_hardening.sql
+++ b/supabase/migrations/20260729_spe347_children_hardening.sql
@@ -1,0 +1,281 @@
+-- SPE-347 follow-up, same ticket: close three holes the deep self-review found
+-- in 20260729_spe347_children_foundation.sql before either migration merged.
+--
+-- Split into its own file because the foundation migration had already been
+-- applied to production (SPE-339 precedent) when the review ran. The foundation
+-- file itself was corrected in place for the parts that only a fresh replay can
+-- reach — the backfill's district-student-id merge rule and the uniqueness
+-- index predicate — which is safe because NO production row carried a
+-- district_student_id at apply time (0 of 285), so both versions of that logic
+-- produce byte-identical results on the data that actually ran through it.
+-- Everything reachable at RUNTIME is re-defined here instead.
+--
+-- ---------------------------------------------------------------------------
+-- 1. The attach-by-district-student-id branch was a privilege escalation
+-- ---------------------------------------------------------------------------
+-- The original trigger attached a new caseload row to an EXISTING child when
+-- the row's (district_id, district_student_id) already identified one. Both of
+-- those columns are supplied by the client and neither is constrained:
+-- `students_insert`'s WITH CHECK only pins provider_id, and
+-- upsert_students_atomic does not validate districtId either. So any signed-in
+-- provider could insert a throwaway caseload row naming someone else's district
+-- and a guessed student id, and the trigger would hand them a link to that
+-- child — which `children_select` and `children_update` then honour.
+--
+-- Reproduced against a local replica of this schema before fixing: a provider
+-- at a different school in a different district read the target child's
+-- first_name, last_name and date_of_birth, then overwrote them. District
+-- student ids are short, low-entropy, and often sequential, so guessing one is
+-- not a meaningful barrier. This is the same "see it" -> "edit it" escalation
+-- the child_id guard was written to stop, reached through the other key.
+--
+-- The fix removes the attach entirely. The branch only ever existed to stop the
+-- SECOND provider importing a known child from hitting
+-- ux_children_district_student_id and failing their whole insert; that goal is
+-- met instead by creating the child WITHOUT the contested id and logging the
+-- conflict. The caseload row still lands, the student keeps its own
+-- district_student_id, and the two child rows stay separate until the
+-- human-confirmed create-or-attach step (SPE-348) reconciles them — which is
+-- exactly where the ticket puts that decision, and matches today's behaviour,
+-- where two providers of one child simply have two rows.
+--
+-- The INSERT is also no longer a SELECT-then-INSERT race: two concurrent
+-- imports carrying the same id would both have seen "no child yet" and both
+-- tried to insert it, and the loser's entire student INSERT would have died on
+-- 23505 — the very regression the branch existed to prevent. Catching
+-- unique_violation covers the pre-existing case and the concurrent one in one
+-- path.
+
+CREATE OR REPLACE FUNCTION public.students_child_link()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_dsid text;
+  v_child_id uuid;
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.child_id IS DISTINCT FROM OLD.child_id AND auth.uid() IS NOT NULL THEN
+      RAISE EXCEPTION 'students.child_id is managed by the database (SPE-347)'
+        USING ERRCODE = '42501';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF NEW.child_id IS NOT NULL THEN
+    -- Only the database sets the link. auth.uid() IS NULL means there is no
+    -- end-user session: this migration, the service client, and the sim seed.
+    IF auth.uid() IS NOT NULL THEN
+      RAISE EXCEPTION 'students.child_id is managed by the database (SPE-347)'
+        USING ERRCODE = '42501';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  v_dsid := NULLIF(btrim(NEW.district_student_id), '');
+
+  BEGIN
+    INSERT INTO public.children (
+      initials, grade_level, school_id, district_id, state_id, district_student_id
+    )
+    VALUES (
+      NEW.initials, NEW.grade_level, NEW.school_id, NEW.district_id, NEW.state_id, v_dsid
+    )
+    RETURNING id INTO v_child_id;
+  EXCEPTION WHEN unique_violation THEN
+    -- Another child in this district already owns that id. Never attach (see
+    -- the header): create this provider's child without the contested id and
+    -- surface the collision for the create-or-attach step. The caseload row
+    -- itself is unaffected and keeps its own district_student_id.
+    INSERT INTO public.children (
+      initials, grade_level, school_id, district_id, state_id, district_student_id
+    )
+    VALUES (
+      NEW.initials, NEW.grade_level, NEW.school_id, NEW.district_id, NEW.state_id, NULL
+    )
+    RETURNING id INTO v_child_id;
+
+    RAISE LOG 'SPE-347 district_student_id collision: student % claims id % in district %, already held by another child — new child % created without it (SPE-348 reconciles)',
+      NEW.id, v_dsid, NEW.district_id, v_child_id;
+  END;
+
+  NEW.child_id := v_child_id;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.students_child_link() IS
+  'SPE-347: BEFORE INSERT OR UPDATE on students. On insert, creates the child this caseload row serves (SECURITY DEFINER: there is no INSERT policy on children); if the row''s district student id is already held by another child in that district, the new child is created WITHOUT it and the collision is logged — it never attaches to an existing child, because both key columns are client-supplied. On update, refuses any attempt by an end-user session to set or change child_id.';
+
+-- ---------------------------------------------------------------------------
+-- 2. The mirror must not flip a child's district_student_id back and forth
+-- ---------------------------------------------------------------------------
+-- Merging two caseload rows that carry DIFFERENT district student ids keeps one
+-- of them on the surviving child. The original mirror then overwrote that value
+-- with whichever row was updated last, so the child's id flapped between the
+-- two on every subsequent write. A district student id is an identity claim, not
+-- a preference: fill it when the child has none, never silently replace it with
+-- a different one — "disagreements surfaced, never auto-merged" (SPE-339).
+CREATE OR REPLACE FUNCTION public.students_mirror_child_facts()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_dsid text;
+  v_child_dsid text;
+  v_diverged jsonb;
+  v_linked bigint;
+BEGIN
+  v_dsid := NULLIF(btrim(NEW.district_student_id), '');
+
+  SELECT district_student_id INTO v_child_dsid FROM public.children WHERE id = NEW.child_id;
+
+  IF v_dsid IS NOT NULL AND v_child_dsid IS NOT NULL
+     AND upper(btrim(v_child_dsid)) IS DISTINCT FROM upper(v_dsid) THEN
+    RAISE LOG 'SPE-347 district_student_id disagreement on child %: caseload row % says %, child says % — not overwritten',
+      NEW.child_id, NEW.id, v_dsid, v_child_dsid;
+    v_dsid := NULL;
+  END IF;
+
+  -- Filling an empty id still has to respect the per-district uniqueness index,
+  -- or the caller's own UPDATE would abort on a constraint they cannot see.
+  IF v_dsid IS NOT NULL AND v_child_dsid IS NULL AND EXISTS (
+    SELECT 1 FROM public.children c
+    WHERE c.id <> NEW.child_id
+      AND c.district_id IS NOT NULL
+      AND c.district_id = NEW.district_id
+      AND upper(btrim(c.district_student_id)) = upper(v_dsid)
+  ) THEN
+    RAISE LOG 'SPE-347 district_student_id collision: student % carries id % in district %, already held by another child — not mirrored',
+      NEW.id, v_dsid, NEW.district_id;
+    v_dsid := NULL;
+  END IF;
+
+  SELECT count(*) INTO v_linked FROM public.students s WHERE s.child_id = NEW.child_id;
+  IF v_linked > 1 THEN
+    SELECT NULLIF(jsonb_strip_nulls(jsonb_build_object(
+      'initials',    CASE WHEN c.initials IS DISTINCT FROM NEW.initials THEN to_jsonb(c.initials) END,
+      'grade_level', CASE WHEN c.grade_level IS DISTINCT FROM NEW.grade_level THEN to_jsonb(c.grade_level) END,
+      'school_id',   CASE WHEN NEW.school_id IS NOT NULL AND c.school_id IS DISTINCT FROM NEW.school_id THEN to_jsonb(c.school_id) END,
+      'district_id', CASE WHEN NEW.district_id IS NOT NULL AND c.district_id IS DISTINCT FROM NEW.district_id THEN to_jsonb(c.district_id) END,
+      'state_id',    CASE WHEN NEW.state_id IS NOT NULL AND c.state_id IS DISTINCT FROM NEW.state_id THEN to_jsonb(c.state_id) END
+    )), '{}'::jsonb)
+    INTO v_diverged
+    FROM public.children c WHERE c.id = NEW.child_id;
+
+    IF v_diverged IS NOT NULL THEN
+      RAISE LOG 'SPE-347 child-fact divergence on child % (% caseload rows): students row % overwrote %',
+        NEW.child_id, v_linked, NEW.id, v_diverged;
+    END IF;
+  END IF;
+
+  UPDATE public.children c
+     SET initials = NEW.initials,
+         grade_level = NEW.grade_level,
+         school_id = COALESCE(NEW.school_id, c.school_id),
+         district_id = COALESCE(NEW.district_id, c.district_id),
+         state_id = COALESCE(NEW.state_id, c.state_id),
+         district_student_id = COALESCE(c.district_student_id, v_dsid)
+   WHERE c.id = NEW.child_id;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.students_mirror_child_facts() IS
+  'SPE-347: mirrors the child-level facts on a students row into its linked children row. Last write wins; NULL never overwrites; district_student_id only ever FILLS an empty value (a differing id is logged, never applied); divergence on a shared child is logged.';
+
+-- ---------------------------------------------------------------------------
+-- 3. Scope the UPDATE grant to the columns "edit the child" actually means
+-- ---------------------------------------------------------------------------
+-- children_update deliberately lets ANY linked provider edit the child (the
+-- ticket's coarse edit scope). A table-wide UPDATE grant made that include the
+-- scoping and identifier columns — district_id, school_id, state_id and
+-- district_student_id — which are not "child fields" a provider edits: they are
+-- mirrored from the caseload row, and rewriting one lets a provider move a
+-- child between districts or re-stamp its district identifier.
+--
+-- Column-level grants are the outer gate (RLS still applies on top), and the
+-- mirror triggers are SECURITY DEFINER, so the database keeps writing every
+-- column while a signed-in caller can only write the identity/compliance ones.
+REVOKE UPDATE ON public.children FROM authenticated;
+GRANT UPDATE (
+  first_name,
+  last_name,
+  date_of_birth,
+  initials,
+  grade_level,
+  upcoming_iep_date,
+  upcoming_triennial_date,
+  accommodations
+) ON public.children TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 4. Re-align the uniqueness index with the corrected foundation file
+-- ---------------------------------------------------------------------------
+-- Production got the NULLS NOT DISTINCT version; the foundation file now
+-- excludes rows with no district instead (see its §5 comment). No production row
+-- carries a district_student_id, so this rebuild moves no data.
+DROP INDEX IF EXISTS public.ux_children_district_student_id;
+CREATE UNIQUE INDEX IF NOT EXISTS ux_children_district_student_id
+  ON public.children (district_id, (upper(btrim(district_student_id))))
+  WHERE district_id IS NOT NULL
+    AND district_student_id IS NOT NULL
+    AND btrim(district_student_id) <> '';
+
+-- CREATE OR REPLACE preserves a function's ACL, but re-assert it so this file
+-- is correct on a fresh replay too (trigger functions must not be RPC-callable).
+REVOKE ALL ON FUNCTION public.students_child_link() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.students_mirror_child_facts() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.student_details_mirror_child_facts() FROM PUBLIC, anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 5. Known, deliberate: the mirrors are not gated by children_update
+-- ---------------------------------------------------------------------------
+-- Both mirror triggers are SECURITY DEFINER and authorize nothing themselves —
+-- the SOURCE table's policy is the gate. That matters in one place:
+-- `student_details`'s UPDATE policy has an SEA branch (an SEA assigned to a
+-- session for the student may write that student's details, columns
+-- unrestricted), so an SEA can change a child's name / DOB / IEP dates THROUGH
+-- student_details even though `children_update` refuses them a direct write.
+--
+-- This is not a new capability — an SEA can already write exactly those columns
+-- today, and nothing reads `children` yet, so no surface changes. But it does
+-- mean children_update is the rule for DIRECT edits only, and it becomes
+-- user-visible at the cross-provider read switch: at that point an SEA's edit
+-- would reach the co-serving provider's view of the child, which it does not
+-- today. Called out here, in ARCHITECTURE §6, and pinned by an assertion in
+-- scripts/sim-district/verify-children-rls.ts so the behaviour cannot change
+-- unnoticed; the read-switch ticket decides whether to narrow it.
+
+DO $spe347_hardening_check$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.role_table_grants
+    WHERE table_schema = 'public' AND table_name = 'children'
+      AND grantee = 'authenticated' AND privilege_type IN ('INSERT', 'DELETE')
+  ) THEN
+    RAISE EXCEPTION 'SPE-347: authenticated must not hold INSERT/DELETE on children';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM information_schema.column_privileges
+    WHERE table_schema = 'public' AND table_name = 'children'
+      AND grantee = 'authenticated' AND privilege_type = 'UPDATE'
+      AND column_name IN ('district_id', 'school_id', 'state_id', 'district_student_id', 'id')
+  ) THEN
+    RAISE EXCEPTION 'SPE-347: authenticated must not hold UPDATE on the children scoping columns';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.column_privileges
+    WHERE table_schema = 'public' AND table_name = 'children'
+      AND grantee = 'authenticated' AND privilege_type = 'UPDATE'
+      AND column_name = 'first_name'
+  ) THEN
+    RAISE EXCEPTION 'SPE-347: authenticated lost UPDATE on the children identity columns';
+  END IF;
+END;
+$spe347_hardening_check$;

--- a/supabase/migrations/20260729_spe347_mirror_fill_race.sql
+++ b/supabase/migrations/20260729_spe347_mirror_fill_race.sql
@@ -1,0 +1,117 @@
+-- SPE-347, third and final piece: close the check-then-write race on the
+-- mirror's district_student_id FILL path. Found by CodeRabbit on PR #789.
+--
+-- 20260729_spe347_children_hardening.sql §1 removed exactly this shape from the
+-- INSERT path (SELECT-then-INSERT) but left it on the UPDATE path: the mirror
+-- probes with EXISTS for another child holding the same id in the district, then
+-- UPDATEs. The two are not atomic. Two concurrent caseload updates that each
+-- fill an empty child id with the SAME value in one district both see "no
+-- holder"; the loser hits ux_children_district_student_id, and because the
+-- mirror is an AFTER trigger on `students`, that 23505 propagates out and
+-- **rolls back the caller's own students UPDATE** — a write that has nothing to
+-- do with the child row failing because of a constraint the caller cannot see.
+--
+-- Reproduced on a local replica with two concurrent sessions before fixing:
+--
+--   session A: BEGIN; UPDATE students SET district_student_id='RACE-1' ... (held)
+--   session B: BEGIN; UPDATE students SET district_student_id='RACE-1' ...
+--              -> blocks on the index, then on A's commit:
+--   ERROR:  duplicate key value violates unique constraint "ux_children_district_student_id"
+--   CONTEXT: SQL statement "UPDATE public.children c ...
+--   ROLLBACK
+--
+-- The fix is the same one §1 used: keep the cheap EXISTS probe (it handles the
+-- common, already-committed case with a clear log line and no subtransaction),
+-- and wrap the UPDATE so a genuine unique_violation falls back to mirroring
+-- everything EXCEPT the contested id. The caseload row keeps its own
+-- district_student_id either way; only the child-level copy is withheld, and
+-- SPE-348's human-confirmed step reconciles it.
+
+CREATE OR REPLACE FUNCTION public.students_mirror_child_facts()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_dsid text;
+  v_child_dsid text;
+  v_diverged jsonb;
+  v_linked bigint;
+BEGIN
+  v_dsid := NULLIF(btrim(NEW.district_student_id), '');
+
+  SELECT district_student_id INTO v_child_dsid FROM public.children WHERE id = NEW.child_id;
+
+  -- A district student id is an identity claim, not a preference: fill an empty
+  -- one, never silently replace it with a different one (that made a merged
+  -- pair's id flap between two values on every write).
+  IF v_dsid IS NOT NULL AND v_child_dsid IS NOT NULL
+     AND upper(btrim(v_child_dsid)) IS DISTINCT FROM upper(v_dsid) THEN
+    RAISE LOG 'SPE-347 district_student_id disagreement on child %: caseload row % says %, child says % — not overwritten',
+      NEW.child_id, NEW.id, v_dsid, v_child_dsid;
+    v_dsid := NULL;
+  END IF;
+
+  -- Committed-collision fast path.
+  IF v_dsid IS NOT NULL AND v_child_dsid IS NULL AND EXISTS (
+    SELECT 1 FROM public.children c
+    WHERE c.id <> NEW.child_id
+      AND c.district_id IS NOT NULL
+      AND c.district_id = NEW.district_id
+      AND upper(btrim(c.district_student_id)) = upper(v_dsid)
+  ) THEN
+    RAISE LOG 'SPE-347 district_student_id collision: student % carries id % in district %, already held by another child — not mirrored',
+      NEW.id, v_dsid, NEW.district_id;
+    v_dsid := NULL;
+  END IF;
+
+  SELECT count(*) INTO v_linked FROM public.students s WHERE s.child_id = NEW.child_id;
+  IF v_linked > 1 THEN
+    SELECT NULLIF(jsonb_strip_nulls(jsonb_build_object(
+      'initials',    CASE WHEN c.initials IS DISTINCT FROM NEW.initials THEN to_jsonb(c.initials) END,
+      'grade_level', CASE WHEN c.grade_level IS DISTINCT FROM NEW.grade_level THEN to_jsonb(c.grade_level) END,
+      'school_id',   CASE WHEN NEW.school_id IS NOT NULL AND c.school_id IS DISTINCT FROM NEW.school_id THEN to_jsonb(c.school_id) END,
+      'district_id', CASE WHEN NEW.district_id IS NOT NULL AND c.district_id IS DISTINCT FROM NEW.district_id THEN to_jsonb(c.district_id) END,
+      'state_id',    CASE WHEN NEW.state_id IS NOT NULL AND c.state_id IS DISTINCT FROM NEW.state_id THEN to_jsonb(c.state_id) END
+    )), '{}'::jsonb)
+    INTO v_diverged
+    FROM public.children c WHERE c.id = NEW.child_id;
+
+    IF v_diverged IS NOT NULL THEN
+      RAISE LOG 'SPE-347 child-fact divergence on child % (% caseload rows): students row % overwrote %',
+        NEW.child_id, v_linked, NEW.id, v_diverged;
+    END IF;
+  END IF;
+
+  BEGIN
+    UPDATE public.children c
+       SET initials = NEW.initials,
+           grade_level = NEW.grade_level,
+           school_id = COALESCE(NEW.school_id, c.school_id),
+           district_id = COALESCE(NEW.district_id, c.district_id),
+           state_id = COALESCE(NEW.state_id, c.state_id),
+           district_student_id = COALESCE(c.district_student_id, v_dsid)
+     WHERE c.id = NEW.child_id;
+  EXCEPTION WHEN unique_violation THEN
+    -- Lost the race to a concurrent filler. Mirror everything else; the caller's
+    -- students UPDATE must not die for this.
+    RAISE LOG 'SPE-347 district_student_id collision (concurrent): student % claims id % in district % — mirrored without it',
+      NEW.id, v_dsid, NEW.district_id;
+    UPDATE public.children c
+       SET initials = NEW.initials,
+           grade_level = NEW.grade_level,
+           school_id = COALESCE(NEW.school_id, c.school_id),
+           district_id = COALESCE(NEW.district_id, c.district_id),
+           state_id = COALESCE(NEW.state_id, c.state_id)
+     WHERE c.id = NEW.child_id;
+  END;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.students_mirror_child_facts() IS
+  'SPE-347: mirrors the child-level facts on a students row into its linked children row. Last write wins; NULL never overwrites; district_student_id only ever FILLS an empty value and never at the cost of the caller''s own write (a differing id, a committed collision, or a lost race all just skip the id and log); divergence on a shared child is logged.';
+
+REVOKE ALL ON FUNCTION public.students_mirror_child_facts() FROM PUBLIC, anon, authenticated;


### PR DESCRIPTION
Closes SPE-347.

**One child = one `children` row.** A `students` row stays exactly what it is today — one provider's caseload/service entry (ownership, `sessions_per_week`, `minutes_per_session`, per-discipline goals). A pupil served by an RSP and an SLP is now **one** child row and **two** caseload rows pointing at it.

Behavior-identical: nothing reads `children` yet, no existing policy is modified, no column is dropped, and every write path (manual add, roster import, `upsert_students_atomic`) is untouched. All 18 FK dependents — 11k+ `schedule_sessions` included — still key off `students.id`. Nothing was re-keyed.

## Duplicate handling — settled

The backfill found **4** duplicate groups and merged 3 (all sim). The one real pair is **held out and stays that way**:

| School | Grade | Initials | Providers | Status |
|---|---|---|---|---|
| **Mt. Diablo Elementary** | 2 | GB | `ctbeckera@mdusd.org` (OT) + `capininj@mdusd.org` (speech) | **held out — not merged** (owner's call, 2026-07-29) |
| Sim Willow Elementary | K | HM | rsp.willow + slp.itinerant | merged |
| Sim Willow Elementary | 1 | LY | rsp.willow + slp.itinerant | merged |
| Sim Cedar Middle | 7 | HL | rsp.cedar + slp.itinerant | merged |

Not merging is the status quo — both copies keep their own child row, exactly as today. The hold-out is an explicit natural-key entry in the migration (`'062271002458|2|GB'`), not a hardcoded row id.

> **Note for whoever picks up SPE-348:** a re-import will *not* collapse this pair on its own. Once imports carry district student ids, the first provider's import fills their child's `district_student_id`; the second provider's mirror finds that id already held in the district, declines to copy it, and logs the collision. Two children remain — one with the id, one without. Collapsing them is SPE-348's create-or-attach step, by design.

## ⚠️ Discrepancy with the ticket

The ticket says **"5 known groups — 4 sim pairs + 1 real pair"**. The live data has **4 groups: 3 sim + 1 real**. Verified two independent ways against a freshly reset fixture — the SPE-255/290 matcher's exact rule, and the legacy `shared_students` view's looser key — both return the same 4. `docs/SIM_DISTRICT.md` §6 agrees: the fixture designs **2** shared Willow pairs; the third sim pair (Cedar, grade-7 HL) is an accidental collision from the initials generator, not a designed pair.

Nothing in the code hardcodes the number — the merge is matcher-driven and the count is asserted dynamically — so this only matters as a fact about the data.

## Production apply

Per the SPE-339 precedent, applied to prod so the sim district could verify against it.

- **PITR restore point: `2026-07-29 01:25:43 UTC`** (captured immediately before the first apply).
- Applied as: `spe347_children_foundation` → `spe347_revoke_trigger_function_execute` → `spe347_children_hardening` → `spe347_mirror_fill_race`.

**Count invariants, measured immediately post-apply against the pre-apply baseline:**

| | before | after |
|---|---|---|
| `students` | 285 | **285** |
| `schedule_sessions` | 11,433 | **11,433** |
| `student_details` | 112 | **112** |
| student-id fingerprint | `1a31fafe…` | **`1a31fafe…`** |
| session→student fingerprint | `ba1f0ef7…` | **`ba1f0ef7…`** |
| per-provider roster + session counts (109 providers) | `4f9b5a59…` | **`4f9b5a59…`** |
| `children` | — | **282** = 285 − 3 merged |
| unlinked students / orphan children | — | **0 / 0** |

Real (non-sim) data today: **83 students → 83 children**, 10,151 sessions, unchanged. (`children` reads 283 total now because the sim namespace has since been reseeded and seeds 200 children for 202 caseload rows — the 2 *designed* shared pairs. The 282 above is the migration's own output.)

The migration asserts all of this itself and aborts if any of it fails.

## What's in it

**Schema.** `children` (identity + context + compliance facts) and `students.child_id` + index. `district_student_id` is **unique per district** on `children` — on `students` it had to be provider-scoped, because that table holds one row per provider per child.

**No cascade path from `profiles`.** `children` is a *parent* of `students`, so deleting a provider (which cascades away their caseload rows) no longer destroys the child record — the first half of the retention gap the 2026-07-27 audit flagged. Documented caveat: a child whose last caseload row is gone has no link for RLS to reach it by, so it is retained but invisible to non-service callers. That, and whether admin "delete student" should take the child with it, are carried to SPE-349.

**Wiring (DB-side, zero app-code changes).** A `BEFORE INSERT` SECURITY DEFINER trigger creates the child for every new caseload row; `AFTER` triggers mirror child facts from `students`/`student_details`. Last write wins, but **NULL never overwrites** — writes on both tables are routinely partial, so an absent value means "not provided", not "cleared". `district_student_id` only ever *fills* an empty value, and never at the cost of the caller's own write.

**`child_id` is not the caller's to set.** The trigger refuses (`42501`) any end-user attempt to set or move it. `students_insert`'s `WITH CHECK` only constrains `provider_id`, so without that guard a signed-in user could insert a throwaway caseload row carrying someone else's `child_id` and inherit that child's read **and write** access.

**RLS.** `children_select` mirrors every branch of `students_select` through the link (owning provider, teacher-of-student, assigned specialist/SEA, SEA-at-school, site admin). `children_update` is narrower — linked providers only — with the UPDATE **grant column-scoped** to the identity/compliance fields, so scoping/identifier columns stay database-managed. No INSERT or DELETE policy **and no INSERT/DELETE grant**. No policy on `students` references `children`, so there is no recursion surface (SPE-332).

The explicit mirror was kept over a SECURITY DEFINER helper because the join predicates measurably do **not** drag: from a real signed-in session, `children` reads are indistinguishable from `students` reads (median 134 ms vs 139 ms unfiltered; 102 ms vs 106 ms as a site admin — both dominated by network round-trip).

## Review found three real defects — all fixed

Every automated gate (typecheck, lint, 672 tests, production build, full sim-district verification) was green through all three of these.

**1. A privilege escalation I introduced** — caught by `/code-review` at high effort, per the standing rule.

The first cut of the link trigger **attached** a new caseload row to an existing child when `(district_id, district_student_id)` matched. Both columns are client-supplied and unconstrained. **Reproduced on a local replica:** a provider at another school in another district read the target child's `first_name`, `last_name` and `date_of_birth`, then overwrote them. The trigger now never attaches — it creates its own child, dropping the contested id and logging it — while the import the attach existed to protect still succeeds. Pinned by a regression test that runs against production.

**2. A non-transitive merge** — caught by Codex.

The SPE-255/290 matcher is **pairwise**, but the backfill treated a connected component as one child. Three rows sharing school + grade + initials + teacher, where A is "Alice Smith", C is "Carol Jones" and B has no name, produce edges A–B and B–C while A–C is explicitly **refused** by the name-authoritative rule — and the old code fused all three and deleted the losers. A component is now merged only when it is a **clique**; anything else is logged as `AMBIGUOUS` and left for the human step.

**3. A check-then-write race on the mirror's fill path** — caught by CodeRabbit.

The `EXISTS` probe and the `UPDATE` were not atomic, so two concurrent caseload updates filling the same district student id both saw "no holder" and the loser's 23505 propagated out of the AFTER trigger and **rolled back the caller's own `students` UPDATE**. Reproduced with two concurrent sessions; after the fix that write commits, both caseload rows keep their own id, and only the contested child-level copy is withheld.

**Four more from the same self-review:** the backfill treated two NULL `district_id`s as "same district" (would have irreversibly merged unrelated children from different real districts); a held-out group sharing a district student id would have failed the migration with an opaque index error instead of a precise one; the mirror made a merged pair's `district_student_id` flap between two values; and a SELECT-then-INSERT race on the insert path. Plus two sim-script gaps.

**Documented, not changed:** both mirrors are SECURITY DEFINER and authorize nothing — the *source* table's policy is the gate. `student_details`'s UPDATE policy has an SEA branch with no column restriction, so an SEA can change a child's name through `student_details` even though `children_update` refuses them a direct write. Not a new capability, invisible while nothing reads `children`, but it becomes user-visible at the read switch. Pinned by an assertion; carried to SPE-349.

## Verification

Unit tests mock the Supabase client and **cannot see RLS at all**, so everything below was exercised with real signed-in sessions through PostgREST — the same path the browser takes.

- **New `npm run sim:verify-children-rls`** — 26 checks, all green against production: owning provider reads exactly their caseload's children; both providers of a shared pair resolve to the **same** row and both may edit it; an unlinked provider gets **0 rows** on SELECT and **0 rows affected** on UPDATE (asserted by reading the value back with the service client — a 2xx with an empty body proves nothing); direct INSERT/DELETE refused with `42501`; teacher/SEA/site-admin can read but not write; the `child_id` guard refuses on both INSERT and UPDATE; ordinary inserts still auto-link and both mirrors still fire; plus the escalation regression test.
- Negative checks use a value the target does **not** already carry, so a no-op patch can't pass for the wrong reason.
- `sim:reset` + `sim:verify` green; `sim:teardown` → `sim:verify --expect-empty` **all zeros** → `sim:reset` + green, district left standing.
- `sim:verify-rls` (profiles contract) still green — untouched.
- Every migration rehearsed end-to-end on a local PostgreSQL replica before prod, with purpose-built fixtures for each merge path (name-matched, fallback-matched, id-matched, held-out, NULL-district, cross-district, non-transitive A/B/C) and two-session concurrency tests for both races. That rehearsal caught `min(uuid)` not existing, a missing `WITH RECURSIVE`, a row-multiplying `array_agg`, and a non-deterministic merge tie-break — all before production.
- typecheck, lint, 74/74 test suites, 672 tests green. All 11 CI checks green.

## Sim district

`children` classified as seeded; the 2 designed shared pairs share one child each via `childKey()`, with `TOTAL_CHILDREN` derived from the same function the seed uses so the count can't drift from the rule. Teardown sweeps children by school **and** district; verify asserts the count and that no caseload row is unlinked. 202 students → 200 children.

## Out of scope

Import create-or-attach UX (SPE-348); cross-provider read switch + matcher retirement (SPE-349); case manager (SPE-201); column retirement (SPE-350); teacher links (SPE-334).

**Not auto-deployable** (schema migration + RLS) — merge on your go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbrcbNmFgPwr8PexvDzFz3