### PR TITLE
SPE-362: let multi-school providers add teachers, and multi-school SEAs read, at every assigned school

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "sim:verify-rls": "tsx scripts/sim-district/verify-profiles-rls.ts",
     "sim:verify-children-rls": "tsx scripts/sim-district/verify-children-rls.ts",
     "sim:verify-child-link": "tsx scripts/sim-district/verify-child-link.ts",
-    "sim:verify-special-activities-rls": "tsx scripts/sim-district/verify-special-activities-rls.ts"
+    "sim:verify-special-activities-rls": "tsx scripts/sim-district/verify-special-activities-rls.ts",
+    "sim:verify-multi-school-rls": "tsx scripts/sim-district/verify-multi-school-rls.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -176,6 +176,15 @@ export const PERSONAS: SimPersona[] = [
     workDays: { [MAPLE]: [1, 2, 3], [REDWOOD]: [4, 5] },
   },
   { key: 'leah', fullName: 'Leah Kim-Sim', role: 'sea', emailLocal: 'sea.willow', schoolIds: [WILLOW] },
+  // SPE-362: the only multi-school SEA. Every other SEA in the fixture (and in
+  // prod, as of 2026-08) sits at one school, so the school-wide SEA read branch
+  // of `students_select` / `children_select` had nothing exercising it across
+  // sites — the gap those policies carried was invisible to the fixture.
+  {
+    key: 'omar', fullName: 'Omar Bekele-Sim', role: 'sea', emailLocal: 'sea.itinerant',
+    schoolIds: [WILLOW, JUNIPER],
+    workDays: { [WILLOW]: [1, 2, 3], [JUNIPER]: [4, 5] },
+  },
   { key: 'nora', fullName: 'Nora Ellison-Sim', role: 'teacher', emailLocal: 'teacher.willow.1', schoolIds: [WILLOW], gradeLevel: '3' },
   { key: 'david', fullName: 'David Osei-Sim', role: 'teacher', emailLocal: 'teacher.willow.2', schoolIds: [WILLOW], gradeLevel: '5' },
   { key: 'fatima', fullName: 'Fatima Haddad-Sim', role: 'teacher', emailLocal: 'teacher.cedar', schoolIds: [CEDAR], gradeLevel: '7' },

--- a/scripts/sim-district/verify-multi-school-rls.ts
+++ b/scripts/sim-district/verify-multi-school-rls.ts
@@ -265,7 +265,12 @@ main()
     // duplicate probe teachers and the next reader cannot tell them from seed.
     if (createdTeacherIds.length > 0) {
       const { error } = await admin.from('teachers').delete().in('id', createdTeacherIds);
-      if (error) console.error(`cleanup failed for ${createdTeacherIds.length} teacher row(s): ${error.message}`);
+      if (error) {
+        // Fail the command: leftover probe teachers are fixture drift, and a
+        // green exit here would hide it behind a passing set of checks.
+        console.error(`cleanup failed for ${createdTeacherIds.length} teacher row(s): ${error.message}`);
+        failures++;
+      }
     }
     process.exit(failures === 0 ? 0 : 1);
   });

--- a/scripts/sim-district/verify-multi-school-rls.ts
+++ b/scripts/sim-district/verify-multi-school-rls.ts
@@ -250,7 +250,9 @@ async function main(): Promise<void> {
   } else {
     console.log(`\n${failures} check(s) failed.`);
   }
-  process.exit(failures === 0 ? 0 : 1);
+  // Deliberately no process.exit() here: it is synchronous and would preempt
+  // the `.finally()` below, leaking this run's probe teachers into the fixture.
+  // The exit code is set there, after cleanup.
 }
 
 main()

