### PR TITLE
SPE-348: import create-or-attach — a human-confirmed "same child?" step

### DIFF
--- a/__tests__/unit/app/import-students-preview.characterization.test.ts
+++ b/__tests__/unit/app/import-students-preview.characterization.test.ts
@@ -113,6 +113,14 @@ function makeSupabase(tables: TableData) {
   return {
     auth: { getUser: async () => ({ data: { user: { id: USER_ID } }, error: null }) },
     from: (table: string) => builder(table),
+    // SPE-348: the preview asks find_shared_child_candidates whether any new row
+    // is a child a colleague already serves. Answer "none" so these
+    // characterizations keep pinning the pre-348 shape exactly; the offer
+    // plumbing has its own tests in __tests__/unit/lib/import/child-match.test.ts.
+    rpc: async (fn: string) =>
+      fn === 'find_shared_child_candidates'
+        ? { data: [], error: null }
+        : { data: null, error: null },
   };
 }
 

--- a/__tests__/unit/lib/import/child-match.test.ts
+++ b/__tests__/unit/lib/import/child-match.test.ts
@@ -159,6 +159,27 @@ describe('attachChildMatches (SPE-348)', () => {
     expect(noInserts.rpc).not.toHaveBeenCalled();
   });
 
+  it('degrades when the client THROWS, not just when it returns an error', async () => {
+    // A preview must never 500 because the offer lookup blew up. Regression:
+    // the first cut only handled a returned `error`, so a client without `rpc`
+    // (or a network throw) failed the whole import preview.
+    const previews = [preview()];
+    const client = {
+      rpc: jest.fn().mockRejectedValue(new Error('supabase.rpc is not a function')),
+    } as unknown as ImportSupabaseClient;
+
+    await expect(run(previews, client)).resolves.toBeUndefined();
+    expect(previews[0].childMatch).toBeUndefined();
+  });
+
+  it('ignores a non-array payload rather than iterating it', async () => {
+    const previews = [preview()];
+    const { client } = stubClient({ data: { nope: true } });
+
+    await expect(run(previews, client)).resolves.toBeUndefined();
+    expect(previews[0].childMatch).toBeUndefined();
+  });
+
   it('does not claim a child with a disputed Student ID (SPE-339 withholds it)', async () => {
     // The preview drops a conflicting id, so nothing here should resurrect it.
     const previews = [preview({ districtStudentIdConflict: { districtStudentId: '100482', existingLabel: 'Other Kid' } })];

--- a/__tests__/unit/lib/import/child-match.test.ts
+++ b/__tests__/unit/lib/import/child-match.test.ts
@@ -1,0 +1,171 @@
+/**
+ * SPE-348: the "same child?" offer attached to a preview.
+ *
+ * The matching itself is SQL (one ladder, shared with the write-time
+ * re-validation), so what needs pinning here is the plumbing around it: which
+ * rows are asked about, that answers land on the right row, that nothing is
+ * offered on a shape we don't recognize, and that a failed lookup degrades to
+ * today's behaviour instead of breaking the import.
+ */
+
+import { attachChildMatches } from '@/lib/import/child-match';
+import type { ImportSupabaseClient, StudentPreview } from '@/lib/import/preview-types';
+
+jest.mock('@/lib/monitoring/logger', () => ({
+  log: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const preview = (over: Partial<StudentPreview> = {}): StudentPreview => ({
+  firstName: 'Maya',
+  lastName: 'Gonzalez',
+  initials: 'MG',
+  gradeLevel: '5',
+  goals: [],
+  action: 'insert',
+  ...over,
+});
+
+/** A stub client whose rpc() records its args and returns a canned payload. */
+function stubClient(result: { data?: unknown; error?: unknown }) {
+  const rpc = jest.fn().mockResolvedValue({ data: result.data ?? null, error: result.error ?? null });
+  return { client: { rpc } as unknown as ImportSupabaseClient, rpc };
+}
+
+const run = (previews: StudentPreview[], client: ImportSupabaseClient, schoolId: string | null = 'school-1') =>
+  attachChildMatches({ supabase: client, userId: 'provider-1', schoolId, previews });
+
+describe('attachChildMatches (SPE-348)', () => {
+  it('asks only about insert rows, and maps answers back by position', async () => {
+    const previews = [
+      preview({ action: 'update', firstName: 'Existing', lastName: 'Student' }),
+      preview({ firstName: 'Maya', lastName: 'Gonzalez' }),
+      preview({ action: 'skip', firstName: 'Skipped', lastName: 'Row' }),
+      preview({ firstName: 'Noah', lastName: 'Park', initials: 'NP' }),
+    ];
+    const { client, rpc } = stubClient({
+      // Answer only the SECOND asked row (idx 1 = previews[3]).
+      data: [{ idx: 1, childId: 'child-noah', reason: 'name-grade', gradeLevel: '5' }],
+    });
+
+    await run(previews, client);
+
+    // Only the two inserts were asked about, renumbered 0..1.
+    const rows = rpc.mock.calls[0][1].p_rows;
+    expect(rpc).toHaveBeenCalledWith('find_shared_child_candidates', {
+      p_school_id: 'school-1',
+      p_rows: expect.any(Array),
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r: { idx: number; lastName: string }) => [r.idx, r.lastName])).toEqual([
+      [0, 'Gonzalez'],
+      [1, 'Park'],
+    ]);
+
+    // The answer landed on previews[3], not previews[1].
+    expect(previews[3].childMatch).toMatchObject({ childId: 'child-noah', reason: 'name-grade' });
+    expect(previews[1].childMatch).toBeUndefined();
+    // Non-insert rows are never touched — an offer there would be a merge.
+    expect(previews[0].childMatch).toBeUndefined();
+    expect(previews[2].childMatch).toBeUndefined();
+  });
+
+  it('carries the offer detail the review copy needs', async () => {
+    const previews = [preview()];
+    const { client } = stubClient({
+      data: [
+        {
+          idx: 0,
+          childId: 'child-1',
+          reason: 'district-student-id',
+          gradeLevel: '5',
+          districtStudentId: '100482',
+          providerName: 'Emily Chen',
+          providerRole: 'speech',
+        },
+      ],
+    });
+
+    await run(previews, client);
+
+    expect(previews[0].childMatch).toEqual({
+      childId: 'child-1',
+      reason: 'district-student-id',
+      gradeLevel: '5',
+      districtStudentId: '100482',
+      providerName: 'Emily Chen',
+      providerRole: 'speech',
+    });
+    expect(previews[0].childMatchConflict).toBeUndefined();
+  });
+
+  it('records a conflict as a conflict — never as an offer', async () => {
+    const previews = [preview(), preview({ initials: 'NP' })];
+    const { client } = stubClient({
+      data: [
+        { idx: 0, conflict: 'ambiguous', count: 2 },
+        { idx: 1, conflict: 'id-name-disagreement' },
+      ],
+    });
+
+    await run(previews, client);
+
+    expect(previews[0].childMatch).toBeUndefined();
+    expect(previews[0].childMatchConflict).toEqual({ kind: 'ambiguous', count: 2 });
+    expect(previews[1].childMatch).toBeUndefined();
+    expect(previews[1].childMatchConflict).toEqual({ kind: 'id-name-disagreement', count: undefined });
+  });
+
+  it('ignores an entry it does not understand rather than rendering a blank prompt', async () => {
+    const previews = [preview(), preview({ initials: 'NP' }), preview({ initials: 'AB' })];
+    const { client } = stubClient({
+      data: [
+        { idx: 0, childId: 'child-1', reason: 'vibes' }, // unknown rung
+        { idx: 1, reason: 'name-grade' }, // no child id
+        { idx: 2, conflict: 'something-else' }, // unknown conflict
+      ],
+    });
+
+    await run(previews, client);
+
+    expect(previews.every((p) => p.childMatch === undefined)).toBe(true);
+    expect(previews.every((p) => p.childMatchConflict === undefined)).toBe(true);
+  });
+
+  it('ignores an answer for a row that was never asked about', async () => {
+    const previews = [preview()];
+    const { client } = stubClient({ data: [{ idx: 7, childId: 'child-x', reason: 'name-grade' }] });
+
+    await expect(run(previews, client)).resolves.toBeUndefined();
+    expect(previews[0].childMatch).toBeUndefined();
+  });
+
+  it('degrades to no offers when the lookup fails — the import still proceeds', async () => {
+    const previews = [preview()];
+    const { client } = stubClient({ error: { message: 'boom' } });
+
+    await run(previews, client);
+
+    expect(previews[0].childMatch).toBeUndefined();
+    expect(previews[0].childMatchConflict).toBeUndefined();
+  });
+
+  it('does not call the RPC with no school (the ladder is school-scoped) or no inserts', async () => {
+    const noSchool = stubClient({ data: [] });
+    await run([preview()], noSchool.client, null);
+    expect(noSchool.rpc).not.toHaveBeenCalled();
+
+    const noInserts = stubClient({ data: [] });
+    await run([preview({ action: 'update' }), preview({ action: 'skip' })], noInserts.client);
+    expect(noInserts.rpc).not.toHaveBeenCalled();
+  });
+
+  it('does not claim a child with a disputed Student ID (SPE-339 withholds it)', async () => {
+    // The preview drops a conflicting id, so nothing here should resurrect it.
+    const previews = [preview({ districtStudentIdConflict: { districtStudentId: '100482', existingLabel: 'Other Kid' } })];
+    const { client, rpc } = stubClient({ data: [] });
+
+    await run(previews, client);
+
+    expect(rpc.mock.calls[0][1].p_rows[0].districtStudentId).toBeNull();
+  });
+});

--- a/__tests__/unit/lib/import/confirmed-child-id.test.ts
+++ b/__tests__/unit/lib/import/confirmed-child-id.test.ts
@@ -1,0 +1,40 @@
+/**
+ * SPE-348: the client-side link decision.
+ *
+ * This one function decides whether an imported student becomes a second
+ * caseload row on an EXISTING child or a brand-new child — the highest-stakes
+ * decision in the child-identity plan, and the only place the importer's answer
+ * turns into a write. A regression here silently links (or fails to link)
+ * children, so the three answers are pinned explicitly.
+ */
+
+import { confirmedChildIdFor } from '@/app/components/students/review/student-import-review';
+import type { ChildMatchOffer } from '@/lib/types/student-import';
+
+const offer: ChildMatchOffer = {
+  childId: 'child-1',
+  reason: 'name-grade',
+  gradeLevel: '5',
+  districtStudentId: null,
+  providerName: 'Emily Chen',
+  providerRole: 'speech',
+};
+
+describe('confirmedChildIdFor (SPE-348)', () => {
+  it('claims the child only on an explicit "same child"', () => {
+    expect(confirmedChildIdFor({ childMatch: offer }, 'link')).toBe('child-1');
+  });
+
+  it('claims nothing when declined', () => {
+    expect(confirmedChildIdFor({ childMatch: offer }, 'separate')).toBeUndefined();
+  });
+
+  it('claims nothing when the offer is left unanswered', () => {
+    expect(confirmedChildIdFor({ childMatch: offer }, undefined)).toBeUndefined();
+  });
+
+  it('claims nothing when there was no offer at all — even if a choice leaked in', () => {
+    expect(confirmedChildIdFor({ childMatch: undefined }, 'link')).toBeUndefined();
+    expect(confirmedChildIdFor({ childMatch: undefined }, undefined)).toBeUndefined();
+  });
+});

--- a/__tests__/unit/lib/import/review-model.test.ts
+++ b/__tests__/unit/lib/import/review-model.test.ts
@@ -230,3 +230,111 @@ describe('adaptTargetStudentPreview (SPE-232)', () => {
     });
   });
 });
+
+describe('adaptBulkPreview — create-or-attach offers (SPE-348)', () => {
+  const offer = {
+    childId: 'child-1',
+    reason: 'district-student-id' as const,
+    gradeLevel: '5',
+    districtStudentId: '100482',
+    providerName: 'Emily Chen',
+    providerRole: 'speech',
+  };
+
+  it('turns an offer on a new student into an answerable exception', () => {
+    const data: BulkPreviewData = {
+      students: [
+        {
+          firstName: 'Maya',
+          lastName: 'Gonzalez',
+          initials: 'MG',
+          gradeLevel: '5',
+          action: 'insert',
+          goals: [{ text: 'Read 90 wpm' }],
+          childMatch: offer,
+        },
+      ],
+      summary: { total: 1, inserts: 1, updates: 0, skips: 0 },
+    };
+
+    const model = adaptBulkPreview(data);
+
+    expect(model.rows[0].childMatch).toEqual(offer);
+    expect(model.exceptions).toEqual([
+      {
+        kind: 'possible-shared-child',
+        rowId: 'new:0',
+        studentLabel: 'Maya Gonzalez',
+        match: offer,
+      },
+    ]);
+  });
+
+  it('reports an ambiguous or contested match without offering it', () => {
+    const data: BulkPreviewData = {
+      students: [
+        {
+          firstName: 'Maya',
+          lastName: 'Gonzalez',
+          initials: 'MG',
+          gradeLevel: '5',
+          action: 'insert',
+          goals: [],
+          childMatchConflict: { kind: 'ambiguous', count: 2 },
+        },
+      ],
+      summary: { total: 1, inserts: 1, updates: 0, skips: 0 },
+    };
+
+    const model = adaptBulkPreview(data);
+
+    expect(model.rows[0].childMatch).toBeUndefined();
+    expect(model.exceptions).toEqual([
+      {
+        kind: 'shared-child-not-offered',
+        rowId: 'new:0',
+        studentLabel: 'Maya Gonzalez',
+        conflict: { kind: 'ambiguous', count: 2 },
+      },
+    ]);
+  });
+
+  it('never offers on an update row — re-pointing an existing caseload row is a merge', () => {
+    const data: BulkPreviewData = {
+      students: [
+        {
+          firstName: 'Maya',
+          lastName: 'Gonzalez',
+          initials: 'MG',
+          gradeLevel: '5',
+          action: 'update',
+          matchedStudentId: 'stu-1',
+          goals: [],
+          childMatch: offer,
+          childMatchConflict: { kind: 'ambiguous', count: 2 },
+        },
+      ],
+      summary: { total: 1, inserts: 0, updates: 1, skips: 0 },
+    };
+
+    const model = adaptBulkPreview(data);
+
+    expect(model.rows[0].childMatch).toBeUndefined();
+    expect(model.rows[0].childMatchConflict).toBeUndefined();
+    expect(model.exceptions).toEqual([]);
+  });
+
+  it('leaves every other import untouched — no offer, no exception', () => {
+    const data: BulkPreviewData = {
+      students: [
+        { firstName: 'Jane', lastName: 'Doe', initials: 'JD', gradeLevel: '3', action: 'insert', goals: [] },
+      ],
+      summary: { total: 1, inserts: 1, updates: 0, skips: 0 },
+    };
+
+    const model = adaptBulkPreview(data);
+
+    expect(model.rows[0].childMatch).toBeUndefined();
+    expect(model.exceptions).toEqual([]);
+  });
+});

