### PR TITLE
SPE-275/SPE-367: stop the auto-scheduler inventing workdays, and say so

### DIFF
--- a/__tests__/unit/lib/scheduling/scheduler-workdays-fail-closed.test.ts
+++ b/__tests__/unit/lib/scheduling/scheduler-workdays-fail-closed.test.ts
@@ -9,7 +9,12 @@ jest.mock('@/lib/supabase/client', () => ({
   createClient: () => mockCreateSupabaseClient(),
 }));
 
-import { OptimizedScheduler, MissingWorkdaysError } from '@/lib/scheduling/optimized-scheduler';
+import {
+  OptimizedScheduler,
+  MissingWorkdaysError,
+  isBlockedOnlyByMissingWorkdays,
+  type EnhancedSchedulingResult,
+} from '@/lib/scheduling/optimized-scheduler';
 
 /**
  * SPE-275 / SPE-367: an empty workday list used to fail OPEN — it silently became
@@ -94,6 +99,55 @@ describe('OptimizedScheduler work days (SPE-275 / SPE-367)', () => {
 
       await scheduler.initializeContext('Rodeo Hills Elementary', 'JSUSD');
       expect(scheduler.context.workDays).toEqual([1, 2, 3, 4, 5]);
+    });
+  });
+
+  /**
+   * Decides whether the caller suppresses its generic "couldn't place all
+   * sessions due to conflicts — adjust your bell schedules" alert. Getting this
+   * wrong either contradicts the real cause or hides a genuine conflict.
+   */
+  describe('isBlockedOnlyByMissingWorkdays', () => {
+    const result = (over: Partial<EnhancedSchedulingResult> = {}): EnhancedSchedulingResult => ({
+      totalScheduled: 0,
+      totalFailed: 0,
+      errors: [],
+      unplacedStudents: [],
+      canManuallyPlace: false,
+      ...over,
+    });
+
+    it('is true when the blocked school explains every failure', () => {
+      expect(isBlockedOnlyByMissingWorkdays(result({
+        totalFailed: 3, workdayBlockedCount: 3, schoolsMissingWorkdays: ['Carquinez Middle'],
+      }))).toBe(true);
+    });
+
+    it('stays true when ANOTHER school scheduled successfully', () => {
+      // The mixed batch: School A placed sessions, School B was blocked. No
+      // conflict caused anything here, so the generic conflict alert would be
+      // wrong — even though totalScheduled > 0.
+      expect(isBlockedOnlyByMissingWorkdays(result({
+        totalScheduled: 5, totalFailed: 3, workdayBlockedCount: 3,
+        schoolsMissingWorkdays: ['Carquinez Middle'],
+      }))).toBe(true);
+    });
+
+    it('is false when another school ALSO failed for real reasons', () => {
+      // 3 blocked by work days + 2 genuinely unplaceable: the second group still
+      // deserves the normal handling, including the manual-placement offer.
+      expect(isBlockedOnlyByMissingWorkdays(result({
+        totalFailed: 5, workdayBlockedCount: 3,
+        schoolsMissingWorkdays: ['Carquinez Middle'],
+      }))).toBe(false);
+    });
+
+    it('is false when no school was blocked at all', () => {
+      expect(isBlockedOnlyByMissingWorkdays(result({ totalFailed: 4 }))).toBe(false);
+    });
+
+    it('is false on a clean run with nothing failed', () => {
+      expect(isBlockedOnlyByMissingWorkdays(result({ totalScheduled: 9 }))).toBe(false);
     });
   });
 