--- a/scripts/sim-district/verify-multi-school-rls.ts
+++ b/scripts/sim-district/verify-multi-school-rls.ts
@@ -1,0 +1,269 @@
+/**
+ * SPE-362 — the RLS paths that scoped a provider by their PRIMARY school only,
+ * run with REAL signed-in sessions.
+ *
+ * Same reason this is a script and not a jest test as its siblings
+ * verify-profiles-rls.ts / verify-children-rls.ts / verify-special-activities-rls.ts:
+ * our unit tests mock the Supabase client, so they cannot see RLS at all — they
+ * pass identically whether a policy permits a write or denies every one.
+ *
+ * Three policies are covered (the fourth path in SPE-362, `profiles_update`'s
+ * site-admin branch, was deliberately left out of this change):
+ *
+ *   1. `teachers_insert` — a provider could only CREATE a teacher at their
+ *      primary school, while `teachers_select` already unioned
+ *      `provider_schools`. So they saw teachers at every assigned school but
+ *      could add at only one. The one path here with live impact.
+ *   2. `students_select` (SEA branch) — a multi-school SEA saw school-wide
+ *      students at their primary school alone.
+ *   3. `children_select` (SEA branch) — the same gap on the child record.
+ *
+ * The contract asserted here:
+ *   - a multi-school provider can create a teacher at a NON-primary assigned
+ *     school, and still at their primary one;
+ *   - and at NO school they are unassigned to — this widens to
+ *     `provider_schools`, not to the district;
+ *   - a multi-school SEA reads students and children at EVERY assigned school;
+ *   - a single-school SEA is unchanged (no accidental widening of the common case);
+ *   - and — the check that matters most — a multi-school NON-SEA provider does
+ *     NOT pick up school-wide student reads. The SEA branch is gated on
+ *     `role = 'sea'`; widening the school-id half of it must not leak the
+ *     school-wide grant to everyone else assigned to that school.
+ *
+ * Three traps this deliberately avoids (CLAUDE.md):
+ *   - assert the ROWS, not the HTTP status — an RLS-filtered write is a 2xx
+ *     with an empty body, exactly like a permitted write of nothing;
+ *   - assert WHY a refusal happened — the negative INSERT matches `42501`
+ *     specifically, so a row rejected incidentally (a later NOT NULL giving
+ *     23502, say) cannot keep this green after the guard it tests is gone;
+ *   - expected row sets come from the service client at runtime, never from a
+ *     hardcoded count, so a seed change cannot quietly make a check vacuous.
+ *
+ * Requires a seeded sim district (`npm run sim:reset -- --yes`), including the
+ * multi-school SEA persona `omar` added for this ticket. Teacher rows this
+ * script creates are removed again on the way out, pass or fail.
+ *
+ * Usage: npm run sim:verify-multi-school-rls
+ */
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createAdmin, requireEnv } from './lib';
+import { CEDAR, JUNIPER, MAPLE, WILLOW, derivePassword, personaEmail } from './manifest';
+
+const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+const secret = requireEnv('SIM_DISTRICT_PASSWORD');
+
+const admin = createAdmin();
+
+let failures = 0;
+function check(ok: boolean, label: string, detail = ''): void {
+  if (!ok) failures++;
+  console.log(`  [${ok ? 'ok  ' : 'FAIL'}] ${label.padEnd(60)} ${detail}`);
+}
+
+async function signIn(personaKey: string): Promise<SupabaseClient> {
+  const email = personaEmail(personaKey);
+  const client = createClient(url, anon, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: derivePassword(secret, email),
+  });
+  if (error) throw new Error(`sim login failed for ${email} — is the district seeded? (${error.message})`);
+  return client;
+}
+
+/** Every student id at a school, per the service client (ground truth). */
+async function fixtureStudentIds(schoolId: string): Promise<Set<string>> {
+  const { data, error } = await admin.from('students').select('id').eq('school_id', schoolId);
+  if (error) throw new Error(`fixture lookup failed for ${schoolId}: ${error.message}`);
+  const ids = new Set((data ?? []).map(r => r.id as string));
+  if (ids.size === 0) {
+    throw new Error(`no students seeded at ${schoolId} — has the seed changed? ` +
+      'A zero-row fixture would make every check here vacuously true.');
+  }
+  return ids;
+}
+
+/** Every child id reachable from a school's students (ground truth). */
+async function fixtureChildIds(schoolId: string): Promise<Set<string>> {
+  const { data, error } = await admin
+    .from('students').select('child_id').eq('school_id', schoolId).not('child_id', 'is', null);
+  if (error) throw new Error(`child fixture lookup failed for ${schoolId}: ${error.message}`);
+  const ids = new Set((data ?? []).map(r => r.child_id as string));
+  if (ids.size === 0) throw new Error(`no linked children at ${schoolId} — has the seed changed?`);
+  return ids;
+}
+
+async function visibleStudentIds(client: SupabaseClient, schoolId: string): Promise<Set<string>> {
+  const { data, error } = await client.from('students').select('id').eq('school_id', schoolId);
+  if (error) throw new Error(`session student read failed for ${schoolId}: ${error.message}`);
+  return new Set((data ?? []).map(r => r.id as string));
+}
+
+/**
+ * Children are not school-scoped themselves, so this asks the session for the
+ * specific child ids the school's students link to, rather than filtering
+ * `children` by a school column it does not have.
+ */
+async function visibleChildIds(client: SupabaseClient, want: Set<string>): Promise<Set<string>> {
+  const ids = [...want];
+  const { data, error } = await client.from('children').select('id').in('id', ids);
+  if (error) throw new Error(`session child read failed: ${error.message}`);
+  return new Set((data ?? []).map(r => r.id as string));
+}
+
+function sameSet(a: Set<string>, b: Set<string>): boolean {
+  return a.size === b.size && [...a].every(id => b.has(id));
+}
+
+/** A fully-populated teacher row: see the header note on 23502 vs 42501. */
+function teacherRow(schoolId: string, tag: string): Record<string, unknown> {
+  return {
+    first_name: 'Probe', last_name: `Teacher-${tag}`,
+    email: `spe362.${tag}.${schoolId}@example.invalid`,
+    classroom_number: '101', phone_number: '555-0100',
+    school_id: schoolId, grade_level: '4',
+  };
+}
+
+const createdTeacherIds: string[] = [];
+
+async function attemptTeacherInsert(
+  client: SupabaseClient, schoolId: string, tag: string,
+): Promise<{ rows: number; code: string | null }> {
+  const { data, error } = await client
+    .from('teachers').insert(teacherRow(schoolId, tag)).select('id');
+  for (const r of data ?? []) createdTeacherIds.push(r.id as string);
+  return { rows: data?.length ?? 0, code: error?.code ?? null };
+}
+
+/** Ground truth that the row really landed — not just that PostgREST said 2xx. */
+async function teacherExists(schoolId: string, tag: string): Promise<boolean> {
+  const { data, error } = await admin
+    .from('teachers').select('id').eq('email', `spe362.${tag}.${schoolId}@example.invalid`);
+  if (error) throw new Error(`teacher readback failed: ${error.message}`);
+  return (data ?? []).length > 0;
+}
+
+async function main(): Promise<void> {
+  const stamp = String(process.hrtime.bigint()).slice(-8);
+
+  const tomas = await signIn('tomas'); // speech: Willow (primary) + Juniper + Cedar
+  const omar = await signIn('omar');   // sea:    Willow (primary) + Juniper
+  const leah = await signIn('leah');   // sea:    Willow only
+
+  console.log('teachers_insert — a provider may add at any ASSIGNED school (SPE-362):');
+  {
+    // Control: the primary school worked before the fix and must still work.
+    const atPrimary = await attemptTeacherInsert(tomas, WILLOW, `${stamp}-primary`);
+    check(atPrimary.rows === 1 && await teacherExists(WILLOW, `${stamp}-primary`),
+      'Tomás CAN add a teacher at Willow (his primary)',
+      `rows=${atPrimary.rows} code=${atPrimary.code ?? 'none'}`);
+
+    // The regression this script exists for. Before the fix this was 0 rows / 42501.
+    const atJuniper = await attemptTeacherInsert(tomas, JUNIPER, `${stamp}-secondary`);
+    check(atJuniper.rows === 1 && await teacherExists(JUNIPER, `${stamp}-secondary`),
+      'Tomás CAN add a teacher at Juniper (assigned, NOT primary)',
+      `rows=${atJuniper.rows} code=${atJuniper.code ?? 'none'}`);
+
+    const atCedar = await attemptTeacherInsert(tomas, CEDAR, `${stamp}-third`);
+    check(atCedar.rows === 1 && await teacherExists(CEDAR, `${stamp}-third`),
+      'Tomás CAN add a teacher at Cedar (his third school)',
+      `rows=${atCedar.rows} code=${atCedar.code ?? 'none'}`);
+  }
+
+  console.log('...and NOT at a school they are unassigned to:');
+  {
+    // Maple is in the same district — if the fix had widened to "any school"
+    // rather than "my schools", this is where it would show. The code must be
+    // 42501 (RLS), not merely "some error".
+    const atMaple = await attemptTeacherInsert(tomas, MAPLE, `${stamp}-forbidden`);
+    check(atMaple.rows === 0 && atMaple.code === '42501',
+      'Tomás CANNOT add a teacher at Maple — refused by RLS',
+      `rows=${atMaple.rows} code=${atMaple.code ?? 'none'}`);
+    check(!(await teacherExists(MAPLE, `${stamp}-forbidden`)),
+      'and no Maple teacher row was created');
+  }
+
+  console.log('students_select — a multi-school SEA reads every assigned school:');
+  {
+    const willow = await fixtureStudentIds(WILLOW);
+    const juniper = await fixtureStudentIds(JUNIPER);
+    const maple = await fixtureStudentIds(MAPLE);
+
+    const omarWillow = await visibleStudentIds(omar, WILLOW);
+    check(sameSet(omarWillow, willow), 'Omar sees Willow students (his primary — worked before)',
+      `${omarWillow.size}/${willow.size}`);
+
+    // Before the fix this was 0.
+    const omarJuniper = await visibleStudentIds(omar, JUNIPER);
+    check(sameSet(omarJuniper, juniper), 'Omar sees Juniper students (assigned, NOT primary)',
+      `${omarJuniper.size}/${juniper.size}`);
+
+    const omarMaple = await visibleStudentIds(omar, MAPLE);
+    check(omarMaple.size === 0, 'Omar sees NO Maple students (not assigned)',
+      `count=${omarMaple.size}/${maple.size}`);
+
+    const leahWillow = await visibleStudentIds(leah, WILLOW);
+    const leahJuniper = await visibleStudentIds(leah, JUNIPER);
+    check(sameSet(leahWillow, willow) && leahJuniper.size === 0,
+      'single-school SEA unchanged: Willow only',
+      `willow ${leahWillow.size}/${willow.size}, juniper ${leahJuniper.size}`);
+  }
+
+  console.log('...but the school-wide grant stays SEA-only:');
+  {
+    // The SEA branch is `school_id IN (my schools) AND role = 'sea'`. Widening
+    // the school-id half must not hand school-wide reads to a non-SEA who is
+    // also assigned to that school. Tomás should see only students he is
+    // actually tied to at Juniper — as provider, or via a session.
+    const juniper = await fixtureStudentIds(JUNIPER);
+    const tomasJuniper = await visibleStudentIds(tomas, JUNIPER);
+    check(tomasJuniper.size > 0 && tomasJuniper.size < juniper.size,
+      'non-SEA at Juniper sees only their OWN students, not school-wide',
+      `${tomasJuniper.size}/${juniper.size}`);
+  }
+
+  console.log('children_select — same SEA branch, through students:');
+  {
+    const willowKids = await fixtureChildIds(WILLOW);
+    const juniperKids = await fixtureChildIds(JUNIPER);
+
+    const omarWillowKids = await visibleChildIds(omar, willowKids);
+    check(sameSet(omarWillowKids, willowKids), 'Omar sees Willow children (primary)',
+      `${omarWillowKids.size}/${willowKids.size}`);
+
+    // Before the fix this was 0.
+    const omarJuniperKids = await visibleChildIds(omar, juniperKids);
+    check(sameSet(omarJuniperKids, juniperKids), 'Omar sees Juniper children (assigned, NOT primary)',
+      `${omarJuniperKids.size}/${juniperKids.size}`);
+
+    const leahJuniperKids = await visibleChildIds(leah, juniperKids);
+    check(leahJuniperKids.size === 0, 'single-school SEA sees NO Juniper children',
+      `count=${leahJuniperKids.size}/${juniperKids.size}`);
+  }
+
+  if (failures === 0) {
+    console.log('\nAll checks passed.');
+  } else {
+    console.log(`\n${failures} check(s) failed.`);
+  }
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main()
+  .catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    failures = failures || 1;
+  })
+  .finally(async () => {
+    // Leave the fixture as we found it, pass or fail — otherwise a re-run hits
+    // duplicate probe teachers and the next reader cannot tell them from seed.
+    if (createdTeacherIds.length > 0) {
+      const { error } = await admin.from('teachers').delete().in('id', createdTeacherIds);
+      if (error) console.error(`cleanup failed for ${createdTeacherIds.length} teacher row(s): ${error.message}`);
+    }
+    process.exit(failures === 0 ? 0 : 1);
+  });

