### PR TITLE
SPE-393: District Tech Admin role foundation

### DIFF
--- a/app/(dashboard)/dashboard/settings/page.tsx
+++ b/app/(dashboard)/dashboard/settings/page.tsx
@@ -7,6 +7,7 @@ import { createClient } from '@/lib/supabase/client';
 import { CurriculumsSettings } from '../../../components/settings/curriculums';
 import { ApiKeysSettings } from '../../../components/settings/api-keys';
 import { EmailNotificationsSettings } from '../../../components/settings/email-notifications';
+import { formatRoleLabel } from '@/lib/utils/role-utils';
 
 export default function SettingsPage() {
   const [userProfile, setUserProfile] = useState<any>(null);
@@ -73,7 +74,9 @@ export default function SettingsPage() {
                 </div>
                 <div>
                   <label className="text-sm font-medium text-gray-700">Role</label>
-                  <p className="mt-1 text-sm text-gray-900 capitalize">{userProfile?.role}</p>
+                  {/* `capitalize` only touches the first letter, so a snake_case
+                      role rendered raw reads "District_tech". */}
+                  <p className="mt-1 text-sm text-gray-900">{formatRoleLabel(userProfile?.role ?? null)}</p>
                 </div>
               </div>
             </CardBody>

--- a/app/(dashboard)/dashboard/settings/page.tsx
+++ b/app/(dashboard)/dashboard/settings/page.tsx
@@ -84,8 +84,12 @@ export default function SettingsPage() {
             <WorkScheduleSettings />
           )}
 
-          {/* Curriculums Settings */}
-          <CurriculumsSettings />
+          {/* Curriculums Settings — teaching roles only. District Tech Admins
+              (SPE-393) reach this page for their account details alone and have
+              no caseload to pick curriculums for. */}
+          {userProfile?.role !== 'district_tech' && (
+            <CurriculumsSettings />
+          )}
 
           {/* Email notifications — daily schedule email opt-in (SPE-320).
               Providers toggle their own; resource specialists additionally

--- a/app/(dashboard)/dashboard/tech/page.tsx
+++ b/app/(dashboard)/dashboard/tech/page.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+/**
+ * District Tech Admin portal home (SPE-393).
+ *
+ * The shell only: it establishes the route the role is pinned to and explains
+ * what will live here. The actual connection surfaces arrive with SPE-396
+ * (Aeries API) and SPE-397 (OneRoster); SPE-395 adds the credential store they
+ * both write to.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import { Card, CardHeader, CardTitle, CardBody } from '../../../components/ui/card';
+
+interface TechProfile {
+  full_name: string | null;
+  school_district: string | null;
+}
+
+export default function TechPortalPage() {
+  const [profile, setProfile] = useState<TechProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const supabase = createClient();
+
+  const loadProfile = useCallback(async () => {
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+
+      const { data } = await supabase
+        .from('profiles')
+        .select('full_name, school_district')
+        .eq('id', user.id)
+        .single();
+
+      setProfile(data);
+    } catch (error) {
+      console.error('Error loading tech portal profile:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [supabase]);
+
+  useEffect(() => {
+    loadProfile();
+  }, [loadProfile]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
+          <p className="mt-2 text-gray-600">Loading integrations...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">Integrations</h1>
+          <p className="mt-2 text-gray-600">
+            Connect {profile?.school_district || 'your district'}&apos;s student
+            information system to Speddy.
+          </p>
+        </div>
+
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>No connection yet</CardTitle>
+            </CardHeader>
+            <CardBody>
+              <p className="text-sm text-gray-600">
+                Your district doesn&apos;t have a student information system
+                connected. Setup runs with help from the Speddy team — we&apos;ll
+                walk you through it and confirm the connection works before
+                anything syncs.
+              </p>
+              <p className="mt-4 text-sm text-gray-600">
+                Setup can begin once your district&apos;s data privacy agreement
+                is signed. Your Speddy contact will let you know when it&apos;s
+                time.
+              </p>
+            </CardBody>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>What you&apos;ll need</CardTitle>
+            </CardHeader>
+            <CardBody>
+              <ul className="space-y-3 text-sm text-gray-600">
+                <li>
+                  <span className="font-medium text-gray-900">
+                    Access to your SIS admin settings.
+                  </span>{' '}
+                  For Aeries that&apos;s the API Security page; for OneRoster
+                  it&apos;s wherever your vendor issues API credentials.
+                </li>
+                <li>
+                  <span className="font-medium text-gray-900">
+                    Permission to create an API account.
+                  </span>{' '}
+                  Speddy only ever reads — we never write back to your SIS.
+                </li>
+                <li>
+                  <span className="font-medium text-gray-900">
+                    A few minutes to test the connection.
+                  </span>{' '}
+                  We check each piece separately and tell you in plain language
+                  what&apos;s working and what isn&apos;t.
+                </li>
+              </ul>
+            </CardBody>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/district/site-admin/route.ts
+++ b/app/api/admin/district/site-admin/route.ts
@@ -15,23 +15,25 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
   try {
     const supabase = await createClient();
 
-    // Verify user is a district admin and get their district
-    const { data: adminPermission, error: permError } = await supabase
+    // Verify user is a district admin and get their district grants.
+    // Holding more than one admin_permissions row is legal, so this reads the
+    // full set rather than .single(), which errors outright on 2+ rows and
+    // would 403 a legitimately multi-district admin. The grant that matches the
+    // target school is resolved below, once the school is known.
+    const { data: adminPermissions, error: permError } = await supabase
       .from('admin_permissions')
       .select('district_id, state_id')
       .eq('admin_id', userId)
       .eq('role', 'district_admin')
-      .single();
+      .not('district_id', 'is', null);
 
-    if (permError || !adminPermission?.district_id) {
+    if (permError || !adminPermissions?.length) {
       log.warn('Non-district-admin tried to create site admin', { userId });
       return NextResponse.json(
         { error: 'Forbidden: District admin access required' },
         { status: 403 }
       );
     }
-
-    const districtId = adminPermission.district_id;
 
     // Parse request body
     const body = await request.json();
@@ -82,11 +84,13 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
       return NextResponse.json({ error: 'School not found' }, { status: 404 });
     }
 
-    if (school.district_id !== districtId) {
+    const grant = adminPermissions.find((p) => p.district_id === school.district_id);
+
+    if (!grant) {
       log.warn('District admin tried to create site admin for school outside district', {
         userId,
         schoolId: school_id,
-        adminDistrict: districtId,
+        adminDistricts: adminPermissions.map((p) => p.district_id),
         schoolDistrict: school.district_id,
       });
       return NextResponse.json(
@@ -94,6 +98,10 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
         { status: 403 }
       );
     }
+
+    // The new site admin inherits the scope of the grant that authorized this
+    // call, so a multi-district admin lands them in the right district/state.
+    const districtId = grant.district_id;
 
     // Check if user already has site_admin permission for this school
     const { data: existingPermission, error: existingError } = await adminClient
@@ -191,7 +199,7 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
           role: 'site_admin',
           school_id,
           district_id: districtId,
-          state_id: adminPermission.state_id,
+          state_id: grant.state_id,
         });
 
       if (permissionError) {

--- a/app/api/admin/district/teachers/route.ts
+++ b/app/api/admin/district/teachers/route.ts
@@ -15,15 +15,18 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
   try {
     const supabase = await createClient();
 
-    // Verify user is a district admin and get their district
-    const { data: adminPermission, error: permError } = await supabase
+    // Verify user is a district admin and get their district grants.
+    // Holding more than one admin_permissions row is legal, so this reads the
+    // full set rather than .single(), which errors outright on 2+ rows and
+    // would 403 a legitimately multi-district admin.
+    const { data: adminPermissions, error: permError } = await supabase
       .from('admin_permissions')
       .select('district_id, state_id')
       .eq('admin_id', userId)
       .eq('role', 'district_admin')
-      .single();
+      .not('district_id', 'is', null);
 
-    if (permError || !adminPermission?.district_id) {
+    if (permError || !adminPermissions?.length) {
       log.warn('Non-district-admin tried to create teacher', { userId });
       return NextResponse.json(
         { error: 'Forbidden: District admin access required' },
@@ -31,7 +34,7 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
       );
     }
 
-    const districtId = adminPermission.district_id;
+    const districtIds = adminPermissions.map((p) => p.district_id);
 
     // Parse request body
     const body = await request.json();
@@ -84,11 +87,11 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
       return NextResponse.json({ error: 'School not found' }, { status: 404 });
     }
 
-    if (school.district_id !== districtId) {
+    if (!districtIds.includes(school.district_id)) {
       log.warn('District admin tried to create teacher for school outside district', {
         userId,
         schoolId: school_id,
-        adminDistrict: districtId,
+        adminDistricts: districtIds,
         schoolDistrict: school.district_id,
       });
       return NextResponse.json(

--- a/app/components/navigation/navbar.tsx
+++ b/app/components/navigation/navbar.tsx
@@ -101,6 +101,14 @@ export default function Navbar() {
         { name: 'Schools', href: '/dashboard/admin/schools' },
         { name: 'CARE', href: '/dashboard/admin/care' },
       ];
+    } else if (role === 'district_tech') {
+      // District Tech Admins only ever see the integrations portal (SPE-393).
+      // Listed explicitly rather than falling through to the default branch
+      // below, which hands out Students/Schedule/Chat.
+      return [
+        { name: 'Integrations', href: '/dashboard/tech' },
+        { name: 'Settings', href: '/dashboard/settings' },
+      ];
     } else if (role === 'site_admin') {
       // Site admins see their dashboard, master schedule, teacher/provider/staff directories, students, and CARE
       // Bell Schedules omitted — bell schedule items are shown within Master Schedule

--- a/app/components/navigation/user-profile-dropdown.tsx
+++ b/app/components/navigation/user-profile-dropdown.tsx
@@ -75,7 +75,8 @@ export default function UserProfileDropdown({ user }: { user: User }) {
       'ot': 'Occupational Therapist',
       'counseling': 'Counselor',
       'specialist': 'Program Specialist',
-      'sea': 'Special Education Assistant'
+      'sea': 'Special Education Assistant',
+      'district_tech': 'District Tech Admin'
     };
     return roleMap[role] || role;
   };
@@ -128,10 +129,15 @@ export default function UserProfileDropdown({ user }: { user: User }) {
                 <p className="mt-1 text-sm text-gray-900">{profile.school_district}</p>
               </div>
 
-              <div>
-                <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">School Site</p>
-                <p className="mt-1 text-sm text-gray-900">{profile.school_site}</p>
-              </div>
+              {/* District-wide roles have no site, and school_site is NOT NULL
+                  so it arrives as an empty string — omit the row rather than
+                  render a labelled blank. */}
+              {profile.school_site && (
+                <div>
+                  <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">School Site</p>
+                  <p className="mt-1 text-sm text-gray-900">{profile.school_site}</p>
+                </div>
+              )}
             </div>
           )}
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -108,30 +108,45 @@ Functionally the roles group like this:
 #### What actually keeps `district_tech` out of the data (SPE-393)
 
 Worth writing down, because it is **not** the role string. Nothing in RLS
