### PR TITLE
SPE-360/SPE-361: derive the primary school, and stop hiding special activities from itinerant providers

### DIFF
--- a/app/(dashboard)/dashboard/admin/create-account/page.tsx
+++ b/app/(dashboard)/dashboard/admin/create-account/page.tsx
@@ -54,7 +54,6 @@ export default function CreateAccountPage() {
     email: '',
     role: 'resource' as 'resource' | 'speech' | 'ot' | 'counseling' | 'sea' | 'psychologist' | 'intervention',
     school_ids: [] as string[],
-    primary_school_id: '',
   });
 
   // Check if current user is a district admin on mount
@@ -109,7 +108,6 @@ export default function CreateAccountPage() {
       setSpecialistData(prev => ({
         ...prev,
         school_ids: [siteAdminSchoolId],
-        primary_school_id: siteAdminSchoolId,
       }));
     }
   }, [accountType, isDistrictAdmin, isSiteAdmin, siteAdminSchoolId]);
@@ -128,21 +126,7 @@ export default function CreateAccountPage() {
   };
 
   const handleSpecialistInputChange = (field: string, value: string | string[]) => {
-    setSpecialistData(prev => {
-      const updated = { ...prev, [field]: value };
-      // Auto-set primary school if only one school is selected
-      if (field === 'school_ids' && Array.isArray(value)) {
-        if (value.length === 1) {
-          updated.primary_school_id = value[0];
-        } else if (value.length === 0) {
-          updated.primary_school_id = '';
-        } else if (!value.includes(updated.primary_school_id)) {
-          // If current primary school was deselected, reset to first selected
-          updated.primary_school_id = value[0];
-        }
-      }
-      return updated;
-    });
+    setSpecialistData(prev => ({ ...prev, [field]: value }));
     setError(null);
   };
 
@@ -279,7 +263,6 @@ export default function CreateAccountPage() {
             email: specialistData.email,
             role: specialistData.role,
             school_ids: specialistData.school_ids,
-            primary_school_id: specialistData.primary_school_id || specialistData.school_ids[0],
           }),
         });
 
@@ -621,33 +604,6 @@ export default function CreateAccountPage() {
                   </p>
                 )}
               </div>
-
-              {/* Primary School Selection (only if multiple schools selected) */}
-              {specialistData.school_ids.length > 1 && (
-                <div>
-                  <label htmlFor="primary_school" className="block text-sm font-medium text-gray-700 mb-1">
-                    Primary School <span className="text-red-500">*</span>
-                  </label>
-                  <select
-                    id="primary_school"
-                    value={specialistData.primary_school_id}
-                    onChange={(e) => handleSpecialistInputChange('primary_school_id', e.target.value)}
-                    className="block w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
-                  >
-                    {specialistData.school_ids.map((schoolId) => {
-                      const school = districtSchools.find(s => s.id === schoolId);
-                      return (
-                        <option key={schoolId} value={schoolId}>
-                          {school?.name || schoolId}
-                        </option>
-                      );
-                    })}
-                  </select>
-                  <p className="mt-1 text-xs text-gray-500">
-                    Select the primary school for this specialist's profile.
-                  </p>
-                </div>
-              )}
             </>
           )}
 

--- a/app/(dashboard)/dashboard/admin/schools/[schoolId]/page.tsx
+++ b/app/(dashboard)/dashboard/admin/schools/[schoolId]/page.tsx
@@ -302,7 +302,6 @@ export default function SchoolDetailPage() {
           email: providerFormData.email.trim(),
           role: providerFormData.role,
           school_ids: [schoolId],
-          primary_school_id: schoolId,
         }),
       });
 