--- a/supabase/migrations/20260805_spe362_multi_school_teachers_insert_and_sea_reads.sql
+++ b/supabase/migrations/20260805_spe362_multi_school_teachers_insert_and_sea_reads.sql
@@ -1,0 +1,126 @@
+-- SPE-362: RLS paths that scope a provider by their *primary* school only, so
+-- a multi-school user silently has fewer rights at their other assigned schools.
+--
+-- Same fix shape as SPE-361 (20260804_fix_special_activities_select_multi_school):
+-- swap the `profiles.school_id`-only subquery for `get_my_school_ids()`, which is
+-- SECURITY DEFINER / STABLE, granted to `authenticated`, and unions the profile
+-- school with the caller's `provider_schools` rows.
+--
+-- Three of the four paths surveyed in SPE-362 are covered here:
+--
+--   1. `teachers_insert`   — a provider could only create teacher records at
+--                            their primary school, while `teachers_select`
+--                            already unions `provider_schools`. So they could
+--                            SEE teachers at every assigned school but only ADD
+--                            at one. This is the only one with live impact:
+--                            8 providers are assigned to more than one school.
+--   2. `students_select`   — SEA branch; a multi-school SEA saw school-wide
+--                            students at their primary school only.
+--   3. `children_select`   — the same SEA branch, reached through `students s`.
+--
+-- The fourth path, `profiles_update`'s site-admin branch, is deliberately NOT
+-- changed here. It governs role and permission columns, so it gets its own
+-- review rather than riding along with these.
+--
+-- Blast radius of 2 and 3 today is zero: no SEA is currently assigned to more
+-- than one school, so the widened branch matches exactly the rows it already
+-- matched. They are fixed now because they are the same one-line change as 1
+-- and would be wrong the day an SEA is assigned to a second site.
+--
+-- Every other branch of each policy is reproduced verbatim from the live
+-- definitions; only the profile-school subquery moves.
+
+-- 1. teachers_insert -------------------------------------------------------
+-- A provider may create a teacher at any school they are assigned to, not just
+-- their primary. Site-admin branch unchanged.
+
+DROP POLICY IF EXISTS "teachers_insert" ON teachers;
+
+CREATE POLICY "teachers_insert" ON teachers
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM admin_permissions
+      WHERE admin_permissions.admin_id = (SELECT auth.uid())
+        AND admin_permissions.role = 'site_admin'
+        AND admin_permissions.school_id::text = teachers.school_id::text
+    )
+    OR school_id::text IN (SELECT school_id FROM get_my_school_ids())
+  );
+
+-- 2. students_select -------------------------------------------------------
+-- SEA school-wide branch only; provider / teacher / session-assignment /
+-- site-admin branches are unchanged.
+
+DROP POLICY IF EXISTS "students_select" ON students;
+
+CREATE POLICY "students_select" ON students
+  FOR SELECT TO authenticated
+  USING (
+    provider_id = (SELECT auth.uid())
+    OR teacher_id IN (
+      SELECT teachers.id FROM teachers WHERE teachers.account_id = (SELECT auth.uid())
+    )
+    OR EXISTS (
+      SELECT 1 FROM schedule_sessions
+      WHERE schedule_sessions.student_id = students.id
+        AND schedule_sessions.assigned_to_specialist_id = (SELECT auth.uid())
+    )
+    OR EXISTS (
+      SELECT 1 FROM schedule_sessions
+      WHERE schedule_sessions.student_id = students.id
+        AND schedule_sessions.assigned_to_sea_id = (SELECT auth.uid())
+    )
+    OR (
+      -- SEAs see students at ANY school they are assigned to, not primary alone
+      school_id::text IN (SELECT school_id FROM get_my_school_ids())
+      AND (SELECT auth.uid()) IN (SELECT profiles.id FROM profiles WHERE profiles.role = 'sea')
+    )
+    OR EXISTS (
+      SELECT 1 FROM admin_permissions
+      WHERE admin_permissions.admin_id = (SELECT auth.uid())
+        AND admin_permissions.role = 'site_admin'
+        AND admin_permissions.school_id::text = students.school_id::text
+    )
+  );
+
+-- 3. children_select -------------------------------------------------------
+-- Mirrors students_select through the `students s` join; same SEA branch swap.
+
+DROP POLICY IF EXISTS "children_select" ON children;
+
+CREATE POLICY "children_select" ON children
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM students s
+      WHERE s.child_id = children.id
+        AND (
+          s.provider_id = (SELECT auth.uid())
+          OR s.teacher_id IN (
+            SELECT t.id FROM teachers t WHERE t.account_id = (SELECT auth.uid())
+          )
+          OR EXISTS (
+            SELECT 1 FROM schedule_sessions ss
+            WHERE ss.student_id = s.id
+              AND ss.assigned_to_specialist_id = (SELECT auth.uid())
+          )
+          OR EXISTS (
+            SELECT 1 FROM schedule_sessions ss
+            WHERE ss.student_id = s.id
+              AND ss.assigned_to_sea_id = (SELECT auth.uid())
+          )
+          OR (
+            -- SEAs see children at ANY school they are assigned to
+            s.school_id::text IN (SELECT school_id FROM get_my_school_ids())
+            AND (SELECT auth.uid()) IN (SELECT p.id FROM profiles p WHERE p.role = 'sea')
+          )
+          OR EXISTS (
+            SELECT 1 FROM admin_permissions ap
+            WHERE ap.admin_id = (SELECT auth.uid())
+              AND ap.role = 'site_admin'
+              AND ap.school_id::text = s.school_id::text
+          )
+        )
+    )
+  );