-mentions `district_tech`. The role reads nothing because it holds none of the
-keys every policy is written against:
+mentions `district_tech`. As seeded, the role reads no domain data because it
+holds none of the keys the policies are written against:
 
-- `profiles.school_id` is null and it has **no `provider_schools` rows**, so
-  every "my school ∪ my provider schools" predicate resolves to the empty set.
+- `profiles.school_id` is null and it has no `provider_schools` rows, so every
+  "my school ∪ my provider schools" predicate resolves to the empty set.
 - It owns no `students`, no `schedule_sessions`, and no `teachers.account_id`
   row, so every ownership predicate misses.
 - Its `admin_permissions` grant has `role = 'district_tech'`, and **every**
   policy consulting that table constrains `ap.role` to
   `site_admin`/`district_admin`.
 
-A few policies (`care_case_status_history`, `holidays`, `exit_ticket_results`)
-do match on the caller's `profiles.district_id` with no role predicate, which
-looks alarming — but their inner `EXISTS` subqueries read `care_referrals` /
-`care_cases` / `students`, which are **themselves RLS-filtered** for the caller.
-With no school and no caseload, those subqueries return nothing. Verified with a
-real signed-in session rather than by reading the policy: a `teacher`, who *does*
-carry `district_id`, reads **0** `care_case_status_history` rows for exactly this
-reason.
+Verified with a real signed-in session (not by reading policies): the role reads
+0 rows from `students`, `children`, `schedule_sessions`, the five `care_*`
+tables, `teachers`, `staff`, `bell_schedules`, `special_activities`, and
+`attendance`.
 
