### PR TITLE
SPE-343: teacher special-activity form offers only the constraint-approved names

### DIFF
--- a/__tests__/unit/components/teacher/special-activities-page.test.tsx
+++ b/__tests__/unit/components/teacher/special-activities-page.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * SPE-343: the teacher "Add Activity" form must offer only the activity names
+ * the special_activities_activity_name_check constraint admits. The old
+ * free-text input let a teacher submit anything — including the form's own
+ * placeholder suggestion ("Art" vs the allowlisted "ART") — and surface a raw
+ * Postgres constraint error. This pins the field as a picker over
+ * SPECIAL_ACTIVITY_TYPES, the same vocabulary the provider form uses, and
+ * that no free-text path to the constraint remains.
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import TeacherSpecialActivitiesPage from '@/app/(dashboard)/dashboard/teacher/special-activities/page';
+import { SPECIAL_ACTIVITY_TYPES } from '@/lib/constants/activity-types';
+
+jest.mock('@/lib/supabase/queries/teacher-portal', () => ({
+  getCurrentTeacher: async () => ({
+    id: 'teacher-1',
+    first_name: 'Test',
+    last_name: 'Teacher',
+    school_id: 'SCH-1',
+  }),
+  getMySpecialActivities: async () => [],
+  createSpecialActivity: jest.fn(),
+  deleteSpecialActivity: jest.fn(),
+}));
+
+jest.mock('@/lib/supabase/client', () => {
+  // The page's school-wide list query awaits the end of a
+  // select().eq().order().order() chain; a self-returning object that also
+  // carries { data, error } satisfies every link and the final await.
+  const chain: Record<string, unknown> = { data: [], error: null };
+  chain.select = () => chain;
+  chain.eq = () => chain;
+  chain.order = () => chain;
+  // One stable client: the real createClient caches a singleton, and the page
+  // keys its fetch effect on the client's identity — a fresh object per call
+  // would re-trigger the fetch on every render and pin the loading state.
+  const client = {
+    auth: { getUser: async () => ({ data: { user: { id: 'user-1' } } }) },
+    from: () => chain,
+  };
+  return { createClient: () => client };
+});
+
+describe('TeacherSpecialActivitiesPage — activity name picker (SPE-343)', () => {
+  it('offers exactly the constraint-approved activity names, with no free-text path', async () => {
+    render(<TeacherSpecialActivitiesPage />);
+
+    fireEvent.click(await screen.findByRole('button', { name: '+ Add Activity' }));
+
+    const picker = screen.getByLabelText('Activity Name') as HTMLSelectElement;
+    expect(picker.tagName).toBe('SELECT');
+
+    const offered = Array.from(picker.options)
+      .map(option => option.value)
+      .filter(value => value !== '');
+    expect(offered).toEqual([...SPECIAL_ACTIVITY_TYPES]);
+
+    expect(document.querySelector('input[name="activity_name"]')).toBeNull();
+  });
+});

--- a/app/(dashboard)/dashboard/teacher/special-activities/page.tsx
+++ b/app/(dashboard)/dashboard/teacher/special-activities/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import { Card } from '@/app/components/ui/card';
 import { getCurrentTeacher, getMySpecialActivities, createSpecialActivity, deleteSpecialActivity } from '@/lib/supabase/queries/teacher-portal';
+import { SPECIAL_ACTIVITY_TYPES } from '@/lib/constants/activity-types';
 
 interface SpecialActivity {
   id: string;
@@ -218,14 +219,26 @@ export default function TeacherSpecialActivitiesPage() {
                   <label htmlFor="activity_name" className="block text-sm font-medium text-gray-700">
                     Activity Name
                   </label>
-                  <input
-                    type="text"
+                  {/* The DB CHECK constraint only admits SPECIAL_ACTIVITY_TYPES;
+                      free text let teachers submit values Postgres rejects with
+                      a raw constraint error (SPE-343). Same picker as the
+                      provider form (add-special-activity-form.tsx). */}
+                  <select
                     name="activity_name"
                     id="activity_name"
                     required
+                    defaultValue=""
                     className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
-                    placeholder="e.g., PE, Library, Art"
-                  />
+                  >
+                    <option value="" disabled>
+                      Select an activity
+                    </option>
+                    {SPECIAL_ACTIVITY_TYPES.map((type) => (
+                      <option key={type} value={type}>
+                        {type}
+                      </option>
+                    ))}
+                  </select>
                 </div>
 
                 <div>


### PR DESCRIPTION
Fixes [SPE-343](https://linear.app/speddy/issue/SPE-343/teacher-special-activity-form-is-free-text-but-the-db-only-accepts-7).

## The bug

The teacher portal's "Add Activity" form was a **free-text input** over a column whose CHECK constraint (`special_activities_activity_name_check`) admits exactly 7 values — so anything else came back as a raw Postgres constraint error. The placeholder itself was a trap: it suggested "Art", the allowlist has `ART`. Invisible until SPE-335 (PR #786) unblocked teacher writes; after that it was the first thing an elementary teacher would hit.

## The change

`app/(dashboard)/dashboard/teacher/special-activities/page.tsx` — the activity field becomes the same `<select>` over `SPECIAL_ACTIVITY_TYPES` the provider form (`add-special-activity-form.tsx`) already uses. The submit handler reads the field from FormData by name, so the swap needs no other logic changes. The two surfaces now share one vocabulary and the constraint is unreachable from the UI.

`__tests__/unit/components/teacher/special-activities-page.test.tsx` — pins that the field is a select offering exactly the allowlisted types and that no free-text input for `activity_name` remains.

Per the ticket, the **vocabulary question** (whether 7 fixed types is the right list for teachers at all) is deliberately deferred as a product decision — this ships the picker first. Checked the other writers: the provider form and the admin master-schedule modal already use pickers; no other free-text path to this column exists.

## Verification

**Sim-district run (real signed-in sessions, per the standing rule) — 17 checks, 0 failures**, district reset before and left standing after (`sim:teardown` → `--expect-empty` all zeros → reset + green):

- Nora (`teacher.willow.1`): the form's activity field is a `<select>`; **no free-text input remains**; the picker offers **exactly** `Library, STEAM, STEM, Garden, Music, ART, PE`; created one activity of each of the 7 types through the real UI, each confirmed by the "My Activities" count advancing.
- **DB tiebreaker:** all 7 rows asserted in `special_activities` with the right `activity_name`, `created_by_role = 'teacher'`, `provider_id NULL`, Willow's `school_id`, and `school_year = '2025-2026'` (the SPE-335 stamp, not the column default).
- **Negative — constraint backstop:** a Node probe signed in as Nora, mirroring the old free-text client path, inserted `activity_name = 'Assembly'` with an otherwise fully valid payload → refused with **23514 naming `special_activities_activity_name_check`** — the failure is the constraint itself, not an incidental error, and it still guards non-UI paths.
- David (`teacher.willow.2`): owns zero activities; the school-wide view shows Nora's teacher-created rows (read posture unchanged).

**Gates:** `typecheck`, `lint`, full test suite (76/76 suites, 675 passed) green.

**Self-review note:** the `/code-review` skill is not model-invocable in this session (same situation PR #787 recorded), so this diff got a manual pass instead. Its one catch: the component test's mocked Supabase client must be a singleton — the real `createClient` caches one, the page keys its fetch effect on the client's identity, and a fresh-object-per-call mock re-triggers the fetch forever and pins the loading state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NFxqgK9zjj2EgVAAoV6VF

---
_Generated by [Claude Code](https://claude.ai/code/session_013NFxqgK9zjj2EgVAAoV6VF)_