--- a/app/(dashboard)/dashboard/students/page.tsx
+++ b/app/(dashboard)/dashboard/students/page.tsx
@@ -426,7 +426,7 @@ export default function StudentsPage() {
               checkUnscheduledSessions();
             }}
             onConfirm={async ({ rows }) => {
-              const students = rows.map(({ row, initials, selectedGoalTexts }) => ({
+              const students = rows.map(({ row, initials, selectedGoalTexts, confirmedChildId }) => ({
                 firstName: row.firstName,
                 lastName: row.lastName,
                 initials,
@@ -451,6 +451,10 @@ export default function StudentsPage() {
                 // when the file carried none, or when the id was disputed — the
                 // preview drops a conflicting id rather than re-pointing it.
                 districtStudentId: row.districtStudentId,
+                // Create-or-attach (SPE-348): present only when the importer
+                // answered "same child" on an offer the preview made. The server
+                // re-validates it, so this is a claim rather than an instruction.
+                confirmedChildId,
               }));
 
               const response = await fetch('/api/import-students/confirm', {

--- a/app/api/import-students/confirm/route.ts
+++ b/app/api/import-students/confirm/route.ts
@@ -187,6 +187,23 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
           continue;
         }
 
+        // Reject a malformed confirmed child id here, before anything is queued
+        // (SPE-348). upsert_students_atomic casts it to uuid inside its per-row
+        // block, so a bad value would surface as a raw SQL cast error instead of
+        // a legible one — and this check has to run BEFORE the batchPayload push
+        // below, since bailing out after it would desynchronize batchPayload from
+        // batchPending and misfile every later row's result.
+        if (student.confirmedChildId && !UUID_REGEX.test(student.confirmedChildId)) {
+          results[index] = {
+            success: false,
+            initials: initialsNormalized,
+            action: 'error',
+            error: 'Invalid confirmed child id'
+          };
+          errorCount++;
+          continue;
+        }
+
         // Determine school context up front so the duplicate key is school-aware
         // (matches the (provider, school_id, grade, initials) DB uniqueness, SPE-269).
         // Priority: student-specific (current school selection) > user profile > null.
@@ -346,7 +363,14 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
             upcomingIepDate: student.upcomingIepDate ?? null,
             upcomingTriennialDate: student.upcomingTriennialDate ?? null,
             // District Student ID (SPE-339). Null when the file carried none.
-            districtStudentId: student.districtStudentId ?? null
+            districtStudentId: student.districtStudentId ?? null,
+            // Create-or-attach (SPE-348). Presence-keyed and INSERT-only:
+            // attaching an EXISTING caseload row to another child would be a
+            // merge, which nothing in this plan does — the update branch above
+            // never sends it. Passed through untrusted; upsert_students_atomic
+            // re-validates the claim against the same matcher the offer used and
+            // refuses the row (42501) if it doesn't hold.
+            ...(student.confirmedChildId ? { childId: student.confirmedChildId } : {})
           });
           addedInThisBatch.add(duplicateKey);
         }

--- a/app/components/students/review/review-exception-row.tsx
+++ b/app/components/students/review/review-exception-row.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import type { ReviewException } from '@/lib/import/review-model';
+import type { ChildMatchOffer } from '@/lib/types/student-import';
 import { TeacherAutocomplete } from '../../teachers/teacher-autocomplete';
+import { formatRoleLabel } from '@/lib/utils/role-utils';
 import { ReviewSignalIcon } from './review-signal';
 
 export interface TeacherResolution {
@@ -9,10 +11,52 @@ export interface TeacherResolution {
   teacherName: string | null;
 }
 
+/** The importer's answer to a "same child?" offer (SPE-348). */
+export type ChildLinkChoice = 'link' | 'separate';
+
 interface ReviewExceptionRowProps {
   exception: ReviewException;
   teacherOverride?: TeacherResolution;
   onResolveTeacher: (rowId: string, teacherId: string | null, teacherName: string | null) => void;
+  /** Undefined until the importer answers — which imports as a separate child. */
+  childLinkChoice?: ChildLinkChoice;
+  onResolveChildLink: (rowId: string, choice: ChildLinkChoice) => void;
+}
+
+/**
+ * "Emily Chen (Speech)", "a Speech provider", or "another provider" — whatever
+ * we actually know about who already serves this child.
+ */
+function describeProvider(match: ChildMatchOffer): string {
+  const role = match.providerRole ? formatRoleLabel(match.providerRole) : null;
+  if (match.providerName) return role ? `${match.providerName} (${role})` : match.providerName;
+  return role ? `A ${role} provider` : 'Another provider';
+}
+
+/** Ordinal grade wording for the copy: "a 5th grader", "a Kindergartener". */
+function describeGrade(gradeLevel: string | null): string {
+  const grade = (gradeLevel ?? '').trim();
+  if (!grade) return 'a student';
+  const upper = grade.toUpperCase();
+  if (upper === 'K') return 'a Kindergartener';
+  if (upper === 'TK') return 'a TK student';
+  const n = Number(grade);
+  if (!Number.isInteger(n) || n < 1 || n > 12) return `a grade ${grade} student`;
+  const suffix = n % 100 >= 11 && n % 100 <= 13 ? 'th' : ['th', 'st', 'nd', 'rd'][n % 10] ?? 'th';
+  return `a ${n}${suffix} grader`;
+}
+
+/** The one-line evidence, in the importer's terms. */
+function describeEvidence(match: ChildMatchOffer): string {
+  const who = describeProvider(match);
+  const grade = describeGrade(match.gradeLevel);
+  if (match.reason === 'district-student-id' && match.districtStudentId) {
+    return `${who} already serves ${grade} with the same Student ID (${match.districtStudentId}).`;
+  }
+  if (match.reason === 'name-grade') {
+    return `${who} already serves ${grade} with the same name.`;
+  }
+  return `${who} already serves ${grade} with the same initials and teacher.`;
 }
 
 /**
@@ -20,7 +64,13 @@ interface ReviewExceptionRowProps {
  * are informational (no full record to import); low-confidence teacher matches
  * resolve inline via TeacherAutocomplete; goal removals are enumerated.
  */
-export function ReviewExceptionRow({ exception, teacherOverride, onResolveTeacher }: ReviewExceptionRowProps) {
+export function ReviewExceptionRow({
+  exception,
+  teacherOverride,
+  onResolveTeacher,
+  childLinkChoice,
+  onResolveChildLink,
+}: ReviewExceptionRowProps) {
   if (exception.kind === 'unmatched-student') {
     return (
       <li className="flex items-start gap-2 px-4 py-2 text-sm">
@@ -91,6 +141,87 @@ export function ReviewExceptionRow({ exception, teacherOverride, onResolveTeache
           <p className="mt-0.5 text-xs text-gray-500">
             The student will still be imported, but this ID won&apos;t be saved. Check the ID in your
             source file, then re-import to attach it.
+          </p>
+        </div>
+      </li>
+    );
+  }
+
+  // SPE-348: the "same child?" offer — the one exception here that decides a
+  // write. Nothing is linked unless the importer clicks "Yes"; leaving it
+  // unanswered imports a separate child, exactly as every import does today.
+  if (exception.kind === 'possible-shared-child') {
+    const { match } = exception;
+    const answered = childLinkChoice !== undefined;
+    const linked = childLinkChoice === 'link';
+    const choiceButton = (choice: ChildLinkChoice, label: string) => {
+      const selected = childLinkChoice === choice;
+      return (
+        <button
+          type="button"
+          aria-pressed={selected}
+          onClick={() => onResolveChildLink(exception.rowId, choice)}
+          className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
+            selected
+              ? 'border-gray-900 bg-gray-900 text-white'
+              : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
+          }`}
+        >
+          {label}
+        </button>
+      );
+    };
+
+    return (
+      <li className="flex items-start gap-2 px-4 py-2 text-sm">
+        <ReviewSignalIcon signal="check" className="mt-0.5" decorative />
+        <div className="min-w-0 flex-1">
+          <p>
+            <span className="font-medium text-gray-900">{exception.studentLabel}</span>
+            <span className="text-gray-600"> — may be the same child a colleague already serves</span>
+          </p>
+          <p className="mt-0.5 text-xs text-gray-600">{describeEvidence(match)}</p>
+          <p className="mt-0.5 text-xs text-gray-500">
+            <span className="font-medium text-gray-700">Same child?</span> Yes records them as one
+            child served by two providers. No imports them as a separate student. This doesn&apos;t
+            share your goals or change your caseload.
+          </p>
+          <div className="mt-1.5 flex flex-wrap items-center gap-2">
+            {choiceButton('link', 'Yes — same child')}
+            {choiceButton('separate', 'No — different child')}
+            <span className="text-xs text-gray-500">
+              {!answered
+                ? 'Not answered — will import as a separate student.'
+                : linked
+                  ? 'Will be recorded as the same child.'
+                  : 'Will import as a separate student.'}
+            </span>
+          </div>
+        </div>
+      </li>
+    );
+  }
+
+  // SPE-348: we found something but won't offer it. Informational — the student
+  // imports as a separate child, which is what happens today anyway.
+  if (exception.kind === 'shared-child-not-offered') {
+    const ambiguous = exception.conflict.kind === 'ambiguous';
+    return (
+      <li className="flex items-start gap-2 px-4 py-2 text-sm">
+        <ReviewSignalIcon signal="check" className="mt-0.5" decorative />
+        <div className="min-w-0">
+          <p>
+            <span className="font-medium text-gray-900">{exception.studentLabel}</span>
+            <span className="text-gray-600">
+              {ambiguous
+                ? ' — more than one possible match'
+                : ' — Student ID points to a different child'}
+            </span>
+          </p>
+          <p className="mt-0.5 text-xs text-gray-500">
+            {ambiguous
+              ? `${exception.conflict.count ?? 2} children here could be this student, so nothing will be linked. They'll import as a separate student.`
+              : "A colleague's student has that Student ID under a different name, so nothing will be linked. They'll import as a separate student."}
           </p>
         </div>
       </li>

--- a/app/components/students/review/review-exceptions-queue.tsx
+++ b/app/components/students/review/review-exceptions-queue.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ReviewException } from '@/lib/import/review-model';
-import { ReviewExceptionRow, type TeacherResolution } from './review-exception-row';
+import { ReviewExceptionRow, type ChildLinkChoice, type TeacherResolution } from './review-exception-row';
 
 /**
  * Zone 3 (SPE-227): the exceptions queue — first-class rows for everything that
@@ -13,12 +13,17 @@ interface ReviewExceptionsQueueProps {
   exceptions: ReviewException[];
   teacherOverrides: Record<string, TeacherResolution>;
   onResolveTeacher: (rowId: string, teacherId: string | null, teacherName: string | null) => void;
+  /** SPE-348: answers to the "same child?" offers, keyed by review row id. */
+  childLinkChoices: Record<string, ChildLinkChoice>;
+  onResolveChildLink: (rowId: string, choice: ChildLinkChoice) => void;
 }
 
 export function ReviewExceptionsQueue({
   exceptions,
   teacherOverrides,
   onResolveTeacher,
+  childLinkChoices,
+  onResolveChildLink,
 }: ReviewExceptionsQueueProps) {
   if (exceptions.length === 0) return null;
 
@@ -38,6 +43,10 @@ export function ReviewExceptionsQueue({
               exception.kind === 'low-confidence-teacher' ? teacherOverrides[exception.rowId] : undefined
             }
             onResolveTeacher={onResolveTeacher}
+            childLinkChoice={
+              exception.kind === 'possible-shared-child' ? childLinkChoices[exception.rowId] : undefined
+            }
+            onResolveChildLink={onResolveChildLink}
           />
         ))}
       </ul>

--- a/app/components/students/review/student-import-review.tsx
+++ b/app/components/students/review/student-import-review.tsx
@@ -8,7 +8,7 @@ import { useReviewSelection } from './use-review-selection';
 import { ReviewSummaryBar } from './review-summary-bar';
 import { ReviewFileReceipts } from './review-file-receipts';
 import { ReviewExceptionsQueue } from './review-exceptions-queue';
-import type { TeacherResolution } from './review-exception-row';
+import type { ChildLinkChoice, TeacherResolution } from './review-exception-row';
 import { ReviewTable } from './review-table';
 
 /**
@@ -20,6 +20,12 @@ export interface ReviewConfirmRow {
   row: ReviewRow;
   initials: string;
   selectedGoalTexts: string[];
+  /**
+   * The child the importer explicitly confirmed this new student IS (SPE-348).
+   * Set only on an answered "Yes — same child"; absent for an unanswered or
+   * declined offer, which imports a separate child exactly as today.
+   */
+  confirmedChildId?: string;
 }
 export interface ReviewConfirmSelection {
   rows: ReviewConfirmRow[];
@@ -55,6 +61,9 @@ export function StudentImportReview({
   // Per-student IEP import merges goals (adds, never removes); bulk replaces.
   const isMerge = model.writeMode === 'merge';
   const [teacherOverrides, setTeacherOverrides] = useState<Record<string, TeacherResolution>>({});
+  // SPE-348: answers to the "same child?" offers. Absent = unanswered = a
+  // separate child, so this never needs seeding and an ignored offer is safe.
+  const [childLinkChoices, setChildLinkChoices] = useState<Record<string, ChildLinkChoice>>({});
   const [importing, setImporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // After a partial failure the modal stays open on the error and collapses to
@@ -68,6 +77,10 @@ export function StudentImportReview({
 
   const resolveTeacher = (rowId: string, teacherId: string | null, teacherName: string | null) => {
     setTeacherOverrides((prev) => ({ ...prev, [rowId]: { teacherId, teacherName } }));
+  };
+
+  const resolveChildLink = (rowId: string, choice: ChildLinkChoice) => {
+    setChildLinkChoices((prev) => ({ ...prev, [rowId]: choice }));
   };
 
   const handleImport = async () => {
@@ -91,7 +104,15 @@ export function StudentImportReview({
         const selectedGoalTexts = row.goals
           .filter((_, i) => goalsSelected.has(i))
           .map((g) => g.text);
-        return { row: resolvedRow, initials: selection.initialsFor(row), selectedGoalTexts };
+        // Only an explicit "Yes — same child" carries a child through (SPE-348).
+        const confirmedChildId =
+          row.childMatch && childLinkChoices[row.id] === 'link' ? row.childMatch.childId : undefined;
+        return {
+          row: resolvedRow,
+          initials: selection.initialsFor(row),
+          selectedGoalTexts,
+          confirmedChildId,
+        };
       });
 
       const result = await onConfirm({ rows });
@@ -123,6 +144,13 @@ export function StudentImportReview({
     }
   };
 
+  // SPE-348: "same child?" offers on rows that are actually being imported and
+  // still have no answer. Import is deliberately NOT blocked on them (owner's
+  // call, 2026-07-29) — the footer just says what silence will do.
+  const unansweredChildOffers = selection.selectedRows.filter(
+    (row) => row.childMatch && childLinkChoices[row.id] === undefined,
+  ).length;
+
   // The merge flow's primary action counts goals, not students.
   const goalCount = selection.totalSelectedGoals;
   const primaryDisabled = importing || (isMerge ? goalCount === 0 : selection.selectedCount === 0);
@@ -140,10 +168,18 @@ export function StudentImportReview({
     </Button>
   ) : (
     <>
-      <div className="mr-auto self-center text-sm tabular-nums text-gray-600">
-        {isMerge
-          ? `${goalCount} goal${goalCount !== 1 ? 's' : ''} selected`
-          : `${selection.selectedCount} selected · ${selection.totalSelectedGoals} goals`}
+      <div className="mr-auto self-center text-sm text-gray-600">
+        <span className="tabular-nums">
+          {isMerge
+            ? `${goalCount} goal${goalCount !== 1 ? 's' : ''} selected`
+            : `${selection.selectedCount} selected · ${selection.totalSelectedGoals} goals`}
+        </span>
+        {unansweredChildOffers > 0 && (
+          <span className="block text-xs text-gray-500">
+            {unansweredChildOffers} possible match
+            {unansweredChildOffers !== 1 ? 'es' : ''} unanswered — will import as separate students.
+          </span>
+        )}
       </div>
       <Button variant="secondary" onClick={onClose} disabled={importing}>
         Cancel
@@ -180,6 +216,8 @@ export function StudentImportReview({
           exceptions={model.exceptions}
           teacherOverrides={teacherOverrides}
           onResolveTeacher={resolveTeacher}
+          childLinkChoices={childLinkChoices}
+          onResolveChildLink={resolveChildLink}
         />
         {model.rows.length > 0 && (
           <ReviewTable

--- a/app/components/students/review/student-import-review.tsx
+++ b/app/components/students/review/student-import-review.tsx
@@ -36,6 +36,20 @@ export interface ReviewWriteResult {
   failed: number;
 }
 
+/**
+ * The single client-side gate that decides whether a new student is linked to an
+ * existing child or created as a fresh one (SPE-348). Pure and exported so the
+ * decision is testable on its own: ONLY an explicit "Yes — same child" on a row
+ * that actually carries an offer produces a claim. Declined and unanswered both
+ * yield undefined, which is today's behaviour — a separate child.
+ */
+export function confirmedChildIdFor(
+  row: Pick<ReviewRow, 'childMatch'>,
+  choice: ChildLinkChoice | undefined,
+): string | undefined {
+  return row.childMatch && choice === 'link' ? row.childMatch.childId : undefined;
+}
+
 interface StudentImportReviewProps {
   isOpen: boolean;
   onClose: () => void;
@@ -105,8 +119,7 @@ export function StudentImportReview({
           .filter((_, i) => goalsSelected.has(i))
           .map((g) => g.text);
         // Only an explicit "Yes — same child" carries a child through (SPE-348).
-        const confirmedChildId =
-          row.childMatch && childLinkChoices[row.id] === 'link' ? row.childMatch.childId : undefined;
+        const confirmedChildId = confirmedChildIdFor(row, childLinkChoices[row.id]);
         return {
           row: resolvedRow,
           initials: selection.initialsFor(row),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -523,22 +523,61 @@ erDiagram
   holds one row per provider per child. Cross-district recurrence stays legal.
 - **Rows are created by the database, never by a caller.** A `BEFORE INSERT`
   trigger (`trg_students_child_link` → `students_child_link()`, SECURITY DEFINER)
-  creates the child for every new `students` row. Manual add, roster import and
-  `upsert_students_atomic` were not modified.
-  **It never attaches to an existing child**, deliberately: an earlier cut did
-  attach when `(district_id, district_student_id)` matched, and because both
-  columns are client-supplied and unconstrained (`students_insert` pins only
-  `provider_id`), any provider could link themselves to any child in any
-  district and read or overwrite its name and DOB — verified exploitable on a
-  replica before merge. When the claimed id is already held in that district,
-  the trigger creates this provider's child **without** it and logs the
-  collision; the caseload row still lands, and the two children stay separate
-  until the human-confirmed create-or-attach step (**SPE-348**) reconciles them.
+  creates the child for every new `students` row. Manual add and roster import
+  were not modified. **It never attaches to an existing child on its own**,
+  deliberately: an earlier cut attached when `(district_id, district_student_id)`
+  matched, and because both columns are client-supplied and unconstrained
+  (`students_insert` pins only `provider_id`), any provider could link themselves
+  to any child in any district and read or overwrite its name and DOB — verified
+  exploitable on a replica before merge. When the claimed id is already held in
+  that district, the trigger creates this provider's child **without** it and
+  logs the collision; the caseload row still lands and the two children stay
+  separate until a human reconciles them at import (create-or-attach, below).
 - **`child_id` is not the caller's to set.** The same trigger refuses (`42501`)
   any attempt by an end-user session to set or change it. `students_insert`'s
   `WITH CHECK` only constrains `provider_id`, so without that guard a signed-in
   user could insert a throwaway caseload row carrying someone else's `child_id`
-  and inherit that child's read **and write** access.
+  and inherit that child's read **and write** access. Re-pointing an *existing*
+  caseload row is refused outright, with no exception — that is a merge, and
+  nothing in the plan merges.
+- **Create-or-attach: the one door, and it needs a human (SPE-348).** At import,
+  a **new** row that looks like a child a colleague at the same school already
+  serves surfaces a "same child?" offer in the review screen's *Needs your
+  review* queue. Answering yes sends the child id to
+  `upsert_students_atomic`, which **re-validates the claim** before honouring it
+  — the client's word is never enough. Declining, or ignoring the offer, creates
+  a fresh child exactly as before. Nothing auto-attaches and nothing auto-merges.
+  - **One ladder, two callers.** `import_child_candidates(school_id, rows)` holds
+    the matching: `district_student_id` → full name + grade → initials + grade +
+    teacher (the SPE-339 precedence, the rungs
+    `matching_provider_student_ids` already uses). The offer
+    (`find_shared_child_candidates`, which adds the co-serving provider's name +
+    role) and the write-time re-validation both call it, so the screen and the
+    database cannot disagree about what "matches". Candidates are children **at
+    that school, served by another provider, not already served by the caller**.
+  - **The offer is narrower than the guard.** An ambiguous match (two candidate
+    children) or an id-vs-name disagreement is *reported* and never offered —
+    SPE-339's conflict rule. Validation refuses a contested row outright, but
+    otherwise accepts any candidate for the row rather than only the unique one,
+    so a second candidate appearing between preview and confirm can't turn a
+    human's correct answer into a hard error.
+  - **How the validated id gets past the trigger.** `upsert_students_atomic` sets
+    a transaction-local `app.spe348_confirmed_child_id` to the exact validated id
+    immediately before its INSERT, and the trigger honours `child_id` only when
+    it matches. Not forgeable from a client: `set_config` lives in `pg_catalog`
+    (not exposed by PostgREST), no exposed RPC sets a caller-controlled GUC, and
+    `is_local` scopes it to the transaction — and PostgREST gives every request
+    its own. Everything else still gets the flat `42501`.
+  - **Scope is the school, not the district.** The ticket said "same
+    school/district", but `students.district_id` is stamped from the importing
+    provider's profile and is inconsistent in production (one school carries
+    three distinct values, two of them on one provider's own rows, plus NULLs).
+    Gating on it would suppress exactly the legitimate offers this exists to make
+    while adding nothing: a school belongs to one district.
+  - **Not covered:** manual add (the students page) — it writes through a
+    different path and would be a second user-visible surface; split out per the
+    ticket's own escape hatch. Also unchanged: the update-only import mode, which
+    creates no new caseload rows.
 - **Dual-write.** `AFTER` triggers mirror child facts from `students` and
   `student_details` onto the linked child. Last write wins, but **NULL never
   overwrites** — writes on both tables are routinely partial (the import RPC
@@ -585,10 +624,13 @@ erDiagram
   the cross-provider read-switch step, not this one (§7).
 
 **Source of truth:** `supabase/migrations/20260729_spe347_children_foundation.sql`
-+ `20260729_spe347_children_hardening.sql`;
++ `20260729_spe347_children_hardening.sql`
++ `20260729_spe348_import_create_or_attach.sql`;
 live `children` table + `children_select` / `children_update` policies;
 `students_child_link()`, `students_mirror_child_facts()`,
-`student_details_mirror_child_facts()`; `scripts/sim-district/manifest.ts`
+`student_details_mirror_child_facts()`, `import_child_candidates()`,
+`find_shared_child_candidates()`, `upsert_students_atomic()`;
+`lib/import/child-match.ts`; `scripts/sim-district/manifest.ts`
 (`childKey` / `childId` / `TOTAL_CHILDREN`).
 
 ### The session tables

--- a/docs/SIM_DISTRICT.md
+++ b/docs/SIM_DISTRICT.md
@@ -369,18 +369,23 @@ scripts/sim-district/
                     seeded AND swept tables (must be 0); always read-only
 ```
 
-npm scripts: `sim:reset`, `sim:teardown`, `sim:verify` (all `npx tsx`), plus the
-real-signed-in-session guards that mocked unit tests structurally cannot cover —
-`sim:verify-rls` (`profiles`), `sim:verify-children-rls` (SPE-347 `children` RLS
-+ the child-link trigger) and `sim:verify-child-link` (SPE-348: the server
-re-validating a claimed create-or-attach). Those three sign in as personas, so
-they need `SIM_DISTRICT_PASSWORD` too, and the last two write sim rows — re-seed
-afterwards to restore a pristine fixture.
-Env requirements are scoped per command: all three need
-`NEXT_PUBLIC_SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`;
-`SIM_DISTRICT_PASSWORD` is required **only** by `sim:reset` (it sets persona
-passwords) — read-only `sim:verify` and delete-only `sim:teardown` never
-receive the credential secret.
+npm scripts: the three lifecycle commands `sim:reset`, `sim:teardown`,
+`sim:verify`, plus the **signed-in-session guards** that mocked unit tests
+structurally cannot cover (they see no RLS policy, trigger or SECURITY DEFINER
+guard at all): `sim:verify-rls` (`profiles`), `sim:verify-children-rls`
+(SPE-347 `children` RLS + the child-link trigger) and `sim:verify-child-link`
+(SPE-348: the server re-validating a claimed create-or-attach). All `npx tsx`.
+The two `children` guards write sim rows — re-seed afterward to restore a
+pristine fixture.
+
+Env requirements are scoped per command. Every command needs
+`NEXT_PUBLIC_SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`. Beyond that:
+
+| command | also needs | why |
+|---|---|---|
+| `sim:reset` | `SIM_DISTRICT_PASSWORD` | it sets the persona passwords |
+| `sim:verify`, `sim:teardown` | — | read-only / delete-only, so they never receive the credential secret |
+| the three `sim:verify-*` guards | `SIM_DISTRICT_PASSWORD` + `NEXT_PUBLIC_SUPABASE_ANON_KEY` | they sign IN as personas, which needs the same derived password and a client-side key |
 
 **Preflight, before any write.** Scripts hard-fail unless: **(a)** the
 project ref extracted from `NEXT_PUBLIC_SUPABASE_URL` equals the ref pinned

--- a/docs/SIM_DISTRICT.md
+++ b/docs/SIM_DISTRICT.md
@@ -369,7 +369,13 @@ scripts/sim-district/
                     seeded AND swept tables (must be 0); always read-only
 ```
 
-npm scripts: `sim:reset`, `sim:teardown`, `sim:verify` (all `npx tsx`).
+npm scripts: `sim:reset`, `sim:teardown`, `sim:verify` (all `npx tsx`), plus the
+real-signed-in-session guards that mocked unit tests structurally cannot cover —
+`sim:verify-rls` (`profiles`), `sim:verify-children-rls` (SPE-347 `children` RLS
++ the child-link trigger) and `sim:verify-child-link` (SPE-348: the server
+re-validating a claimed create-or-attach). Those three sign in as personas, so
+they need `SIM_DISTRICT_PASSWORD` too, and the last two write sim rows — re-seed
+afterwards to restore a pristine fixture.
 Env requirements are scoped per command: all three need
 `NEXT_PUBLIC_SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`;
 `SIM_DISTRICT_PASSWORD` is required **only** by `sim:reset` (it sets persona

--- a/lib/import/child-match.ts
+++ b/lib/import/child-match.ts
@@ -1,0 +1,124 @@
+/**
+ * "Same child?" offers for the bulk import preview (SPE-348).
+ *
+ * SPE-347 gave every caseload row a `children` row but never attaches to an
+ * existing one, so two providers who serve the same pupil still end up with two
+ * children. This asks the database, for the NEW rows in a preview, whether any
+ * of them look like a child a colleague at this school already serves — and
+ * hands the answer to the review screen as an offer the importer confirms or
+ * declines. Nothing here decides anything.
+ *
+ * Deliberately narrow:
+ *   - INSERT rows only. An update row already has a caseload row with its own
+ *     child; re-pointing it would be a MERGE, which the plan does not do.
+ *   - Fail-soft. If the lookup fails the import proceeds exactly as it does
+ *     today (a fresh child per row). A create-or-attach offer is an improvement
+ *     on the status quo, never a precondition for importing.
+ *
+ * The matching itself lives in one place — the `import_child_candidates` SQL
+ * ladder that the write-time re-validation in `upsert_students_atomic` also
+ * calls — so the offer on screen and the guard on the write cannot drift.
+ */
+import { log } from '@/lib/monitoring/logger';
+import type { ChildMatchConflict, ChildMatchOffer } from '@/lib/types/student-import';
+import type { ImportSupabaseClient, StudentPreview } from '@/lib/import/preview-types';
+
+/** One entry of the `find_shared_child_candidates` payload. */
+type CandidateRow = {
+  idx: number;
+  childId?: string;
+  reason?: string;
+  gradeLevel?: string | null;
+  districtStudentId?: string | null;
+  providerName?: string | null;
+  providerRole?: string | null;
+  conflict?: string;
+  count?: number;
+};
+
+const MATCH_REASONS = new Set(['district-student-id', 'name-grade', 'initials-grade-teacher']);
+const CONFLICT_KINDS = new Set(['ambiguous', 'id-name-disagreement']);
+
+/**
+ * Attach "same child?" offers to the insert rows of a preview, in place.
+ *
+ * `schoolId` is the school being imported into; without one there is no
+ * candidate set (the ladder is school-scoped) and nothing is offered.
+ */
+export async function attachChildMatches(params: {
+  supabase: ImportSupabaseClient;
+  userId: string;
+  schoolId: string | null;
+  previews: StudentPreview[];
+}): Promise<void> {
+  const { supabase, userId, schoolId, previews } = params;
+  if (!schoolId) return;
+
+  // Position in `previews` for each row we ask about, so the RPC's idx-keyed
+  // answers land back on the right row.
+  const askIndexes: number[] = [];
+  const rows = previews.flatMap((preview, index) => {
+    if (preview.action !== 'insert') return [];
+    const idx = askIndexes.length;
+    askIndexes.push(index);
+    return [
+      {
+        idx,
+        firstName: preview.firstName || null,
+        lastName: preview.lastName || null,
+        initials: preview.initials || null,
+        gradeLevel: preview.gradeLevel || null,
+        // A disputed id (SPE-339) is withheld from the write, so it must not be
+        // used to claim a child either — `districtStudentId` is already absent
+        // in that case, which is exactly the behaviour we want here.
+        districtStudentId: preview.districtStudentId || null,
+        teacherId: preview.teacher?.teacherId || null,
+        teacherName: preview.teacher?.teacherName || null,
+      },
+    ];
+  });
+
+  if (rows.length === 0) return;
+
+  const { data, error } = await supabase.rpc('find_shared_child_candidates', {
+    p_school_id: schoolId,
+    p_rows: rows,
+  });
+
+  if (error) {
+    // Degrade to today's behaviour: no offers, import unaffected.
+    log.error(
+      'Failed to look up shared-child candidates for import preview',
+      error instanceof Error ? error : null,
+      { userId, schoolId, rowCount: rows.length },
+    );
+    return;
+  }
+
+  for (const candidate of (data as CandidateRow[] | null) ?? []) {
+    const target = previews[askIndexes[candidate.idx]];
+    if (!target) continue;
+
+    if (candidate.conflict) {
+      if (!CONFLICT_KINDS.has(candidate.conflict)) continue;
+      target.childMatchConflict = {
+        kind: candidate.conflict as ChildMatchConflict['kind'],
+        count: candidate.count,
+      };
+      continue;
+    }
+
+    // Guard the offer shape rather than trusting it: an unknown reason would
+    // render as an unlabelled "same child?" prompt with no stated evidence.
+    if (!candidate.childId || !candidate.reason || !MATCH_REASONS.has(candidate.reason)) continue;
+
+    target.childMatch = {
+      childId: candidate.childId,
+      reason: candidate.reason as ChildMatchOffer['reason'],
+      gradeLevel: candidate.gradeLevel ?? null,
+      districtStudentId: candidate.districtStudentId ?? null,
+      providerName: candidate.providerName ?? null,
+      providerRole: candidate.providerRole ?? null,
+    };
+  }
+}

--- a/lib/import/child-match.ts
+++ b/lib/import/child-match.ts
@@ -80,13 +80,18 @@ export async function attachChildMatches(params: {
 
   if (rows.length === 0) return;
 
-  const { data, error } = await supabase.rpc('find_shared_child_candidates', {
-    p_school_id: schoolId,
-    p_rows: rows,
-  });
-
-  if (error) {
-    // Degrade to today's behaviour: no offers, import unaffected.
+  // Degrade to today's behaviour on ANY failure — a returned error or a thrown
+  // one. The offer is an improvement on the status quo, never a precondition for
+  // importing, so it must not be able to fail the preview.
+  let data: unknown = null;
+  try {
+    const result = await supabase.rpc('find_shared_child_candidates', {
+      p_school_id: schoolId,
+      p_rows: rows,
+    });
+    if (result.error) throw result.error;
+    data = result.data;
+  } catch (error) {
     log.error(
       'Failed to look up shared-child candidates for import preview',
       error instanceof Error ? error : null,
@@ -95,7 +100,9 @@ export async function attachChildMatches(params: {
     return;
   }
 
-  for (const candidate of (data as CandidateRow[] | null) ?? []) {
+  if (!Array.isArray(data)) return;
+
+  for (const candidate of data as CandidateRow[]) {
     const target = previews[askIndexes[candidate.idx]];
     if (!target) continue;
 

--- a/lib/import/pipeline.ts
+++ b/lib/import/pipeline.ts
@@ -48,6 +48,7 @@ import {
   summarizePreviews,
 } from '@/lib/import/respond';
 import type { ImportSupabaseClient } from '@/lib/import/preview-types';
+import { attachChildMatches } from '@/lib/import/child-match';
 import { createNormalizedKey } from '@/lib/parsers/name-utils';
 
 type Perf = ReturnType<typeof measurePerformanceWithAlerts>;
@@ -376,6 +377,10 @@ export async function runStudentsPreview(ctx: PipelineContext, file: File): Prom
     matchedIepDatesNames,
   );
 
+  // SPE-348: ask whether any of the NEW rows are a child a colleague at this
+  // school already serves, so the review screen can offer "same child?".
+  await attachChildMatches({ supabase, userId, schoolId: currentSchoolId, previews: studentPreviews });
+
   const counts = summarizePreviews(studentPreviews);
   track.event('student_import_preview_generated', {
     userId,
@@ -431,6 +436,15 @@ async function runRosterTemplatePreview(
     dbStudents: dbStudents || [],
     currentSchoolId: form.currentSchoolId,
     dbTeachers,
+  });
+
+  // SPE-348, same as the main path. Roster rows carry no names, so they can only
+  // reach the id rung or the initials+grade+teacher fallback.
+  await attachChildMatches({
+    supabase,
+    userId,
+    schoolId: form.currentSchoolId,
+    previews: studentPreviews,
   });
 
   const insertCount = studentPreviews.filter(s => s.action === 'insert').length;

--- a/lib/import/preview-types.ts
+++ b/lib/import/preview-types.ts
@@ -8,7 +8,11 @@
  * consumed by the review UI).
  */
 import type { DatabaseStudent } from '@/lib/utils/student-matcher';
-import type { IepDatesPreview } from '@/lib/types/student-import';
+import type {
+  ChildMatchConflict,
+  ChildMatchOffer,
+  IepDatesPreview,
+} from '@/lib/types/student-import';
 
 /** Awaited server Supabase client type, without a runtime import of the module. */
 export type ImportSupabaseClient = Awaited<
@@ -84,6 +88,11 @@ export interface StudentPreview {
   /** The incoming id is already on file against a different child (SPE-339).
    *  Surfaced in the review queue; the id itself is not carried to the write. */
   districtStudentIdConflict?: { districtStudentId: string; existingLabel: string };
+  /** "Same child?" offer for a NEW row that looks like a child another provider
+   *  at this school already serves (SPE-348). Attached by attachChildMatches. */
+  childMatch?: ChildMatchOffer;
+  /** Why the match was reported but not offered (SPE-348). */
+  childMatchConflict?: ChildMatchConflict;
 }
 
 /**

--- a/lib/import/review-model.ts
+++ b/lib/import/review-model.ts
@@ -17,6 +17,8 @@ import type {
   BulkPreviewData,
   TargetPreviewData,
   IepDatesPreview,
+  ChildMatchOffer,
+  ChildMatchConflict,
 } from '@/lib/types/student-import';
 
 // The preview/confirm wire contract lives in one shared module (SPE-236) so the
@@ -81,6 +83,12 @@ export interface ReviewRow {
   /** Set when that id already belongs to a different child — surfaced as an
    *  exception and withheld from the write (SPE-339). */
   districtStudentIdConflict?: { districtStudentId: string; existingLabel: string };
+  /** A child a colleague at this school already serves that this NEW row looks
+   *  like (SPE-348). Surfaced as an answerable exception; nothing is linked
+   *  unless the importer says so. */
+  childMatch?: ChildMatchOffer;
+  /** Found something, but not something we're willing to offer (SPE-348). */
+  childMatchConflict?: ChildMatchConflict;
 }
 
 export interface ReviewFileReceipt {
@@ -107,6 +115,20 @@ export type ReviewException =
       studentLabel: string;
       districtStudentId: string;
       existingLabel: string;
+    }
+  // SPE-348: the one answerable exception that writes something. Everything else
+  // in this queue either resolves a field or is informational.
+  | {
+      kind: 'possible-shared-child';
+      rowId: string;
+      studentLabel: string;
+      match: ChildMatchOffer;
+    }
+  | {
+      kind: 'shared-child-not-offered';
+      rowId: string;
+      studentLabel: string;
+      conflict: ChildMatchConflict;
     };
 
 export interface ReviewSummary {
@@ -202,6 +224,10 @@ function toReviewRow(student: BulkStudentPreview, srcIndex: number): ReviewRow {
     iepDates: student.iepDates,
     districtStudentId: student.districtStudentId,
     districtStudentIdConflict: student.districtStudentIdConflict,
+    // SPE-348 — only ever set by the producer on an insert row, but pinned here
+    // too: an offer on an update row would be a merge, which nothing does.
+    childMatch: action === 'insert' ? student.childMatch : undefined,
+    childMatchConflict: action === 'insert' ? student.childMatchConflict : undefined,
     goals,
     goalsRemoved,
     targetStudentId,
@@ -258,6 +284,24 @@ export function adaptBulkPreview(data: BulkPreviewData): ReviewModel {
         studentLabel: row.displayName,
         districtStudentId: row.districtStudentIdConflict.districtStudentId,
         existingLabel: row.districtStudentIdConflict.existingLabel,
+      });
+    }
+    // SPE-348: this new student may be a child a colleague already serves. An
+    // offer, answered by a human — an unanswered one imports as a separate child.
+    if (row.childMatch) {
+      exceptions.push({
+        kind: 'possible-shared-child',
+        rowId: row.id,
+        studentLabel: row.displayName,
+        match: row.childMatch,
+      });
+    } else if (row.childMatchConflict) {
+      // Never both: the RPC returns a conflict INSTEAD of an offer.
+      exceptions.push({
+        kind: 'shared-child-not-offered',
+        rowId: row.id,
+        studentLabel: row.displayName,
+        conflict: row.childMatchConflict,
       });
     }
   }

--- a/lib/types/student-import.ts
+++ b/lib/types/student-import.ts
@@ -89,6 +89,40 @@ export interface BulkStudentPreview {
    *  The id is withheld from the write and the clash is raised in the review
    *  queue for a human to resolve. */
   districtStudentIdConflict?: { districtStudentId: string; existingLabel: string };
+  /** A child already served by another provider at this school that this NEW
+   *  row looks like (SPE-348). An offer, never a decision: nothing links unless
+   *  the importer says "same child". Only ever set on `action: 'insert'` rows. */
+  childMatch?: ChildMatchOffer;
+  /** Why no offer was made even though something was found (SPE-348) — an
+   *  ambiguous match or a Student ID that points at a differently-named child.
+   *  Reported in the review queue; the row imports as a separate child. */
+  childMatchConflict?: ChildMatchConflict;
+}
+
+/** How an incoming row matched an existing child (SPE-348), strongest first. */
+export type ChildMatchReason = 'district-student-id' | 'name-grade' | 'initials-grade-teacher';
+
+/**
+ * The "same child?" offer for one incoming row (SPE-348). Produced by the
+ * `find_shared_child_candidates` RPC, which only ever offers an unambiguous,
+ * uncontested match — so the review screen renders it as a straight yes/no.
+ */
+export interface ChildMatchOffer {
+  childId: string;
+  reason: ChildMatchReason;
+  /** The child's grade, for the review copy ("a 5th grader"). */
+  gradeLevel: string | null;
+  /** The district Student ID that matched, when the match was made on one. */
+  districtStudentId: string | null;
+  /** The co-serving provider — name and role, per the owner's 2026-07-29 call. */
+  providerName: string | null;
+  providerRole: string | null;
+}
+
+export interface ChildMatchConflict {
+  kind: 'ambiguous' | 'id-name-disagreement';
+  /** How many children could be this student. Only set for 'ambiguous'. */
+  count?: number;
 }
 
 export interface BulkFileReceipt {
@@ -173,6 +207,13 @@ export interface StudentToImport {
    * import without ids never erases a stored id.
    */
   districtStudentId?: string;
+  /**
+   * The child the importer confirmed this new student IS (SPE-348). Sent only
+   * after an explicit "same child" click on an offer the preview made, and only
+   * on an insert row. The server re-validates it against the same matcher before
+   * honouring it, so this is a claim, not an instruction.
+   */
+  confirmedChildId?: string;
   /** Defaults to 'insert' server-side for backward compatibility. */
   action?: RowAction;
   /** Required for the 'update' action. */

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "sim:teardown": "tsx scripts/sim-district/teardown.ts",
     "sim:verify": "tsx scripts/sim-district/verify.ts",
     "sim:verify-rls": "tsx scripts/sim-district/verify-profiles-rls.ts",
-    "sim:verify-children-rls": "tsx scripts/sim-district/verify-children-rls.ts"
+    "sim:verify-children-rls": "tsx scripts/sim-district/verify-children-rls.ts",
+    "sim:verify-child-link": "tsx scripts/sim-district/verify-child-link.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",

--- a/scripts/sim-district/verify-child-link.ts
+++ b/scripts/sim-district/verify-child-link.ts
@@ -181,6 +181,52 @@ async function main(): Promise<void> {
   check(!!madeChild && madeChild !== childHereOther && madeChild !== childElsewhere,
     '  ...and got its own fresh child, not a shared one');
 
+  // --- 6. The handshake must not leak between rows of one batch -------------
+  // Every element of a batch runs in the SAME transaction, and the handshake is
+  // a transaction-local setting. If it outlived its own INSERT, the NEXT row
+  // would silently attach to a child nobody confirmed for it — a silent
+  // wrong-child attach, the exact failure this whole ticket exists to prevent.
+  // Reasoning cannot settle this; only the database can.
+  const rachel = await signIn('rachel');
+  const rachelId = await profileId('rachel');
+  await rachel.rpc('upsert_students_atomic', {
+    p_provider_id: rachelId,
+    p_students: [{ ...forgedRow('QQA'), districtStudentId: 'SIM348-GUC' }],
+  });
+  const shared = await childOf(rachelId, 'QQA');
+  check(!!shared, 'setup: a colleague established a genuinely offerable child', String(shared));
+
+  const { data: offered } = await tomas.rpc('find_shared_child_candidates', {
+    p_school_id: WILLOW,
+    p_rows: [{
+      idx: 0, initials: 'QQA', gradeLevel: '5', districtStudentId: 'SIM348-GUC',
+      firstName: 'Forged', lastName: 'Claim',
+    }],
+  });
+  check((offered as any[])?.[0]?.childId === shared, '  ...and it is genuinely OFFERED (so the attach below is legitimate)');
+
+  const { data: r6 } = await callUpsert([
+    { ...forgedRow('QQA', shared!), districtStudentId: 'SIM348-GUC' }, // confirmed attach
+    forgedRow('QQB'),                                                  // ordinary row, no claim
+  ]);
+  const rows6 = ((r6 as any)?.results ?? []) as Array<{ success?: boolean; error?: string }>;
+  check(rows6[0]?.success === true, 'a legitimately confirmed attach succeeds', rows6[0]?.error ?? '');
+  check((await childOf(tomasId, 'QQA')) === shared, '  ...onto the offered child');
+  const nextChild = await childOf(tomasId, 'QQB');
+  check(rows6[1]?.success === true && !!nextChild && nextChild !== shared,
+    'THE HANDSHAKE DOES NOT LEAK: the next row in the batch got its OWN child',
+    `next=${nextChild} attached=${shared}`);
+
+  // --- 7. No back-door merge ------------------------------------------------
+  // Two of the CALLER'S OWN caseload rows on one child is a merge, which nothing
+  // in this plan does. The candidate set excludes children the caller already
+  // serves, so the second claim has nothing to match and is refused.
+  const { data: r7 } = await callUpsert([{ ...forgedRow('QQC', shared!), districtStudentId: 'SIM348-GUC' }]);
+  const row7 = (r7 as any)?.results?.[0];
+  check(row7?.success === false && REFUSED_348.test(String(row7?.error ?? '')),
+    'a SECOND caseload row of his own onto that child is refused (no back-door merge)',
+    row7?.error ?? 'IT SUCCEEDED');
+
   console.log(`\n${failures === 0 ? 'All checks passed.' : `${failures} check(s) FAILED.`}`);
   console.log('Re-seed to restore a pristine fixture: npm run sim:reset -- --yes');
   process.exit(failures > 0 ? 1 : 0);

--- a/scripts/sim-district/verify-child-link.ts
+++ b/scripts/sim-district/verify-child-link.ts
@@ -1,0 +1,192 @@
+/**
+ * SPE-348 — the import create-or-attach guard, run with REAL signed-in sessions.
+ *
+ * Same reason this is a script and not a jest test as its siblings
+ * verify-children-rls.ts / verify-profiles-rls.ts: our unit tests mock the
+ * Supabase client, so they cannot see a trigger, an RLS policy, or a SECURITY
+ * DEFINER guard at all — they pass identically whether the server re-validates a
+ * claimed child link or waves every one through.
+ *
+ * The one thing that must never be true: a client attaching a caseload row to a
+ * child of its choosing. A wrong attach shows a provider a different child's
+ * record, which is why the ticket makes every attach human-confirmed and the
+ * server re-validate every confirmation. This asserts the server half.
+ *
+ * The contract asserted here:
+ *   - a confirmed child at ANOTHER school is refused;
+ *   - a confirmed child at the caller's OWN school that is a different pupil is
+ *     refused (matcher agreement, not just school scoping);
+ *   - a forged row fails ALONE — the honest rows in the same batch still import;
+ *   - the validating RPC cannot be skipped: a raw PostgREST insert carrying
+ *     `child_id` is still refused by the trigger (SPE-347);
+ *   - positive control — the same row WITHOUT a claim imports and gets its own
+ *     fresh child, so the guard is not simply refusing everything.
+ *
+ * Three traps this deliberately avoids (CLAUDE.md):
+ *   - assert the write did NOT PERSIST (row counts read back with the service
+ *     client), never the returned status alone;
+ *   - assert WHY each refusal happened, matching the SPE-348 / SPE-347 message,
+ *     so a value rejected incidentally (a type cast, an FK, a length limit —
+ *     this probe hit exactly that while being written) cannot keep a negative
+ *     check green after the guard it tests is gone;
+ *   - every forged target is a child the caller does NOT already serve, on a
+ *     freshly seeded fixture, so the guard is genuinely exercised.
+ *
+ * Requires a seeded sim district (`npm run sim:reset -- --yes`). It creates sim
+ * caseload rows, so re-seed afterwards to restore a pristine fixture.
+ *
+ * Usage: npm run sim:verify-child-link
+ */
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createAdmin, requireEnv } from './lib';
+import { MAPLE, WILLOW, derivePassword, personaEmail } from './manifest';
+
+const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+const secret = requireEnv('SIM_DISTRICT_PASSWORD');
+
+const admin = createAdmin();
+
+let failures = 0;
+function check(ok: boolean, label: string, detail = ''): void {
+  if (!ok) failures++;
+  console.log(`  [${ok ? 'ok  ' : 'FAIL'}] ${label.padEnd(62)} ${detail}`);
+}
+
+async function signIn(personaKey: string): Promise<SupabaseClient> {
+  const email = personaEmail(personaKey);
+  const client = createClient(url, anon, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: derivePassword(secret, email),
+  });
+  if (error) throw new Error(`sim login failed for ${email} — is the district seeded? (${error.message})`);
+  return client;
+}
+
+async function profileId(personaKey: string): Promise<string> {
+  const { data, error } = await admin
+    .from('profiles').select('id').eq('email', personaEmail(personaKey)).single();
+  if (error) throw new Error(`profile lookup failed for ${personaKey}: ${error.message}`);
+  return data.id as string;
+}
+
+/** Read back with the SERVICE client — the caller's own view can be RLS-filtered. */
+async function countRows(providerId: string, initials: string): Promise<number> {
+  const { count } = await admin
+    .from('students').select('id', { count: 'exact', head: true })
+    .eq('provider_id', providerId).eq('initials', initials);
+  return count ?? 0;
+}
+
+async function childOf(providerId: string, initials: string): Promise<string | null> {
+  const { data } = await admin
+    .from('students').select('child_id')
+    .eq('provider_id', providerId).eq('initials', initials).maybeSingle();
+  return (data?.child_id as string | undefined) ?? null;
+}
+
+/** A caseload row's child at a given school, owned by someone other than `notProvider`. */
+async function someChildAt(schoolId: string, notProvider: string): Promise<string> {
+  const { data, error } = await admin
+    .from('students').select('child_id')
+    .eq('school_id', schoolId).neq('provider_id', notProvider)
+    .not('child_id', 'is', null).limit(1).single();
+  if (error) throw new Error(`no child found at ${schoolId}: ${error.message}`);
+  return data.child_id as string;
+}
+
+const REFUSED_348 = /Confirmed child link refused/;
+
+/** The confirm route's insert payload shape, with an optional claimed child. */
+function forgedRow(initials: string, childId?: string): Record<string, unknown> {
+  return {
+    action: 'insert',
+    initials,
+    gradeLevel: '5',
+    schoolId: WILLOW,
+    districtId: 'SIM-D001',
+    // state_id is varchar(2) — a longer value fails the INSERT for an entirely
+    // unrelated reason and would make these negative checks pass for the wrong
+    // reason. Keep it valid so the ONLY thing that can refuse is the guard.
+    stateId: 'CA',
+    firstName: 'Forged',
+    lastName: 'Claim',
+    goals: [],
+    sessionsPerWeek: 1,
+    minutesPerSession: 30,
+    ...(childId ? { childId } : {}),
+  };
+}
+
+async function main(): Promise<void> {
+  console.log('SPE-348 create-or-attach guard — real signed-in sessions\n');
+
+  const tomas = await signIn('tomas');
+  const tomasId = await profileId('tomas');
+
+  // Tomás works Willow/Juniper/Cedar. Maple is outside his reach entirely.
+  const childElsewhere = await someChildAt(MAPLE, tomasId);
+  const childHereOther = await someChildAt(WILLOW, tomasId);
+  console.log(`  forged targets: other-school=${childElsewhere}  same-school-other-pupil=${childHereOther}\n`);
+
+  const callUpsert = (rows: Array<Record<string, unknown>>) =>
+    tomas.rpc('upsert_students_atomic', { p_provider_id: tomasId, p_students: rows });
+
+  // --- 1. A child at another school ----------------------------------------
+  const { data: r1 } = await callUpsert([forgedRow('ZZA', childElsewhere)]);
+  const row1 = (r1 as any)?.results?.[0];
+  check(row1?.success === false, 'forged claim on a child at ANOTHER school is refused', row1?.error ?? '');
+  check(REFUSED_348.test(String(row1?.error ?? '')), '  ...for the right reason (SPE-348 re-validation)', String(row1?.error ?? ''));
+  check((await countRows(tomasId, 'ZZA')) === 0, '  ...and the caseload row did not persist');
+
+  // --- 2. A child at his own school, but a different pupil ------------------
+  const { data: r2 } = await callUpsert([forgedRow('ZZB', childHereOther)]);
+  const row2 = (r2 as any)?.results?.[0];
+  check(row2?.success === false, 'forged claim on a NON-MATCHING child at his own school is refused', row2?.error ?? '');
+  check(REFUSED_348.test(String(row2?.error ?? '')), '  ...for the right reason (matcher agreement, not just school)', String(row2?.error ?? ''));
+  check((await countRows(tomasId, 'ZZB')) === 0, '  ...and the caseload row did not persist');
+
+  // --- 3. A forged row must not take the honest rows down with it -----------
+  const { data: r3 } = await callUpsert([forgedRow('ZZD', childElsewhere), forgedRow('ZZC')]);
+  const rows3 = ((r3 as any)?.results ?? []) as Array<{ success?: boolean }>;
+  check(rows3[0]?.success === false && rows3[1]?.success === true,
+    'a forged row fails alone; the rest of the batch still imports',
+    `forged=${rows3[0]?.success} honest=${rows3[1]?.success}`);
+  check((await countRows(tomasId, 'ZZC')) === 1, '  ...the honest row landed');
+  check((await countRows(tomasId, 'ZZD')) === 0, '  ...the forged row did not');
+
+  // --- 4. The validating RPC cannot be skipped -----------------------------
+  const { error: e4 } = await tomas.from('students').insert({
+    provider_id: tomasId,
+    initials: 'ZZE',
+    grade_level: '5',
+    school_id: WILLOW,
+    district_id: 'SIM-D001',
+    child_id: childHereOther,
+  });
+  check(!!e4, 'a RAW insert carrying child_id is refused by the trigger', e4?.message ?? 'NO ERROR — it succeeded!');
+  check(/managed by the database/.test(e4?.message ?? '') || (e4 as any)?.code === '42501',
+    '  ...for the right reason (child_id is database-managed, 42501)',
+    `${(e4 as any)?.code ?? ''} ${e4?.message ?? ''}`);
+  check((await countRows(tomasId, 'ZZE')) === 0, '  ...and nothing persisted');
+
+  // --- 5. Positive control --------------------------------------------------
+  const { data: r5 } = await callUpsert([forgedRow('ZZF')]);
+  const row5 = (r5 as any)?.results?.[0];
+  const madeChild = await childOf(tomasId, 'ZZF');
+  check(row5?.success === true, 'positive control: the same row WITHOUT a claim imports normally', row5?.error ?? '');
+  check(!!madeChild && madeChild !== childHereOther && madeChild !== childElsewhere,
+    '  ...and got its own fresh child, not a shared one');
+
+  console.log(`\n${failures === 0 ? 'All checks passed.' : `${failures} check(s) FAILED.`}`);
+  console.log('Re-seed to restore a pristine fixture: npm run sim:reset -- --yes');
+  process.exit(failures > 0 ? 1 : 0);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/sim-district/verify-child-link.ts
+++ b/scripts/sim-district/verify-child-link.ts
@@ -88,14 +88,32 @@ async function childOf(providerId: string, initials: string): Promise<string | n
   return (data?.child_id as string | undefined) ?? null;
 }
 
-/** A caseload row's child at a given school, owned by someone other than `notProvider`. */
+/**
+ * A child at `schoolId` that `notProvider` does NOT already serve.
+ *
+ * Filtering only the selected ROW's provider is not enough: the fixture
+ * deliberately models co-served children (Tomás's first two Willow students are
+ * Rachel's, spec §6), so a row owned by someone else can still point at a child
+ * the caller has their own row for. Picking one of those would make the forged
+ * claims below refuse because the candidate set excludes children you already
+ * serve — the right answer for the wrong reason, and the check would stay green
+ * even if the school scoping and matcher agreement it is meant to test were
+ * gone. Exclude by CHILD, not by row.
+ */
 async function someChildAt(schoolId: string, notProvider: string): Promise<string> {
+  const { data: mine } = await admin
+    .from('students').select('child_id').eq('provider_id', notProvider).not('child_id', 'is', null);
+  const alreadyServed = new Set((mine ?? []).map(r => r.child_id as string));
+
   const { data, error } = await admin
     .from('students').select('child_id')
     .eq('school_id', schoolId).neq('provider_id', notProvider)
-    .not('child_id', 'is', null).limit(1).single();
+    .not('child_id', 'is', null);
   if (error) throw new Error(`no child found at ${schoolId}: ${error.message}`);
-  return data.child_id as string;
+
+  const candidate = (data ?? []).map(r => r.child_id as string).find(id => !alreadyServed.has(id));
+  if (!candidate) throw new Error(`no unserved child at ${schoolId} — fixture drifted?`);
+  return candidate;
 }
 
 const REFUSED_348 = /Confirmed child link refused/;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -4622,6 +4622,10 @@ export type Database = {
           start_time: string
         }[]
       }
+      find_shared_child_candidates: {
+        Args: { p_school_id: string; p_rows: Json }
+        Returns: Json
+      }
       find_school_ids_by_names: {
         Args: {
           p_school_district_name: string

--- a/supabase/migrations/20260729_spe348_import_create_or_attach.sql
+++ b/supabase/migrations/20260729_spe348_import_create_or_attach.sql
@@ -88,8 +88,21 @@ AS $function$
       NULLIF(upper(regexp_replace(COALESCE(r.value->>'initials', ''), '[^A-Za-z]', '', 'g')), '') AS initials,
       NULLIF(r.value->>'teacherId', '')::uuid                                AS teacher_id,
       NULLIF(lower(btrim(COALESCE(r.value->>'teacherName', ''))), '')        AS teacher_name
-    FROM jsonb_array_elements(p_rows) AS r
-    WHERE jsonb_typeof(p_rows) = 'array'
+    -- Guard the SRF's INPUT rather than filtering its output. A `WHERE
+    -- jsonb_typeof(p_rows) = 'array'` does hold in the current plan (Postgres
+    -- evaluates the constant-per-execution qual as a one-time filter), but
+    -- leaning on qual ordering for a correctness guard is fragile — and this is
+    -- reached from an authenticated-callable RPC with a client-supplied payload,
+    -- where the failure mode is a raw SQL error instead of "no candidates".
+    -- Also caps the batch: a direct PostgREST call is not bounded by a file the
+    -- way the import preview is, and each row cross-joins the school's children.
+    FROM jsonb_array_elements(
+           CASE
+             WHEN jsonb_typeof(p_rows) = 'array' AND jsonb_array_length(p_rows) <= 2000
+             THEN p_rows
+             ELSE '[]'::jsonb
+           END
+         ) AS r
   ),
   cand AS (
     SELECT

--- a/supabase/migrations/20260729_spe348_import_create_or_attach.sql
+++ b/supabase/migrations/20260729_spe348_import_create_or_attach.sql
@@ -154,9 +154,19 @@ AS $function$
     WHERE r.initials IS NOT NULL
       AND r.grade_level IS NOT NULL
       AND (r.norm_name IS NULL OR cand.norm_name IS NULL)
+      -- Teacher agreement, verbatim from `matching_provider_student_ids`: ids
+      -- win when BOTH sides have one, and the name is a fallback only when one
+      -- side is missing an id. Without that second guard two rows with
+      -- DIFFERENT teacher ids whose display names happen to collide would count
+      -- as the same teacher — and on this rung (nameless pupils, same initials
+      -- and grade) the teacher is the only thing left doing any work.
       AND (
         (cand.teacher_id IS NOT NULL AND r.teacher_id IS NOT NULL AND cand.teacher_id = r.teacher_id)
-        OR (cand.teacher_name IS NOT NULL AND cand.teacher_name = r.teacher_name)
+        OR (
+          (cand.teacher_id IS NULL OR r.teacher_id IS NULL)
+          AND cand.teacher_name IS NOT NULL
+          AND cand.teacher_name = r.teacher_name
+        )
       )
 
     UNION ALL
@@ -227,9 +237,11 @@ AS $function$
       c.idx,
       bool_or(c.reason = 'id-name-disagreement')  AS has_disagreement,
       count(*) FILTER (WHERE c.reason <> 'id-name-disagreement') AS match_count,
-      -- Only meaningful when match_count = 1.
-      min(c.child_id) FILTER (WHERE c.reason <> 'id-name-disagreement') AS child_id,
-      min(c.reason)   FILTER (WHERE c.reason <> 'id-name-disagreement') AS reason
+      -- Only meaningful when match_count = 1. Both aggregates see the same
+      -- filtered input in the same order, so [1] picks the id and the reason off
+      -- the SAME candidate. (There is no min(uuid) in Postgres anyway.)
+      (array_agg(c.child_id) FILTER (WHERE c.reason <> 'id-name-disagreement'))[1] AS child_id,
+      (array_agg(c.reason)   FILTER (WHERE c.reason <> 'id-name-disagreement'))[1] AS reason
     FROM cands c
     GROUP BY c.idx
   )

--- a/supabase/migrations/20260729_spe348_import_create_or_attach.sql
+++ b/supabase/migrations/20260729_spe348_import_create_or_attach.sql
@@ -1,0 +1,655 @@
+-- SPE-348: import create-or-attach — a human-confirmed "same child?" step.
+--
+-- SPE-347 gave every caseload row a `children` row, but the linking trigger
+-- deliberately NEVER attaches to an existing child: both `district_id` and
+-- `district_student_id` are client-supplied and unconstrained, so attach-on-
+-- insert let any provider link themselves to any child in any district (verified
+-- exploitable before that merge). So today two providers who serve the same
+-- pupil still create two children, and new shared children keep arriving as
+-- duplicates.
+--
+-- This migration opens exactly one narrow, human-confirmed door:
+--
+--   1. `import_child_candidates`  — the matching ladder, in ONE place. Given the
+--      school and a batch of incoming rows it returns the children at that
+--      school, served by OTHER providers, that each row plausibly is. Both the
+--      offer and the write-time re-validation call it, so the screen and the
+--      database can never disagree about what "matches".
+--   2. `find_shared_child_candidates` — the offer the review screen renders.
+--      Collapses ambiguity (never offers a weak or contested match) and adds the
+--      co-serving provider's name + role so the importer can judge.
+--   3. `upsert_students_atomic` — accepts an optional confirmed `childId` per
+--      INSERT element, presence-keyed like the rest of its contract, and
+--      RE-VALIDATES it before honoring it. A client cannot attach a caseload row
+--      to an arbitrary child: the claim has to survive the same ladder, at a
+--      school the caller can actually reach, against a child served by someone
+--      else and not already by the caller.
+--   4. `students_child_link` — keeps its hard 42501 refusal for every other
+--      path; the ONLY exception is a transaction-local handshake that the
+--      validating RPC sets immediately before its INSERT (see the note there).
+--
+-- Nothing auto-attaches and nothing auto-merges. An unanswered offer, an
+-- ambiguous match and an id-vs-name disagreement all fall through to today's
+-- behavior: a fresh child.
+
+-- ---------------------------------------------------------------------------
+-- 1. The ladder (internal — the offer and the validator both call this)
+-- ---------------------------------------------------------------------------
+--
+-- Precedence is SPE-339's, and the rungs are the ones
+-- `matching_provider_student_ids` and `lib/utils/student-matcher.ts` already
+-- use:
+--
+--   1. `district_student_id` — the only identifier in an import that is
+--      actually stable, so it outranks every heuristic. UNLESS the stored child
+--      it lands on has a plainly different name: that is SPE-339's conflict
+--      rule, and it makes the whole ROW un-attachable (reason
+--      'id-name-disagreement') rather than merging two children.
+--   2. Full name + grade.
+--   3. Initials + grade + teacher, and only when a name is missing on one side
+--      — a name that is present and disagrees means a different child (SPE-266).
+--
+-- Candidate set (the ticket's): children AT THIS SCHOOL with caseload rows owned
+-- by OTHER providers. Excluded: children the caller already serves (attaching a
+-- second caseload row of your own to one child is a merge, not a link).
+--
+-- Known limitation, shared with `matching_provider_student_ids`: grades compare
+-- literally, so a legacy SEIS grade ('18' for TK, '0' for K) does not reconcile
+-- with the 'TK'/'K' the parsers emit the way the TypeScript matcher's
+-- normalizeGradeLevel does. That costs a missed OFFER, never a wrong link.
+-- Left alone here on purpose — changing the SQL ladder's grade semantics would
+-- move `matching_provider_student_ids` too, which is SPE-349's surface.
+--
+-- Scope is the SCHOOL, not the district. The ticket says "same school/district",
+-- but `students.district_id` is stamped from the importing provider's profile
+-- and is demonstrably inconsistent in production — one school (062271002457)
+-- carries three distinct district_id values, two of them on rows belonging to
+-- ONE provider, plus NULLs. Gating on it would suppress exactly the legitimate
+-- cross-provider offers this ticket exists to create, while adding no safety: a
+-- school belongs to one district, so school equality already implies it.
+CREATE OR REPLACE FUNCTION public.import_child_candidates(
+  p_school_id character varying,
+  p_rows jsonb
+)
+RETURNS TABLE(idx integer, child_id uuid, reason text)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'auth', 'pg_temp'
+AS $function$
+  WITH rows_in AS (
+    SELECT
+      (r.value->>'idx')::integer AS idx,
+      -- Trim + case-fold only, matching normalizeDistrictStudentId (SPE-339):
+      -- "0012345" and "12345" can be two different children.
+      NULLIF(upper(btrim(COALESCE(r.value->>'districtStudentId', ''))), '') AS dsid,
+      public.norm_student_name(r.value->>'firstName', r.value->>'lastName')  AS norm_name,
+      NULLIF(btrim(COALESCE(r.value->>'gradeLevel', '')), '')                AS grade_level,
+      NULLIF(upper(regexp_replace(COALESCE(r.value->>'initials', ''), '[^A-Za-z]', '', 'g')), '') AS initials,
+      NULLIF(r.value->>'teacherId', '')::uuid                                AS teacher_id,
+      NULLIF(lower(btrim(COALESCE(r.value->>'teacherName', ''))), '')        AS teacher_name
+    FROM jsonb_array_elements(p_rows) AS r
+    WHERE jsonb_typeof(p_rows) = 'array'
+  ),
+  cand AS (
+    SELECT
+      s.child_id,
+      -- The child's own identity facts, falling back to the caseload row's.
+      -- `children.district_student_id` is only ever FILLED, never overwritten
+      -- (SPE-347), so it is still empty for every production child today while
+      -- `students.district_student_id` is what SPE-339's import populates.
+      NULLIF(upper(btrim(COALESCE(c.district_student_id, s.district_student_id, ''))), '') AS dsid,
+      COALESCE(
+        public.norm_student_name(c.first_name, c.last_name),
+        public.norm_student_name(d.first_name, d.last_name)
+      ) AS norm_name,
+      NULLIF(btrim(COALESCE(c.grade_level, s.grade_level, '')), '') AS grade_level,
+      NULLIF(upper(regexp_replace(COALESCE(c.initials, s.initials, ''), '[^A-Za-z]', '', 'g')), '') AS initials,
+      -- Teacher is a caseload fact, not a child fact, so it comes off the row.
+      s.teacher_id,
+      NULLIF(lower(btrim(COALESCE(s.teacher_name, ''))), '') AS teacher_name
+    FROM public.students s
+    JOIN public.children c ON c.id = s.child_id
+    LEFT JOIN public.student_details d ON d.student_id = s.id
+    WHERE auth.uid() IS NOT NULL
+      AND p_school_id IS NOT NULL
+      AND s.school_id = p_school_id
+      AND c.school_id = p_school_id
+      AND s.provider_id <> auth.uid()
+      -- The caller has to actually be at this school. Without this a provider
+      -- could name any school id and enumerate its children.
+      AND EXISTS (
+        SELECT 1 FROM public.user_accessible_school_ids() a WHERE a.school_id = p_school_id
+      )
+      -- Already on the caller's caseload → not a create-or-attach candidate.
+      AND NOT EXISTS (
+        SELECT 1 FROM public.students mine
+        WHERE mine.child_id = s.child_id AND mine.provider_id = auth.uid()
+      )
+  ),
+  matched AS (
+    -- Rung 1: the district's own student id.
+    SELECT r.idx, cand.child_id, 1 AS rung, 'district-student-id' AS reason
+    FROM rows_in r
+    JOIN cand ON cand.dsid = r.dsid
+    WHERE r.dsid IS NOT NULL
+      -- SPE-339's conflict rule: an id landing on a plainly different name is
+      -- not a match. It is reported (below) and nothing is merged.
+      AND (r.norm_name IS NULL OR cand.norm_name IS NULL OR cand.norm_name = r.norm_name)
+
+    UNION ALL
+
+    -- Rung 2: full name + grade.
+    SELECT r.idx, cand.child_id, 2, 'name-grade'
+    FROM rows_in r
+    JOIN cand ON cand.norm_name = r.norm_name AND cand.grade_level = r.grade_level
+    WHERE r.norm_name IS NOT NULL AND r.grade_level IS NOT NULL
+
+    UNION ALL
+
+    -- Rung 3: initials + grade + teacher, only when a name is missing on a side.
+    SELECT r.idx, cand.child_id, 3, 'initials-grade-teacher'
+    FROM rows_in r
+    JOIN cand ON cand.initials = r.initials AND cand.grade_level = r.grade_level
+    WHERE r.initials IS NOT NULL
+      AND r.grade_level IS NOT NULL
+      AND (r.norm_name IS NULL OR cand.norm_name IS NULL)
+      AND (
+        (cand.teacher_id IS NOT NULL AND r.teacher_id IS NOT NULL AND cand.teacher_id = r.teacher_id)
+        OR (cand.teacher_name IS NOT NULL AND cand.teacher_name = r.teacher_name)
+      )
+
+    UNION ALL
+
+    -- Not a match — a REPORT. An incoming id that resolves to a child whose
+    -- stored name disagrees poisons the whole row: no attach is offered and none
+    -- is honored, because we have no basis to choose between the id and the name.
+    SELECT r.idx, cand.child_id, 0, 'id-name-disagreement'
+    FROM rows_in r
+    JOIN cand ON cand.dsid = r.dsid
+    WHERE r.dsid IS NOT NULL
+      AND r.norm_name IS NOT NULL
+      AND cand.norm_name IS NOT NULL
+      AND cand.norm_name <> r.norm_name
+  )
+  -- One row per (incoming row, child), labelled by the strongest rung that hit.
+  SELECT DISTINCT ON (m.idx, m.child_id) m.idx, m.child_id, m.reason
+  FROM matched m
+  ORDER BY m.idx, m.child_id, m.rung;
+$function$;
+
+COMMENT ON FUNCTION public.import_child_candidates(character varying, jsonb) IS
+  'SPE-348: the create-or-attach matching ladder. Internal — the offer '
+  '(find_shared_child_candidates) and the write-time re-validation '
+  '(upsert_students_atomic) both call it so they cannot disagree.';
+
+REVOKE ALL ON FUNCTION public.import_child_candidates(character varying, jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.import_child_candidates(character varying, jsonb)
+  TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- 2. The offer the review screen renders
+-- ---------------------------------------------------------------------------
+--
+-- Returns one entry per incoming row that has something to say. Three shapes:
+--
+--   {idx, childId, reason, gradeLevel, districtStudentId, providerName, providerRole}
+--     → offer "same child?" for this row.
+--   {idx, conflict: 'ambiguous', count}
+--     → more than one child could be this student. Never offered: "no
+--       auto-attach on weak signals".
+--   {idx, conflict: 'id-name-disagreement'}
+--     → the incoming Student ID belongs to a child with a different name.
+--
+-- Disclosure: the co-serving provider's NAME and role. That is wider than
+-- find_matching_provider_sessions (role only, never a name), and deliberate —
+-- owner's call on 2026-07-29: the importer is deciding whether two records are
+-- one child, and "ask Emily" is the only way to actually settle it. Note what is
+-- still NOT disclosed: the other provider's stored name for the child, their
+-- goals, and anything about children that did NOT match a row the caller
+-- already holds in their own file.
+CREATE OR REPLACE FUNCTION public.find_shared_child_candidates(
+  p_school_id character varying,
+  p_rows jsonb
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'auth', 'pg_temp'
+AS $function$
+  WITH cands AS (
+    SELECT * FROM public.import_child_candidates(p_school_id, p_rows)
+  ),
+  per_row AS (
+    SELECT
+      c.idx,
+      bool_or(c.reason = 'id-name-disagreement')  AS has_disagreement,
+      count(*) FILTER (WHERE c.reason <> 'id-name-disagreement') AS match_count,
+      -- Only meaningful when match_count = 1.
+      min(c.child_id) FILTER (WHERE c.reason <> 'id-name-disagreement') AS child_id,
+      min(c.reason)   FILTER (WHERE c.reason <> 'id-name-disagreement') AS reason
+    FROM cands c
+    GROUP BY c.idx
+  )
+  SELECT COALESCE(jsonb_agg(payload ORDER BY idx), '[]'::jsonb)
+  FROM (
+    SELECT
+      pr.idx,
+      CASE
+        WHEN pr.has_disagreement
+          THEN jsonb_build_object('idx', pr.idx, 'conflict', 'id-name-disagreement')
+        WHEN pr.match_count > 1
+          THEN jsonb_build_object('idx', pr.idx, 'conflict', 'ambiguous', 'count', pr.match_count)
+        WHEN pr.match_count = 1
+          THEN jsonb_build_object(
+                 'idx', pr.idx,
+                 'childId', pr.child_id,
+                 'reason', pr.reason,
+                 'gradeLevel', ch.grade_level,
+                 'districtStudentId', NULLIF(btrim(COALESCE(ch.district_student_id, owner.district_student_id, '')), ''),
+                 'providerName', NULLIF(btrim(COALESCE(op.full_name, '')), ''),
+                 'providerRole', op.role
+               )
+        ELSE NULL
+      END AS payload
+    FROM per_row pr
+    LEFT JOIN public.children ch ON ch.id = pr.child_id
+    -- The co-serving caseload row to attribute the match to. A child can be on
+    -- several other caseloads; name the longest-standing one.
+    LEFT JOIN LATERAL (
+      SELECT s.provider_id, s.district_student_id
+      FROM public.students s
+      WHERE s.child_id = pr.child_id AND s.provider_id <> auth.uid()
+      ORDER BY s.created_at, s.id
+      LIMIT 1
+    ) owner ON true
+    LEFT JOIN public.profiles op ON op.id = owner.provider_id
+  ) rows_out
+  WHERE payload IS NOT NULL;
+$function$;
+
+COMMENT ON FUNCTION public.find_shared_child_candidates(character varying, jsonb) IS
+  'SPE-348: the import review screen''s "same child?" offer. Never offers an '
+  'ambiguous or id-vs-name-contested match — those come back as conflicts.';
+
+REVOKE ALL ON FUNCTION public.find_shared_child_candidates(character varying, jsonb)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.find_shared_child_candidates(character varying, jsonb)
+  TO authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 3. The trigger keeps its refusal, plus one handshake
+-- ---------------------------------------------------------------------------
+--
+-- Unchanged from SPE-347 except the INSERT branch. `child_id` is still not the
+-- caller's to set: `students_insert`'s WITH CHECK only constrains provider_id,
+-- so without this guard any signed-in user could insert a throwaway caseload row
+-- carrying someone else's child_id and inherit that child's read AND write
+-- access through `children_select` / `children_update`.
+--
+-- The single exception is a transaction-local handshake. `upsert_students_atomic`
+-- validates the claimed child (§4) and then sets
+-- `app.spe348_confirmed_child_id` to that exact id with is_local => true,
+-- immediately before its INSERT. This is not forgeable from a client:
+--   * `set_config` lives in pg_catalog, which PostgREST does not expose, and no
+--     exposed RPC sets a caller-controlled GUC;
+--   * is_local => true scopes it to the transaction, and PostgREST runs every
+--     request in its own — so it cannot be planted by an earlier request;
+--   * it must equal the child_id being written, so a stale or wrong value
+--     refuses rather than waving anything through.
+-- A service-role/migration caller (auth.uid() IS NULL) is unaffected, as before.
+CREATE OR REPLACE FUNCTION public.students_child_link()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_dsid text;
+  v_child_id uuid;
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    -- Re-pointing an existing caseload row at another child is a MERGE, which
+    -- nothing in SPE-348 does. Still refused outright.
+    IF NEW.child_id IS DISTINCT FROM OLD.child_id AND auth.uid() IS NOT NULL THEN
+      RAISE EXCEPTION 'students.child_id is managed by the database (SPE-347)'
+        USING ERRCODE = '42501';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF NEW.child_id IS NOT NULL THEN
+    IF auth.uid() IS NOT NULL
+       AND NEW.child_id::text IS DISTINCT FROM
+           NULLIF(current_setting('app.spe348_confirmed_child_id', true), '')
+    THEN
+      RAISE EXCEPTION 'students.child_id is managed by the database (SPE-347/348)'
+        USING ERRCODE = '42501';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  v_dsid := NULLIF(btrim(NEW.district_student_id), '');
+
+  BEGIN
+    INSERT INTO public.children (
+      initials, grade_level, school_id, district_id, state_id, district_student_id
+    )
+    VALUES (
+      NEW.initials, NEW.grade_level, NEW.school_id, NEW.district_id, NEW.state_id, v_dsid
+    )
+    RETURNING id INTO v_child_id;
+  EXCEPTION WHEN unique_violation THEN
+    INSERT INTO public.children (
+      initials, grade_level, school_id, district_id, state_id, district_student_id
+    )
+    VALUES (
+      NEW.initials, NEW.grade_level, NEW.school_id, NEW.district_id, NEW.state_id, NULL
+    )
+    RETURNING id INTO v_child_id;
+
+    RAISE LOG 'SPE-347 district_student_id collision: student % claims id % in district %, already held by another child — new child % created without it (SPE-348 reconciles)',
+      NEW.id, v_dsid, NEW.district_id, v_child_id;
+  END;
+
+  NEW.child_id := v_child_id;
+  RETURN NEW;
+END;
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- 4. The write path: an optional confirmed child, re-validated server-side
+-- ---------------------------------------------------------------------------
+--
+-- Only the INSERT branch changes. `childId` is presence-keyed like the rest of
+-- the contract, and honoured only if ALL of these hold — re-checked here, never
+-- taken on the client's word:
+--   * the claimed child is among the candidates the ladder returns for THIS
+--     row's own facts (§1), which pins school, other-provider ownership, "not
+--     already mine", and matcher agreement in one place;
+--   * the row carries no id-vs-name disagreement.
+-- Anything else raises 42501 INSIDE the per-row subtransaction, so the forged
+-- row fails and the rest of the batch still imports.
+--
+-- Deliberately "among the candidates" rather than "the only candidate": the
+-- offer already refuses to surface an ambiguous match, so a second candidate
+-- appearing between preview and confirm (another provider importing concurrently)
+-- must not turn the human's confirmed, correct choice into a hard error.
+CREATE OR REPLACE FUNCTION public.upsert_students_atomic(p_provider_id uuid, p_students jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_student jsonb;
+  v_action text;
+  v_student_id uuid;
+  v_new_student_id uuid;
+  v_results jsonb := '[]'::jsonb;
+  v_result jsonb;
+  v_inserted integer := 0;
+  v_updated integer := 0;
+  v_skipped integer := 0;
+  v_errors integer := 0;
+  v_new_sessions_per_week integer;
+  v_provider_role text;
+  v_child_id uuid;
+  v_school_id character varying;
+BEGIN
+  IF auth.uid() IS NULL OR p_provider_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Unauthorized' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT role INTO v_provider_role
+  FROM public.profiles
+  WHERE id = p_provider_id;
+
+  v_provider_role := COALESCE(v_provider_role, 'resource');
+
+  FOR v_student IN SELECT * FROM jsonb_array_elements(p_students)
+  LOOP
+    v_action := v_student->>'action';
+    v_student_id := (v_student->>'studentId')::uuid;
+
+    BEGIN
+      CASE v_action
+        WHEN 'insert' THEN
+          -- SPE-348: an optional confirmed child link. Absent for every import
+          -- that isn't answering a "same child?" offer, which is almost all of
+          -- them.
+          v_child_id := NULL;
+          IF NULLIF(v_student->>'childId', '') IS NOT NULL THEN
+            v_child_id := (v_student->>'childId')::uuid;
+            v_school_id := v_student->>'schoolId';
+
+            -- One pass over the ladder: the claim has to hit, and the row has to
+            -- be free of an id-vs-name disagreement. With no candidates at all
+            -- both aggregates are NULL and the guard refuses, which is right.
+            IF NOT EXISTS (
+              SELECT 1
+              FROM (
+                SELECT
+                  bool_or(c.child_id = v_child_id AND c.reason <> 'id-name-disagreement') AS claim_matches,
+                  bool_or(c.reason = 'id-name-disagreement')                              AS row_contested
+                FROM public.import_child_candidates(
+                       v_school_id,
+                       jsonb_build_array(v_student || jsonb_build_object('idx', 0))
+                     ) c
+              ) v
+              WHERE v.claim_matches AND NOT v.row_contested
+            ) THEN
+              RAISE EXCEPTION
+                'Confirmed child link refused: child % is not a match for this student at this school (SPE-348)',
+                v_child_id
+                USING ERRCODE = '42501';
+            END IF;
+
+            -- Validated. Hand the trigger the one-shot handshake (see §3).
+            PERFORM set_config('app.spe348_confirmed_child_id', v_child_id::text, true);
+          END IF;
+
+          INSERT INTO public.students (
+            provider_id,
+            initials,
+            grade_level,
+            school_site,
+            school_id,
+            district_id,
+            state_id,
+            district_student_id,
+            sessions_per_week,
+            minutes_per_session,
+            teacher_id,
+            teacher_name,
+            child_id
+          )
+          VALUES (
+            p_provider_id,
+            v_student->>'initials',
+            v_student->>'gradeLevel',
+            v_student->>'schoolSite',
+            v_student->>'schoolId',
+            v_student->>'districtId',
+            v_student->>'stateId',
+            NULLIF(btrim(v_student->>'districtStudentId'), ''),
+            (v_student->>'sessionsPerWeek')::integer,
+            (v_student->>'minutesPerSession')::integer,
+            (v_student->>'teacherId')::uuid,
+            v_student->>'teacherName',
+            v_child_id
+          )
+          RETURNING id INTO v_new_student_id;
+
+          -- Close the door behind us: nothing later in this transaction (or a
+          -- later element of this batch) may reuse the handshake.
+          PERFORM set_config('app.spe348_confirmed_child_id', '', true);
+
+          INSERT INTO public.student_details (
+            student_id,
+            first_name,
+            last_name,
+            iep_goals,
+            upcoming_iep_date,
+            upcoming_triennial_date
+          )
+          VALUES (
+            v_new_student_id,
+            v_student->>'firstName',
+            v_student->>'lastName',
+            ARRAY(SELECT jsonb_array_elements_text(v_student->'goals')),
+            (v_student->>'upcomingIepDate')::date,
+            (v_student->>'upcomingTriennialDate')::date
+          );
+
+          v_new_sessions_per_week := (v_student->>'sessionsPerWeek')::integer;
+
+          IF v_new_sessions_per_week IS NOT NULL AND v_new_sessions_per_week > 0 THEN
+            INSERT INTO public.schedule_sessions (
+              student_id,
+              provider_id,
+              day_of_week,
+              start_time,
+              end_time,
+              service_type,
+              status,
+              delivered_by
+            )
+            SELECT
+              v_new_student_id,
+              p_provider_id,
+              NULL,
+              NULL,
+              NULL,
+              v_provider_role,
+              'active',
+              'provider'
+            FROM generate_series(1, v_new_sessions_per_week);
+          END IF;
+
+          v_inserted := v_inserted + 1;
+          v_result := jsonb_build_object(
+            'action', 'inserted',
+            'studentId', v_new_student_id,
+            'initials', v_student->>'initials',
+            'success', true
+          );
+
+        WHEN 'update' THEN
+          IF NOT EXISTS (
+            SELECT 1 FROM public.students
+            WHERE id = v_student_id AND provider_id = p_provider_id
+          ) THEN
+            RAISE EXCEPTION 'Student % not found or not owned by provider', v_student_id;
+          END IF;
+
+          UPDATE public.students
+          SET
+            grade_level = COALESCE(v_student->>'gradeLevel', grade_level),
+            sessions_per_week = COALESCE((v_student->>'sessionsPerWeek')::integer, sessions_per_week),
+            minutes_per_session = COALESCE((v_student->>'minutesPerSession')::integer, minutes_per_session),
+            teacher_id = CASE
+              WHEN v_student ? 'teacherId' THEN (v_student->>'teacherId')::uuid
+              ELSE teacher_id
+            END,
+            teacher_name = CASE
+              WHEN v_student ? 'teacherName' THEN v_student->>'teacherName'
+              ELSE teacher_name
+            END,
+            district_student_id = CASE
+              WHEN v_student ? 'districtStudentId'
+              THEN NULLIF(btrim(v_student->>'districtStudentId'), '')
+              ELSE district_student_id
+            END,
+            updated_at = now()
+          WHERE id = v_student_id;
+
+          INSERT INTO public.student_details (
+            student_id,
+            first_name,
+            last_name,
+            iep_goals,
+            upcoming_iep_date,
+            upcoming_triennial_date
+          )
+          VALUES (
+            v_student_id,
+            v_student->>'firstName',
+            v_student->>'lastName',
+            CASE
+              WHEN v_student ? 'goals' AND jsonb_array_length(v_student->'goals') > 0
+              THEN ARRAY(SELECT jsonb_array_elements_text(v_student->'goals'))
+              ELSE '{}'::text[]
+            END,
+            (v_student->>'upcomingIepDate')::date,
+            (v_student->>'upcomingTriennialDate')::date
+          )
+          ON CONFLICT (student_id) DO UPDATE
+          SET
+            first_name = COALESCE(EXCLUDED.first_name, student_details.first_name),
+            last_name = COALESCE(EXCLUDED.last_name, student_details.last_name),
+            iep_goals = CASE
+              WHEN v_student ? 'goals' AND jsonb_array_length(v_student->'goals') > 0
+              THEN EXCLUDED.iep_goals
+              ELSE student_details.iep_goals
+            END,
+            upcoming_iep_date = CASE
+              WHEN v_student ? 'upcomingIepDate' THEN (v_student->>'upcomingIepDate')::date
+              ELSE student_details.upcoming_iep_date
+            END,
+            upcoming_triennial_date = CASE
+              WHEN v_student ? 'upcomingTriennialDate' THEN (v_student->>'upcomingTriennialDate')::date
+              ELSE student_details.upcoming_triennial_date
+            END,
+            updated_at = now();
+
+          v_updated := v_updated + 1;
+          v_result := jsonb_build_object(
+            'action', 'updated',
+            'studentId', v_student_id,
+            'initials', v_student->>'initials',
+            'success', true
+          );
+
+        WHEN 'skip' THEN
+          v_skipped := v_skipped + 1;
+          v_result := jsonb_build_object(
+            'action', 'skipped',
+            'studentId', v_student_id,
+            'initials', v_student->>'initials',
+            'success', true
+          );
+
+        ELSE
+          RAISE EXCEPTION 'Unknown action: %', v_action;
+      END CASE;
+
+    EXCEPTION
+      WHEN OTHERS THEN
+        v_errors := v_errors + 1;
+        v_result := jsonb_build_object(
+          'action', v_action,
+          'studentId', COALESCE(v_student_id, v_new_student_id),
+          'initials', v_student->>'initials',
+          'success', false,
+          'error', SQLERRM
+        );
+    END;
+
+    v_results := v_results || v_result;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'inserted', v_inserted,
+    'updated', v_updated,
+    'skipped', v_skipped,
+    'errors', v_errors,
+    'results', v_results
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.upsert_students_atomic(uuid, jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.upsert_students_atomic(uuid, jsonb) TO authenticated, service_role;


### PR DESCRIPTION
Step 3 of the child-identity plan. [SPE-348](https://linear.app/speddy/issue/SPE-348)

SPE-347 gave every caseload row a `children` row but deliberately never attaches to an existing one, so two providers serving the same pupil still create two children. This makes **new** shared children arrive linked — when a human says they're the same child, and only then.

## Restore point

**Applied to production before the sim verification, per house precedent.** Recorded before the apply:

| | |
|---|---|
| PITR restore point | `2026-07-29 03:03:23 UTC` |
| `students_child_link` (pre-change `pg_get_functiondef` md5) | `70e530f9c22bfa0d06ce35edc825ca7d` |
| `upsert_students_atomic` (pre-change md5) | `2c563721f642c18aa22e3785732e4896` |

Only three objects change and all three are `CREATE OR REPLACE FUNCTION` — **no DDL, no data migration, nothing dropped**, so rollback is re-running the prior definitions rather than a restore:

- `students_child_link()` → re-run `supabase/migrations/20260729_spe347_children_hardening.sql:49`
- `upsert_students_atomic()` → re-run `supabase/migrations/20260727_add_students_district_student_id.sql:72`
- `import_child_candidates()` / `find_shared_child_candidates()` → new; `DROP FUNCTION` (nothing else references them)

Re-running those two restores the exact pre-change md5s above. New rows written while this is live keep their `child_id`; the columns and constraints they use all predate this PR.

## What changes for a user

One question, on one screen. When an import row is a **new** student who looks like a child a colleague at the same school already serves, the review screen's existing *Needs your review* queue asks:

> ⚠ **Maya Gonzalez** — may be the same child a colleague already serves
> Emily Chen (Speech) already serves a 5th grader with the same Student ID (100482).
> **Same child?** Yes records them as one child served by two providers. No imports them as a separate student. This doesn't share your goals or change your caseload.
> `[ Yes — same child ]` `[ No — different child ]`
> *Not answered — will import as a separate student.*

No answer, or "No", imports a separate student exactly as today. Ambiguous matches and Student-ID-vs-name disagreements are **reported and never offered**, per SPE-339's conflict rule.

Owner's calls (2026-07-29): name **and** role for the colleague; an unanswered offer does **not** block Import (the footer says what silence will do); it lives in the existing queue rather than a new zone.

Linking has no visible effect yet — nothing reads `children` until SPE-349. The copy deliberately describes only the decision, so it stays true both before and after that switch.

## How it's kept safe

**One ladder, two callers.** `import_child_candidates(school_id, rows)` holds the matching — district Student ID → full name + grade → initials + grade + teacher (SPE-339's precedence, the rungs `matching_provider_student_ids` already uses). Candidates are children **at that school, served by another provider, not already served by the caller**. Both the offer (`find_shared_child_candidates`) and the write-time re-validation call it, so the screen and the database cannot disagree about what "matches".

**The server re-validates every claimed link.** A confirmed child id is a claim, not an instruction. `upsert_students_atomic` re-runs the ladder against the row's own facts and refuses with `42501` — inside the row's own subtransaction, so the rest of the batch still imports — unless the claim holds at a school the caller can actually reach. A contested row is refused outright.

**How the validated id gets past the trigger.** The RPC sets a transaction-local `app.spe348_confirmed_child_id` to the exact validated id immediately before its INSERT; the trigger honours `child_id` only on an exact match. Not forgeable from a client: `set_config` lives in `pg_catalog` (not exposed by PostgREST), no exposed RPC sets a caller-controlled GUC, and `is_local` scopes it to the transaction — and PostgREST gives every request its own. Every other path still gets the flat refusal, and re-pointing an *existing* caseload row is refused with no exception at all (that's a merge; nothing merges).

## Discrepancies reported, not worked around

- **"Same school/district" → school only.** `students.district_id` is stamped from the importing provider's profile and is inconsistent in production: school `062271002457` carries three distinct `district_id` values — two of them on a *single* provider's own rows — plus NULLs. Gating on it would suppress exactly the legitimate cross-provider offers this ticket exists to create, while adding no safety, since a school belongs to one district. School equality is the scope; this is called out in the migration and in ARCHITECTURE.md.
- **Manual add is not covered.** The ticket allows splitting it at pickup. It writes through a different path than the import RPC and would be a *second* user-visible surface, against the ticket's own "only one user-visible change". Filed as a follow-up rather than improvised in.
- **Offers are insert-only.** An update row already has a caseload row with its own child; re-pointing it is a merge, which SPE-347 held out and this plan does not do.
- **Grades compare literally in SQL**, so a legacy SEIS grade (`'18'`/`'0'`) won't reconcile with `TK`/`K` the way the TypeScript matcher's `normalizeGradeLevel` does. That costs a missed *offer*, never a wrong link. Left alone deliberately — changing it would move `matching_provider_student_ids` too, which is SPE-349's surface.

## Verification

Sim-district walk and the negative probe run against production after this PR is up; results posted in a follow-up comment with the DB assertions (one `children` row + two caseload rows on confirm, two children on decline, and a forged confirm refused for the right reason on a fresh fixture).

Gates green locally: typecheck, lint, 12 import suites (126 tests) plus 12 new ones covering the offer plumbing and the review-model exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FmuLCFcePBY3TWzzQqmdFq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmuLCFcePBY3TWzzQqmdFq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Same child?” matching to the bulk student import review, including “Yes — same child” linking and “No — different child” separate import options.
* **Bug Fixes**
  * Fail-soft behavior prevents match lookup issues or unexpected responses from breaking the preview/import flow.
  * The confirm step now validates per-row selections before applying attachments.
* **Documentation**
  * Expanded architecture notes for the student create-or-attach workflow.
* **Tests**
  * Added unit tests covering offer vs conflict outcomes, confirmation behavior, and preview-state robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->