### PR TITLE
docs(ndpa): record the Sentry DPA acceptance (SPE-283)

### DIFF
--- a/docs/ndpa/attorney-review-brief.md
+++ b/docs/ndpa/attorney-review-brief.md
@@ -58,7 +58,7 @@ addendum as "No AI used at this time" with a planned-use disclosure.
 6. `incident-response-plan.md` — written IR plan (required by Art. V §4(3))
 7. `security-framework-mapping.md` — NIST CSF 1.1 self-assessment
 8. `offboarding-runbook.md` — deletion/return tooling backing Art. IV §6
-9. Subprocessor DPA records (OpenAI, Anthropic, Help Scout; Supabase/Sentry/Vercel in progress)
+9. Subprocessor DPA records (OpenAI, Anthropic, Help Scout, Sentry, Vercel; Supabase in progress)
 
 ---
 
@@ -201,11 +201,11 @@ defensible reading of Art. IV §6 / Exhibit D.**
 ### 11. Subprocessor flow-down — Art. II §5 (confirmation, one open item)
 
 Status: OpenAI + Anthropic DPAs executed; Help Scout DPA incorporated via
-ToS with DPF/SCCs; Supabase DPA being signed via their dashboard; Sentry
-DPA being click-accepted. **Open item:** production hosting is currently on
-Vercel's **Hobby** plan, whose DPA applies to Pro/Enterprise customers —
-we are upgrading to Pro before signing (Linear SPE-173). **Confirm the
-resulting set satisfies "no less stringent" flow-down.**
+ToS with DPF/SCCs; Sentry DPA accepted 2026-08-04; Vercel DPA applies via
+ToS now that hosting is on the **Pro** plan (upgraded 2026-07-28, Linear
+SPE-173). **Open item:** the Supabase DPA is still being signed via their
+dashboard and is the last one outstanding. **Confirm the resulting set
+satisfies "no less stringent" flow-down.**
 
 ### 12. Public-policy consistency (confirmation)
 

--- a/docs/ndpa/ca-ndpa-execution-packet.md
+++ b/docs/ndpa/ca-ndpa-execution-packet.md
@@ -226,7 +226,7 @@ Source: `subprocessors.md` (last reviewed 2026-06-11).
 |---|---|---|---|---|
 | Supabase | Database, auth, file storage — system of record | Yes — all categories in Exhibit B | US (us-west-1, N. California) | DPA available; **sign via dashboard → Legal Documents [ACTION]** |
 | Vercel | Application hosting; traffic + runtime logs | Yes — in transit and incidentally in logs | US-configurable | DPA incorporated into ToS — **on Pro since 2026-07-28**; **save copy [ACTION]** |
-| Sentry | Error monitoring, minimized (no logs/replay, PII scrubbed, `sendDefaultPii: false`) | Incidental only | US ingest | DPA self-serve; **accept in Settings → Legal & Compliance [ACTION]** |
+| Sentry | Error monitoring, minimized (no logs/replay, PII scrubbed, `sendDefaultPii: false`) | Incidental only | US ingest | DPA self-serve — **accepted 2026-08-04 (owner-confirmed)**; **save acceptance record [ACTION]** |
 | Help Scout | Support help desk + chat widget | No by design (provider PII only) | US | DPA v2 via ToS; DPF + SCCs (SPE-170, on file) |
 | OpenAI — **planned, NOT enabled** | AI lesson generation (when enabled) | None today (hard-gated off); initials + IEP goal text when enabled | US | DPA executed 2026-06-12 (SPE-163) |
 | Anthropic — **planned, NOT enabled** | AI generation/grading/parsing (when enabled) | None today (hard-gated off) | US | DPA via Commercial Terms, copy on file 2026-06-12 (SPE-163) |
@@ -267,9 +267,12 @@ only when active); Supabase Auth transactional email.
      plan~~ **Upgraded Hobby → Pro 2026-07-28 (owner-confirmed)** — the DPA
      now applies. Remaining (SPE-173): save a copy of vercel.com/legal/dpa
      for the records file; sanity-check the daily crons on Pro.