-The consequence to remember: this role is protected by *absence*, so the guard
-that matters is never granting it a school, a caseload, or a
-`site_admin`/`district_admin` grant. The sim walk asserts the whole negative
-space so a future change that hands it one of those turns the fixture red.
+**Two honest caveats — this is protection by *absence*, and absence is not a
+guard:**
+
+1. **`holidays` IS readable.** Its SELECT policy matches the caller's
+   `profiles.district_id` and — unlike the CARE policies — its `EXISTS`
+   subquery reads only the caller's own `profiles` row, so nothing filters it.
+   A district-scoped role sees its district's holidays. Accepted: holidays are
+   calendar dates with no student or staff data attached. (The equivalent CARE
+   policies *are* saved by nested RLS — their subqueries read `care_referrals` /
+   `care_cases`, which are themselves filtered. A `teacher`, who also carries
+   `district_id`, reads 0 `care_case_status_history` rows for that reason.)
+2. **`provider_schools` has no INSERT guard.** Its policy is
+   `WITH CHECK (provider_id = auth.uid())` — no role predicate, no
+   school-membership check. Any authenticated user can self-attach to any
+   school and unlock every `get_my_school_ids()`-scoped policy. Confirmed
+   against live RLS for `district_tech`, **and equally for `teacher` and
+   `sea`** — this is a pre-existing, platform-wide hole, not something this
+   role introduces. Tracked separately in Linear; do not mistake the sim walk's
+   green negatives for proof that it is closed.
+
+So the guard that matters is never granting this role a school, a caseload, or a
+`site_admin`/`district_admin` grant. The sim walk asserts that negative space, so
+a change that hands it one of those turns the fixture red.
 
 ### "provider" is a delivery category, not a role
 There is **no `provider` role** in the enum, yet `schedule_sessions.delivered_by`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,9 +33,9 @@
   table is the real data-authorization layer, scoped by school/ownership.
   Middleware only does **coarse route redirects**; the API `withRoute` wrapper
   does auth + rate-limit + an AI kill-switch but **has no role gate**.
-- **`profiles.role` has 11 values** (live CHECK constraint):
+- **`profiles.role` has 12 values** (live CHECK constraint):
   `resource, speech, ot, counseling, specialist, sea, teacher, site_admin,
-  district_admin, psychologist, intervention`.
+  district_admin, psychologist, intervention, district_tech`.
 - **`is_speddy_admin` is a separate boolean**, not a role — it gates `/internal`
   (platform/internal admin).
 - **"provider" is not a role.** It's a *delivery category*. `delivered_by`
@@ -57,7 +57,7 @@
 
 | Concern | File / migration |
 |---|---|
-| Role enum (source of truth) | `supabase/migrations/20260410_add_intervention_role.sql` + live `profiles_role_check` |
+| Role enum (source of truth) | `supabase/migrations/20260806_spe393_add_district_tech_role.sql` + live `profiles_role_check` |
 | Role → delivery mapping | `lib/auth/role-utils.ts` (`normalizeDeliveredBy`, `SPECIALIST_SOURCE_ROLES`) |
 | Role display labels | `lib/utils/role-utils.ts` (`formatRoleLabel`) |
 | Route guards | `middleware.ts` |
@@ -105,7 +105,7 @@ Functionally the roles group like this:
 | **District tech admin** | `district_tech` | Routed to `/dashboard/tech`. District IT, not SpEd staff: sees the SIS integrations portal and `/dashboard/settings` and **nothing else** — no students, no CARE, no chat, no scheduling, no admin pages. Scope comes from `admin_permissions` (§3); see the carve-out note below. |
 | **Platform admin** | *(flag)* `is_speddy_admin = true` | Not a role. Gates `/internal`. |
 
-#### What actually keeps `district_tech` out of the data (SPE-393)
+### What actually keeps `district_tech` out of the data (SPE-393)
 
 Worth writing down, because it is **not** the role string. Nothing in RLS
 mentions `district_tech`. As seeded, the role reads no domain data because it

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,7 +90,7 @@
 
 ## 1. User Types & Roles
 
-`profiles.role` is a single `text` column constrained to **11 values** (live
+`profiles.role` is a single `text` column constrained to **12 values** (live
 `profiles_role_check`). A separate boolean `profiles.is_speddy_admin` marks
 platform/internal admins and is **orthogonal** to `role`.
 
@@ -102,7 +102,24 @@ Functionally the roles group like this:
 | **SEA** (Special Ed Assistant) | `sea` | Delivers sessions under supervision. Intentionally **lesson view-only** at the RLS layer (`20260529_restrict_sea_lesson_access.sql`). Normalizes to `delivered_by = 'sea'`. |
 | **Gen-ed teacher** | `teacher` | Routed to `/dashboard/teacher`. |
 | **Org admins** | `site_admin`, `district_admin` | Routed to `/dashboard/admin`. Scope comes from `admin_permissions` (§3). |
+| **District tech admin** | `district_tech` | Routed to `/dashboard/tech`. District IT, not SpEd staff: sees the SIS integrations portal and `/dashboard/settings` and **nothing else** — no students, no CARE, no chat, no scheduling, no admin pages. Scope comes from `admin_permissions` (§3); see the carve-out note below. |
 | **Platform admin** | *(flag)* `is_speddy_admin = true` | Not a role. Gates `/internal`. |
+
+#### `district_tech` carries no `profiles.district_id` (SPE-393)
+
+Every other role stores its district on the profile. `district_tech`
+deliberately does **not**: a handful of RLS policies match on the *caller's*
+`profiles.district_id` with **no role predicate at all** —
+`care_case_status_history` (select **and** insert), `holidays`, and
+`exit_ticket_results` — so a populated `district_id` would silently grant this
+role district-wide CARE reads, contradicting the "integrations and nothing
+else" decision. Its district scope therefore lives **only** in
+`admin_permissions.district_id`, which confers nothing on its own because every
+policy consulting that table constrains `ap.role` to
+`site_admin`/`district_admin`.
+
+The sim-district walk asserts this negative, so re-populating the column turns
+the fixture red rather than leaking quietly.
 
 ### "provider" is a delivery category, not a role
 There is **no `provider` role** in the enum, yet `schedule_sessions.delivered_by`
@@ -123,9 +140,10 @@ psychologist, intervention]` (`lib/auth/role-utils.ts`).
 
 **Display labels** (`formatRoleLabel`, `lib/utils/role-utils.ts`): `speech→Speech`,
 `ot→OT`, `counseling→Counseling`, `resource→Resource`, `psychologist→Psych`,
-`specialist→Specialist`; anything else is capitalized.
+`specialist→Specialist`, `district_tech→District Tech Admin`; anything else is
+capitalized.
 
-**Source of truth:** `supabase/migrations/20260410_add_intervention_role.sql`
+**Source of truth:** `supabase/migrations/20260806_spe393_add_district_tech_role.sql`
 (latest `profiles_role_check`); `lib/auth/role-utils.ts`;
 `lib/utils/role-utils.ts`; `supabase/migrations/20260529_restrict_sea_lesson_access.sql`.
 
