### PR TITLE
Prep Supabase custom domain so Google sign-in shows our domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 # Supabase Configuration
+# The project API origin. Everything the app builds off it follows it, including
+# signed storage URLs — so if a custom domain is ever activated for the project,
+# switch this deliberately (docs/supabase-custom-domain.md), not casually.
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key

--- a/app/(dashboard)/dashboard/tools/components/saved-worksheets.tsx
+++ b/app/(dashboard)/dashboard/tools/components/saved-worksheets.tsx
@@ -131,9 +131,11 @@ export default function SavedWorksheets() {
 
       const data = await response.json();
 
-      // Validate that the URL is from Supabase storage
+      // Validate that the URL is from our Supabase project. Compared against the
+      // configured project origin rather than a hardcoded supabase.co host, so a
+      // custom domain keeps working — see docs/supabase-custom-domain.md.
       const url = new URL(data.signedUrl);
-      if (!url.hostname.includes('supabase.co')) {
+      if (url.origin !== new URL(process.env.NEXT_PUBLIC_SUPABASE_URL!).origin) {
         throw new Error('Invalid download URL');
       }
 

--- a/docs/SIM_DISTRICT.md
+++ b/docs/SIM_DISTRICT.md
@@ -387,10 +387,11 @@ Env requirements are scoped per command. Every command needs
 | `sim:verify`, `sim:teardown` | — | read-only / delete-only, so they never receive the credential secret |
 | the three `sim:verify-*` guards | `SIM_DISTRICT_PASSWORD` + `NEXT_PUBLIC_SUPABASE_ANON_KEY` | they sign IN as personas, which needs the same derived password and a client-side key |
 
-**Preflight, before any write.** Scripts hard-fail unless: **(a)** the
-project ref extracted from `NEXT_PUBLIC_SUPABASE_URL` equals the ref pinned
-in `manifest.ts` — env vars alone don't prove which database you're pointed
-at; **(b)** the sim sentinel checks out — district `SIM-D001` exists with
+**Preflight, before any write.** Scripts hard-fail unless: **(a)** the host in
+`NEXT_PUBLIC_SUPABASE_URL` is a front for the project pinned in `manifest.ts` —
+either `<ref>.supabase.co` or the `SUPABASE_CUSTOM_HOST` custom domain, if one
+is set (`docs/supabase-custom-domain.md`) — because env vars alone don't prove
+which database you're pointed at; **(b)** the sim sentinel checks out — district `SIM-D001` exists with
 the exact expected name; on first seed, sentinel-absent is **not** taken as
 proof of emptiness — bootstrap requires a manifest-wide zero-state check
 (no SIM-owned IDs and no sim-domain auth users anywhere), so a half-failed

--- a/docs/auth-google-sso.md
+++ b/docs/auth-google-sso.md
@@ -48,6 +48,8 @@ first, then enable.
    - Create an **OAuth 2.0 Client ID** (type: Web application).
    - Authorized redirect URI: `https://qkcruccytmmdajfavpgb.supabase.co/auth/v1/callback`
      (the Supabase project's callback, *not* the app's `/auth/callback`).
+     If the custom domain is set up, `https://auth.speddy.xyz/auth/v1/callback`
+     must be registered **in addition** — see `docs/supabase-custom-domain.md`.
    - Consent screen / Audience: **External**, **Published / In production**. Scopes
      are just `email`/`profile`/`openid`, which need **no Google verification**.
    - Note the **Client ID** and **Client secret**.
@@ -76,6 +78,13 @@ first, then enable.
 
 ## Notes / known edges
 
+- **What users see on the Google screen.** Google shows the root domain of the
+  OAuth callback — today `qkcruccytmmdajfavpgb.supabase.co`. Filling in the
+  Branding form in Google Cloud does *not* change that: Google only substitutes
+  the app name after its verification review, which asks you to prove ownership
+  of every authorized domain — including `supabase.co`, which isn't ours. The
+  reliable fix is to move the callback onto a domain we own; see
+  `docs/supabase-custom-domain.md`.
 - **Account model unchanged.** Admins still create accounts (which creates the
   `auth.users` row with a confirmed email). Google just adds a second way for
   those users to sign in.

--- a/docs/supabase-custom-domain.md
+++ b/docs/supabase-custom-domain.md
@@ -1,0 +1,163 @@
+# Supabase custom domain (`auth.speddy.xyz`)
+
+Moves the Supabase API/Auth endpoint from `qkcruccytmmdajfavpgb.supabase.co` to a
+domain we own, so **Google's sign-in screen says `auth.speddy.xyz`** instead of
+the project ref.
+
+## Why this and not Google brand verification
+
+Google shows the root domain of the OAuth **callback** it is about to send the
+user to. Ours is `https://qkcruccytmmdajfavpgb.supabase.co/auth/v1/callback`, so
+that string is what users see. Filling in the Branding form in Google Cloud does
+not change it — Google only substitutes the app name after its **verification
+review**, and that review asks you to prove ownership of every authorized
+domain, one of which is `supabase.co`. We don't own it. People do get through by
+listing only `speddy.xyz` and explaining the third-party redirect, but reported
+turnaround is 2 days to 2 weeks with inconsistent results.
+
+Owning the callback domain removes the dependency on that review entirely.
+
+## Before you start
+
+| | |
+|---|---|
+| Plan | Org must be on a paid plan — **we're on Pro** ✅ |
+| Cost | Custom Domain add-on, **$10/month** per project, billed hourly while active |
+| Access | Supabase **Owner or Admin** on the `Speddy` project |
+| DNS | Ability to add CNAME + TXT records for `speddy.xyz` |
+| Host | Must be a **subdomain** — apex `speddy.xyz` is not supported, and only CNAME records work |
+
+We use `auth.speddy.xyz`. It fronts the whole project API (auth, REST, storage,
+realtime, edge functions), not just auth — the name just reflects why we bought it.
+
+## Steps
+
+Run these in order. Nothing user-visible changes until step 6.
+
+### 1. Buy the add-on
+
+Supabase Dashboard → **Project Settings → Add-ons → Custom Domain**.
+
+### 2. Register the domain and get the verification record
+
+Dashboard → **Project Settings → General → Custom Domains**, enter
+`auth.speddy.xyz`. It returns a TXT verification value.
+
+CLI equivalent, if you prefer:
+
+```bash
+supabase domains create --project-ref qkcruccytmmdajfavpgb --custom-hostname auth.speddy.xyz
+```
+
+### 3. Add the DNS records
+
+| Type | Name | Value | TTL |
+|---|---|---|---|
+| CNAME | `auth` | `qkcruccytmmdajfavpgb.supabase.co` | low (300s) |
+| TXT | `_acme-challenge.auth` | *(value from step 2)* | low (300s) |
+
+Three gotchas:
+
+- **Use the short names** (`auth`, `_acme-challenge.auth`), not the full
+  hostnames. Most registrars append the domain themselves, so entering
+  `auth.speddy.xyz` creates `auth.speddy.xyz.speddy.xyz`.
+- Some registrars want a trailing dot on the CNAME value
+  (`qkcruccytmmdajfavpgb.supabase.co.`) and some reject it. Follow whatever the
+  registrar's existing records do.
+- Trim any surrounding whitespace from the TXT value.
+
+Keep the TTL low until this is done, so a mistake is quick to undo.
+
+### 4. Verify
+
+Work through the verification step in the same Custom Domains panel, or:
+
+```bash
+supabase domains reverify --project-ref qkcruccytmmdajfavpgb
+```
+
+DNS takes time to propagate, so this may need a few attempts. Supabase then
+issues the SSL certificate, which can take up to 30 minutes.
+
+### 5. Add the new callback to Google — do this BEFORE activating
+
+Google Cloud Console → **Google Auth Platform → Clients** → the Supabase sign-in
+client → Authorized redirect URIs. **Add** (do not replace):
+
+```
+https://auth.speddy.xyz/auth/v1/callback
+```
+
+The existing `https://qkcruccytmmdajfavpgb.supabase.co/auth/v1/callback` stays.
+Both must be present so sign-in works before, during, and after the switch.
+
+The **Google Calendar** OAuth client is a different client whose redirect is
+already on our own domain (`<origin>/api/calendar/google/callback`). It is
+unaffected — leave it alone.
+
+### 6. Activate
+
+Activate from the same Custom Domains panel, or:
+
+```bash
+supabase domains activate --project-ref qkcruccytmmdajfavpgb
+```
+
+Auth starts advertising `auth.speddy.xyz` as its callback immediately, which is
+what fixes the Google screen. The old `*.supabase.co` domain keeps working —
+both address the same project — so there is no rush on step 8.
+
+### 7. Verify it worked
+
+- Sign out, click **Continue with Google** on the login page — the Google screen
+  should now say `auth.speddy.xyz`.
+- Complete the sign-in and confirm you land in the dashboard (this exercises the
+  provisioning gate in `app/auth/callback/route.ts`, not just the redirect).
+- Sign in with email/password too, to confirm nothing else regressed.
+
+### 8. Optional, later: point the app at the new domain
+
+Not required for the Google fix, and worth doing as its own change so any
+fallout is isolated:
+
+1. Vercel → `NEXT_PUBLIC_SUPABASE_URL` → `https://auth.speddy.xyz`, then redeploy.
+2. Set `SUPABASE_CUSTOM_HOST = 'auth.speddy.xyz'` in
+   `scripts/sim-district/manifest.ts` so the sim-district preflight accepts the
+   new host (it pins the project by hostname and will otherwise refuse to run).
+
+Everything the app builds off that URL follows it, including **signed storage
+URLs**. `app/(dashboard)/dashboard/tools/components/saved-worksheets.tsx`
+validates download URLs against the configured project origin for exactly this
+reason — it used to hardcode `supabase.co`, which would have rejected every
+worksheet download the moment the env var changed.
+
+After this step, smoke-test a worksheet download and a document upload/download
+alongside sign-in.
+
+Nothing else in the codebase pins the Supabase host: there are no CSP or image
+host allowlists, and the Chrome extension only ever talks to `speddy.xyz`.
+
+## Rollback
+
+```bash
+supabase domains delete --project-ref qkcruccytmmdajfavpgb
+```
+
+If step 8 was done, revert `NEXT_PUBLIC_SUPABASE_URL` to
+`https://qkcruccytmmdajfavpgb.supabase.co` **first** and redeploy — otherwise the
+app points at a domain that no longer resolves. Leave the extra Google redirect
+URI in place; a stale entry is harmless.
+
+## Alternative considered
+
+**Vanity subdomains** (Supabase, experimental) would give `speddy.supabase.co`
+instead of the random ref. Cheaper-looking, but the screen would still read
+`…supabase.co`, which is the part district IT reviewers actually question — so
+it doesn't solve the problem we bought this for.
+
+## Source of truth
+
+- `docs/auth-google-sso.md` — the Google sign-in flow and its enablement steps
+- `scripts/sim-district/manifest.ts`, `scripts/sim-district/lib.ts` — project pin / preflight
+- `app/(dashboard)/dashboard/tools/components/saved-worksheets.tsx` — signed-URL origin check
+- `.env.example` — `NEXT_PUBLIC_SUPABASE_URL`

--- a/docs/supabase-custom-domain.md
+++ b/docs/supabase-custom-domain.md
@@ -15,7 +15,12 @@ domain, one of which is `supabase.co`. We don't own it. People do get through by
 listing only `speddy.xyz` and explaining the third-party redirect, but reported
 turnaround is 2 days to 2 weeks with inconsistent results.
 
-Owning the callback domain removes the dependency on that review entirely.
+Owning the callback domain settles **which domain users see**, without waiting on
+Google. It is not a substitute for brand verification: displaying our app *name
+and logo* on the consent screen still needs that, so the branding work already
+done in Google Cloud stays worth finishing. Full app verification is a separate
+bar we don't hit — our scopes are only `email`/`profile`/`openid`, which Google
+treats as non-sensitive.
 
 ## Before you start
 
@@ -86,7 +91,7 @@ issues the SSL certificate, which can take up to 30 minutes.
 Google Cloud Console → **Google Auth Platform → Clients** → the Supabase sign-in
 client → Authorized redirect URIs. **Add** (do not replace):
 
-```
+```text
 https://auth.speddy.xyz/auth/v1/callback
 ```
 

--- a/docs/supabase-custom-domain.md
+++ b/docs/supabase-custom-domain.md
@@ -32,7 +32,9 @@ realtime, edge functions), not just auth — the name just reflects why we bough
 
 ## Steps
 
-Run these in order. Nothing user-visible changes until step 6.
+Run these in order. Steps 1–5 are safe to do any time and change nothing for
+users. **Steps 6–7 are a single maintenance window with a sign-in outage in the
+middle** — read them both before starting either.
 
 ### 1. Buy the add-on
 
@@ -103,27 +105,31 @@ Activate from the same Custom Domains panel, or:
 supabase domains activate --project-ref qkcruccytmmdajfavpgb
 ```
 
-Auth starts advertising `auth.speddy.xyz` as its callback immediately, which is
-what fixes the Google screen. The old `*.supabase.co` domain keeps working —
-both address the same project — so there is no rush on step 8.
+> ⚠️ **Activation causes a short sign-in outage. Schedule it.**
+>
+> The guides page says the project's `*.supabase.co` domain "continues to work",
+> but that is only true of the REST/storage API. The CLI is explicit:
+> *"After the custom hostname is activated, your project's auth services will no
+> longer function on the Supabase-provisioned subdomain."*
+>
+> Our login form, middleware and auth callback all build their Supabase client
+> from `NEXT_PUBLIC_SUPABASE_URL`. So from the moment you activate until the
+> redeploy in step 7 finishes, **nobody can sign in and existing sessions stop
+> refreshing.** Do this outside school hours, and have step 7 queued up first.
 
-### 7. Verify it worked
-
-- Sign out, click **Continue with Google** on the login page — the Google screen
-  should now say `auth.speddy.xyz`.
-- Complete the sign-in and confirm you land in the dashboard (this exercises the
-  provisioning gate in `app/auth/callback/route.ts`, not just the redirect).
-- Sign in with email/password too, to confirm nothing else regressed.
-
-### 8. Optional, later: point the app at the new domain
-
-Not required for the Google fix, and worth doing as its own change so any
-fallout is isolated:
+### 7. Point the app at the new domain — immediately after activating
 
 1. Vercel → `NEXT_PUBLIC_SUPABASE_URL` → `https://auth.speddy.xyz`, then redeploy.
+   This is the step that ends the outage, so do it right away, not later.
 2. Set `SUPABASE_CUSTOM_HOST = 'auth.speddy.xyz'` in
    `scripts/sim-district/manifest.ts` so the sim-district preflight accepts the
    new host (it pins the project by hostname and will otherwise refuse to run).
+
+To shrink the outage to seconds instead of a build: in Vercel, set the env var
+and build the deployment *before* activating, then **promote** it to production
+the moment activation completes. `NEXT_PUBLIC_*` values are baked in at build
+time, so a pre-built deployment is ready to swap in instantly. Don't promote it
+early — before activation, `auth.speddy.xyz` isn't serving yet.
 
 Everything the app builds off that URL follows it, including **signed storage
 URLs**. `app/(dashboard)/dashboard/tools/components/saved-worksheets.tsx`
@@ -131,22 +137,36 @@ validates download URLs against the configured project origin for exactly this
 reason — it used to hardcode `supabase.co`, which would have rejected every
 worksheet download the moment the env var changed.
 
-After this step, smoke-test a worksheet download and a document upload/download
-alongside sign-in.
-
 Nothing else in the codebase pins the Supabase host: there are no CSP or image
 host allowlists, and the Chrome extension only ever talks to `speddy.xyz`.
 
+### 8. Verify
+
+- Sign out, click **Continue with Google** on the login page — the Google screen
+  should now say `auth.speddy.xyz`.
+- Complete the sign-in and confirm you land in the dashboard (this exercises the
+  provisioning gate in `app/auth/callback/route.ts`, not just the redirect).
+- Sign in with email/password too, to confirm nothing else regressed.
+- Download a saved worksheet and upload/download a document, to confirm signed
+  storage URLs still pass the origin check.
+
 ## Rollback
 
-```bash
-supabase domains delete --project-ref qkcruccytmmdajfavpgb
-```
+Order matters here for the same reason activation does.
 
-If step 8 was done, revert `NEXT_PUBLIC_SUPABASE_URL` to
-`https://qkcruccytmmdajfavpgb.supabase.co` **first** and redeploy — otherwise the
-app points at a domain that no longer resolves. Leave the extra Google redirect
-URI in place; a stale entry is harmless.
+1. **Revert `NEXT_PUBLIC_SUPABASE_URL`** to
+   `https://qkcruccytmmdajfavpgb.supabase.co` and redeploy. REST and storage
+   resume immediately; auth stays down because it is still bound to the custom
+   domain.
+2. **Then release the domain**, which returns auth to the project subdomain:
+
+   ```bash
+   supabase domains delete --project-ref qkcruccytmmdajfavpgb
+   ```
+
+Doing it in the other order points the app at a host that has stopped serving,
+which takes down everything rather than just auth. Leave the extra Google
+redirect URI in place; a stale entry is harmless.
 
 ## Alternative considered
 

--- a/scripts/sim-district/lib.ts
+++ b/scripts/sim-district/lib.ts
@@ -10,6 +10,7 @@ import {
   DISTRICT,
   SCHOOLS,
   SIM_EMAIL_DOMAIN,
+  SUPABASE_CUSTOM_HOST,
   SUPABASE_PROJECT_REF,
   SWEPT_TABLES,
 } from './manifest';
@@ -33,15 +34,18 @@ export function createAdmin(): Admin {
   return createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
 }
 
-/** Preflight (a): the URL's project ref must equal the manifest pin. */
+/** Preflight (a): the connected host must be a manifest-pinned front for the project. */
 export function assertProjectRef(): void {
   const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
-  const host = new URL(url).hostname; // <ref>.supabase.co
-  const ref = host.split('.')[0];
-  if (ref !== SUPABASE_PROJECT_REF) {
+  const host = new URL(url).hostname;
+  // The project's own `<ref>.supabase.co`, or the custom domain pinned in the
+  // manifest — both address the same project.
+  const pinned = `${SUPABASE_PROJECT_REF}.supabase.co`;
+  if (host !== pinned && !(SUPABASE_CUSTOM_HOST && host === SUPABASE_CUSTOM_HOST)) {
     console.error(
-      `Preflight FAILED: connected project ref "${ref}" does not match the manifest pin ` +
-        `"${SUPABASE_PROJECT_REF}". Refusing to touch this database.`,
+      `Preflight FAILED: connected host "${host}" is not the manifest pin "${pinned}"` +
+        (SUPABASE_CUSTOM_HOST ? ` or its custom domain "${SUPABASE_CUSTOM_HOST}"` : '') +
+        `. Refusing to touch this database.`,
     );
     process.exit(1);
   }

--- a/scripts/sim-district/lib.ts
+++ b/scripts/sim-district/lib.ts
@@ -29,6 +29,9 @@ export function requireEnv(name: string): string {
 }
 
 export function createAdmin(): Admin {
+  // Pin the project here, not just in the scripts that remember to ask: this is
+  // the one place a service-role client is minted, so no caller can skip it.
+  assertProjectRef();
   const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
   const key = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
   return createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });

--- a/scripts/sim-district/lib.ts
+++ b/scripts/sim-district/lib.ts
@@ -28,6 +28,7 @@ export function requireEnv(name: string): string {
   return value;
 }
 
+/** Service-role client for the pinned project. Runs the host pin first, always. */
 export function createAdmin(): Admin {
   // Pin the project here, not just in the scripts that remember to ask: this is
   // the one place a service-role client is minted, so no caller can skip it.
@@ -40,7 +41,7 @@ export function createAdmin(): Admin {
 /** Preflight (a): the connected host must be a manifest-pinned front for the project. */
 export function assertProjectRef(): void {
   const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
-  const host = new URL(url).hostname;
+  const { hostname: host, protocol } = new URL(url);
   // The project's own `<ref>.supabase.co`, or the custom domain pinned in the
   // manifest — both address the same project.
   const pinned = `${SUPABASE_PROJECT_REF}.supabase.co`;
@@ -49,6 +50,15 @@ export function assertProjectRef(): void {
       `Preflight FAILED: connected host "${host}" is not the manifest pin "${pinned}"` +
         (SUPABASE_CUSTOM_HOST ? ` or its custom domain "${SUPABASE_CUSTOM_HOST}"` : '') +
         `. Refusing to touch this database.`,
+    );
+    process.exit(1);
+  }
+  // Right host, wrong scheme still puts the service-role key on the wire in
+  // cleartext, so the pin is only worth as much as this second check.
+  if (protocol !== 'https:') {
+    console.error(
+      `Preflight FAILED: NEXT_PUBLIC_SUPABASE_URL uses "${protocol}//". The service-role ` +
+        `key must not travel in cleartext — use https://.`,
     );
     process.exit(1);
   }

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -21,6 +21,13 @@ import { createHash, createHmac } from 'node:crypto';
 /** Supabase project this manifest is allowed to touch. Preflight hard-fails on mismatch. */
 export const SUPABASE_PROJECT_REF = 'qkcruccytmmdajfavpgb';
 
+/**
+ * Custom domain fronting the same project, once one is active — preflight
+ * accepts it in addition to `<ref>.supabase.co`. Empty means none is set up,
+ * which keeps the check strict until it is. See docs/supabase-custom-domain.md.
+ */
+export const SUPABASE_CUSTOM_HOST: string = '';
+
 /** Reserved, undeliverable email domain — the sole sim identity namespace. */
 export const SIM_EMAIL_DOMAIN = 'sim.speddy.test';
 


### PR DESCRIPTION
## Why

The "Continue with Google" screen currently reads `qkcruccytmmdajfavpgb.supabase.co`. Google shows the root domain of the OAuth **callback**, and ours lives on the Supabase project domain.

Filling in the Branding form in Google Cloud does not change this — Google only substitutes the app name after its **verification review**, and that review asks you to prove ownership of every authorized domain, including `supabase.co`. We don't own it. Owning the callback domain settles which domain users see without waiting on Google. It does not replace brand verification, which is still what puts our app *name and logo* on the consent screen.

## What this is

**Groundwork, not the switch.** Nothing in production changes until the Custom Domain add-on is purchased and the domain activated — both manual steps outside this diff.

### `docs/supabase-custom-domain.md` (new)

The runbook: prerequisites and cost, exact DNS records for `auth.speddy.xyz`, the "register both redirect URIs in Google **before** activating" ordering, verification, and rollback.

⚠️ **Activation is a maintenance window, not a background task.** The guides page says the project's `*.supabase.co` domain "continues to work" after activation, but that holds only for REST/storage. `supabase domains activate --help` is explicit: *"your project's auth services will no longer function on the Supabase-provisioned subdomain."* Since the login form, middleware and auth callback all build their client from `NEXT_PUBLIC_SUPABASE_URL`, activation and the app-URL switch are one sequence with a sign-in outage between them. The runbook states this up front and includes a pre-build-then-promote trick to cut the gap to seconds. Rollback ordering is spelled out for the same reason.

### Code that would have broken when the project URL moves

- **`saved-worksheets.tsx`** — the signed download URL was validated with a hardcoded `hostname.includes('supabase.co')`. Signed storage URLs follow `NEXT_PUBLIC_SUPABASE_URL`, so flipping that env var would have made **every worksheet download fail** with "Invalid download URL". Now compares against the configured project origin. Side effect: closes the substring match, where `<ref>.supabase.co.evil.com` satisfied `includes`.

- **`scripts/sim-district/lib.ts`** — the preflight derived the project ref from `<ref>.supabase.co` and hard-fails on mismatch, so a custom host would have blocked every sim-district script. Now pins the full host and accepts an optional `SUPABASE_CUSTOM_HOST` from the manifest, left empty so the guard stays strict until a domain exists.

### Two pre-existing holes closed in the same guard

Found while reworking the preflight, both in the code path that protects the service-role key:

- **The guard didn't cover its own callers.** `verify-child-link.ts` and `verify-children-rls.ts` minted a service-role client via `createAdmin()` without ever calling `assertProjectRef()`, and both write sim rows. The pin now lives inside `createAdmin()` — the single place such a client is created — so no caller can skip it. This compounded with the old ref check comparing only the first hostname label: `<ref>.attacker.com` would have passed, and those two scripts never asked.

- **Right host, wrong scheme.** The pin validated only the hostname, so `http://<pinned-host>` passed and put the service-role key on the wire in cleartext. Now rejects any scheme but `https:`.

## Verification

- `typecheck`, `lint`, and the full suite green (79 suites, 702 tests); CI green on `1b23be6`.
- **Preflight exercised directly** — current project URL passes; foreign project ref refused; custom host refused while none is pinned; with a host pinned, the matching host passes and `auth.speddy.xyz.evil.com` is refused; `http://` + pinned host refused. The two previously-bypassing scripts now exit 1 against a foreign host (tested against a `.invalid` host, so nothing could be transmitted even if the guard had failed).
- **The origin assumption was checked against the real project, not reasoned about** — generated a signed URL from the actual `saved-worksheets` bucket and confirmed it comes back on the project origin, so the new check passes today and follows the domain later.
- Swept for other Supabase-host dependencies: no CSP or image host allowlists exist, and the Chrome extension only talks to `speddy.xyz`.

No unit tests added for the preflight — these scripts have no jest harness; the guard is verified by execution, as above.

Deferred: [SPE-366](https://linear.app/speddy/issue/SPE-366/reject-redirects-on-sim-district-service-role-requests) (reject redirects on service-role requests).

The activation steps themselves need a real signed-in session to confirm, which happens when the domain goes live.

---
_Generated by [Claude Code](https://claude.ai/code/session_013yGLFSYJTFKKDHQge7cTvX)_