-   - **Sentry**: self-serve click-accept — Sentry → Settings → Legal &
-     Compliance (requires Owner/Billing role); DocuSign option if a signed
-     copy is preferred. Save the acceptance record.
+   - **Sentry**: ~~self-serve click-accept — Sentry → Settings → Legal &
+     Compliance~~ **Accepted 2026-08-04 (owner-confirmed)** — the DPA now
+     applies. Remaining: save the acceptance record to the records file.
+     Note Sentry only began actually receiving data on 2026-08-04 (SPE-175):
+     until then its DSN pointed at a nonexistent project and every event was
+     rejected, so no error data reached it despite the listing above.
 9. ~~Stale security overview~~ **Resolved 2026-06-12** — rewritten (v2.0):
    Vercel hosting, us-west-1 data residency, accurate data inventory (full
    names/DOB disclosed), AI-disabled posture, Help Scout + Chrome extension
@@ -312,7 +315,7 @@ only when active); Supabase Auth transactional email.
 5. ☑ AI stance: "No AI used at this time" (decided 2026-06-12; attorney confirms, brief item 3; enablement runbook = SPE-174)
 6. ☑ Framework: NIST CSF 1.1 + mapping memo `docs/security-framework-mapping.md` (done 2026-06-12; attorney confirms, brief item 5)
 7. ☐ Email CITE about Exhibit H (tracked: **SPE-172**)
-8. ☐ Sign Supabase DPA (dashboard) · accept Sentry DPA (Settings → Legal & Compliance) · ~~upgrade Vercel Hobby → Pro~~ **done 2026-07-28** — save Vercel DPA copy (SPE-173); collate with OpenAI/Anthropic/Help Scout records (Gap 8)
+8. ☐ Sign Supabase DPA (dashboard) — **the last outstanding subprocessor DPA** · ~~accept Sentry DPA~~ **done 2026-08-04** · ~~upgrade Vercel Hobby → Pro~~ **done 2026-07-28** — save Sentry acceptance + Vercel DPA copies (SPE-173); collate with OpenAI/Anthropic/Help Scout records (Gap 8)
 9. ☑ Security overview rewritten to current reality, v2.0 (Gap 9 — done 2026-06-12)
 10. ☑ MFA references removed from privacy page (Gap 10 — done 2026-06-12)
 11. ☑ Incident-response plan written: `docs/incident-response-plan.md` (Gap 11 — done 2026-06-12; **[DPO]** review recommended)

--- a/docs/ndpa/ca-ndpa-execution-packet.md
+++ b/docs/ndpa/ca-ndpa-execution-packet.md
@@ -45,7 +45,7 @@ though the Standard Clauses reference one (Art. V §3, Art. VII §3) — see Gap
 | Clause | Commitment | Our position | Source |
 |---|---|---|---|
 | Art. II §2 (+ Ex. G ¶2) | Parent access/correction via the LEA within **45 days** | Supported operationally — requests routed through the district; deletion tooling exists | `offboarding-runbook.md` §A |