### PR DESCRIPTION
Closes SPE-362 (three of its four paths — see "Deliberately out of scope").

## What was wrong

Three RLS policies scoped a provider by `profiles.school_id` — their single "primary" school — with no `provider_schools` union. A multi-school user silently had fewer rights at their other assigned schools.

| Policy | Gap | Who this affects today |
| -- | -- | -- |
| `teachers_insert` (WITH CHECK) | Could only CREATE a teacher at their primary school, while `teachers_select` already unioned `provider_schools` — so they saw teachers at every assigned school but could add at only one. | **8 providers** assigned to more than one school, including the JSUSD pilot. A live, broken workflow. |
| `students_select` (SEA branch) | A multi-school SEA saw school-wide students at their primary school alone. | Nobody — no SEA is currently assigned to more than one school. |
| `children_select` (SEA branch) | The same gap on the child record. | Nobody — same reason. |

## The fix

Same shape as SPE-361: swap the `profiles.school_id`-only subquery for `get_my_school_ids()`, which is `SECURITY DEFINER` / `STABLE`, granted to `authenticated`, and unions the profile school with the caller's `provider_schools` rows. Every other branch of each policy is reproduced verbatim.

The two SEA paths change nothing for anyone today — the widened branch matches exactly the rows it already matched. They are fixed now because they are the same one-line change as the first and would be wrong the day an SEA is assigned to a second site.