@@ -191,8 +209,14 @@ live `profiles_update` policy + `profiles_guard_immutable_columns` trigger.
 | `/internal` | `is_speddy_admin` only | `/dashboard` |
 | `/dashboard/admin` | `site_admin`, `district_admin` | `/dashboard` |
 | `/dashboard/teacher` | `teacher` | `/dashboard` |
-| `/dashboard/care` | **all authenticated users** | — |
-| other `/dashboard/*` | authenticated; admins & teachers redirected to their own dashboards | — |
+| `/dashboard/tech` | `district_tech` only | `/dashboard` |
+| `/dashboard/care` | all authenticated users **except `district_tech`** | `/dashboard/tech` |
+| other `/dashboard/*` | authenticated; admins & teachers redirected to their own dashboards; `district_tech` redirected to `/dashboard/tech` (its only other allowed page is `/dashboard/settings`) | — |
+
+> **Ordering matters:** the `district_tech` branch runs *before* the
+> CARE/Chat early return. That return is unconditional for every authenticated
+> user, so an "everything except" rule placed after it would wave the role
+> straight into both surfaces (SPE-393).
 
 > **Known gap — SPE-187 (security, Medium):** the AI generation routes
 > (`app/api/lessons/generate`, `lessons/v2`, `exit-tickets/generate`,
@@ -279,6 +303,16 @@ erDiagram
   level (`school_id`/`district_id`/`state_id` nullable; `granted_by`,
   `granted_at`). This is what gives `site_admin`/`district_admin` their reach in
   RLS — distinct from `is_speddy_admin`, which is platform-wide.
+  Two CHECK constraints guard it: one enumerating the allowed
+  `role` values, one pairing each role with the scope column it requires
+  (`site_admin ⇒ school_id`, `district_admin ⇒ district_id`,
+  `district_tech ⇒ district_id`). Both must be updated together when a role is
+  added, or the insert fails on whichever was missed.
+  A `district_tech` grant is a **scope marker only** and confers no data access:
+  every policy that consults this table constrains `ap.role` to
+  `site_admin`/`district_admin`, so the row matches none of them. That is the
+  point — it gives the role a district without giving it the district's data
+  (SPE-393; see the §1 carve-out on `profiles.district_id`).
 
 **Source of truth:** live tables `states`, `districts`, `schools`, `profiles`,
 `provider_schools`, `admin_permissions`;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -105,21 +105,33 @@ Functionally the roles group like this:
 | **District tech admin** | `district_tech` | Routed to `/dashboard/tech`. District IT, not SpEd staff: sees the SIS integrations portal and `/dashboard/settings` and **nothing else** — no students, no CARE, no chat, no scheduling, no admin pages. Scope comes from `admin_permissions` (§3); see the carve-out note below. |
 | **Platform admin** | *(flag)* `is_speddy_admin = true` | Not a role. Gates `/internal`. |
 
-#### `district_tech` carries no `profiles.district_id` (SPE-393)
+#### What actually keeps `district_tech` out of the data (SPE-393)
 
-Every other role stores its district on the profile. `district_tech`
-deliberately does **not**: a handful of RLS policies match on the *caller's*
-`profiles.district_id` with **no role predicate at all** —
-`care_case_status_history` (select **and** insert), `holidays`, and
-`exit_ticket_results` — so a populated `district_id` would silently grant this
-role district-wide CARE reads, contradicting the "integrations and nothing
-else" decision. Its district scope therefore lives **only** in
-`admin_permissions.district_id`, which confers nothing on its own because every
-policy consulting that table constrains `ap.role` to
-`site_admin`/`district_admin`.
+Worth writing down, because it is **not** the role string. Nothing in RLS
+mentions `district_tech`. The role reads nothing because it holds none of the
+keys every policy is written against:
 
-The sim-district walk asserts this negative, so re-populating the column turns
-the fixture red rather than leaking quietly.
+- `profiles.school_id` is null and it has **no `provider_schools` rows**, so
+  every "my school ∪ my provider schools" predicate resolves to the empty set.
+- It owns no `students`, no `schedule_sessions`, and no `teachers.account_id`
+  row, so every ownership predicate misses.
+- Its `admin_permissions` grant has `role = 'district_tech'`, and **every**
+  policy consulting that table constrains `ap.role` to
+  `site_admin`/`district_admin`.
+
+A few policies (`care_case_status_history`, `holidays`, `exit_ticket_results`)
+do match on the caller's `profiles.district_id` with no role predicate, which
+looks alarming — but their inner `EXISTS` subqueries read `care_referrals` /
+`care_cases` / `students`, which are **themselves RLS-filtered** for the caller.
+With no school and no caseload, those subqueries return nothing. Verified with a
+real signed-in session rather than by reading the policy: a `teacher`, who *does*
+carry `district_id`, reads **0** `care_case_status_history` rows for exactly this
+reason.
+
+The consequence to remember: this role is protected by *absence*, so the guard
+that matters is never granting it a school, a caseload, or a
+`site_admin`/`district_admin` grant. The sim walk asserts the whole negative
+space so a future change that hands it one of those turns the fixture red.
 
 ### "provider" is a delivery category, not a role
 There is **no `provider` role** in the enum, yet `schedule_sessions.delivered_by`
@@ -312,7 +324,7 @@ erDiagram
   every policy that consults this table constrains `ap.role` to
   `site_admin`/`district_admin`, so the row matches none of them. That is the
   point — it gives the role a district without giving it the district's data
-  (SPE-393; see the §1 carve-out on `profiles.district_id`).
+  (SPE-393; see §1 for what actually keeps the role out).
 
 **Source of truth:** live tables `states`, `districts`, `schools`, `profiles`,
 `provider_schools`, `admin_permissions`;

--- a/docs/CAPABILITIES_MATRIX.md
+++ b/docs/CAPABILITIES_MATRIX.md
@@ -30,7 +30,7 @@
 
 ### Axis 1 — Role
 
-Three **buying/deciding audiences**, plus two **included portals** for people
+Three **buying/deciding audiences**, plus three **included portals** for people
 who participate but don't run the product:
 
 | Audience | Who that is | Center of gravity |
@@ -40,6 +40,7 @@ who participate but don't run the product:
 | **Provider** | Resource specialist / case manager, SLP, OT, counselor, school psychologist, intervention specialist | The day-to-day work: caseload, weekly service schedule, sessions, materials, progress, referrals, IEP meeting planning. |
 | *Teacher portal (included)* | Gen-ed classroom teacher | Sees which of their students receive services and when; contributes classroom activities so providers schedule around them. Never required to run anything. |
 | *SEA portal (included)* | Special Ed Assistant / paraprofessional | Sees the sessions assigned to them, their students, and the daily plan. View-and-deliver, not manage. |
+| *District tech portal (included)* 🗓️ | District IT / technology staff (or the county office acting for them) | Connects the district's student information system and nothing else. Deliberately sees **zero student data** — the person who plugs in the pipe is not the person who reads what flows through it. |
 
 Parents/guardians are a sixth touchpoint with **no account and no login**: the
 IEP-meeting flow (in development) reaches them by text/email link to confirm a
@@ -304,18 +305,23 @@ in charter networks and private-school learning-support teams.
 
 ✅ full use · 👁 view/oversight · ✏️ contributes · — not part of the role's view
 
-| Feature group | District admin | Site admin | Provider | Teacher | SEA |
-|---|---|---|---|---|---|
-| Provider schedule building | 👁 | 👁 | ✅ | 👁 (their students) | 👁 (assigned sessions) |
-| Master Schedule (bells, specials, yard duty) | 👁 | ✅ | ✏️ (can enter site data; consumes it) | ✏️ (own class activities) | — |
-| IEP meeting calendaring 🗓️ | 👁 (planned) | 🔶 rules setup shipped; dashboard planned | 🗓️ planner in review; reschedule planned | ✏️ one-time availability (shipped) | — |
-| Referral tracking (CARE) | 👁 across schools | ✅ oversight | ✅ works the queue | ✏️ submits + follows | 👁 |
-| Student & caseload management | 👁 across schools | 👁 school-wide | ✅ | 👁 (their students) | 👁 (their students) |
-| Lesson planning & materials | — | — | ✅ | — | 👁 view-only |
-| Progress monitoring & assessment | 👁 | 👁 | ✅ | — | ✏️ (curriculum progress) |
-| Team coordination & chat | — | ✅ | ✅ | ✅ | 🔶 session assignments only — no chat (excluded by design) |
-| Staff & account administration | ✅ district-wide | ✅ site | — | — | — |
-| Multi-school support | ✅ (scope is the district) | — | ✅ | — | — |
+| Feature group | District admin | Site admin | Provider | Teacher | SEA | District tech |
+|---|---|---|---|---|---|---|
+| Provider schedule building | 👁 | 👁 | ✅ | 👁 (their students) | 👁 (assigned sessions) | — |
+| Master Schedule (bells, specials, yard duty) | 👁 | ✅ | ✏️ (can enter site data; consumes it) | ✏️ (own class activities) | — | — |
+| IEP meeting calendaring 🗓️ | 👁 (planned) | 🔶 rules setup shipped; dashboard planned | 🗓️ planner in review; reschedule planned | ✏️ one-time availability (shipped) | — | — |
+| Referral tracking (CARE) | 👁 across schools | ✅ oversight | ✅ works the queue | ✏️ submits + follows | 👁 | — |
+| Student & caseload management | 👁 across schools | 👁 school-wide | ✅ | 👁 (their students) | 👁 (their students) | — |
+| Lesson planning & materials | — | — | ✅ | — | 👁 view-only | — |
+| Progress monitoring & assessment | 👁 | 👁 | ✅ | — | ✏️ (curriculum progress) | — |
+| Team coordination & chat | — | ✅ | ✅ | ✅ | 🔶 session assignments only — no chat (excluded by design) | — |
+| Staff & account administration | ✅ district-wide | ✅ site | — | — | — | — |
+| Multi-school support | ✅ (scope is the district) | — | ✅ | — | — | ✅ (scope is the district) |
+| SIS connections & credentials 🗓️ | — | — | — | — | — | ✅ sole surface |
+
+The District tech column is an unbroken row of dashes by design, not by
+omission: the role's whole point is that connecting the SIS requires no access
+to anything the SIS is connected *for*.
 
 ---
 

--- a/docs/CAPABILITIES_MATRIX.md
+++ b/docs/CAPABILITIES_MATRIX.md
@@ -184,7 +184,8 @@ The front door for student concerns, before and around the IEP: a shared
 queue instead of sticky notes and hallway conversations.
 
 - Anyone on staff can submit a referral: academic, behavioral, attendance,
-  social-emotional, speech, OT, or other.
+  social-emotional, speech, OT, or other. (District tech admins are the one
+  exception — they hold no student-facing surface at all.)
 - Two intake lanes, matching how referrals actually arrive:
   - **Discussion lane** — a teacher or staff concern enters a pending queue,
     the team reviews it, and it becomes an active case (or doesn't).
@@ -268,8 +269,8 @@ entering data.
   provider there can coordinate with them.
 - Chat: built-in messaging between staff at the school — the scheduling
   conversation happens next to the schedule. Available to providers, site
-  admins, and teachers; SEAs and district admins are deliberately excluded
-  from the chat module.
+  admins, and teachers; SEAs, district admins, and district tech admins are
+  deliberately excluded from the chat module.
 - Teacher portal: teachers see when their students are pulled and add their
   own class activities (Library day, field trips) that providers'
   conflict-detection respects.

--- a/lib/utils/role-utils.test.ts
+++ b/lib/utils/role-utils.test.ts
@@ -11,6 +11,8 @@ describe('formatRoleLabel', () => {
     expect(formatRoleLabel('sea')).toBe('SEA');
     expect(formatRoleLabel('site_admin')).toBe('Site Admin');
     expect(formatRoleLabel('district_admin')).toBe('District Admin');
+    // Needs its own case: the default title-caser would render "District Tech".
+    expect(formatRoleLabel('district_tech')).toBe('District Tech Admin');
   });
 
   it('is case-insensitive for known roles', () => {

--- a/lib/utils/role-utils.ts
+++ b/lib/utils/role-utils.ts
@@ -25,6 +25,10 @@ export function formatRoleLabel(role: string | null): string {
       return 'Site Admin';
     case 'district_admin':
       return 'District Admin';
+    case 'district_tech':
+      // Not derivable from the default title-caser, which would yield
+      // "District Tech".
+      return 'District Tech Admin';
     default:
       // Title-case each word, splitting snake_case/kebab-case so codes like
       // "site_admin" render as "Site Admin" rather than "Site_admin".

--- a/middleware.ts
+++ b/middleware.ts
@@ -134,7 +134,35 @@ export async function middleware(request: NextRequest) {
   const isTeacherRoute = pathname.startsWith('/dashboard/teacher')
   const isCareRoute = pathname.startsWith('/dashboard/care')
   const isChatRoute = pathname.startsWith('/dashboard/chat')
+  const isTechRoute = pathname.startsWith('/dashboard/tech')
+  const isSettingsRoute = pathname.startsWith('/dashboard/settings')
   const isDashboardRoute = pathname.startsWith('/dashboard')
+
+  // District Tech Admins (SPE-393) see the integrations portal and nothing
+  // else — no student data, no CARE, no chat, no scheduling, no admin pages.
+  // This runs BEFORE the CARE/Chat early return below, which would otherwise
+  // wave them straight through: that exemption is unconditional for every
+  // authenticated user, so an "everything except" rule placed after it would
+  // silently leak both surfaces.
+  // The one exemption is /internal, which stays governed by is_speddy_admin
+  // below — that flag is orthogonal to the role and shouldn't be revoked here.
+  if (userRole === 'district_tech' && !(isInternalRoute && isSpeddyAdmin)) {
+    // Settings is the one shared page they keep: it renders their own account
+    // only, and they need somewhere to change their password.
+    if (isTechRoute || isSettingsRoute) {
+      return response
+    }
+    const redirectUrl = request.nextUrl.clone()
+    redirectUrl.pathname = '/dashboard/tech'
+    return NextResponse.redirect(redirectUrl)
+  }
+
+  // Conversely, nobody else has a reason to be in the tech portal.
+  if (isTechRoute) {
+    const redirectUrl = request.nextUrl.clone()
+    redirectUrl.pathname = '/dashboard'
+    return NextResponse.redirect(redirectUrl)
+  }
 
   // CARE and Chat are cross-role surfaces: exempt them from the admin/teacher
   // section redirects below so site admins and teachers can reach them. (Chat

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -127,6 +127,7 @@ export function schoolById(id: string): SimSchool {
 
 export type SimRole =
   | 'district_admin'
+  | 'district_tech'
   | 'site_admin'
   | 'resource'
   | 'speech'
@@ -150,6 +151,10 @@ export interface SimPersona {
 
 export const PERSONAS: SimPersona[] = [
   { key: 'dana', fullName: 'Dana Alvarez-Sim', role: 'district_admin', emailLocal: 'district.admin', schoolIds: [] },
+  // SPE-393: District Tech Admin — district-wide scope, integrations portal
+  // only. Exists chiefly to be walked NEGATIVELY: the fixture's job is proving
+  // this persona cannot reach students, CARE, chat, scheduling or admin pages.
+  { key: 'theo', fullName: 'Theo Nakamura-Sim', role: 'district_tech', emailLocal: 'techadmin.district', schoolIds: [] },
   { key: 'priya', fullName: 'Priya Natarajan-Sim', role: 'site_admin', emailLocal: 'siteadmin.willow', schoolIds: [WILLOW] },
   { key: 'elena', fullName: 'Elena Rodriguez-Sim', role: 'site_admin', emailLocal: 'siteadmin.maple', schoolIds: [MAPLE] },
   { key: 'kwame', fullName: 'Kwame Mensah-Sim', role: 'site_admin', emailLocal: 'siteadmin.juniper', schoolIds: [JUNIPER] },

--- a/scripts/sim-district/seed.ts
+++ b/scripts/sim-district/seed.ts
@@ -145,22 +145,13 @@ async function main() {
     });
     if (rpcErr) throw new Error(`create_profile_for_new_user failed for ${email}: ${rpcErr.message}`);
 
-    // SPE-393: District Tech Admins carry their district scope in
-    // admin_permissions ONLY — profiles.district_id stays null. Several RLS
-    // policies (care_case_status_history, holidays, exit_ticket_results) match
-    // on the caller's profiles.district_id with no role predicate at all, so
-    // setting it here would hand this role district-wide CARE reads and
-    // contradict the "integrations and nothing else" decision. The walk asserts
-    // that negative, which is what keeps this from being re-set by accident.
-    const districtIdForProfile = p.role === 'district_tech' ? null : DISTRICT.id;
-
     // Pin structured FK ids to manifest values (never trust the name matcher blindly).
     const { error: patchErr } = await admin.from('profiles').update({
       full_name: p.fullName,
       role: p.role,
       state: DISTRICT.state_id,
       state_id: DISTRICT.state_id,
-      district_id: districtIdForProfile,
+      district_id: DISTRICT.id,
       school_id: primarySchool?.id ?? null,
       school_district: DISTRICT.name,
       school_site: primarySchool?.name ?? '',
@@ -175,7 +166,7 @@ async function main() {
       .eq('id', id)
       .single();
     if (checkErr) throw new Error(`profile readback failed for ${email}: ${checkErr.message}`);
-    if (profile.role !== p.role || profile.district_id !== districtIdForProfile ||
+    if (profile.role !== p.role || profile.district_id !== DISTRICT.id ||
         profile.school_id !== (primarySchool?.id ?? null) || profile.district_domain !== SIM_EMAIL_DOMAIN) {
       throw new Error(`profile assertion failed for ${email}: ${JSON.stringify(profile)}`);
     }
@@ -184,9 +175,11 @@ async function main() {
 
   // ---- Admin permissions --------------------------------------------------
   console.log('Step 4/9: admin permissions + provider school assignments...');
-  // district_tech joins this set (SPE-393): admin_permissions is the ONLY place
-  // its district scope lives. The grant itself confers nothing — every policy
-  // that consults this table constrains ap.role to site_admin/district_admin.
+  // district_tech joins this set (SPE-393). The grant is a scope marker only —
+  // every policy that consults this table constrains ap.role to
+  // site_admin/district_admin, so the row confers no data access. Note it gets
+  // NO provider_schools row below and no school_id above: that absence, not the
+  // role string, is what keeps it out of the data (see ARCHITECTURE.md §1).
   const adminPerms = PERSONAS.filter(
     p => p.role === 'district_admin' || p.role === 'site_admin' || p.role === 'district_tech',
   ).map(p => ({

--- a/scripts/sim-district/seed.ts
+++ b/scripts/sim-district/seed.ts
@@ -145,13 +145,22 @@ async function main() {
     });
     if (rpcErr) throw new Error(`create_profile_for_new_user failed for ${email}: ${rpcErr.message}`);
 
+    // SPE-393: District Tech Admins carry their district scope in
+    // admin_permissions ONLY — profiles.district_id stays null. Several RLS
+    // policies (care_case_status_history, holidays, exit_ticket_results) match
+    // on the caller's profiles.district_id with no role predicate at all, so
+    // setting it here would hand this role district-wide CARE reads and
+    // contradict the "integrations and nothing else" decision. The walk asserts
+    // that negative, which is what keeps this from being re-set by accident.
+    const districtIdForProfile = p.role === 'district_tech' ? null : DISTRICT.id;
+
     // Pin structured FK ids to manifest values (never trust the name matcher blindly).
     const { error: patchErr } = await admin.from('profiles').update({
       full_name: p.fullName,
       role: p.role,
       state: DISTRICT.state_id,
       state_id: DISTRICT.state_id,
-      district_id: DISTRICT.id,
+      district_id: districtIdForProfile,
       school_id: primarySchool?.id ?? null,
       school_district: DISTRICT.name,
       school_site: primarySchool?.name ?? '',
@@ -166,7 +175,7 @@ async function main() {
       .eq('id', id)
       .single();
     if (checkErr) throw new Error(`profile readback failed for ${email}: ${checkErr.message}`);
-    if (profile.role !== p.role || profile.district_id !== DISTRICT.id ||
+    if (profile.role !== p.role || profile.district_id !== districtIdForProfile ||
         profile.school_id !== (primarySchool?.id ?? null) || profile.district_domain !== SIM_EMAIL_DOMAIN) {
       throw new Error(`profile assertion failed for ${email}: ${JSON.stringify(profile)}`);
     }
@@ -175,7 +184,12 @@ async function main() {
 
   // ---- Admin permissions --------------------------------------------------
   console.log('Step 4/9: admin permissions + provider school assignments...');
-  const adminPerms = PERSONAS.filter(p => p.role === 'district_admin' || p.role === 'site_admin').map(p => ({
+  // district_tech joins this set (SPE-393): admin_permissions is the ONLY place
+  // its district scope lives. The grant itself confers nothing — every policy
+  // that consults this table constrains ap.role to site_admin/district_admin.
+  const adminPerms = PERSONAS.filter(
+    p => p.role === 'district_admin' || p.role === 'site_admin' || p.role === 'district_tech',
+  ).map(p => ({
     admin_id: userIds.get(p.key)!,
     role: p.role,
     district_id: DISTRICT.id,

--- a/scripts/sim-district/verify.ts
+++ b/scripts/sim-district/verify.ts
@@ -222,7 +222,13 @@ async function main() {
     expect('districts', n => n === 1, '1');
     expect('schools', n => n === SCHOOLS.length, String(SCHOOLS.length));
     expect('profiles', n => n === PERSONAS.length, String(PERSONAS.length));
-    expect('admin_permissions', n => n === 6, '6');
+    // Derived, not hardcoded: the seed grants one row per admin-ish persona
+    // (site_admin, district_admin, and — since SPE-393 — district_tech), so
+    // adding such a persona shouldn't require editing a magic number here.
+    const scopedGrants = PERSONAS.filter(
+      p => p.role === 'district_admin' || p.role === 'site_admin' || p.role === 'district_tech',
+    ).length;
+    expect('admin_permissions', n => n === scopedGrants, String(scopedGrants));
     expect('teachers', n => n === RECORD_TEACHERS.length + teacherLogins, String(RECORD_TEACHERS.length + teacherLogins));
     expect('students', n => n === TOTAL_STUDENTS, String(TOTAL_STUDENTS));
     // SPE-347: one children row per child. Fewer children than students is the

--- a/supabase/migrations/20260806_spe393_add_district_tech_role.sql
+++ b/supabase/migrations/20260806_spe393_add_district_tech_role.sql
@@ -1,0 +1,64 @@
+-- SPE-393: District Tech Admin role foundation.
+--
+-- Adds the 12th profile role, `district_tech` ("District Tech Admin"), a
+-- district-scoped role whose entire surface is the integrations/credentials
+-- portal at /dashboard/tech. It gets NO access to students, sessions, CARE,
+-- chat, or scheduling.
+--
+-- Deliberately NOT in this migration: any new RLS grant on a domain table.
+-- The role's district scope rides the existing admin_permissions mechanism,
+-- and every policy that consults admin_permissions constrains ap.role to
+-- 'site_admin'/'district_admin' explicitly, so a `district_tech` grant row
+-- matches none of them. That was verified against the live policy set rather
+-- than inferred from the migration history.
+
+-- ---------------------------------------------------------------------------
+-- 1. profiles.role — allow the new value
+--    (pattern: 20260410_add_intervention_role.sql)
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.profiles
+  DROP CONSTRAINT profiles_role_check;
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_role_check CHECK (
+    role = ANY (ARRAY[
+      'resource'::text, 'speech'::text, 'ot'::text, 'counseling'::text,
+      'specialist'::text, 'sea'::text, 'teacher'::text, 'site_admin'::text,
+      'district_admin'::text, 'psychologist'::text, 'intervention'::text,
+      'district_tech'::text
+    ])
+  );
+
+COMMENT ON CONSTRAINT profiles_role_check ON public.profiles
+IS 'Valid profile roles. district_tech (SPE-393) is district-scoped and sees only the integrations portal.';
+
+-- ---------------------------------------------------------------------------
+-- 2. admin_permissions — accept district_tech as a scope grant
+--
+-- Two separate CHECKs guard this table: one enumerating the allowed roles,
+-- one pairing each role with the scope column it requires. Both must learn
+-- the new role, or the insert fails on whichever is missed.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.admin_permissions
+  DROP CONSTRAINT admin_permissions_role_check;
+
+ALTER TABLE public.admin_permissions
+  ADD CONSTRAINT admin_permissions_role_check CHECK (
+    role = ANY (ARRAY['site_admin'::text, 'district_admin'::text, 'district_tech'::text])
+  );
+
+ALTER TABLE public.admin_permissions
+  DROP CONSTRAINT admin_permissions_check;
+
+ALTER TABLE public.admin_permissions
+  ADD CONSTRAINT admin_permissions_check CHECK (
+    -- Site admin must have school_id
+    (role = 'site_admin' AND school_id IS NOT NULL) OR
+    -- District admin must have district_id
+    (role = 'district_admin' AND district_id IS NOT NULL) OR
+    -- District tech admin is district-scoped, same as a district admin
+    (role = 'district_tech' AND district_id IS NOT NULL)
+  );
+
+COMMENT ON TABLE public.admin_permissions
+IS 'Tracks which schools/districts each site_admin, district_admin and district_tech can manage';

--- a/supabase/migrations/20260806_spe393_add_district_tech_role.sql
+++ b/supabase/migrations/20260806_spe393_add_district_tech_role.sql
@@ -62,3 +62,31 @@ ALTER TABLE public.admin_permissions
 
 COMMENT ON TABLE public.admin_permissions
 IS 'Tracks which schools/districts each site_admin, district_admin and district_tech can manage';
+
+-- ---------------------------------------------------------------------------
+-- 3. is_chat_eligible — the one role check in the schema that is a DENY-list
+--
+-- Every other role gate is an allow-list, so a new role is excluded by simply
+-- not being named. This one is inverted: `role NOT IN ('sea','district_admin')`
+-- means an unnamed role is eligible BY DEFAULT. Left alone, district_tech would
+-- be able to open direct conversations with staff through the chat RLS
+-- policies, which all funnel through this function — the middleware bounce off
+-- /dashboard/chat hides the UI but does nothing about the data layer.
+--
+-- Definition otherwise preserved verbatim (sql, STABLE, SECURITY DEFINER,
+-- pinned search_path) from 20260627_chat_direct_messages.sql.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.is_chat_eligible(p_uid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+  SELECT EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = p_uid AND p.role NOT IN ('sea', 'district_admin', 'district_tech')
+  );
+$function$;
+
+COMMENT ON FUNCTION public.is_chat_eligible(uuid)
+IS 'Chat participation gate. DENY-list: any role not named here is eligible by default — add new non-chat roles explicitly.';


### PR DESCRIPTION
Closes SPE-393 — the first ticket of epic SPE-392 (District Tech Admin role + SIS connections v1).

Adds the 12th profile role, `district_tech` ("District Tech Admin"): a district-scoped role for district IT whose entire surface is the SIS integrations portal at `/dashboard/tech`. It is the account a district's tech contact will use to connect Aeries or OneRoster, and it is deliberately blind to everything else — no students, no CARE, no chat, no scheduling, no admin pages.

## What's here

**Database** (migration applied to prod after owner approval; `20260806_spe393_add_district_tech_role.sql`)
- `profiles_role_check` gains `district_tech`.
- `admin_permissions` learns it in **both** of its CHECK constraints — the role enum and the role/scope pairing (`district_tech ⇒ district_id NOT NULL`). Missing either one fails the insert.
- `is_chat_eligible` — see "The one real leak" below.
- No new RLS grant on any domain table.

**App**
- `middleware.ts`: the role is pinned to `/dashboard/tech` + `/dashboard/settings` and bounced from everything else. The branch is placed **before** the CARE/Chat early return — that return is unconditional for every authenticated user, so an "everything except" rule placed after it would have waved the role straight into both surfaces.
- `navbar.tsx`: an explicit branch (Integrations + Settings). The existing fallthrough hands out Students/Schedule/Chat, so an unnamed role fails *open*.
- New `/dashboard/tech` shell page (content arrives with SPE-396/397). Settings hides the curriculum picker and now renders the role through `formatRoleLabel` — CSS `capitalize` was showing "District_tech".
- Profile dropdown: adds the role label, and stops rendering a labelled blank "School Site" for district-wide roles.

**Drive-by fix** (called out in the ticket): `/api/admin/district/teachers` and `/api/admin/district/site-admin` gated with `.eq('role','district_admin').single()`, which **throws** for an admin holding two `admin_permissions` rows — already legal in this schema. Both now read the full grant set; the site-admin route resolves the grant matching the target school so a multi-district admin's new site admin inherits the right district *and* state.

**Fixture & docs**: `district_tech` persona (Theo Nakamura-Sim) in the sim manifest; `verify.ts` now derives the `admin_permissions` count instead of hardcoding `6`; ARCHITECTURE §1/§2/§3 and CAPABILITIES_MATRIX updated.

## The one real leak this found

`is_chat_eligible` is the **only** role check in the schema written as a deny-list (`role NOT IN ('sea','district_admin')`). Every other gate is an allow-list, so a new role is excluded by simply not being named — this one is inverted, and `district_tech` was chat-eligible **by default**. Middleware blocks the chat *page*, but the chat RLS policies all funnel through this function, so the data layer would still have permitted direct conversations with staff. Added to the exclusion list, with a control probe confirming `resource`/`teacher`/`site_admin` are still eligible. Inverting the pattern properly is SPE-400.

## Verification

Sim-district walk with real signed-in sessions — **46 checks, 0 failed**:
- Routing: lands on `/dashboard/tech`; bounced from 13 surfaces including `/dashboard/care` and `/dashboard/chat`.
- Data layer, through the role's own PostgREST session: **0 rows** from `students`, `children`, `schedule_sessions`, all five `care_*` tables, `teachers`, `staff`, `bell_schedules`, `special_activities`, `attendance`.
- `is_chat_eligible` false; `get_dm_eligible_people` returns nobody.

Also green: `sim:verify`, `sim:verify-rls`, and the full teardown → `--expect-empty` → reseed lifecycle. Typecheck, lint and 713 unit tests pass.

## Two things I got wrong and corrected

Both were caught by review and fixed by **probing rather than re-reading policies**:

1. I first withheld `profiles.district_id` from the role, believing the district-keyed CARE policies were role-blind. A real teacher session — which *does* carry `district_id` and is excluded from CARE elsewhere — reads **0** `care_case_status_history` rows, because those policies' inner `EXISTS` reads `care_referrals`/`care_cases`, themselves RLS-filtered. The carve-out was solving a non-problem, so it's gone and the fixture stays consistent.
2. My first ARCHITECTURE wording claimed the role is kept out purely by absence. Two corrections, both verified live: `holidays` **is** readable district-wide (its subquery reads only the caller's own profile row, so nothing filters it — accepted, they're calendar dates), and `provider_schools` has no insert guard at all.

## Filed separately

- **SPE-399 (urgent)** — `provider_schools`'s only INSERT policy is `WITH CHECK (provider_id = auth.uid())`: any authenticated user can self-attach to any school and widen their own scope via `get_my_school_ids()`. Reproduced for `district_tech` (0 → 4 CARE referrals), **and equally for `teacher` and `sea`** — pre-existing and platform-wide, not introduced here. Probe rows deleted immediately. The doc now says this plainly rather than implying the role is sealed.
- **SPE-400** — invert `is_chat_eligible` to an allow-list.

## Reviewer notes

Screenshots of the portal and settings pages are in the Linear ticket. The middleware branch ordering and the navbar fallthrough are the two places where a plausible-looking change silently opens access, so they're the parts most worth a second pair of eyes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9wB9cKyt21z79WXbhyFtp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a District Tech Admin role with a dedicated integrations portal and SIS setup guidance.
  * Added role-specific navigation for Integrations and Settings.
  * Added support for district administrators managing access across multiple districts.

* **Bug Fixes**
  * Improved role labels and profile display behavior.
  * Restricted District Tech Admin access to approved dashboard areas and student data.
  * Hid curriculum settings from District Tech Admins.

* **Documentation**
  * Updated architecture and capabilities documentation for the new role and access boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->