### PR TITLE
SPE-399: provider_schools is admin-writable only (privilege escalation)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -135,14 +135,12 @@ guard:**
    policies *are* saved by nested RLS — their subqueries read `care_referrals` /
    `care_cases`, which are themselves filtered. A `teacher`, who also carries
    `district_id`, reads 0 `care_case_status_history` rows for that reason.)
-2. **`provider_schools` has no INSERT guard.** Its policy is
-   `WITH CHECK (provider_id = auth.uid())` — no role predicate, no
-   school-membership check. Any authenticated user can self-attach to any
-   school and unlock every `get_my_school_ids()`-scoped policy. Confirmed
-   against live RLS for `district_tech`, **and equally for `teacher` and
-   `sea`** — this is a pre-existing, platform-wide hole, not something this
-   role introduces. Tracked separately in Linear; do not mistake the sim walk's
-   green negatives for proof that it is closed.
+2. ~~**`provider_schools` has no INSERT guard.**~~ **Closed by SPE-399.** All
+   three write commands were gated on ownership alone
+   (`provider_id = auth.uid()`), so any authenticated user could self-attach to
+   any school and unlock every `get_my_school_ids()`-scoped policy —
+   reproduced for `district_tech`, `teacher` and `sea` alike. The table is now
+   admin/service-role-writable only; see §3.
 
 So the guard that matters is never granting this role a school, a caseload, or a
 `site_admin`/`district_admin` grant. The sim walk asserts that negative space, so
@@ -323,6 +321,17 @@ erDiagram
     nullable) — the newer normalized refs into the hierarchy tables.
   - Treat this as a migration-in-progress: code may read either. Check which a
     given query uses before assuming.
+- **`provider_schools` is an authorization input, not user data (SPE-399).**
+  `get_my_school_ids()` returns `profiles.school_id` **UNION** the caller's
+  `provider_schools.school_id`, so a row here *grants* a school's worth of
+  reads. It is therefore **admin/service-role-writable only** — all three write
+  policies are `false` for browser sessions. Both application writers
+  (`app/api/admin/district/providers/**`) use the service-role client, and
+  signup writes via `handle_new_user_schools()`, a postgres-owned
+  `SECURITY DEFINER` trigger; neither is affected. Reads are unchanged.
+  Guarded by `npm run sim:verify-provider-schools-rls`.
+  The general lesson: when a table feeds an authorization function, "it's my
+  row" is not a sufficient write check — ownership is the thing being escalated.
 - **`provider_schools` (M:N):** a provider can serve multiple schools; rows carry
   both the legacy text pair and structured ids, plus `is_primary`. RLS policies
   commonly union "my profile's school" with "my `provider_schools` schools".

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "sim:verify-children-rls": "tsx scripts/sim-district/verify-children-rls.ts",
     "sim:verify-child-link": "tsx scripts/sim-district/verify-child-link.ts",
     "sim:verify-special-activities-rls": "tsx scripts/sim-district/verify-special-activities-rls.ts",
-    "sim:verify-multi-school-rls": "tsx scripts/sim-district/verify-multi-school-rls.ts"
+    "sim:verify-multi-school-rls": "tsx scripts/sim-district/verify-multi-school-rls.ts",
+    "sim:verify-provider-schools-rls": "tsx scripts/sim-district/verify-provider-schools-rls.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",

