### PR TITLE
Fix district admin account creation: cancel destination and teacher school picker

### DIFF
--- a/__tests__/unit/app/admin-create-account.test.tsx
+++ b/__tests__/unit/app/admin-create-account.test.tsx
@@ -129,6 +129,17 @@ describe('Admin Create New Account page', () => {
     })
   })
 
+  it('keeps Cancel on the dashboard when the permission check fails', async () => {
+    mockGetCurrentAdminPermissions.mockRejectedValue(new Error('network'))
+    await renderPage()
+
+    // We can't prove the admin has a school, so don't gamble on the
+    // school-scoped directory loading.
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Cancel' })).toHaveAttribute('href', '/dashboard/admin')
+    })
+  })
+
   describe('site admin', () => {
     beforeEach(() => {
       mockGetCurrentAdminPermissions.mockResolvedValue(SITE_ADMIN)

--- a/__tests__/unit/app/admin-create-account.test.tsx
+++ b/__tests__/unit/app/admin-create-account.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react'
+import { render, screen, waitFor, userEvent } from '../../../test-utils'
+import CreateAccountPage from '@/app/(dashboard)/dashboard/admin/create-account/page'
+
+const mockPush = jest.fn()
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, refresh: jest.fn(), replace: jest.fn() }),
+}))
+
+jest.mock('next/link', () => {
+  const MockLink = ({ children, href, ...rest }: any) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  )
+  MockLink.displayName = 'MockLink'
+  return MockLink
+})
+
+const mockGetCurrentAdminPermissions = jest.fn()
+const mockGetDistrictSchools = jest.fn()
+const mockCheckDuplicateTeachers = jest.fn()
+const mockGetCurrentUserSchoolId = jest.fn()
+
+jest.mock('@/lib/supabase/queries/admin-accounts', () => ({
+  getCurrentAdminPermissions: (...args: any[]) => mockGetCurrentAdminPermissions(...args),
+  getDistrictSchools: (...args: any[]) => mockGetDistrictSchools(...args),
+  checkDuplicateTeachers: (...args: any[]) => mockCheckDuplicateTeachers(...args),
+}))
+
+jest.mock('@/lib/supabase/queries/school-directory', () => ({
+  getCurrentUserSchoolId: (...args: any[]) => mockGetCurrentUserSchoolId(...args),
+}))
+
+const DISTRICT_ADMIN = [{ role: 'district_admin', district_id: 'district-1', school_id: null }]
+const SITE_ADMIN = [{ role: 'site_admin', district_id: null, school_id: 'school-a' }]
+
+const DISTRICT_SCHOOLS = [
+  { id: 'school-a', name: 'Alpha Elementary' },
+  { id: 'school-b', name: 'Bravo Elementary' },
+]
+
+/** Waits for the mount-time permission check to settle before asserting. */
+const renderPage = async () => {
+  const result = render(<CreateAccountPage />)
+  await waitFor(() => expect(mockGetCurrentAdminPermissions).toHaveBeenCalled())
+  return result
+}
+
+describe('Admin Create New Account page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetDistrictSchools.mockResolvedValue(DISTRICT_SCHOOLS)
+    mockCheckDuplicateTeachers.mockResolvedValue([])
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ credentials: { email: 'new@school.edu', temporaryPassword: 'temp-pass' } }),
+    })
+  })
+
+  describe('district admin', () => {
+    beforeEach(() => {
+      mockGetCurrentAdminPermissions.mockResolvedValue(DISTRICT_ADMIN)
+      // District admins have no school of their own.
+      mockGetCurrentUserSchoolId.mockResolvedValue(null)
+    })
+
+    it('sends Cancel to the admin dashboard, not the school-scoped teacher directory', async () => {
+      await renderPage()
+
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: 'Cancel' })).toHaveAttribute('href', '/dashboard/admin')
+      })
+    })
+
+    it('offers a school picker for teachers and creates via the district endpoint', async () => {
+      const user = userEvent.setup()
+      await renderPage()
+
+      const schoolSelect = await screen.findByLabelText(/school/i)
+      await user.type(screen.getByLabelText(/first name/i), 'Jane')
+      await user.type(screen.getByLabelText(/last name/i), 'Doe')
+      await user.type(screen.getByLabelText(/email/i), 'jane.doe@school.edu')
+      await user.selectOptions(schoolSelect, 'school-b')
+      await user.click(screen.getByRole('button', { name: /create account/i }))
+
+      await waitFor(() => expect(global.fetch).toHaveBeenCalled())
+
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0]
+      expect(url).toBe('/api/admin/district/teachers')
+      expect(JSON.parse(init.body)).toMatchObject({
+        first_name: 'Jane',
+        last_name: 'Doe',
+        email: 'jane.doe@school.edu',
+        school_id: 'school-b',
+      })
+    })
+
+    it('asks for a school instead of submitting when none is picked', async () => {
+      // With no schools to pick from there is no required <select> to block
+      // submission, so this exercises the guard in handleSubmit rather than
+      // HTML5 validation.
+      mockGetDistrictSchools.mockResolvedValue([])
+      const user = userEvent.setup()
+      await renderPage()
+
+      await screen.findByText(/no schools found in your district/i)
+      await user.type(screen.getByLabelText(/first name/i), 'Jane')
+      await user.type(screen.getByLabelText(/last name/i), 'Doe')
+      await user.type(screen.getByLabelText(/email/i), 'jane.doe@school.edu')
+      await user.click(screen.getByRole('button', { name: /create account/i }))
+
+      expect(await screen.findByText(/select the school this teacher works at/i)).toBeInTheDocument()
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+
+    it('does not show an error when the name is blurred before a school is picked', async () => {
+      const user = userEvent.setup()
+      await renderPage()
+
+      await user.type(screen.getByLabelText(/first name/i), 'Jane')
+      await user.type(screen.getByLabelText(/last name/i), 'Doe')
+      await user.tab()
+
+      await waitFor(() => expect(mockGetCurrentAdminPermissions).toHaveBeenCalled())
+      expect(screen.queryByText(/could not determine your school/i)).not.toBeInTheDocument()
+      expect(mockCheckDuplicateTeachers).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('site admin', () => {
+    beforeEach(() => {
+      mockGetCurrentAdminPermissions.mockResolvedValue(SITE_ADMIN)
+      mockGetCurrentUserSchoolId.mockResolvedValue('school-a')
+    })
+
+    it('keeps Cancel pointed at the teacher directory', async () => {
+      await renderPage()
+
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: 'Cancel' })).toHaveAttribute(
+          'href',
+          '/dashboard/admin/teachers'
+        )
+      })
+    })
+
+    it('creates teachers at their own school without a picker', async () => {
+      const user = userEvent.setup()
+      await renderPage()
+
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: 'Cancel' })).toHaveAttribute(
+          'href',
+          '/dashboard/admin/teachers'
+        )
+      })
+      expect(screen.queryByLabelText(/^school/i)).not.toBeInTheDocument()
+
+      await user.type(screen.getByLabelText(/first name/i), 'Jane')
+      await user.type(screen.getByLabelText(/last name/i), 'Doe')
+      await user.type(screen.getByLabelText(/email/i), 'jane.doe@school.edu')
+      await user.click(screen.getByRole('button', { name: /create account/i }))
+
+      await waitFor(() => expect(global.fetch).toHaveBeenCalled())
+
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0]
+      expect(url).toBe('/api/admin/create-teacher-account')
+      expect(JSON.parse(init.body)).toMatchObject({ school_id: 'school-a' })
+    })
+  })
+})