--- a/__tests__/unit/lib/scheduling/scheduler-workdays-fail-closed.test.ts
+++ b/__tests__/unit/lib/scheduling/scheduler-workdays-fail-closed.test.ts
@@ -1,0 +1,120 @@
+// Aliased with a `mock` prefix so the jest.mock factory (hoisted above imports by
+// babel-plugin-jest-hoist) may reference it.
+import { createMockSupabaseClient as mockCreateSupabaseClient } from '@/test-utils/supabase-test-helpers';
+
+// The scheduler constructs a Supabase client and the singleton data manager on
+// construction; mock the client module so both resolve to a harmless stub. These
+// tests exercise the workday decision, not any I/O.
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockCreateSupabaseClient(),
+}));
+
+import { OptimizedScheduler, MissingWorkdaysError } from '@/lib/scheduling/optimized-scheduler';
+
+/**
+ * SPE-275 / SPE-367: an empty workday list used to fail OPEN — it silently became
+ * all five weekdays, so an itinerant provider got sessions on days they were at a
+ * different school (observed in prod 2026-07-17: a Monday 08:00 session at a
+ * Thursday/Friday-only site).
+ *
+ * The two empty cases are NOT the same, and conflating them is the whole risk here:
+ *   - a single-school provider legitimately has no `user_site_schedules` rows, and
+ *     all weekdays is the right answer — failing closed for them would break
+ *     auto-scheduling for the majority of users;
+ *   - a multi-school provider's empty list means we do not know where they are.
+ *
+ * These tests pin both directions.
+ */
+function makeScheduler(worksAtMultipleSchools: boolean, workSchedule: Array<{ day_of_week: number }>) {
+  const scheduler = new OptimizedScheduler(
+    'provider-1',
+    'resource',
+    false,
+    worksAtMultipleSchools,
+  ) as any;
+
+  // initializeContext only touches these two collaborators before the workday
+  // decision; stub both so the test stays on the decision itself.
+  scheduler.dataManager = {
+    isInitializedForSchool: () => true,
+    initialize: async () => undefined,
+  };
+  scheduler.getDataFromManager = async () => ({
+    workSchedule,
+    bellSchedules: [],
+    specialActivities: [],
+    existingSessions: [],
+    schoolHours: [],
+    crossProviderSessionsByStudent: new Map(),
+  });
+
+  return scheduler;
+}
+
+describe('OptimizedScheduler work days (SPE-275 / SPE-367)', () => {
+  describe('multi-school provider', () => {
+    it('refuses to schedule when no work days are recorded for the school', async () => {
+      const scheduler = makeScheduler(true, []);
+      await expect(scheduler.initializeContext('Carquinez Middle', 'JSUSD'))
+        .rejects.toBeInstanceOf(MissingWorkdaysError);
+    });
+
+    it('names the school on the error so the caller can skip just that one', async () => {
+      const scheduler = makeScheduler(true, []);
+      const err = await scheduler.initializeContext('Carquinez Middle', 'JSUSD').catch((e: any) => e);
+      expect(err.schoolSite).toBe('Carquinez Middle');
+      // The message is shown to the provider verbatim in the auto-schedule alert.
+      expect(err.message).toContain('Carquinez Middle');
+      expect(err.message).toContain('Work Schedule');
+    });
+
+    it('schedules normally when work days ARE recorded, using only those days', async () => {
+      const scheduler = makeScheduler(true, [{ day_of_week: 4 }, { day_of_week: 5 }]);
+      await scheduler.initializeContext('Carquinez Middle', 'JSUSD');
+      expect(scheduler.context.workDays).toEqual([4, 5]);
+    });
+  });
+
+  describe('single-school provider (must NOT regress)', () => {
+    it('still defaults to all weekdays when no work days are recorded', async () => {
+      const scheduler = makeScheduler(false, []);
+      await scheduler.initializeContext('Rodeo Hills Elementary', 'JSUSD');
+      expect(scheduler.context.workDays).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('defaults to all weekdays by default, when the flag is not passed at all', async () => {
+      // Guards the constructor default — a caller that predates the new argument
+      // must keep its previous behaviour rather than start throwing.
+      const scheduler = new OptimizedScheduler('provider-1', 'resource') as any;
+      scheduler.dataManager = { isInitializedForSchool: () => true, initialize: async () => undefined };
+      scheduler.getDataFromManager = async () => ({
+        workSchedule: [], bellSchedules: [], specialActivities: [],
+        existingSessions: [], schoolHours: [], crossProviderSessionsByStudent: new Map(),
+      });
+
+      await scheduler.initializeContext('Rodeo Hills Elementary', 'JSUSD');
+      expect(scheduler.context.workDays).toEqual([1, 2, 3, 4, 5]);
+    });
+  });
+
+  describe('findStudentSlots defensive guard', () => {
+    it('places nothing rather than assuming all weekdays on an empty context', () => {
+      // Reaching this means a context was built by some path other than
+      // initializeContext. A missing session is recoverable; a session on a day
+      // the provider is at another school is not.
+      const scheduler = new OptimizedScheduler('provider-1', 'resource', false, true) as any;
+      scheduler.context = {
+        schoolSite: 'Carquinez Middle',
+        workDays: [],
+        existingSessions: [],
+      };
+
+      const slots = scheduler.findStudentSlots(
+        { initials: 'AB', grade_level: '3' },
+        30,
+        2,
+      );
+      expect(slots).toEqual([]);
+    });
+  });
+});

--- a/app/components/schedule/schedule-sessions.tsx
+++ b/app/components/schedule/schedule-sessions.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import { useAutoSchedule } from '../../../lib/supabase/hooks/use-auto-schedule';
+import { isBlockedOnlyByMissingWorkdays } from '../../../lib/scheduling/optimized-scheduler';
 import { Button } from '../ui/button';
 import { LongHoverTooltip } from '../ui/long-hover-tooltip';
 import { saveScheduleSnapshot, saveScheduledSessionIds } from './undo-schedule';
@@ -181,8 +182,13 @@ Continue?`;
       // this is the one failure the provider can actually fix.
       if (results.schoolsMissingWorkdays?.length) {
         const schools = results.schoolsMissingWorkdays;
+        // A batch can span several schools, so say what DID schedule before
+        // explaining what didn't — otherwise the run reads as a total failure.
+        const placed = results.totalScheduled > 0
+          ? `Scheduled ${results.totalScheduled} student${results.totalScheduled !== 1 ? 's' : ''} at your other schools.\n\n`
+          : '';
         alert(
-          `Can't schedule at ${schools.join(' or ')} yet.\n\n` +
+          `${placed}Can't schedule at ${schools.join(' or ')} yet.\n\n` +
           `You work at more than one school, and Speddy doesn't know which days you're ` +
           `at ${schools.length > 1 ? 'these schools' : schools[0]}. Without that it could place sessions on days ` +
           `you're somewhere else.\n\n` +
@@ -190,18 +196,11 @@ Continue?`;
         );
       }
 
-      // When missing work days is the ONLY reason nothing scheduled, the alert
-      // above has already said the one useful thing. Following it with the
-      // generic "couldn't place due to conflicts, adjust your bell schedules"
-      // message would contradict it and send the provider somewhere useless.
-      //
-      // Every failure must be accounted for by a blocked school — if another
-      // school also failed for real scheduling reasons, that still deserves the
-      // normal handling (including the manual-placement offer).
-      const blockedOnlyByWorkdays =
-        !!results.schoolsMissingWorkdays?.length &&
-        results.totalScheduled === 0 &&
-        results.workdayBlockedCount === results.totalFailed;
+      // When missing work days explains every failure, the alert above has
+      // already said the one useful thing. Following it with the generic
+      // "couldn't place due to conflicts, adjust your bell schedules" message
+      // would contradict it and send the provider somewhere useless.
+      const blockedOnlyByWorkdays = isBlockedOnlyByMissingWorkdays(results);
 
       // Check if all sessions were successfully scheduled
       if (blockedOnlyByWorkdays) {

--- a/app/components/schedule/schedule-sessions.tsx
+++ b/app/components/schedule/schedule-sessions.tsx
@@ -176,8 +176,40 @@ Continue?`;
       // Schedule only these students
       const results = await scheduleBatchStudents(studentsNeedingScheduling);
 
+      // SPE-367: surface missing work days on its own, before the branching
+      // below — the manual-placement branch never shows `results.errors`, and
+      // this is the one failure the provider can actually fix.
+      if (results.schoolsMissingWorkdays?.length) {
+        const schools = results.schoolsMissingWorkdays;
+        alert(
+          `Can't schedule at ${schools.join(' or ')} yet.\n\n` +
+          `You work at more than one school, and Speddy doesn't know which days you're ` +
+          `at ${schools.length > 1 ? 'these schools' : schools[0]}. Without that it could place sessions on days ` +
+          `you're somewhere else.\n\n` +
+          `Go to Settings → Work Schedule, set your days, then run Auto-Schedule again.`
+        );
+      }
+
+      // When missing work days is the ONLY reason nothing scheduled, the alert
+      // above has already said the one useful thing. Following it with the
+      // generic "couldn't place due to conflicts, adjust your bell schedules"
+      // message would contradict it and send the provider somewhere useless.
+      //
+      // Every failure must be accounted for by a blocked school — if another
+      // school also failed for real scheduling reasons, that still deserves the
+      // normal handling (including the manual-placement offer).
+      const blockedOnlyByWorkdays =
+        !!results.schoolsMissingWorkdays?.length &&
+        results.totalScheduled === 0 &&
+        results.workdayBlockedCount === results.totalFailed;
+
       // Check if all sessions were successfully scheduled
-      if (results.totalFailed > 0 && results.canManuallyPlace) {
+      if (blockedOnlyByWorkdays) {
+        await saveScheduledSessionIds(user.id);
+        if (onComplete) {
+          onComplete();
+        }
+      } else if (results.totalFailed > 0 && results.canManuallyPlace) {
         // Show manual placement modal (snapshot will be finalized after manual placement)
         setUnplacedStudents(results.unplacedStudents || []);
         setShowManualPlacementModal(true);

--- a/lib/scheduling/optimized-scheduler.ts
+++ b/lib/scheduling/optimized-scheduler.ts
@@ -126,6 +126,26 @@ export interface EnhancedSchedulingResult {
   workdayBlockedCount?: number;
 }
 
+/**
+ * True when every failure in a run is explained by a school with no work days
+ * recorded (SPE-367). The caller uses this to suppress its generic "couldn't
+ * place all sessions due to conflicts — adjust your bell schedules" message,
+ * which would contradict the real cause and send the provider somewhere useless.
+ *
+ * Deliberately does NOT require `totalScheduled === 0`: in a batch spanning
+ * several schools, one school can schedule fine while another is blocked, and
+ * that run still has no conflict to report. It DOES require every failure to be
+ * accounted for — if another school failed for real scheduling reasons, that
+ * deserves the normal handling, including the manual-placement offer.
+ */
+export function isBlockedOnlyByMissingWorkdays(result: EnhancedSchedulingResult): boolean {
+  return (
+    !!result.schoolsMissingWorkdays?.length &&
+    result.totalFailed > 0 &&
+    result.workdayBlockedCount === result.totalFailed
+  );
+}
+
 export class OptimizedScheduler {
   private supabase = createClient();
   private context: SchedulingContext | null = null;

--- a/lib/scheduling/optimized-scheduler.ts
+++ b/lib/scheduling/optimized-scheduler.ts
@@ -12,6 +12,28 @@ import type {
   SpecialActivity
 } from './types/scheduling-data';
 
+/**
+ * Thrown when a multi-school provider has no workdays recorded for the school
+ * being scheduled (SPE-275 / SPE-367). Typed so callers can present the
+ * actionable "set your work schedule" message instead of a generic failure,
+ * and so a batch across several schools can skip just this one.
+ */
+export class MissingWorkdaysError extends Error {
+  readonly schoolSite: string;
+
+  constructor(schoolSite: string) {
+    super(
+      `No work days are set for ${schoolSite}. ` +
+      `Because you work at more than one school, Speddy needs to know which days ` +
+      `you're at ${schoolSite} before it can schedule sessions there — otherwise it ` +
+      `could place sessions on days you're at another school. ` +
+      `Set them under Settings → Work Schedule, then try again.`
+    );
+    this.name = 'MissingWorkdaysError';
+    this.schoolSite = schoolSite;
+  }
+}
+
 interface TimeSlot {
   dayOfWeek: number;
   startTime: string;
@@ -88,6 +110,20 @@ export interface EnhancedSchedulingResult {
   unplacedStudents: Student[];
   canManuallyPlace: boolean;
   availableSlots?: TimeSlot[];
+  /**
+   * Schools skipped because the provider has no work days recorded there
+   * (SPE-367). Reported separately from `errors` because the caller's
+   * manual-placement branch swallows `errors` entirely — and this one is
+   * always worth showing, since it is the user's to fix and nothing at that
+   * school can be scheduled until they do.
+   */
+  schoolsMissingWorkdays?: string[];
+  /**
+   * How many students sit at those schools. Lets a caller tell "missing work
+   * days is the whole story" from "one school was blocked AND another failed
+   * for real reasons" — the second still deserves the normal failure handling.
+   */
+  workdayBlockedCount?: number;
 }
 
 export class OptimizedScheduler {
@@ -106,7 +142,15 @@ export class OptimizedScheduler {
   constructor(
     private providerId: string,
     private providerRole: string,
-    debug: boolean = false
+    debug: boolean = false,
+    /**
+     * SPE-275: only an itinerant provider's empty workday list is ambiguous.
+     * A single-school provider legitimately has no `user_site_schedules` rows,
+     * and "all weekdays" is the right answer for them — so the fail-closed
+     * guard in `initializeContext` is gated on this. Defaults to false, which
+     * preserves the previous behaviour for any caller that doesn't pass it.
+     */
+    private worksAtMultipleSchools: boolean = false
   ) {
     // Get or create the singleton data manager instance
     this.dataManager = SchedulingDataManager.getInstance();
@@ -223,12 +267,22 @@ export class OptimizedScheduler {
     // Extract work days from preloaded data
     const workDays = preloadedData.workSchedule?.map((s: any) => s.day_of_week) || [];
     
-    // If no work schedule defined, assume all weekdays (backwards compatibility)
+    // SPE-275: this used to fail OPEN — an empty workday list silently became
+    // all five weekdays, so an itinerant provider got sessions placed on days
+    // they are not at the school (observed in prod 2026-07-17: a Monday 8:00 AM
+    // session at a Thursday/Friday-only site).
+    //
+    // The two empty cases are not the same:
+    //   - single-school provider: no `user_site_schedules` rows is normal, and
+    //     all weekdays is the correct answer. Keep the default.
+    //   - multi-school provider: an empty list means we genuinely do not know
+    //     which days they are on site. Refuse rather than invent availability,
+    //     and tell the caller what to fix (SPE-367).
     if (workDays.length === 0) {
-      // Check if provider has any schedule at all (already in preloaded data)
-      if (!preloadedData.workSchedule || preloadedData.workSchedule.length === 0) {
-        workDays.push(1, 2, 3, 4, 5);
+      if (this.worksAtMultipleSchools) {
+        throw new MissingWorkdaysError(schoolSite);
       }
+      workDays.push(1, 2, 3, 4, 5);
     }
     
     this.log(`Work days at ${schoolSite}: ${workDays.join(", ")}`);
@@ -784,12 +838,20 @@ export class OptimizedScheduler {
     const foundSlots: TimeSlot[] = [];
 
     // Use provider's actual work days at this school to prevent cross-school conflicts
-    let validWorkDays = this.context!.workDays;
+    const validWorkDays = this.context!.workDays;
 
-    // If no work days configured, fall back to all weekdays as a safety measure
+    // SPE-275: this used to substitute all five weekdays here too. `initializeContext`
+    // now guarantees a non-empty list (defaulting for single-school providers,
+    // throwing for multi-school ones), so reaching this branch means the context
+    // was built by some other path. Place nothing rather than invent availability —
+    // a missing session is recoverable, a session on a day the provider is at
+    // another school is not.
     if (!validWorkDays || validWorkDays.length === 0) {
-      this.log('WARNING: No work days configured for provider at this school, using all weekdays as fallback');
-      validWorkDays = [1, 2, 3, 4, 5];
+      console.warn(
+        `[Scheduler] No work days in context for ${this.context!.schoolSite}; ` +
+        `placing no sessions rather than assuming all weekdays.`
+      );
+      return foundSlots;
     }
 
     // Sort days to distribute sessions evenly when possible

--- a/lib/supabase/hooks/use-auto-schedule.ts
+++ b/lib/supabase/hooks/use-auto-schedule.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
-import { OptimizedScheduler, EnhancedSchedulingResult } from '../../scheduling/optimized-scheduler';
+import { OptimizedScheduler, MissingWorkdaysError, EnhancedSchedulingResult } from '../../scheduling/optimized-scheduler';
 import { SchedulingDataManager } from '../../scheduling/scheduling-data-manager';
 import type { Database } from '../../../src/types/database';
 
@@ -22,14 +22,14 @@ export function useAutoSchedule(debug: boolean = false) {
 
       const { data: profile } = await supabase
         .from('profiles')
-        .select('role')
+        .select('role, works_at_multiple_schools')
         .eq('id', user.id)
         .single();
 
       if (!profile) throw new Error('Profile not found');
 
       // Create optimized scheduler instance
-      const scheduler = new OptimizedScheduler(user.id, profile.role, debug);
+      const scheduler = new OptimizedScheduler(user.id, profile.role, debug, !!profile.works_at_multiple_schools);
 
       // Initialize context for the student's school
       if (!student.school_site) {
@@ -89,7 +89,7 @@ export function useAutoSchedule(debug: boolean = false) {
 
       const { data: profile } = await supabase
         .from('profiles')
-        .select('role')
+        .select('role, works_at_multiple_schools')
         .eq('id', user.id)
         .single();
 
@@ -128,21 +128,38 @@ export function useAutoSchedule(debug: boolean = false) {
         }
 
         // Create optimized scheduler instance (uses refactored version by default)
-        const scheduler = new OptimizedScheduler(user.id, profile.role, debug);
+        const scheduler = new OptimizedScheduler(user.id, profile.role, debug, !!profile.works_at_multiple_schools);
 
-        // Initialize context once for the school
-        await scheduler.initializeContext(schoolSite, schoolDistrict);
+        try {
+          // Initialize context once for the school
+          await scheduler.initializeContext(schoolSite, schoolDistrict);
 
-        // Schedule all students at this school
-        const schoolResults = await scheduler.scheduleBatch(schoolStudents);
+          // Schedule all students at this school
+          const schoolResults = await scheduler.scheduleBatch(schoolStudents);
 
-        results.totalScheduled += schoolResults.totalScheduled;
-        results.totalFailed += schoolResults.totalFailed;
-        results.errors.push(...schoolResults.errors);
-        results.unplacedStudents.push(...(schoolResults.unplacedStudents || []));
-        results.canManuallyPlace = results.canManuallyPlace || schoolResults.canManuallyPlace;
-        if (schoolResults.availableSlots) {
-          results.availableSlots = schoolResults.availableSlots;
+          results.totalScheduled += schoolResults.totalScheduled;
+          results.totalFailed += schoolResults.totalFailed;
+          results.errors.push(...schoolResults.errors);
+          results.unplacedStudents.push(...(schoolResults.unplacedStudents || []));
+          results.canManuallyPlace = results.canManuallyPlace || schoolResults.canManuallyPlace;
+          if (schoolResults.availableSlots) {
+            results.availableSlots = schoolResults.availableSlots;
+          }
+        } catch (error) {
+          // A school with no work days recorded is skipped, not fatal (SPE-367):
+          // the provider's other schools still schedule, and they get one clear
+          // message naming the school to fix.
+          if (!(error instanceof MissingWorkdaysError)) throw error;
+
+          results.totalFailed += schoolStudents.length;
+          results.errors.push(error.message);
+          results.unplacedStudents.push(...schoolStudents);
+          results.schoolsMissingWorkdays = [
+            ...(results.schoolsMissingWorkdays || []),
+            error.schoolSite,
+          ];
+          results.workdayBlockedCount =
+            (results.workdayBlockedCount || 0) + schoolStudents.length;
         }
       }
 
@@ -175,7 +192,7 @@ export function useAutoSchedule(debug: boolean = false) {
 
       const { data: profile } = await supabase
         .from('profiles')
-        .select('role')
+        .select('role, works_at_multiple_schools')
         .eq('id', user.id)
         .single();
 
@@ -202,15 +219,25 @@ export function useAutoSchedule(debug: boolean = false) {
         const schoolDistrict = schoolStudents[0]?.school_district || '';
         
         // Create scheduler and initialize context
-        const scheduler = new OptimizedScheduler(user.id, profile.role, debug);
-        await scheduler.initializeContext(schoolSite, schoolDistrict);
+        const scheduler = new OptimizedScheduler(user.id, profile.role, debug, !!profile.works_at_multiple_schools);
 
-        // Try manual placement with conflict tolerance
-        const result = await scheduler.tryManualPlacement(schoolStudents, true);
-        
-        allPlacedSessions.push(...result.placedSessions);
-        allFailedStudents.push(...result.failedStudents);
-        allErrors.push(...result.errors);
+        try {
+          await scheduler.initializeContext(schoolSite, schoolDistrict);
+
+          // Try manual placement with conflict tolerance
+          const result = await scheduler.tryManualPlacement(schoolStudents, true);
+
+          allPlacedSessions.push(...result.placedSessions);
+          allFailedStudents.push(...result.failedStudents);
+          allErrors.push(...result.errors);
+        } catch (error) {
+          // Same treatment as the auto path (SPE-367): skip this school, keep
+          // the others, and surface the actionable message.
+          if (!(error instanceof MissingWorkdaysError)) throw error;
+
+          allFailedStudents.push(...schoolStudents);
+          allErrors.push(error.message);
+        }
       }
 
       return {


### PR DESCRIPTION
The auto-scheduler failed **open** on an empty workday list:

```ts
if (!validWorkDays || validWorkDays.length === 0) validWorkDays = [1, 2, 3, 4, 5];
```

An itinerant provider whose workdays weren't recorded for a school got sessions placed on days they were at a *different* school. Observed in prod 2026-07-17: a Monday 08:00 session at a Thursday/Friday-only site (SPE-275).

## The distinction that makes this safe

The two empty cases are not the same, and conflating them is the entire risk here:

- a **single-school** provider legitimately has no `user_site_schedules` rows, and all weekdays *is* the right answer. Failing closed for them would break auto-scheduling for most users.
- a **multi-school** provider's empty list means we genuinely don't know where they are.

So the guard is gated on `works_at_multiple_schools`. For that case `initializeContext` throws a typed `MissingWorkdaysError` naming the school instead of inventing availability. The second, duplicate fallback in `findStudentSlots` now places nothing rather than substituting weekdays.

## Where the prompt lives (SPE-367)

The nudge that used to tell people to set this up was removed by accident: PR #774 dropped the whole `<OnboardingNotifications />` mount, even though SPE-157 explicitly said *"Keep the multi-school banner alone — separate concern."* The component is still in the tree, fully functional, mounted nowhere.

Rather than restore a dashboard banner — SPE-157 removed banners because they'd become noise — the prompt now lives where the damage actually happens. Auto-Schedule names the school and points at Settings → Work Schedule.

Two details that matter:

- **A blocked school is skipped, not fatal.** The provider's other schools still schedule. `schoolsMissingWorkdays` is reported separately from `errors` because the manual-placement branch swallows `errors` entirely — this is the one failure the provider can actually fix, so it must not be swallowed.
- **When missing workdays is the whole story, the generic alert is suppressed.** Otherwise the provider got the clear message followed immediately by "couldn't place all sessions due to conflicts — adjust your bell schedules," which contradicts it and sends them somewhere useless. `workdayBlockedCount === totalFailed` keeps that exact: a second school failing for real reasons still gets the normal handling, including the manual-placement offer.

## Verification

Exercised with **real signed-in sessions through the actual Auto-Schedule UI** against the sim district. Rachel (`rsp.willow`) is the fixture — single school, no `user_site_schedules` rows, at an elementary site — and toggling her `works_at_multiple_schools` flag reproduces both directions on one fixture. That's exactly the JSUSD shape: multi-school flag true, no workdays recorded.

| | warning | sessions placed |
|---|---|---|
| multi-school, no workdays | names the school + Settings → Work Schedule | **none** (46 → 46) |
| single-school, no workdays | none | **placed** (43 → 45) |

The second row is the regression that mattered; failing closed indiscriminately would have broken auto-scheduling for every single-school provider.

A note on how that was measured: the scheduler *creates* new scheduled rows rather than filling the null-day ones, so an assertion on "unscheduled count went down" reports a successful run as a failure. The check counts placed sessions instead — the first draft got this wrong and looked like a regression that wasn't one.

Unit tests (`scheduler-workdays-fail-closed.test.ts`, 6 cases) pin both directions plus the constructor default, so a caller that predates the new argument can't start throwing.

Also green: typecheck, lint (only pre-existing warnings in unrelated files), 708 unit tests, `sim:verify`, and `sim:verify-special-activities-rls`. Fixture re-seeded after the walk.

## Not in scope

SPE-275's open question about *why* the workday list was empty for only part of that run (the per-student `school_site` string-mismatch theory) is untouched. This closes the fail-open so a mismatch surfaces as a clear refusal instead of a silent wrong placement, but the mismatch itself is still worth chasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBQpZtN31mhpK4W2HEGZHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBQpZtN31mhpK4W2HEGZHQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-scheduling identifies schools without configured workdays and displays actionable alerts.
  * Scheduling continues for unaffected schools while recording impacted schools and students.
  * Schedules affected only by missing workdays can complete without manual placement or generic conflict errors.

* **Bug Fixes**
  * Prevented student slots from being created when no workdays are configured.
  * Preserved weekday defaults for single-school and legacy scheduling scenarios.
  * Improved handling of missing-workday errors during batch and manual scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->