--- a/scripts/sim-district/verify-provider-schools-rls.ts
+++ b/scripts/sim-district/verify-provider-schools-rls.ts
@@ -76,16 +76,30 @@ function check(ok: boolean, label: string, detail = ''): void {
  * fixture and, worse, leaving three personas holding the escalated authorization
  * the failing check just reported. The verifier must not become the thing that
  * makes the leak durable.
+ *
+ * Each undo returns its PostgREST error, if any. supabase-js RESOLVES on a
+ * failed write — it does not throw — so a try/catch alone would let a cleanup
+ * that did nothing look like a cleanup that worked. That is the same trap this
+ * script warns about above for UPDATE/DELETE, and it matters more here: a
+ * silently-failed undo leaves the fixture escalated while reporting success.
  */
-const cleanups: Array<() => Promise<void>> = [];
+type Undo = () => Promise<{ error: { message: string } | null }>;
+
+const cleanups: Array<{ what: string; undo: Undo }> = [];
+
+/** Fixed id for the service-role write probe, so the final sweep can look for it. */
+const probeId = '00000000-0000-4000-8000-00000000e399';
+
+/** Captured during the run so the post-cleanup assertions can re-read her rows. */
+let mariaId: string | null = null;
 
 async function runCleanups(): Promise<void> {
-  for (const undo of cleanups.reverse()) {
+  for (const { what, undo } of cleanups.reverse()) {
     try {
-      await undo();
+      const { error } = await undo();
+      if (error) check(false, `cleanup: ${what}`, error.message);
     } catch (err) {
-      failures++;
-      console.log(`  [FAIL] ${'cleanup step threw'.padEnd(64)} ${String(err)}`);
+      check(false, `cleanup threw: ${what}`, String(err));
     }
   }
 }
@@ -144,8 +158,9 @@ async function assertCannotSelfAttach(
   // Register the undo BEFORE asserting, so a thrown assertion cannot strand the row.
   if (data?.length) {
     const ids = data.map(r => r.id);
-    cleanups.push(async () => {
-      await admin.from('provider_schools').delete().in('id', ids);
+    cleanups.push({
+      what: `remove ${label} probe row(s)`,
+      undo: async () => await admin.from('provider_schools').delete().in('id', ids),
     });
   }
 
@@ -186,8 +201,9 @@ async function main(): Promise<void> {
   console.log('\nlegitimate multi-school provider (Maria: Maple + Juniper):');
   const maria = await signIn('maria');
   const { data: { user: mariaUser } } = await maria.auth.getUser();
+  mariaId = mariaUser!.id;
 
-  const { data: before } = await maria
+  const { data: before, error: beforeErr } = await maria
     .from('provider_schools')
     .select('id, school_id')
     .order('school_id');
@@ -195,9 +211,9 @@ async function main(): Promise<void> {
   // so a sorted array puts them in the opposite order to how they read.
   const beforeIds = new Set((before ?? []).map(r => r.school_id));
   check(
-    beforeIds.size === 2 && beforeIds.has(MAPLE) && beforeIds.has(JUNIPER),
+    !beforeErr && beforeIds.size === 2 && beforeIds.has(MAPLE) && beforeIds.has(JUNIPER),
     'reads exactly her own two schools (reads untouched)',
-    [...beforeIds].join(', ') || 'none',
+    beforeErr ? `read failed: ${beforeErr.message}` : ([...beforeIds].join(', ') || 'none'),
   );
 
   const targetRow = before?.[0];
@@ -208,22 +224,27 @@ async function main(): Promise<void> {
     // below is permitted — the regression this is looking for — the fixture
     // would otherwise be left with Maria repointed at Willow or missing a
     // school entirely.
-    const { data: original } = await admin
+    const { data: original, error: snapshotErr } = await admin
       .from('provider_schools').select('*').eq('id', targetRow.id).single();
+    check(!snapshotErr && !!original, 'snapshotted Maria\'s row for restore',
+      snapshotErr ? snapshotErr.message : targetRow.id);
+
     if (original) {
-      cleanups.push(async () => {
-        const { count } = await admin
-          .from('provider_schools')
-          .select('id', { count: 'exact', head: true })
-          .eq('id', original.id);
-        if (count === 0) {
-          await admin.from('provider_schools').insert(original);
-        } else {
-          await admin
+      cleanups.push({
+        what: 'restore Maria\'s row',
+        undo: async () => {
+          const { count, error: countErr } = await admin
             .from('provider_schools')
-            .update({ school_id: original.school_id, school_site: original.school_site })
+            .select('id', { count: 'exact', head: true })
             .eq('id', original.id);
-        }
+          if (countErr) return { error: countErr };
+          return count === 0
+            ? await admin.from('provider_schools').insert(original)
+            : await admin
+                .from('provider_schools')
+                .update({ school_id: original.school_id, school_site: original.school_site })
+                .eq('id', original.id);
+        },
       });
     }
 
@@ -257,9 +278,9 @@ async function main(): Promise<void> {
   // The service client — how the real admin flows write — must still work.
   // (sim:reset already proves this at scale; re-assert it here so this script
   // fails loudly if a future tightening catches the admin path too.)
-  const probeId = '00000000-0000-4000-8000-00000000e399';
-  cleanups.push(async () => {
-    await admin.from('provider_schools').delete().eq('id', probeId);
+  cleanups.push({
+    what: 'remove service-role probe row',
+    undo: async () => await admin.from('provider_schools').delete().eq('id', probeId),
   });
   const { error: adminInsertErr } = await admin.from('provider_schools').insert({
     id: probeId,
@@ -286,15 +307,36 @@ main()
     // Always. A failing run is precisely the run that has rows to undo.
     await runCleanups();
 
-    // Prove the undo worked rather than trusting it: the fixture must hold no
-    // provider_schools row for a persona that should have none, and Maria must
-    // be back to exactly her two schools.
-    const { data: leftovers } = await admin
+    // Prove the undo worked rather than trusting it. Three separate things can
+    // be left behind, and each needs its own check — a persona probe row, the
+    // service-role probe row (which carries a REAL school_site, so the
+    // school_site='probe' sweep below cannot see it), and Maria's row being
+    // repointed or missing.
+    const { data: leftovers, error: leftoverErr } = await admin
       .from('provider_schools')
       .select('provider_id, school_id, school_site')
       .eq('school_site', 'probe');
-    check((leftovers?.length ?? 0) === 0, 'fixture left clean (no probe rows remain)',
-      `${leftovers?.length ?? 0} leftover row(s)`);
+    check(!leftoverErr && (leftovers?.length ?? 0) === 0,
+      'no persona probe rows remain',
+      leftoverErr ? leftoverErr.message : `${leftovers?.length ?? 0} leftover row(s)`);
+
+    const { count: probeCount, error: probeErr } = await admin
+      .from('provider_schools')
+      .select('id', { count: 'exact', head: true })
+      .eq('id', probeId);
+    check(!probeErr && probeCount === 0, 'service-role probe row removed',
+      probeErr ? probeErr.message : `${probeCount} row(s)`);
+
+    const { data: mariaAfter, error: mariaErr } = await admin
+      .from('provider_schools')
+      .select('school_id')
+      .eq('provider_id', mariaId);
+    const afterIds = new Set((mariaAfter ?? []).map(r => r.school_id));
+    check(
+      !mariaErr && afterIds.size === 2 && afterIds.has(MAPLE) && afterIds.has(JUNIPER),
+      'Maria restored to exactly Maple + Juniper',
+      mariaErr ? mariaErr.message : ([...afterIds].join(', ') || 'none'),
+    );
 
     console.log(`\n${failures === 0 ? 'All checks passed.' : `${failures} check(s) FAILED.`}`);
     process.exit(failures > 0 ? 1 : 0);

--- a/scripts/sim-district/verify-provider-schools-rls.ts
+++ b/scripts/sim-district/verify-provider-schools-rls.ts
@@ -43,7 +43,11 @@
  *     script writes nothing that survives it — there is no already-escalated
  *     target that would make a negative pass for the wrong reason.
  *
- * Requires a seeded sim district (`npm run sim:reset -- --yes`).
+ * Requires a seeded sim district (`npm run sim:reset -- --yes`). Every write this
+ * script attempts is undone on the way out, pass or fail — see `cleanups`. That
+ * matters more here than in the sibling scripts: when the guard regresses these
+ * writes SUCCEED, so the run that reports the leak is exactly the run that would
+ * otherwise make it permanent.
  *
  * Usage: npm run sim:verify-provider-schools-rls
  */
@@ -61,6 +65,29 @@ let failures = 0;
 function check(ok: boolean, label: string, detail = ''): void {
   if (!ok) failures++;
   console.log(`  [${ok ? 'ok  ' : 'FAIL'}] ${label.padEnd(64)} ${detail}`);
+}
+
+/**
+ * Undo steps, run in a finally, pass or fail.
+ *
+ * This is not boilerplate: on the exact regression this script exists to catch,
+ * the writes SUCCEED. Without cleanup a single run would leave Theo, Nora and
+ * Dana permanently attached to schools they don't serve — corrupting the shared
+ * fixture and, worse, leaving three personas holding the escalated authorization
+ * the failing check just reported. The verifier must not become the thing that
+ * makes the leak durable.
+ */
+const cleanups: Array<() => Promise<void>> = [];
+
+async function runCleanups(): Promise<void> {
+  for (const undo of cleanups.reverse()) {
+    try {
+      await undo();
+    } catch (err) {
+      failures++;
+      console.log(`  [FAIL] ${'cleanup step threw'.padEnd(64)} ${String(err)}`);
+    }
+  }
 }
 
 async function signIn(personaKey: string): Promise<SupabaseClient> {
@@ -90,8 +117,16 @@ async function assertCannotSelfAttach(
   // sees their district). The escalation claim is that the count GROWS, so that
   // is what gets asserted; a fixed zero would be wrong for most roles and would
   // have to be relaxed into meaninglessness.
-  const { data: refsBefore } = await client.from('care_referrals').select('id').limit(50);
-  const baseline = refsBefore?.length ?? 0;
+  //
+  // Counted exactly, not via a capped page of rows: a `.limit(n)` on both sides
+  // reads n vs n once the fixture exceeds n, so a real escalation past the cap
+  // would pass. And an errored read must fail the check rather than coalesce to
+  // 0, which would look identical to "reads nothing".
+  const { count: baseline, error: baselineErr } = await client
+    .from('care_referrals')
+    .select('id', { count: 'exact', head: true });
+  check(!baselineErr, `${label}: baseline care_referrals read succeeded`,
+    baselineErr ? baselineErr.message : `${baseline}`);
 
   const { data, error } = await client
     .from('provider_schools')
@@ -106,6 +141,14 @@ async function assertCannotSelfAttach(
     })
     .select();
 
+  // Register the undo BEFORE asserting, so a thrown assertion cannot strand the row.
+  if (data?.length) {
+    const ids = data.map(r => r.id);
+    cleanups.push(async () => {
+      await admin.from('provider_schools').delete().in('id', ids);
+    });
+  }
+
   check(
     error?.code === '42501',
     `${label}: self-insert into ${targetSchool} refused`,
@@ -114,11 +157,13 @@ async function assertCannotSelfAttach(
 
   // Belt and braces: prove the escalation did not land even if the insert
   // somehow slipped through — this is the consequence the policy exists to stop.
-  const { data: refsAfter } = await client.from('care_referrals').select('id').limit(50);
+  const { count: after, error: afterErr } = await client
+    .from('care_referrals')
+    .select('id', { count: 'exact', head: true });
   check(
-    (refsAfter?.length ?? 0) === baseline,
+    !afterErr && after === baseline,
     `${label}: care_referrals reach did not grow`,
-    `${baseline} -> ${refsAfter?.length ?? 0}`,
+    afterErr ? `read failed: ${afterErr.message}` : `${baseline} -> ${after}`,
   );
 
   await client.auth.signOut();
@@ -159,6 +204,29 @@ async function main(): Promise<void> {
   if (!targetRow) {
     check(false, 'fixture sanity: Maria has provider_schools rows', 'none found');
   } else {
+    // Snapshot the real row and register its restore up front. If either write
+    // below is permitted — the regression this is looking for — the fixture
+    // would otherwise be left with Maria repointed at Willow or missing a
+    // school entirely.
+    const { data: original } = await admin
+      .from('provider_schools').select('*').eq('id', targetRow.id).single();
+    if (original) {
+      cleanups.push(async () => {
+        const { count } = await admin
+          .from('provider_schools')
+          .select('id', { count: 'exact', head: true })
+          .eq('id', original.id);
+        if (count === 0) {
+          await admin.from('provider_schools').insert(original);
+        } else {
+          await admin
+            .from('provider_schools')
+            .update({ school_id: original.school_id, school_site: original.school_site })
+            .eq('id', original.id);
+        }
+      });
+    }
+
     // UPDATE: repoint a real row at Willow, which she does not serve.
     await maria
       .from('provider_schools')
@@ -190,6 +258,9 @@ async function main(): Promise<void> {
   // (sim:reset already proves this at scale; re-assert it here so this script
   // fails loudly if a future tightening catches the admin path too.)
   const probeId = '00000000-0000-4000-8000-00000000e399';
+  cleanups.push(async () => {
+    await admin.from('provider_schools').delete().eq('id', probeId);
+  });
   const { error: adminInsertErr } = await admin.from('provider_schools').insert({
     id: probeId,
     provider_id: mariaUser!.id,
@@ -202,15 +273,29 @@ async function main(): Promise<void> {
   });
   check(!adminInsertErr, 'service role can still write (admin assignment path)',
     adminInsertErr ? adminInsertErr.message : 'inserted');
-  await admin.from('provider_schools').delete().eq('id', probeId);
 
   await maria.auth.signOut();
-
-  console.log(`\n${failures === 0 ? 'All checks passed.' : `${failures} check(s) FAILED.`}`);
-  process.exit(failures > 0 ? 1 : 0);
 }
 
-main().catch(err => {
-  console.error(err);
-  process.exit(1);
-});
+main()
+  .catch(err => {
+    failures++;
+    console.error(err);
+  })
+  .then(async () => {
+    // Always. A failing run is precisely the run that has rows to undo.
+    await runCleanups();
+
+    // Prove the undo worked rather than trusting it: the fixture must hold no
+    // provider_schools row for a persona that should have none, and Maria must
+    // be back to exactly her two schools.
+    const { data: leftovers } = await admin
+      .from('provider_schools')
+      .select('provider_id, school_id, school_site')
+      .eq('school_site', 'probe');
+    check((leftovers?.length ?? 0) === 0, 'fixture left clean (no probe rows remain)',
+      `${leftovers?.length ?? 0} leftover row(s)`);
+
+    console.log(`\n${failures === 0 ? 'All checks passed.' : `${failures} check(s) FAILED.`}`);
+    process.exit(failures > 0 ? 1 : 0);
+  });

--- a/scripts/sim-district/verify-provider-schools-rls.ts
+++ b/scripts/sim-district/verify-provider-schools-rls.ts
@@ -1,0 +1,216 @@
+/**
+ * SPE-399 — `provider_schools` must never be self-writable, run with REAL
+ * signed-in sessions.
+ *
+ * Same reason this is a script and not a jest test as its siblings
+ * (verify-profiles-rls.ts, verify-multi-school-rls.ts, ...): our unit tests mock
+ * the Supabase client, so they cannot see RLS at all — they pass identically
+ * whether a policy permits a write or denies every one.
+ *
+ * WHY THIS TABLE IS SPECIAL. `provider_schools` is not ordinary user data — it
+ * is an authorization INPUT. `get_my_school_ids()` returns
+ * `profiles.school_id UNION provider_schools.school_id WHERE provider_id = auth.uid()`,
+ * so a row here grants the caller a school's worth of reads: care_referrals,
+ * care_cases, care_action_items, care_meeting_notes, iep_meetings,
+ * student_parent_contacts, site_meeting_rules, special_activities,
+ * teacher_availability_prefs, and the school branch of profiles_select.
+ *
+ * Before SPE-399 all three write commands were gated on ownership alone
+ * (`provider_id = auth.uid()`), so "it's my row" was the entire check — and any
+ * authenticated user could hand themselves any school. That was reproduced for
+ * a district_tech (0 -> 4 readable care_referrals from one insert), a teacher,
+ * and an SEA. Writes are now admin/service-role only.
+ *
+ * The contract asserted here:
+ *   - no persona, of any role, can INSERT itself into a school;
+ *   - a provider who legitimately HAS rows cannot repoint one at another school
+ *     via UPDATE, nor remove one via DELETE;
+ *   - and the escalation genuinely does not land: the same session still reads
+ *     no care_referrals at the school it tried to claim;
+ *   - while reads are untouched — a multi-school provider still sees exactly
+ *     their own assigned schools, so the fix did not overshoot into a lockout.
+ *
+ * Three traps this deliberately avoids (CLAUDE.md):
+ *   - assert the ROWS, not the HTTP status. `USING (false)` makes UPDATE and
+ *     DELETE match zero rows, which PostgREST reports as a perfectly happy 2xx
+ *     with an empty body — indistinguishable from a permitted write of nothing.
+ *     So those two are checked by re-reading the row afterwards and proving it
+ *     is unchanged / still present, not by looking for an error.
+ *   - assert WHY a refusal happened. The negative INSERT matches `42501`
+ *     specifically, so a row rejected incidentally (a NOT NULL giving 23502,
+ *     say) cannot keep this green after the guard it tests is gone.
+ *   - use a fresh fixture. Every check runs against seeded state and the
+ *     script writes nothing that survives it — there is no already-escalated
+ *     target that would make a negative pass for the wrong reason.
+ *
+ * Requires a seeded sim district (`npm run sim:reset -- --yes`).
+ *
+ * Usage: npm run sim:verify-provider-schools-rls
+ */
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createAdmin, requireEnv } from './lib';
+import { JUNIPER, MAPLE, WILLOW, derivePassword, personaEmail } from './manifest';
+
+const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+const secret = requireEnv('SIM_DISTRICT_PASSWORD');
+
+const admin = createAdmin();
+
+let failures = 0;
+function check(ok: boolean, label: string, detail = ''): void {
+  if (!ok) failures++;
+  console.log(`  [${ok ? 'ok  ' : 'FAIL'}] ${label.padEnd(64)} ${detail}`);
+}
+
+async function signIn(personaKey: string): Promise<SupabaseClient> {
+  const email = personaEmail(personaKey);
+  const client = createClient(url, anon, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: derivePassword(secret, email),
+  });
+  if (error) throw new Error(`sim login failed for ${email} — is the district seeded? (${error.message})`);
+  return client;
+}
+
+/** The self-insert that used to work, for one persona. Must be refused 42501. */
+async function assertCannotSelfAttach(
+  personaKey: string,
+  label: string,
+  targetSchool: string,
+): Promise<void> {
+  const client = await signIn(personaKey);
+  const { data: { user } } = await client.auth.getUser();
+
+  // Baseline BEFORE the attempt. Not "reads zero" — several personas legitimately
+  // read referrals already (a teacher sees the ones they filed, a district admin
+  // sees their district). The escalation claim is that the count GROWS, so that
+  // is what gets asserted; a fixed zero would be wrong for most roles and would
+  // have to be relaxed into meaninglessness.
+  const { data: refsBefore } = await client.from('care_referrals').select('id').limit(50);
+  const baseline = refsBefore?.length ?? 0;
+
+  const { data, error } = await client
+    .from('provider_schools')
+    .insert({
+      provider_id: user!.id,
+      school_id: targetSchool,
+      school_district: 'Sim Unified School District',
+      school_site: 'probe',
+      district_id: 'SIM-D001',
+      state_id: 'CA',
+      is_primary: false,
+    })
+    .select();
+
+  check(
+    error?.code === '42501',
+    `${label}: self-insert into ${targetSchool} refused`,
+    error ? `code=${error.code}` : `NO ERROR — inserted ${data?.length ?? 0} row(s)`,
+  );
+
+  // Belt and braces: prove the escalation did not land even if the insert
+  // somehow slipped through — this is the consequence the policy exists to stop.
+  const { data: refsAfter } = await client.from('care_referrals').select('id').limit(50);
+  check(
+    (refsAfter?.length ?? 0) === baseline,
+    `${label}: care_referrals reach did not grow`,
+    `${baseline} -> ${refsAfter?.length ?? 0}`,
+  );
+
+  await client.auth.signOut();
+}
+
+async function main(): Promise<void> {
+  console.log('provider_schools is admin-writable only (SPE-399):\n');
+
+  // 1. Personas with NO legitimate rows here. Each holds a different role, to
+  //    show the guard is not role-specific — the old policy let all of them in.
+  console.log('self-attach, personas with no assignment (must be refused):');
+  await assertCannotSelfAttach('theo', 'district_tech (Theo)', WILLOW);
+  await assertCannotSelfAttach('nora', 'teacher      (Nora)', MAPLE);
+  await assertCannotSelfAttach('dana', 'district_adm (Dana)', WILLOW);
+
+  // 2. A provider who legitimately HAS rows: Maria is itinerant across Maple +
+  //    Juniper. She must not be able to repoint one at a school she does not
+  //    serve, nor delete one. Both commands now match zero rows rather than
+  //    erroring, so these are asserted by re-reading the row.
+  console.log('\nlegitimate multi-school provider (Maria: Maple + Juniper):');
+  const maria = await signIn('maria');
+  const { data: { user: mariaUser } } = await maria.auth.getUser();
+
+  const { data: before } = await maria
+    .from('provider_schools')
+    .select('id, school_id')
+    .order('school_id');
+  // Compare as sets, not positionally — MAPLE is SIM-S002 and JUNIPER SIM-S003,
+  // so a sorted array puts them in the opposite order to how they read.
+  const beforeIds = new Set((before ?? []).map(r => r.school_id));
+  check(
+    beforeIds.size === 2 && beforeIds.has(MAPLE) && beforeIds.has(JUNIPER),
+    'reads exactly her own two schools (reads untouched)',
+    [...beforeIds].join(', ') || 'none',
+  );
+
+  const targetRow = before?.[0];
+  if (!targetRow) {
+    check(false, 'fixture sanity: Maria has provider_schools rows', 'none found');
+  } else {
+    // UPDATE: repoint a real row at Willow, which she does not serve.
+    await maria
+      .from('provider_schools')
+      .update({ school_id: WILLOW, school_site: 'Sim Willow Elementary' })
+      .eq('id', targetRow.id);
+
+    const { data: afterUpdate } = await admin
+      .from('provider_schools')
+      .select('school_id')
+      .eq('id', targetRow.id)
+      .single();
+    check(
+      afterUpdate?.school_id === targetRow.school_id,
+      'cannot repoint an owned row at an unassigned school',
+      `school_id=${afterUpdate?.school_id} (was ${targetRow.school_id})`,
+    );
+
+    // DELETE: drop a real row.
+    await maria.from('provider_schools').delete().eq('id', targetRow.id);
+
+    const { count } = await admin
+      .from('provider_schools')
+      .select('id', { count: 'exact', head: true })
+      .eq('id', targetRow.id);
+    check(count === 1, 'cannot delete an owned row', `${count} row(s) remain`);
+  }
+
+  // The service client — how the real admin flows write — must still work.
+  // (sim:reset already proves this at scale; re-assert it here so this script
+  // fails loudly if a future tightening catches the admin path too.)
+  const probeId = '00000000-0000-4000-8000-00000000e399';
+  const { error: adminInsertErr } = await admin.from('provider_schools').insert({
+    id: probeId,
+    provider_id: mariaUser!.id,
+    school_id: WILLOW,
+    school_district: 'Sim Unified School District',
+    school_site: 'Sim Willow Elementary',
+    district_id: 'SIM-D001',
+    state_id: 'CA',
+    is_primary: false,
+  });
+  check(!adminInsertErr, 'service role can still write (admin assignment path)',
+    adminInsertErr ? adminInsertErr.message : 'inserted');
+  await admin.from('provider_schools').delete().eq('id', probeId);
+
+  await maria.auth.signOut();
+
+  console.log(`\n${failures === 0 ? 'All checks passed.' : `${failures} check(s) FAILED.`}`);
+  process.exit(failures > 0 ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/supabase/migrations/20260806_spe399_provider_schools_no_self_write.sql
+++ b/supabase/migrations/20260806_spe399_provider_schools_no_self_write.sql
@@ -1,0 +1,70 @@
+-- SPE-399: stop users from granting themselves school scope.
+--
+-- `provider_schools` gated all three write commands on nothing but ownership:
+--
+--   INSERT ... WITH CHECK (provider_id = auth.uid())
+--   UPDATE ... USING      (provider_id = auth.uid())   -- no WITH CHECK at all
+--   DELETE ... USING      (provider_id = auth.uid())
+--
+-- "It's my row" is not authorization here, because this table IS the
+-- authorization. `get_my_school_ids()` returns
+-- `profiles.school_id UNION provider_schools.school_id WHERE provider_id = auth.uid()`,
+-- so a single self-inserted row silently widens the caller's school scope and
+-- unlocks every policy written against that union — care_referrals, care_cases,
+-- care_action_items, care_meeting_notes, iep_meetings, student_parent_contacts,
+-- site_meeting_rules, special_activities, teacher_availability_prefs, and the
+-- school branch of profiles_select.
+--
+-- Reproduced against live RLS before writing this: a district_tech went from 0
+-- to 4 readable care_referrals with one insert, and a teacher and an SEA could
+-- both self-attach to a school they have no relationship with. The UPDATE path
+-- was equally open — omitting WITH CHECK makes Postgres reuse USING, which
+-- constrains provider_id but leaves school_id free to be rewritten.
+--
+-- Compare `profiles`, where `profiles_guard_immutable_columns()` already blocks
+-- self-writes to role / is_speddy_admin / school_id / district_id. This was the
+-- unguarded back door to the same escalation.
+--
+-- WHY DENYING OUTRIGHT IS SAFE (verified, not assumed):
+--   * Both application writers — app/api/admin/district/providers/route.ts and
+--     .../providers/[providerId]/route.ts — use the service-role client, and
+--     service_role has rolbypassrls = true.
+--   * Signup writes rows via handle_new_user_schools(), a SECURITY DEFINER
+--     trigger owned by postgres; provider_schools is owned by postgres with
+--     relforcerowsecurity = false, so that path bypasses RLS too.
+--   * Every other reference in app/ and lib/ is a .select(). There is no
+--     browser-side flow that inserts, updates or deletes here, and no
+--     post-signup "add a school" UI — school assignments are an admin action.
+--
+-- Reads are untouched: providers still see their own rows, and site/district
+-- admins still see their scope (provider_schools_select is unchanged).
+--
+-- Shape follows the existing precedent on admin_permissions ("Only service role
+-- can update/delete admin permissions"), which pins the same intent with an
+-- explicit false rather than by dropping the policy — a named policy states the
+-- rule where a missing one just looks like an oversight.
+
+DROP POLICY IF EXISTS provider_schools_insert ON public.provider_schools;
+CREATE POLICY provider_schools_insert
+ON public.provider_schools
+FOR INSERT
+TO public
+WITH CHECK (false);
+
+DROP POLICY IF EXISTS provider_schools_update ON public.provider_schools;
+CREATE POLICY provider_schools_update
+ON public.provider_schools
+FOR UPDATE
+TO public
+USING (false)
+WITH CHECK (false);
+
+DROP POLICY IF EXISTS provider_schools_delete ON public.provider_schools;
+CREATE POLICY provider_schools_delete
+ON public.provider_schools
+FOR DELETE
+TO public
+USING (false);
+
+COMMENT ON TABLE public.provider_schools
+IS 'Which schools each provider serves. This table IS an authorization input (get_my_school_ids), so it is admin/service-role-writable only — never self-writable. See SPE-399.';


### PR DESCRIPTION
Closes SPE-399. Found while auditing the negative space for SPE-393; pre-existing and open to **every** authenticated user, not just the new role.

## The problem

`provider_schools` is not ordinary user data — it is an **authorization input**. `get_my_school_ids()` returns `profiles.school_id` **UNION** the caller's `provider_schools.school_id`, so a row here *grants* a school's worth of reads: `care_referrals`, `care_cases`, `care_action_items`, `care_meeting_notes`, `iep_meetings`, `student_parent_contacts`, `site_meeting_rules`, `special_activities`, `teacher_availability_prefs`, and the school branch of `profiles_select`.

All three write commands were gated on ownership alone:

```sql
INSERT ... WITH CHECK (provider_id = auth.uid())
UPDATE ... USING      (provider_id = auth.uid())   -- no WITH CHECK
DELETE ... USING      (provider_id = auth.uid())
```

"It's my row" is not authorization when the row *is* the authorization. Anyone could hand themselves any school.

The UPDATE path was equally open and easy to miss: omitting `WITH CHECK` makes Postgres reuse `USING`, which pins `provider_id` but leaves `school_id` free to be rewritten — so a legitimate provider could repoint an existing row at any school.

Compare `profiles`, where `profiles_guard_immutable_columns()` already blocks self-writes to `role` / `is_speddy_admin` / `school_id` / `district_id`. This was the unguarded back door to the same escalation.

### Reproduced against live RLS, before the fix

| Persona | Role | Result |
|---|---|---|
| Theo | `district_tech` | self-insert accepted → **0 → 4** readable `care_referrals` |
| Nora | `teacher` | self-insert accepted (school she has no relationship with) |
| Leah | `sea` | self-insert accepted (same) |

Teachers are deliberately excluded from CARE by `care_referrals_select`'s `role <> 'teacher'` predicate — but that guards the *role*, and this bypasses the school-scope half. All probe rows were deleted immediately.

## The fix

One migration: all three write policies become `false` for browser sessions. `provider_schools_select` is **unchanged** — reads are untouched.

**Verified this breaks nothing rather than assuming it:**
- Both application writers (`app/api/admin/district/providers/route.ts`, `.../[providerId]/route.ts`) use the **service-role** client, and `service_role` has `rolbypassrls = true`.
- Signup writes via `handle_new_user_schools()` — a **postgres-owned `SECURITY DEFINER`** trigger, on a table with `relforcerowsecurity = false`, so it bypasses RLS.
- Every other reference in `app/` and `lib/` is a `.select()`. There is no post-signup "add a school" UI; school assignment is an admin action.

Shape follows the existing `admin_permissions` precedent ("Only service role can update/delete…"), which pins intent with an explicit `false` rather than by dropping the policy — a named policy states the rule where a missing one just looks like an oversight.

## Verification

**New permanent guard: `npm run sim:verify-provider-schools-rls`** — 11 checks, all green:
- self-insert refused with **`42501` specifically** (not merely "it failed"), for three different roles;
- `care_referrals` reach **does not grow** — asserting the consequence, not just the write. Baselines are captured per persona rather than hardcoded to zero, since a teacher legitimately sees referrals they filed and a district admin sees their district;
- an owned row cannot be repointed or deleted — checked by **re-reading the row**, because `USING (false)` makes those match zero rows and return a cheerful 2xx with an empty body;
- reads untouched: a multi-school provider still sees exactly her two assigned schools;
- the service-role path still writes.

**Also confirmed:**
- `sim:reset` seeds 15 `provider_schools` rows through the admin path *after* the change — a live proof the legitimate writer survived.
- All four pre-existing RLS guards pass (`sim:verify-rls`, `multi-school`, `children`, `special-activities`). The multi-school one matters most here: it exercises `teachers_insert` widening through `provider_schools`, so it would fail if reads had regressed.
- UI walk as the itinerant provider: school switcher shows her active site, offers her other one, offers **no** unassigned school, and the caseload renders. 5/5.
- Full `teardown` → `--expect-empty` → `reseed` lifecycle clean; typecheck, lint, 713 unit tests pass.

Two of my first walk assertions were wrong and are worth noting, because both would have been easy to mistake for regressions: the itinerant provider's active school follows her seeded workdays (Juniper Thu–Fri), so pinning "Maple" by name made the check day-dependent; and the caseload column header is "STUDENT", not "Initials". The walk is now day-agnostic.

## Docs

`ARCHITECTURE.md` §1 marks the caveat closed and §3 gains the general lesson: **when a table feeds an authorization function, "it's my row" is not a sufficient write check — ownership is the thing being escalated.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9wB9cKyt21z79WXbhyFtp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Restricted changes to provider-school assignments to authorized administrative and service processes.
  - Preserved existing read access, including visibility across multiple schools.
  - Prevented unauthorized assignment changes from affecting authorization decisions.

- **Documentation**
  - Updated architecture documentation with the revised access rules and security rationale.

- **Tests**
  - Added verification covering blocked unauthorized writes, preserved reads, and successful authorized operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->