### Deliberately out of scope

**`profiles_update`'s site-admin branch** — the fourth path surveyed in SPE-362 — is **not** changed here. It governs role and permission columns, so it gets its own review rather than riding along with these. It remains open on the ticket.

**The SEA UI does not go through the widened policy** (found by Codex in review, confirmed — SPE-384). `get_sea_students()` is SECURITY DEFINER and filters on `ss.assigned_to_sea_id = auth.uid() AND ss.delivered_by = 'sea'`, never on school; `lib/supabase/queries/sea-students.ts:70` uses that RPC result whenever the call succeeds — including a zero-row result — and falls back to the RLS-backed query only on RPC **error**. So the widened `students_select` SEA branch governs the fallback and other direct-table reads, not the Students or Plan page.

Not fixed here on purpose: making the RPC school-wide would change what all 5 existing single-school SEAs see today, from "my assigned students" to "every student at my school" — a user-facing permissions change outside this PR's scope. The RPC and the policy have disagreed since before this change, and which one is correct is a product decision, tracked in **SPE-384** with both options. No live impact either way while no SEA is multi-school.

## Verification

Unit tests mock the Supabase client and cannot see RLS at all, so they are not evidence here. This was verified with **real signed-in sessions** against the sim district, via a new probe: `npm run sim:verify-multi-school-rls`.

