### PR TITLE
SPE-353: say "student", not "child", in the import review copy

### DIFF
--- a/app/components/students/review/review-exception-row.tsx
+++ b/app/components/students/review/review-exception-row.tsx
@@ -178,22 +178,22 @@ export function ReviewExceptionRow({
         <div className="min-w-0 flex-1">
           <p>
             <span className="font-medium text-gray-900">{exception.studentLabel}</span>
-            <span className="text-gray-600"> — may be the same child a colleague already serves</span>
+            <span className="text-gray-600"> — may be the same student a colleague already serves</span>
           </p>
           <p className="mt-0.5 text-xs text-gray-600">{describeEvidence(match)}</p>
           <p className="mt-0.5 text-xs text-gray-500">
-            <span className="font-medium text-gray-700">Same child?</span> Yes records them as one
-            child served by two providers. No imports them as a separate student. This doesn&apos;t
+            <span className="font-medium text-gray-700">Same student?</span> Yes records them as one
+            student served by two providers. No imports them as a separate student. This doesn&apos;t
             share your goals or change your caseload.
           </p>
           <div className="mt-1.5 flex flex-wrap items-center gap-2">
-            {choiceButton('link', 'Yes — same child')}
-            {choiceButton('separate', 'No — different child')}
+            {choiceButton('link', 'Yes — same student')}
+            {choiceButton('separate', 'No — different student')}
             <span className="text-xs text-gray-500">
               {!answered
                 ? 'Not answered — will import as a separate student.'
                 : linked
-                  ? 'Will be recorded as the same child.'
+                  ? 'Will be recorded as the same student.'
                   : 'Will import as a separate student.'}
             </span>
           </div>
@@ -215,12 +215,12 @@ export function ReviewExceptionRow({
             <span className="text-gray-600">
               {ambiguous
                 ? ' — more than one possible match'
-                : ' — Student ID points to a different child'}
+                : ' — Student ID points to a different student'}
             </span>
           </p>
           <p className="mt-0.5 text-xs text-gray-500">
             {ambiguous
-              ? `${exception.conflict.count ?? 2} children here could be this student, so nothing will be linked. They'll import as a separate student.`
+              ? `More than one student here could be a match (${exception.conflict.count ?? 2}), so nothing will be linked. They'll import as a separate student.`
               : "A colleague's student has that Student ID under a different name, so nothing will be linked. They'll import as a separate student."}
           </p>
         </div>


### PR DESCRIPTION
First slice of [SPE-353](https://linear.app/speddy/issue/SPE-353). Owner's call: we don't call the people we serve "children" — the vocabulary is **"student"** (or "individual"), and above all not user-facing.

The create-or-attach step that shipped in #791 is the only place a provider reads the word in normal use, so this is the whole user-visible surface of that decision. It doesn't wait on the naming question, because it doesn't depend on it.

## What changes

Seven visible strings in one file. **Copy only** — no logic, no schema, no type or identifier changes.

| Before | After |
|---|---|
| — may be the same **child** a colleague already serves | — may be the same **student** a colleague already serves |
| **Same child?** Yes records them as one **child** served by two providers… | **Same student?** Yes records them as one **student** served by two providers… |
| `Yes — same child` | `Yes — same student` |
| `No — different child` | `No — different student` |
| Will be recorded as the same **child**. | Will be recorded as the same **student**. |
| — Student ID points to a different **child** | — Student ID points to a different **student** |
| `2 children here could be this student…` | `More than one student here could be a match (2)…` |

Two notes on the wording:

- The panel **already** said "student" in adjacent strings — *"will import as a separate student"*, *"a colleague's student has that Student ID"*. This makes one panel internally consistent rather than introducing a new voice.
- The last row is **reworded, not swapped**. A literal substitution reads *"2 students here could be this student"*, so the count moved into a parenthetical.

## Deliberately not in scope

Still open in SPE-353, because they need the naming decision first:

- the `children` table and `students.child_id`
- `students_child_link()`, `import_child_candidates()`, `find_shared_child_candidates()`, the `app.spe348_confirmed_child_id` GUC
- the TypeScript surface (`ChildMatchOffer`, `ChildLinkChoice`, `confirmedChildIdFor`)
- **CARE's expansion — "Child Assistance Response in Education."** The word is baked into a module name; that's its own call.

Also untouched on purpose: the privacy and FERPA pages say "children" in the **statutory** sense (FERPA's own language, children's-privacy law). Those are quoting law and should stay.

## Verification

Gates green locally on this base (latest `main`, `c9814f5`): typecheck clean, lint clean (only two pre-existing `react-hooks/exhaustive-deps` warnings in unrelated admin files), full suite **78 suites / 693 passed**.

No test asserted on any of these strings — the only `"same child"` hits under `__tests__` are test *names* and comments describing the internal concept, which stays `child` for now. Nothing in `scripts/` selects these buttons by label, so the sim walk is unaffected.

No sim-district run this time: the change touches no database read or write, so there is nothing an RLS-bearing session would exercise that the suite doesn't already cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FmuLCFcePBY3TWzzQqmdFq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmuLCFcePBY3TWzzQqmdFq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated review exception messages to use “student” terminology instead of “child.”
  * Clarified ambiguous-match messaging to refer to multiple possible students.
  * Updated related button labels and explanatory text for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->