--- a/app/api/admin/district/providers/[providerId]/route.ts
+++ b/app/api/admin/district/providers/[providerId]/route.ts
@@ -250,8 +250,20 @@ export const PATCH = withRoute<{ providerId: string }>({}, async ({ req: request
       }
     }
 
-    // Update school assignments if changed
-    if (school_ids && primary_school_id) {
+    // An explicitly empty school list is a malformed request, not "leave the
+    // assignments alone". Fail loudly — silently ignoring it is how SPE-95
+    // happened.
+    if (school_ids && school_ids.length === 0) {
+      return NextResponse.json(
+        { error: 'school_ids must contain at least one school' },
+        { status: 400 }
+      );
+    }
+
+    // Update school assignments if changed. `primary_school_id` is optional
+    // (SPE-360) — it defaults to the first assigned school below, so a caller
+    // sending only `school_ids` still gets the assignment updated.
+    if (school_ids?.length) {
       // Site admins can only assign to their own school
       if (accessCheck.siteAdminSchoolId) {
         const invalidSchools = school_ids.filter(id => id !== accessCheck.siteAdminSchoolId);
@@ -283,12 +295,13 @@ export const PATCH = withRoute<{ providerId: string }>({}, async ({ req: request
         }
       }
 
-      if (!school_ids.includes(primary_school_id)) {
+      if (primary_school_id && !school_ids.includes(primary_school_id)) {
         return NextResponse.json(
           { error: 'Primary school must be one of the assigned schools' },
           { status: 400 }
         );
       }
+      const effectivePrimarySchoolId = primary_school_id || school_ids[0];
 
       // Fetch existing provider_schools for rollback if needed
       const { data: existingProviderSchools } = await adminClient
@@ -318,7 +331,7 @@ export const PATCH = withRoute<{ providerId: string }>({}, async ({ req: request
           school_id: schoolId,
           school_site: school?.name || '',
           school_district: '',
-          is_primary: schoolId === primary_school_id,
+          is_primary: schoolId === effectivePrimarySchoolId,
           district_id: accessCheck.districtId!,
         };
       });
@@ -354,7 +367,7 @@ export const PATCH = withRoute<{ providerId: string }>({}, async ({ req: request
       await adminClient
         .from('profiles')
         .update({
-          school_id: primary_school_id,
+          school_id: effectivePrimarySchoolId,
           works_at_multiple_schools: school_ids.length > 1,
         })
         .eq('id', providerId);

--- a/app/api/admin/district/providers/[providerId]/route.ts
+++ b/app/api/admin/district/providers/[providerId]/route.ts
@@ -250,12 +250,23 @@ export const PATCH = withRoute<{ providerId: string }>({}, async ({ req: request
       }
     }
 
-    // An explicitly empty school list is a malformed request, not "leave the
-    // assignments alone". Fail loudly — silently ignoring it is how SPE-95
-    // happened.
-    if (school_ids && school_ids.length === 0) {
+    // `school_ids` is only asserted by the TypeScript type — the body is
+    // whatever the caller sent. A non-array (e.g. a bare string) would pass a
+    // bare `.length` check and then throw inside `.filter()` below, turning a
+    // bad request into a 500.
+    if (school_ids !== undefined && (!Array.isArray(school_ids) || school_ids.length === 0)) {
       return NextResponse.json(
-        { error: 'school_ids must contain at least one school' },
+        { error: 'school_ids must be a non-empty array of school ids' },
+        { status: 400 }
+      );
+    }
+
+    // The assignment rewrite below is keyed off `school_ids`, so a primary sent
+    // on its own cannot be applied. Reject it rather than returning success
+    // having changed nothing — that silent no-op is the SPE-95 failure mode.
+    if (primary_school_id && !school_ids?.length) {
+      return NextResponse.json(
+        { error: 'primary_school_id requires school_ids' },
         { status: 400 }
       );
     }

--- a/app/api/admin/district/providers/route.ts
+++ b/app/api/admin/district/providers/route.ts
@@ -76,10 +76,18 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
     const body: CreateProviderRequest = await request.json();
     const { first_name, last_name, email, role, school_ids } = body;
 
-    // Validate required fields
+    // Validate required fields. `school_ids` is only asserted by the
+    // TypeScript type, so check the shape too — a non-array would survive a
+    // bare `.length` check and fail later as a 500 instead of a 400.
     if (!first_name?.trim() || !last_name?.trim() || !email?.trim() || !role || !school_ids?.length) {
       return NextResponse.json(
         { error: 'Missing required fields: first_name, last_name, email, role, school_ids' },
+        { status: 400 }
+      );
+    }
+    if (!Array.isArray(school_ids)) {
+      return NextResponse.json(
+        { error: 'school_ids must be an array of school ids' },
         { status: 400 }
       );
     }

--- a/app/api/admin/district/providers/route.ts
+++ b/app/api/admin/district/providers/route.ts
@@ -15,7 +15,13 @@ interface CreateProviderRequest {
   email: string;
   role: ProviderRole;
   school_ids: string[];
-  primary_school_id: string;
+  /**
+   * Optional. The school stamped on `profiles.school_id` and flagged
+   * `is_primary` in `provider_schools`. Admins no longer choose this (SPE-360)
+   * — it defaults to the first assigned school. Still accepted, and still
+   * validated against `school_ids`, so existing callers keep working.
+   */
+  primary_school_id?: string;
 }
 
 /**
@@ -68,12 +74,12 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
 
     // Parse request body
     const body: CreateProviderRequest = await request.json();
-    const { first_name, last_name, email, role, school_ids, primary_school_id } = body;
+    const { first_name, last_name, email, role, school_ids } = body;
 
     // Validate required fields
-    if (!first_name?.trim() || !last_name?.trim() || !email?.trim() || !role || !school_ids?.length || !primary_school_id) {
+    if (!first_name?.trim() || !last_name?.trim() || !email?.trim() || !role || !school_ids?.length) {
       return NextResponse.json(
-        { error: 'Missing required fields: first_name, last_name, email, role, school_ids, primary_school_id' },
+        { error: 'Missing required fields: first_name, last_name, email, role, school_ids' },
         { status: 400 }
       );
     }
@@ -145,13 +151,15 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
       }
     }
 
-    // Validate primary_school_id is in school_ids
-    if (!school_ids.includes(primary_school_id)) {
+    // The primary school is derived, not chosen (SPE-360). Callers may still
+    // send one explicitly; if so it must be one of the assigned schools.
+    if (body.primary_school_id && !school_ids.includes(body.primary_school_id)) {
       return NextResponse.json(
         { error: 'Primary school must be one of the assigned schools' },
         { status: 400 }
       );
     }
+    const primary_school_id = body.primary_school_id || school_ids[0];
 
     // Check if email already exists
     const { data: existingUsers } = await adminClient.auth.admin.listUsers();

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "sim:verify": "tsx scripts/sim-district/verify.ts",
     "sim:verify-rls": "tsx scripts/sim-district/verify-profiles-rls.ts",
     "sim:verify-children-rls": "tsx scripts/sim-district/verify-children-rls.ts",
-    "sim:verify-child-link": "tsx scripts/sim-district/verify-child-link.ts"
+    "sim:verify-child-link": "tsx scripts/sim-district/verify-child-link.ts",
+    "sim:verify-special-activities-rls": "tsx scripts/sim-district/verify-special-activities-rls.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",

--- a/scripts/sim-district/verify-special-activities-rls.ts
+++ b/scripts/sim-district/verify-special-activities-rls.ts
@@ -93,11 +93,16 @@ function sameSet(a: Set<string>, b: Set<string>): boolean {
   return a.size === b.size && [...a].every(id => b.has(id));
 }
 
+/**
+ * `maybeSingle`, not `single`: if the DELETE probe below ever succeeds the row
+ * is gone, and `single()` would throw a confusing "readback failed" instead of
+ * letting the missing row flow into the DELETE check that is actually failing.
+ */
 async function activityName(id: string): Promise<string | null> {
   const { data, error } = await admin
-    .from('special_activities').select('activity_name').eq('id', id).single();
+    .from('special_activities').select('activity_name').eq('id', id).maybeSingle();
   if (error) throw new Error(`activity readback failed: ${error.message}`);
-  return data.activity_name as string | null;
+  return (data?.activity_name as string | null) ?? null;
 }
 
 async function main(): Promise<void> {

--- a/scripts/sim-district/verify-special-activities-rls.ts
+++ b/scripts/sim-district/verify-special-activities-rls.ts
@@ -1,0 +1,201 @@
+/**
+ * SPE-361 — `special_activities` SELECT scoping, run with REAL signed-in sessions.
+ *
+ * Same reason this is a script and not a jest test as its siblings
+ * verify-profiles-rls.ts / verify-children-rls.ts: our unit tests mock the
+ * Supabase client, so they cannot see RLS at all — they pass identically
+ * whether a policy returns every row or none.
+ *
+ * The bug: `special_activities_select` scoped school-wide reads through
+ * `profiles.school_id` alone — the caller's single "primary" school — so an
+ * itinerant provider saw special activities at exactly one of their schools.
+ * Special activities are the constraints the scheduler schedules AROUND, so a
+ * provider planning at a non-primary site was working from an incomplete
+ * picture of when classes are unavailable.
+ *
+ * The contract asserted here:
+ *   - a multi-school provider reads special activities at EVERY assigned
+ *     school, not just the primary one (Tomás: Willow primary + Juniper;
+ *     Maria: Maple primary + Juniper);
+ *   - and at NO school they are unassigned to — the fix widens to
+ *     provider_schools, not to the district;
+ *   - a single-school provider's visibility is unchanged (no accidental
+ *     widening for the common case);
+ *   - the teacher and owning-provider read branches still work;
+ *   - the fix is SELECT-only: a provider still cannot write an activity they
+ *     do not own at a non-primary school.
+ *
+ * Three traps this deliberately avoids (CLAUDE.md):
+ *   - assert the ROWS, not the HTTP status — an RLS-filtered read is a 2xx
+ *     with an empty body, exactly like a permitted read of nothing;
+ *   - expected row sets come from the service client at runtime, not from a
+ *     hardcoded 3, so a seed change cannot quietly make a check vacuous;
+ *   - the negative WRITE check patches a value the row does NOT already carry
+ *     and reads back with the service client, so a no-op update cannot pass
+ *     for the wrong reason.
+ *
+ * Requires a seeded sim district (`npm run sim:reset -- --yes`). It leaves the
+ * fixture unchanged on success (the one write it attempts must be refused).
+ *
+ * Usage: npm run sim:verify-special-activities-rls
+ */
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createAdmin, requireEnv } from './lib';
+import { JUNIPER, MAPLE, WILLOW, derivePassword, personaEmail } from './manifest';
+
+const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+const secret = requireEnv('SIM_DISTRICT_PASSWORD');
+
+const admin = createAdmin();
+
+let failures = 0;
+function check(ok: boolean, label: string, detail = ''): void {
+  if (!ok) failures++;
+  console.log(`  [${ok ? 'ok  ' : 'FAIL'}] ${label.padEnd(58)} ${detail}`);
+}
+
+async function signIn(personaKey: string): Promise<SupabaseClient> {
+  const email = personaEmail(personaKey);
+  const client = createClient(url, anon, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: derivePassword(secret, email),
+  });
+  if (error) throw new Error(`sim login failed for ${email} — is the district seeded? (${error.message})`);
+  return client;
+}
+
+/** Every special-activity id at a school, per the service client (ground truth). */
+async function fixtureIds(schoolId: string): Promise<Set<string>> {
+  const { data, error } = await admin
+    .from('special_activities').select('id').eq('school_id', schoolId);
+  if (error) throw new Error(`fixture lookup failed for ${schoolId}: ${error.message}`);
+  const ids = new Set((data ?? []).map(r => r.id as string));
+  if (ids.size === 0) {
+    throw new Error(`no special activities seeded at ${schoolId} — has the seed changed? ` +
+      'A zero-row fixture would make every check here vacuously true.');
+  }
+  return ids;
+}
+
+/** The ids a signed-in session can actually see at a school. */
+async function visibleIds(client: SupabaseClient, schoolId: string): Promise<Set<string>> {
+  const { data, error } = await client
+    .from('special_activities').select('id').eq('school_id', schoolId);
+  if (error) throw new Error(`session read failed for ${schoolId}: ${error.message}`);
+  return new Set((data ?? []).map(r => r.id as string));
+}
+
+function sameSet(a: Set<string>, b: Set<string>): boolean {
+  return a.size === b.size && [...a].every(id => b.has(id));
+}
+
+async function activityName(id: string): Promise<string | null> {
+  const { data, error } = await admin
+    .from('special_activities').select('activity_name').eq('id', id).single();
+  if (error) throw new Error(`activity readback failed: ${error.message}`);
+  return data.activity_name as string | null;
+}
+
+async function main(): Promise<void> {
+  const willow = await fixtureIds(WILLOW);
+  const juniper = await fixtureIds(JUNIPER);
+  const maple = await fixtureIds(MAPLE);
+
+  const tomas = await signIn('tomas');   // Willow (primary) + Juniper + Cedar
+  const maria = await signIn('maria');   // Maple (primary) + Juniper
+  const alicia = await signIn('alicia'); // Maple only
+  const derek = await signIn('derek');   // Juniper only — owns Juniper's rows
+  const nora = await signIn('nora');     // teacher at Willow
+
+  console.log('multi-school provider reads EVERY assigned school (SPE-361):');
+  {
+    const atWillow = await visibleIds(tomas, WILLOW);
+    check(sameSet(atWillow, willow), 'Tomás sees Willow (his primary — worked before)',
+      `${atWillow.size}/${willow.size}`);
+
+    // The regression this whole script exists for. Before the fix this was 0.
+    const atJuniper = await visibleIds(tomas, JUNIPER);
+    check(sameSet(atJuniper, juniper), 'Tomás sees Juniper (assigned, NOT primary)',
+      `${atJuniper.size}/${juniper.size}`);
+
+    // Maria's primary is Maple, so Juniper exercises the same gap from the
+    // other direction — a different provider, a different primary.
+    const mariaJuniper = await visibleIds(maria, JUNIPER);
+    const mariaMaple = await visibleIds(maria, MAPLE);
+    check(sameSet(mariaJuniper, juniper) && sameSet(mariaMaple, maple),
+      'Maria sees both Maple (primary) and Juniper',
+      `maple ${mariaMaple.size}/${maple.size}, juniper ${mariaJuniper.size}/${juniper.size}`);
+  }
+
+  console.log('...and no school they are unassigned to:');
+  {
+    // Maple has activities and is in the same district — if the fix had widened
+    // to "any school" rather than "my schools", this is where it would show.
+    const tomasMaple = await visibleIds(tomas, MAPLE);
+    check(tomasMaple.size === 0, 'Tomás sees NOTHING at Maple (not assigned)',
+      `count=${tomasMaple.size}`);
+
+    const mariaWillow = await visibleIds(maria, WILLOW);
+    check(mariaWillow.size === 0, 'Maria sees NOTHING at Willow (not assigned)',
+      `count=${mariaWillow.size}`);
+  }
+
+  console.log('single-school and non-provider read paths are unchanged:');
+  {
+    const aliciaMaple = await visibleIds(alicia, MAPLE);
+    const aliciaWillow = await visibleIds(alicia, WILLOW);
+    check(sameSet(aliciaMaple, maple) && aliciaWillow.size === 0,
+      'single-school provider: own school only',
+      `maple ${aliciaMaple.size}/${maple.size}, willow ${aliciaWillow.size}`);
+
+    // Derek is provider_id on Juniper's rows — the owner branch, independent of
+    // any school scoping.
+    const derekJuniper = await visibleIds(derek, JUNIPER);
+    check(sameSet(derekJuniper, juniper), 'owning provider still reads their own rows',
+      `${derekJuniper.size}/${juniper.size}`);
+
+    const noraWillow = await visibleIds(nora, WILLOW);
+    check(sameSet(noraWillow, willow), 'teacher still reads their school',
+      `${noraWillow.size}/${willow.size}`);
+  }
+
+  console.log('the fix is SELECT-only — writes are NOT widened:');
+  {
+    const target = [...juniper][0]!;
+    const before = await activityName(target);
+    // A value the row does not already carry: a no-op patch would be permitted
+    // by any policy and would prove nothing.
+    const forbidden = `spe361-probe-${Date.now()}`;
+    check(before !== forbidden, 'negative-write fixture starts from a different value', `stored=${before}`);
+
+    const { data: rows, status } = await tomas.from('special_activities')
+      .update({ activity_name: forbidden }).eq('id', target).select('id');
+    const after = await activityName(target);
+    check((rows?.length ?? 0) === 0, 'Tomás UPDATE of a Juniper activity affects 0 rows',
+      `HTTP ${status}, ${rows?.length ?? 0} row(s)`);
+    check(after === before && after !== forbidden, 'and does not persist', `stored=${after}`);
+
+    const { data: delRows, error: delErr } = await tomas.from('special_activities')
+      .delete().eq('id', target).select('id');
+    const stillThere = await activityName(target);
+    check((delRows?.length ?? 0) === 0 && stillThere === before,
+      'Tomás DELETE of a Juniper activity is refused',
+      `code=${delErr?.code ?? 'none'} rows=${delRows?.length ?? 0}`);
+  }
+
+  if (failures === 0) {
+    console.log('\nAll checks passed.');
+  } else {
+    console.log(`\n${failures} check(s) failed.`);
+  }
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/supabase/migrations/20260804_fix_special_activities_select_multi_school.sql
+++ b/supabase/migrations/20260804_fix_special_activities_select_multi_school.sql
@@ -1,0 +1,40 @@
+-- SPE-361: multi-school providers can't see special activities at their
+-- non-primary schools.
+--
+-- `special_activities_select` scoped school-wide reads through
+-- `profiles.school_id` only — the caller's single "primary" school — so an
+-- itinerant provider assigned to three schools saw teacher-created special
+-- activities (PE, music, library, assemblies) at exactly one of them. Those
+-- activities are the constraints the scheduler is supposed to schedule
+-- around, so planning at a non-primary site worked off an incomplete picture
+-- of when classes are unavailable.
+--
+-- `get_my_school_ids()` (SECURITY DEFINER, STABLE, granted to `authenticated`)
+-- already unions `profiles.school_id` with the caller's `provider_schools`
+-- rows. `bell_schedules` SELECT has unioned `provider_schools` for this same
+-- reason since 20251216; bell schedules and special activities are the same
+-- class of school-level scheduling constraint, and the inconsistency between
+-- them was the bug.
+--
+-- SELECT only. INSERT/UPDATE/DELETE on special_activities key off
+-- provider_id / created_by_id / admin_permissions, never the profile-school
+-- branch, and are deliberately left untouched.
+
+DROP POLICY IF EXISTS "special_activities_select" ON special_activities;
+
+CREATE POLICY "special_activities_select" ON special_activities
+  FOR SELECT TO authenticated
+  USING (
+    -- Users can view their own activities (as provider)
+    provider_id = (SELECT auth.uid())
+    OR
+    -- Teachers can view their activities
+    provider_id IN (SELECT teachers.id FROM teachers WHERE teachers.account_id = (SELECT auth.uid()))
+    OR
+    -- Users can view activities at ANY school they are assigned to —
+    -- their profile school unioned with provider_schools, not primary alone
+    school_id::text IN (SELECT school_id FROM get_my_school_ids())
+    OR
+    -- Teachers can view activities at their school
+    school_id::text IN (SELECT teachers.school_id FROM teachers WHERE teachers.account_id = (SELECT auth.uid()))
+  );


### PR DESCRIPTION
Started as a research question — *why does a multi-school user need a "primary school" at all?* The answer turned out to be "they don't, and the concept is actively costing us one real bug." This PR removes the choice and fixes the bug.

## Why "primary school" exists

It is not a product concept. `profiles.school_id` predates multi-school support; when `provider_schools` (M:N) arrived, the single-school column stayed, and "primary" became the name for whatever value goes in it. The create-specialist form asked a district admin to make a choice they have no basis for making.

What the flag actually drove: a "Primary" badge in the school switcher, sort order, and **priority 3 of 4** in the login school-selection ladder — behind manual selection and the day's `user_site_schedules` site, which are the better signals anyway.

## SPE-360 — remove the choice, keep the column

- Dropped the `Primary School` `<select>`, its form state, and the auto-set/reset logic from the admin create-account page.
- `primary_school_id` is now **optional** on the district-providers `POST` and `PATCH` routes, defaulting to the first assigned school. An explicitly supplied value is still validated against `school_ids`, so any existing caller keeps working unchanged.
- `PATCH` previously required **both** `school_ids` and `primary_school_id` and silently skipped the school update otherwise. It now updates on `school_ids` alone, and rejects an explicitly empty list instead of ignoring it (silent no-ops are how SPE-95 happened).

**Not in scope:** retiring `profiles.school_id` itself. It is still load-bearing in RLS and in several "which school did you mean?" fallbacks. That is SPE-54 territory. This removes the *human choice*; the column is still populated, automatically.

## SPE-361 — the bug that split caused

`special_activities_select` scoped school-wide reads through `profiles.school_id` alone, so an itinerant provider saw teacher-created special activities (PE, music, library, assemblies) at **exactly one** of their schools. Those activities are the constraints the scheduler is supposed to schedule *around* — so planning at a non-primary site ran on an incomplete picture of when classes are unavailable. Confirmed live in prod before the fix: **2 providers, 6 hidden rows**.

The school branch now uses `get_my_school_ids()`, which already unions `profiles.school_id` with `provider_schools`. `bell_schedules` SELECT has done exactly this since `20251216` — bell schedules and special activities are the same class of school-level scheduling constraint, and the inconsistency between them *was* the bug.

**SELECT only.** The INSERT/UPDATE/DELETE policies key off `provider_id` / `created_by_id` / `admin_permissions`, never the profile-school branch, and are untouched.

## Verification

Unit tests mock the Supabase client and cannot see RLS, so this was exercised with **real signed-in sessions** against the sim district. `npm run sim:verify-special-activities-rls` is added here as a permanent regression guard, alongside its `verify-profiles-rls` / `verify-children-rls` siblings.

| | before | after |
|---|---|---|
| Tomás (Willow primary) at Juniper | 0/3 | **3/3** |
| Maria (Maple primary) at Juniper | 0/3 | **3/3** |
| Tomás at Maple (not assigned) | 0 | 0 |
| Maria at Willow (not assigned) | 0 | 0 |
| Single-school provider (Alicia) | own school only | unchanged |
| Owning provider / teacher branches | pass | unchanged |
| Tomás write to a Juniper activity | refused | **still refused** |

The probe derives its expected row sets from the service client at runtime rather than hardcoding a count, asserts rows-affected plus a readback rather than HTTP status, and patches a value the row does not already carry — so a seed change, an RLS-filtered 2xx, or a no-op update cannot make a check pass for the wrong reason.

Separately confirmed that **every in-app reader of `special_activities` filters by school explicitly**, so none was relying on RLS as its school filter and none starts showing cross-school rows.

SPE-360 was also verified end-to-end through the real UI: created a specialist assigned to three schools with no primary picker, and the database landed exactly one `is_primary` row, agreeing with `profiles.school_id`, with `works_at_multiple_schools = true`. The probe account was removed by a re-seed; `sim:verify` is green.

Also green: typecheck, lint (only pre-existing warnings in unrelated files), 702 unit tests.

## The form after the change

Verified in the running app as a district admin: with three schools checked, **Assigned Schools** now flows straight to Cancel / Create Account — no Primary School field, no gap in the layout. (Screenshot shared with @bstewart2255 directly.)

## Follow-ups filed

- **SPE-362** — the same profile-school-only pattern survives in `teachers_insert`, the SEA branches of `students_select` / `children_select`, and `profiles_update`. Each is a *widening* of access and deserves its own judgement call, so they were deliberately left out of this PR.
- **SPE-363** — 5 providers carry two primary-flagged rows (from the `20260410` backfill's per-school `NOT EXISTS` guard), and 2 have multiple schools but `works_at_multiple_schools = false`. No constraint prevents either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBQpZtN31mhpK4W2HEGZHQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Providers can be assigned to multiple schools without requiring a designated primary school.
  * The first assigned school becomes the effective primary when none is specified.
  * Multi-school providers can view special activities across all assigned schools.

* **Bug Fixes**
  * Improved validation for school assignments and special activity access.
  * Preserved access controls for single-school providers, owners, and teachers.

* **Tests**
  * Added verification for multi-school visibility and unauthorized access restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->