The probe was run **before** the migration and fails exactly 4 checks, then **after** and passes all 13:

```
BEFORE                                                          AFTER
[FAIL] Tomás CAN add a teacher at Juniper      rows=0 code=42501 → [ok] rows=1
[FAIL] Tomás CAN add a teacher at Cedar        rows=0 code=42501 → [ok] rows=1
[FAIL] Omar sees Juniper students                          0/49  → [ok] 49/49
[FAIL] Omar sees Juniper children                          0/49  → [ok] 49/49
```

Every guard check holds in **both** runs — these are the ones that would catch an over-wide fix:

- `Tomás CANNOT add a teacher at Maple` — still refused, and matched on `42501` specifically, so a row rejected incidentally (a later `NOT NULL` giving `23502`) cannot keep it green after the guard is gone
- `Omar sees NO Maple students` — widened to `provider_schools`, not to the district
- `single-school SEA unchanged: Willow only`
- **`non-SEA at Juniper sees only their OWN students, not school-wide` — 15/49, unchanged.** The SEA branch is `school_id IN (my schools) AND role = 'sea'`; widening the school-id half must not hand the school-wide grant to everyone else assigned to that school. This is the check that matters most.

The three sibling RLS probes (`sim:verify-rls`, `sim:verify-children-rls`, `sim:verify-special-activities-rls`) all pass, as does `sim:verify`. Typecheck, lint, and the unit suite (80 files, 713 passing) are green.

