### PR TITLE
Pin auth.speddy.xyz in the sim-district preflight; mark the runbook done

### DIFF
--- a/docs/supabase-custom-domain.md
+++ b/docs/supabase-custom-domain.md
@@ -17,8 +17,9 @@ the project ref.
 ## Why this and not Google brand verification
 
 Google shows the root domain of the OAuth **callback** it is about to send the
-user to. Ours is `https://qkcruccytmmdajfavpgb.supabase.co/auth/v1/callback`, so
-that string is what users see. Filling in the Branding form in Google Cloud does
+user to. Before this change ours was
+`https://qkcruccytmmdajfavpgb.supabase.co/auth/v1/callback`, so that project-ref
+string is what users saw. Filling in the Branding form in Google Cloud does
 not change it — Google only substitutes the app name after its **verification
 review**, and that review asks you to prove ownership of every authorized
 domain, one of which is `supabase.co`. We don't own it. People do get through by
@@ -179,9 +180,15 @@ Order matters here for the same reason activation does.
    supabase domains delete --project-ref qkcruccytmmdajfavpgb
    ```
 
-Doing it in the other order points the app at a host that has stopped serving,
-which takes down everything rather than just auth. Leave the extra Google
-redirect URI in place; a stale entry is harmless.
+3. **Clear the manifest pin** — set `SUPABASE_CUSTOM_HOST` back to `''` in
+   `scripts/sim-district/manifest.ts` and merge. Once released, the host no
+   longer fronts our project, so the preflight must stop treating it as a valid
+   place to send `SUPABASE_SERVICE_ROLE_KEY`. Easy to forget, because nothing
+   breaks if you skip it.
+
+Doing 1 and 2 in the other order points the app at a host that has stopped
+serving, which takes down everything rather than just auth. Leave the extra
+Google redirect URI in place; a stale entry is harmless.
 
 ## Alternative considered
 

--- a/docs/supabase-custom-domain.md
+++ b/docs/supabase-custom-domain.md
@@ -1,5 +1,15 @@
 # Supabase custom domain (`auth.speddy.xyz`)
 
+> **Status: done — live since 2026-08-04.** The steps below have been executed;
+> keep them as the record of how it was set up and as the rollback procedure.
+> Confirmed by asking Supabase what it advertises to Google:
+> `/auth/v1/authorize?provider=google` now redirects with
+> `redirect_uri=https://auth.speddy.xyz/auth/v1/callback`.
+>
+> One correction learned during the switch: **the old subdomain's `/auth/v1/*`
+> API endpoints keep answering after activation**, so they are *not* a test of
+> whether activation happened. The `redirect_uri` above is the reliable check.
+
 Moves the Supabase API/Auth endpoint from `qkcruccytmmdajfavpgb.supabase.co` to a
 domain we own, so **Google's sign-in screen says `auth.speddy.xyz`** instead of
 the project ref.

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -22,11 +22,12 @@ import { createHash, createHmac } from 'node:crypto';
 export const SUPABASE_PROJECT_REF = 'qkcruccytmmdajfavpgb';
 
 /**
- * Custom domain fronting the same project, once one is active — preflight
- * accepts it in addition to `<ref>.supabase.co`. Empty means none is set up,
- * which keeps the check strict until it is. See docs/supabase-custom-domain.md.
+ * Custom domain fronting the same project — preflight accepts it in addition to
+ * `<ref>.supabase.co`. Live since 2026-08-04; both hosts address this project,
+ * so either is a valid connection for the sim scripts. Empty would mean none is
+ * set up. See docs/supabase-custom-domain.md.
  */
-export const SUPABASE_CUSTOM_HOST: string = '';
+export const SUPABASE_CUSTOM_HOST: string = 'auth.speddy.xyz';
 
 /** Reserved, undeliverable email domain — the sole sim identity namespace. */
 export const SIM_EMAIL_DOMAIN = 'sim.speddy.test';


### PR DESCRIPTION
## Why

The Supabase custom domain went live on 2026-08-04. PR #797 left `SUPABASE_CUSTOM_HOST` empty on purpose, so the sim-district host pin would stay strict until a domain actually existed. One now does, so this is the follow-up that PR deferred.

Without it, the sim scripts hard-fail the moment anyone points `NEXT_PUBLIC_SUPABASE_URL` at the production value — the guard would be refusing the project's own domain. (The remote environment's sim env still uses `*.supabase.co`, so nothing is broken today; this stops it breaking later.)

## What changed

- `scripts/sim-district/manifest.ts` — `SUPABASE_CUSTOM_HOST` set to `auth.speddy.xyz`.
- `docs/supabase-custom-domain.md` — status note at the top recording that the runbook has been executed, so it reads as a record and rollback procedure rather than pending work.

Both hosts front the same project, so the pin is exactly as strict as before: two known hosts, everything else refused.

## A correction worth keeping

The runbook now records something the switch taught us: **the old subdomain's `/auth/v1/*` endpoints keep answering after activation**, so they are not a test of whether activation happened. I used them as one during the cutover and raised a false alarm off the back of it.

The reliable check is what Supabase advertises to Google:

```text
GET https://<project>.supabase.co/auth/v1/authorize?provider=google
→ 302 …&redirect_uri=https%3A%2F%2Fauth.speddy.xyz%2Fauth%2Fv1%2Fcallback
```

That `redirect_uri` is also the string driving the consent screen, so it doubles as confirmation the original goal was met.

## Verification

- Preflight exercised across five cases: old `*.supabase.co` host passes, `auth.speddy.xyz` passes, `auth.speddy.xyz.evil.com` refused, `http://auth.speddy.xyz` refused, foreign project ref refused.
- **`createAdmin()` called end-to-end against the real database** — the guard runs inside it, and a live `profiles` count came back, confirming it doesn't block legitimate use rather than only that it rejects bad input.
- `typecheck`, `lint`, and the full suite green (79 suites, 702 tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_013yGLFSYJTFKKDHQge7cTvX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented the completed custom authentication domain activation.
  * Confirmed the Google OAuth redirect address and recommended activation verification method.
  * Noted that legacy authentication endpoints may remain responsive after activation.
  * Added rollback guidance for reverting the custom domain configuration.

* **Configuration**
  * Updated the application to use the live custom authentication domain: `auth.speddy.xyz`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->