-| Art. II §5 | **Written agreements with all subprocessors**, no less stringent | OpenAI, Anthropic, Help Scout DPAs on file. Researched 2026-06-12: **Supabase** DPA requires a signing step (dashboard → Legal Documents); **Vercel** DPA is incorporated into the ToS (deemed signed — Pro/Enterprise plans; confirm plan tier + download copy); **Sentry** DPA is self-serve click-accept (Settings → Legal & Compliance, Owner/Billing role). See Gap 8 | `subprocessors.md`; supabase.com/legal/dpa, vercel.com/legal/dpa, sentry.io/legal/dpa |
+| Art. II §5 | **Written agreements with all subprocessors**, no less stringent | OpenAI, Anthropic, Help Scout DPAs on file. **Sentry** DPA accepted 2026-08-04; **Vercel** DPA applies via ToS on the Pro plan (upgraded 2026-07-28). **One outstanding: the Supabase DPA still requires a signing step** (dashboard → Legal Documents). See Gap 8 | `subprocessors.md`; supabase.com/legal/dpa, vercel.com/legal/dpa, sentry.io/legal/dpa |
 | Art. IV §6 / Art. VII §2 | Dispose of Student Data within **60 days** of written request; destroy on termination | Supported: per-student cascade delete + Storage cleanup, provider/account deletion, district offboarding runbook, extension-cache TTL/clear | `offboarding-runbook.md` (SPE-143, PR #655) |
 | Art. V §1 | US data storage where required; list of storage locations on request | Supabase project region **us-west-1 (N. California)** — verified 2026-06-12; Vercel function region configurable; Sentry US ingest | `subprocessors.md`; live project settings |
 | Art. V §2 | Annual LEA audit right (10 business days' notice + NDA) | Acceptable; no tooling needed | — |
@@ -258,8 +258,10 @@ only when active); Supabase Auth transactional email.
    (with honest gaps table). Attorney to confirm sufficiency (brief item 5).
 7. ~~Exhibit H question~~ **Tracked as SPE-172** — email CITE/CSPA; question
    text is in the ticket. Also raised in attorney brief item 5(b).
-8. **Subprocessor DPAs (Art. II §5)** — researched 2026-06-12. Three quick
-   self-serve actions remain (~15 min total):
+8. **Subprocessor DPAs (Art. II §5)** — researched 2026-06-12; two of the
+   three self-serve actions are now done (Vercel 2026-07-28, Sentry
+   2026-08-04). **One remains: signing the Supabase DPA (~10 min).** Records
+   housekeeping — saving the Vercel and Sentry copies — is also outstanding:
    - **Supabase**: DPA must be signed — Supabase dashboard → Organization →
      Legal Documents (PandaDoc flow). Save the executed copy.
    - **Vercel**: DPA is incorporated by reference into the Terms of Service

--- a/docs/ndpa/jsusd-dpa-fix-sheet.md
+++ b/docs/ndpa/jsusd-dpa-fix-sheet.md
@@ -51,9 +51,10 @@ only real controls (the SPE-134 principle).
 
 **Prerequisite for this paragraph:** the subprocessor-agreements sentence
 must be true when the corrected PDF leaves the building. OpenAI, Anthropic,
-Help Scout, and Vercel (Pro since 2026-07-28) are in place; the **Supabase
-DPA signing and Sentry DPA acceptance (§8 item 2) must be completed before
-sending** — they are two self-serve click-throughs, not negotiations.
+Help Scout, Vercel (Pro since 2026-07-28) and Sentry (accepted 2026-08-04)
+are in place; the **Supabase DPA signing (§8 item 2) must be completed
+before sending** — it is one self-serve click-through, not a negotiation,
+and it is now the only thing holding this paragraph.
 
 ---
 
@@ -289,10 +290,10 @@ collected."
    Vercel DPA (incorporated via ToS for Pro) now applies. Remaining
    housekeeping (SPE-173): save a copy of vercel.com/legal/dpa to the
    records file; sanity-check the two daily crons on Pro.
-2. ☐ Sign the Supabase DPA (dashboard → Organization → Legal Documents);
-   accept the Sentry DPA (Settings → Legal & Compliance). ~15 min total.
+2. ☐ Sign the Supabase DPA (dashboard → Organization → Legal Documents).
+   ~10 min. ~~Accept the Sentry DPA~~ **done 2026-08-04 (owner-confirmed)**.
    **Prerequisite for the Exhibit F representation in §1 — do before the
-   corrected PDF is sent anywhere.**
+   corrected PDF is sent anywhere.** Supabase is now the only one left.
 3. ☐ Apply §§1–6 above to the PDF, then send to counsel with
    `attorney-review-brief.md` (its enclosure list) + this fix sheet.
 4. ☐ SPE-172 — CITE Exhibit H question; now more relevant since this draft

--- a/docs/ndpa/jsusd-dpa-fix-sheet.md
+++ b/docs/ndpa/jsusd-dpa-fix-sheet.md
@@ -284,7 +284,7 @@ ID, State ID (with §2c note), student name, parent/guardian name (limited —
 Lane B CARE requester, see §2a note), in-app performance, "Other data
 collected."
 
-## 8. Pre-signing checklist (state as of 2026-07-28)
+## 8. Pre-signing checklist (state as of 2026-08-04)
 
 1. ✅ **Vercel Hobby → Pro — upgraded 2026-07-28** (owner-confirmed). The
    Vercel DPA (incorporated via ToS for Pro) now applies. Remaining

--- a/docs/pilots/john-swett-unified.md
+++ b/docs/pilots/john-swett-unified.md
@@ -52,8 +52,9 @@ secondary-school experience; Rodeo Hills gets the full elementary experience.
   housekeeping: save the DPA copy to the records file; sanity-check crons on Pro.
 - **Attorney FERPA/COPPA sign-off.** The attorney review brief is prepared; final
   counsel sign-off should be confirmed on record.
-- **Subprocessor DPA housekeeping.** OpenAI/Anthropic done (SPE-163). Confirm the
-  Supabase DPA is signed and the Sentry DPA accepted, and save copies.
+- **Subprocessor DPA housekeeping.** OpenAI/Anthropic done (SPE-163); Sentry
+  accepted 2026-08-04 (SPE-283). **Supabase DPA signing is the last one
+  outstanding** — confirm it is signed, and save copies of all of them.
 - **CITE Exhibit H question (SPE-172, open, minor).** How variances attach, given
   v1.5 has no Exhibit H page.
 - **Audit logging (SPE-169, open).** Named in the attorney brief as the most


### PR DESCRIPTION
## Summary

Sentry DPA accepted **2026-08-04** (owner-confirmed). Four documents still described it as an outstanding action — including the JSUSD fix sheet and the execution packet's pre-signing checklist, both of which are district- and counsel-facing.

Docs-only. No Supabase item was touched; all remain unchecked.

## Changes

| File | What changed |
|---|---|
| `ca-ndpa-execution-packet.md` | Subprocessor table row, Gap 8 detail, checklist item 8 |
| `jsusd-dpa-fix-sheet.md` | Exhibit F prerequisite (§1) and §8 item 2 |
| `attorney-review-brief.md` | Enclosure list (item 9) and item 11 |
| `pilots/john-swett-unified.md` | Subprocessor housekeeping bullet |

Checklist item 8 and the Exhibit F prerequisite both **stay gated** — Supabase is still outstanding, so nothing district-facing unblocks from this. What changes is that Supabase is now the *only* thing holding them, rather than two click-throughs. The remaining Sentry task (save the acceptance record) is called out separately from the acceptance itself.

## Two things I'd rather flag than bury

**1. I corrected a Vercel statement outside the stated scope.** Item 11 of the attorney brief claimed hosting was on Vercel's **Hobby** plan and that we were "upgrading to Pro before signing." That has been false since 2026-07-28, and three other documents already record the upgrade as owner-confirmed. It sits in the same paragraph as the Sentry clause I was editing.

I fixed it rather than leaving it: a known-false statement immediately beside a freshly corrected one, in the section counsel reads specifically about subprocessor flow-down, seemed worse than the small scope increase. The paragraph's "open item" is now the Supabase signature, which is accurate. **Flagging explicitly because it changes what's presented to counsel as outstanding — please sanity-check that framing.**

**2. The execution packet now records when Sentry actually started receiving data.** Until 2026-08-04 its DSN pointed at a nonexistent project and Sentry rejected every event ([SPE-175](https://linear.app/speddy/issue/SPE-175), PR #792), so the packet has been listing a subprocessor that was in practice receiving nothing. Added a note so the record isn't read as describing a longer data flow than actually occurred — relevant if anyone reconstructs the timeline later.

## Verification

Grepped all of `docs/` afterwards to confirm no remaining text describes the Sentry DPA as pending, and that every Supabase DPA item is still present and unchecked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rzptu6oU6M4YkN9PdGC43K)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated privacy and compliance records to reflect completed Sentry and Vercel DPA requirements.
  * Identified Supabase DPA signing as the only remaining outstanding item.
  * Recorded Sentry’s acceptance date and data-processing start date.
  * Updated execution checklists and tracking requirements for retaining DPA records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->