--- a/__tests__/unit/app/admin-create-account.test.tsx
+++ b/__tests__/unit/app/admin-create-account.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, waitFor, userEvent } from '../../../test-utils'
+import { act, render, screen, waitFor, userEvent } from '../../../test-utils'
 import CreateAccountPage from '@/app/(dashboard)/dashboard/admin/create-account/page'
 
 const mockPush = jest.fn()
@@ -127,6 +127,61 @@ describe('Admin Create New Account page', () => {
       expect(screen.queryByText(/could not determine your school/i)).not.toBeInTheDocument()
       expect(mockCheckDuplicateTeachers).not.toHaveBeenCalled()
     })
+  })
+
+  it('blocks submission until the permission lookup settles', async () => {
+    // Until we know the admin's scope we can't tell which endpoint to post to,
+    // so a district admin submitting early would take the site-admin branch.
+    let resolvePerms: (v: unknown) => void = () => {}
+    mockGetCurrentAdminPermissions.mockReturnValue(
+      new Promise(resolve => { resolvePerms = resolve })
+    )
+    const user = userEvent.setup()
+    render(<CreateAccountPage />)
+
+    const submit = screen.getByRole('button', { name: /create account/i })
+    expect(submit).toBeDisabled()
+
+    await user.type(screen.getByLabelText(/first name/i), 'Jane')
+    await user.type(screen.getByLabelText(/last name/i), 'Doe')
+    await user.type(screen.getByLabelText(/email/i), 'jane.doe@school.edu')
+    await user.click(submit)
+    expect(global.fetch).not.toHaveBeenCalled()
+
+    resolvePerms(DISTRICT_ADMIN)
+    await waitFor(() => expect(submit).toBeEnabled())
+    // ...and now it knows to demand a school.
+    expect(await screen.findByLabelText(/school/i)).toBeInTheDocument()
+  })
+
+  it('ignores a duplicate-check response that a newer check superseded', async () => {
+    mockGetCurrentAdminPermissions.mockResolvedValue(DISTRICT_ADMIN)
+    let resolveAlpha: (v: unknown) => void = () => {}
+    mockCheckDuplicateTeachers
+      // Alpha's check hangs; Bravo's answers straight away and wins.
+      .mockImplementationOnce(() => new Promise(resolve => { resolveAlpha = resolve }))
+      .mockResolvedValue([{ first_name: 'Jane', last_name: 'Bravomatch', classroom_number: '9' }])
+
+    const user = userEvent.setup()
+    await renderPage()
+    const schoolSelect = await screen.findByLabelText(/school/i)
+
+    await user.type(screen.getByLabelText(/first name/i), 'Jane')
+    await user.type(screen.getByLabelText(/last name/i), 'Doe')
+    await user.selectOptions(schoolSelect, 'school-a')
+    await user.selectOptions(schoolSelect, 'school-b')
+
+    expect(await screen.findByText(/Bravomatch/)).toBeInTheDocument()
+
+    // The stale Alpha result lands last. It must not replace the warning for
+    // the school the admin is actually creating at.
+    await act(async () => {
+      resolveAlpha([{ first_name: 'Jane', last_name: 'Alphamatch', classroom_number: '3' }])
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    expect(screen.queryByText(/Alphamatch/)).not.toBeInTheDocument()
+    expect(screen.getByText(/Bravomatch/)).toBeInTheDocument()
   })
 
   it('keeps Cancel on the dashboard when the permission check fails', async () => {

--- a/app/(dashboard)/dashboard/admin/create-account/page.tsx
+++ b/app/(dashboard)/dashboard/admin/create-account/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { checkDuplicateTeachers, getCurrentAdminPermissions, getDistrictSchools } from '@/lib/supabase/queries/admin-accounts';
 import { getCurrentUserSchoolId } from '@/lib/supabase/queries/school-directory';
@@ -36,7 +36,10 @@ export default function CreateAccountPage() {
   const [showCredentialsModal, setShowCredentialsModal] = useState(false);
   const [credentials, setCredentials] = useState<{ email: string; temporaryPassword: string } | null>(null);
 
+  const duplicateCheckSeq = useRef(0);
+
   // Admin state
+  const [permissionsChecked, setPermissionsChecked] = useState(false);
   const [isDistrictAdmin, setIsDistrictAdmin] = useState(false);
   const [isSiteAdmin, setIsSiteAdmin] = useState(false);
   const [siteAdminSchoolId, setSiteAdminSchoolId] = useState<string | null>(null);
@@ -71,6 +74,10 @@ export default function CreateAccountPage() {
         }
       } catch (err) {
         console.error('Error checking admin permissions:', err);
+      } finally {
+        // Marks the lookup as settled either way — submitting before this
+        // resolves would pick the wrong endpoint for a district admin.
+        setPermissionsChecked(true);
       }
     };
     checkPermissions();
@@ -150,6 +157,10 @@ export default function CreateAccountPage() {
   const checkForDuplicates = async (schoolIdOverride?: string) => {
     if (!formData.first_name || !formData.last_name) return;
 
+    // Both name fields and the school picker fire this, so responses can land
+    // out of order. Only the newest request may write the warning.
+    const seq = ++duplicateCheckSeq.current;
+
     try {
       // District admins pick the school on the form; everyone else inherits theirs.
       const schoolId = isDistrictAdmin
@@ -165,6 +176,8 @@ export default function CreateAccountPage() {
         formData.last_name,
         schoolId
       );
+
+      if (seq !== duplicateCheckSeq.current) return;
 
       if (duplicates.length > 0) {
         const names = duplicates.map(t =>
@@ -660,7 +673,7 @@ export default function CreateAccountPage() {
             </Link>
             <button
               type="submit"
-              disabled={loading}
+              disabled={loading || !permissionsChecked}
               className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
             >
               {loading ? (

--- a/app/(dashboard)/dashboard/admin/create-account/page.tsx
+++ b/app/(dashboard)/dashboard/admin/create-account/page.tsx
@@ -37,7 +37,6 @@ export default function CreateAccountPage() {
   const [credentials, setCredentials] = useState<{ email: string; temporaryPassword: string } | null>(null);
 
   // Admin state
-  const [permissionsChecked, setPermissionsChecked] = useState(false);
   const [isDistrictAdmin, setIsDistrictAdmin] = useState(false);
   const [isSiteAdmin, setIsSiteAdmin] = useState(false);
   const [siteAdminSchoolId, setSiteAdminSchoolId] = useState<string | null>(null);
@@ -72,8 +71,6 @@ export default function CreateAccountPage() {
         }
       } catch (err) {
         console.error('Error checking admin permissions:', err);
-      } finally {
-        setPermissionsChecked(true);
       }
     };
     checkPermissions();
@@ -111,9 +108,9 @@ export default function CreateAccountPage() {
   }, [accountType, isDistrictAdmin, isSiteAdmin, siteAdminSchoolId]);
 
   // District admins have no school of their own, so the school-scoped teacher
-  // directory can't load for them. Default to the admin dashboard until we know
-  // the directory is safe to link to.
-  const returnHref = permissionsChecked && !isDistrictAdmin
+  // directory can't load for them. Only link it once we positively know the
+  // admin has a school; the dashboard works for everyone otherwise.
+  const returnHref = isSiteAdmin && !isDistrictAdmin
     ? '/dashboard/admin/teachers'
     : '/dashboard/admin';
 

--- a/app/(dashboard)/dashboard/admin/create-account/page.tsx
+++ b/app/(dashboard)/dashboard/admin/create-account/page.tsx
@@ -27,6 +27,8 @@ export default function CreateAccountPage() {
     email: '',
     classroom_number: '',
     phone_number: '',
+    // Only used by district admins, who aren't tied to a single school.
+    school_id: '',
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -35,6 +37,7 @@ export default function CreateAccountPage() {
   const [credentials, setCredentials] = useState<{ email: string; temporaryPassword: string } | null>(null);
 
   // Admin state
+  const [permissionsChecked, setPermissionsChecked] = useState(false);
   const [isDistrictAdmin, setIsDistrictAdmin] = useState(false);
   const [isSiteAdmin, setIsSiteAdmin] = useState(false);
   const [siteAdminSchoolId, setSiteAdminSchoolId] = useState<string | null>(null);
@@ -69,37 +72,50 @@ export default function CreateAccountPage() {
         }
       } catch (err) {
         console.error('Error checking admin permissions:', err);
+      } finally {
+        setPermissionsChecked(true);
       }
     };
     checkPermissions();
   }, []);
 
-  // Fetch district schools when specialist mode is activated (district admin)
-  // or auto-set the school for site admins
+  // District admins pick a school for both account types, so load the district's
+  // schools as soon as we know who they are.
   useEffect(() => {
-    if (accountType === 'specialist' && isDistrictAdmin && districtId && districtSchools.length === 0) {
-      const fetchSchools = async () => {
-        setLoadingSchools(true);
-        try {
-          const schools = await getDistrictSchools(districtId);
-          setDistrictSchools(schools.map(s => ({ id: s.id, name: s.name })));
-        } catch (err) {
-          console.error('Error fetching district schools:', err);
-          setError('Failed to load schools');
-        } finally {
-          setLoadingSchools(false);
-        }
-      };
-      fetchSchools();
-    } else if (accountType === 'specialist' && isSiteAdmin && siteAdminSchoolId) {
-      // Site admins can only assign specialists to their own school
+    if (!isDistrictAdmin || !districtId || districtSchools.length > 0) return;
+
+    const fetchSchools = async () => {
+      setLoadingSchools(true);
+      try {
+        const schools = await getDistrictSchools(districtId);
+        setDistrictSchools(schools.map(s => ({ id: s.id, name: s.name })));
+      } catch (err) {
+        console.error('Error fetching district schools:', err);
+        setError('Failed to load schools');
+      } finally {
+        setLoadingSchools(false);
+      }
+    };
+    fetchSchools();
+  }, [isDistrictAdmin, districtId, districtSchools.length]);
+
+  // Site admins can only assign specialists to their own school
+  useEffect(() => {
+    if (accountType === 'specialist' && !isDistrictAdmin && isSiteAdmin && siteAdminSchoolId) {
       setSpecialistData(prev => ({
         ...prev,
         school_ids: [siteAdminSchoolId],
         primary_school_id: siteAdminSchoolId,
       }));
     }
-  }, [accountType, isDistrictAdmin, isSiteAdmin, siteAdminSchoolId, districtId, districtSchools.length]);
+  }, [accountType, isDistrictAdmin, isSiteAdmin, siteAdminSchoolId]);
+
+  // District admins have no school of their own, so the school-scoped teacher
+  // directory can't load for them. Default to the admin dashboard until we know
+  // the directory is safe to link to.
+  const returnHref = permissionsChecked && !isDistrictAdmin
+    ? '/dashboard/admin/teachers'
+    : '/dashboard/admin';
 
   const handleInputChange = (field: string, value: string) => {
     setFormData(prev => ({ ...prev, [field]: value }));
@@ -134,16 +150,18 @@ export default function CreateAccountPage() {
     handleSpecialistInputChange('school_ids', newSelection);
   };
 
-  const checkForDuplicates = async () => {
+  const checkForDuplicates = async (schoolIdOverride?: string) => {
     if (!formData.first_name || !formData.last_name) return;
 
     try {
-      // Get current user's school ID
-      const schoolId = await getCurrentUserSchoolId();
-      if (!schoolId) {
-        setError('Could not determine your school. Please try again.');
-        return;
-      }
+      // District admins pick the school on the form; everyone else inherits theirs.
+      const schoolId = isDistrictAdmin
+        ? (schoolIdOverride ?? formData.school_id)
+        : await getCurrentUserSchoolId();
+
+      // Nothing to compare against yet. This check is advisory, so stay quiet
+      // rather than showing an error the admin can't act on.
+      if (!schoolId) return;
 
       const duplicates = await checkDuplicateTeachers(
         formData.first_name,
@@ -180,15 +198,29 @@ export default function CreateAccountPage() {
           throw new Error('Email is required to create a teacher account');
         }
 
-        // Get current user's school ID
-        const schoolId = await getCurrentUserSchoolId();
+        // District admins create teachers at any school in their district, so the
+        // school comes from the form. Site admins only have their own school.
+        let endpoint: string;
+        let schoolId: string;
 
-        if (!schoolId) {
-          throw new Error('Could not determine your school. Please contact support.');
+        if (isDistrictAdmin) {
+          if (!formData.school_id) {
+            throw new Error('Please select the school this teacher works at');
+          }
+          endpoint = '/api/admin/district/teachers';
+          schoolId = formData.school_id;
+        } else {
+          const ownSchoolId = await getCurrentUserSchoolId();
+
+          if (!ownSchoolId) {
+            throw new Error('Could not determine your school. Please contact support.');
+          }
+          endpoint = '/api/admin/create-teacher-account';
+          schoolId = ownSchoolId;
         }
 
-        // Call the new API endpoint to create teacher account with credentials
-        const response = await fetch('/api/admin/create-teacher-account', {
+        // Call the API endpoint to create teacher account with credentials
+        const response = await fetch(endpoint, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -266,7 +298,7 @@ export default function CreateAccountPage() {
     if (accountType === 'specialist') {
       router.push('/dashboard/admin');
     } else {
-      router.push('/dashboard/admin/teachers');
+      router.push(returnHref);
     }
   };
 
@@ -285,7 +317,9 @@ export default function CreateAccountPage() {
         </Link>
         <h1 className="text-3xl font-bold text-gray-900">Create New Account</h1>
         <p className="mt-2 text-gray-600">
-          Add a teacher or specialist account at your school
+          {isDistrictAdmin
+            ? 'Add a teacher or specialist account at any school in your district'
+            : 'Add a teacher or specialist account at your school'}
         </p>
       </div>
 
@@ -346,7 +380,7 @@ export default function CreateAccountPage() {
                     required
                     value={formData.first_name}
                     onChange={(e) => handleInputChange('first_name', e.target.value)}
-                    onBlur={checkForDuplicates}
+                    onBlur={() => checkForDuplicates()}
                     className="block w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
                     placeholder="John"
                   />
@@ -361,7 +395,7 @@ export default function CreateAccountPage() {
                     required
                     value={formData.last_name}
                     onChange={(e) => handleInputChange('last_name', e.target.value)}
-                    onBlur={checkForDuplicates}
+                    onBlur={() => checkForDuplicates()}
                     className="block w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
                     placeholder="Smith"
                   />
@@ -377,6 +411,41 @@ export default function CreateAccountPage() {
                     </svg>
                     <p className="ml-3 text-sm text-yellow-700">{duplicateWarning}</p>
                   </div>
+                </div>
+              )}
+
+              {/* School (district admins aren't tied to a single school) */}
+              {isDistrictAdmin && (
+                <div>
+                  <label htmlFor="teacher_school" className="block text-sm font-medium text-gray-700 mb-1">
+                    School <span className="text-red-500">*</span>
+                  </label>
+                  {loadingSchools ? (
+                    <div className="text-sm text-gray-500">Loading schools...</div>
+                  ) : districtSchools.length === 0 ? (
+                    <div className="text-sm text-gray-500">No schools found in your district</div>
+                  ) : (
+                    <select
+                      id="teacher_school"
+                      required
+                      value={formData.school_id}
+                      onChange={(e) => {
+                        handleInputChange('school_id', e.target.value);
+                        checkForDuplicates(e.target.value);
+                      }}
+                      className="block w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
+                    >
+                      <option value="">Select a school</option>
+                      {districtSchools.map((school) => (
+                        <option key={school.id} value={school.id}>
+                          {school.name}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                  <p className="mt-1 text-xs text-gray-500">
+                    The school this teacher works at.
+                  </p>
                 </div>
               )}
 
@@ -587,7 +656,7 @@ export default function CreateAccountPage() {
           {/* Action Buttons */}
           <div className="flex justify-end space-x-3 pt-4 border-t border-gray-200">
             <Link
-              href="/dashboard/admin/teachers"
+              href={returnHref}
               className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors"
             >
               Cancel


### PR DESCRIPTION
## What was broken

The admin **Create New Account** page assumed every admin belongs to a single school. That is only true for site admins — all four district admins in prod have `school_id = NULL` on both their `admin_permissions` row and their profile. Two user-visible bugs followed:

1. **Cancel dead-ended on an error page.** Cancel linked to `/dashboard/admin/teachers`, a school-scoped page that isn't even in a district admin's nav. Opening the form and clicking Cancel without typing anything threw **"Error loading teachers — No school ID found for current user."**
2. **No way to say which school a teacher works at.** The Teacher tab offered no school field and posted to `/api/admin/create-teacher-account`, which requires site-admin permission *on the target school*. A district admin could add a teacher by drilling into a school first, but never from this page. (The Specialist tab already had a school selector.)

The on-blur duplicate check had the same assumption, flashing "Could not determine your school" as soon as a district admin tabbed out of the name field.

## What changed

- **Cancel and the post-create redirect are role-aware.** The teacher directory is linked only on a positive site-admin signal; every other case (district admin, or a permission lookup that failed) gets the admin dashboard, which works for all admins.
- **District admins pick a school on the Teacher tab**, from the same district school list the Specialist tab already loads, and create via `/api/admin/district/teachers` — which independently re-validates that the school is in their district. Site admins are unchanged: no picker, same endpoint, same implicit school.
- **The duplicate check is advisory again.** It uses the picked school for district admins, stays quiet until a school is known instead of raising an error, and re-runs when the school changes.
- Header copy reads "at any school in your district" for district admins.

No schema, RLS, or API changes — `/api/admin/district/teachers` already existed and is used by the school detail page today.

## Verification

- New unit suite (`__tests__/unit/app/admin-create-account.test.tsx`, 7 tests) covering both roles' cancel destinations, the school picker and endpoint routing, the missing-school guard, and the failed-permission-lookup case. Full suite green: 79 suites / 699 tests. Typecheck and lint clean.
- **Sim district walk with real signed-in sessions — 15/15 checks pass.** As Dana (district admin): Cancel never points at the teacher directory at any moment during load, clicking it with an empty form lands on the dashboard with no error, the picker lists all five district schools, and creating a teacher at Maple — a school she holds no site-admin permission for — persists a `teachers` row with a linked `teacher` profile scoped to Maple and no admin rows. As Priya (site admin, Willow): no picker, Cancel still settles on the teacher directory, and creation still lands at her own school. Teardown swept every account the app created (25 teachers / 22 profiles / 22 auth users), `--expect-empty` reported zero orphans, and the district was reseeded green.

Reported from a district admin session; screenshot showed the error immediately after Cancel.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6o6Rs5V2WvB5AoSkEdHs6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * District administrators can select a school when creating teacher accounts.
  * Validation and account creation use the selected school where applicable.
  * Site administrators can create specialist accounts without selecting a school.
  * Navigation, cancel links, and guidance reflect administrator scope.

* **Bug Fixes**
  * Improved handling of missing schools and permission-check failures.
  * Prevented submissions while permissions are loading.
  * Improved duplicate-account checking, including stale responses and early field validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->