Additionally, the applied policies were read back from `pg_policies` and compared branch-by-branch against the pre-change definitions. Postgres re-renders these from its own parse tree, so the comparison also proves no operator-precedence or grouping change slipped in: every branch is byte-identical except the intended subquery swap, including the `role = 'sea'` conjunct.

## Fixture change

The sim district had no multi-school SEA — every SEA sat at one school — so the school-wide SEA read branch had nothing exercising it across sites, and the gap was invisible to the fixture. Adds **Omar Bekele-Sim** (Willow + Juniper). `profiles` counts derive from `PERSONAS`, so `sim:verify` adjusts automatically.

## Review fixes

- **Self-review:** `process.exit()` at the end of `main()` is synchronous and preempted the `.finally()` that deletes the probe's teacher rows, so cleanup could only ever run on the error path. Every green run would have leaked three teacher records into the fixture — invisibly, since the checks still passed. Exit code now comes from the `.finally()`, after cleanup; verified 0 rows remaining after a full green run.
- **CodeRabbit:** a cleanup *failure* was only logged, so the command could still exit `0` with probe rows left behind. It now increments `failures`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Providers can add teachers at any assigned school.
  * SEAs can view students and children across all assigned schools.
  * Added support for multi-school SEA scheduling.

* **Bug Fixes**
  * Preserved existing single-school access behavior.
  * Prevented non-SEA users from gaining school-wide access.

* **Tests**
  * Added verification coverage for multi-school access permissions, denied access, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->