### PR TITLE
SPE-394: district admins can create District Tech Admin accounts

### DIFF
--- a/app/(dashboard)/dashboard/admin/create-account/page.tsx
+++ b/app/(dashboard)/dashboard/admin/create-account/page.tsx
@@ -20,7 +20,7 @@ const SPECIALIST_ROLES = [
 
 export default function CreateAccountPage() {
   const router = useRouter();
-  const [accountType, setAccountType] = useState<'teacher' | 'specialist'>('teacher');
+  const [accountType, setAccountType] = useState<'teacher' | 'specialist' | 'tech_admin'>('teacher');
   const [formData, setFormData] = useState({
     first_name: '',
     last_name: '',
@@ -46,6 +46,14 @@ export default function CreateAccountPage() {
   const [districtId, setDistrictId] = useState<string | null>(null);
   const [districtSchools, setDistrictSchools] = useState<Array<{ id: string; name: string }>>([]);
   const [loadingSchools, setLoadingSchools] = useState(false);
+
+  // District Tech Admin form data. District-scoped, so no school field —
+  // the API resolves the district from the caller's own grant.
+  const [techAdminData, setTechAdminData] = useState({
+    first_name: '',
+    last_name: '',
+    email: '',
+  });
 
   // Specialist form data
   const [specialistData, setSpecialistData] = useState({
@@ -239,6 +247,34 @@ export default function CreateAccountPage() {
         // Show credentials modal with the generated password
         setCredentials(data.credentials);
         setShowCredentialsModal(true);
+      } else if (accountType === 'tech_admin') {
+        if (!techAdminData.first_name || !techAdminData.last_name) {
+          throw new Error('First name and last name are required');
+        }
+        if (!techAdminData.email) {
+          throw new Error('Email is required');
+        }
+
+        const response = await fetch('/api/admin/district/tech-admin', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            first_name: techAdminData.first_name,
+            last_name: techAdminData.last_name,
+            email: techAdminData.email,
+          }),
+        });
+
+        const data = await response.json();
+
+        if (!response.ok) {
+          throw new Error(data.error || 'Failed to create district tech admin account');
+        }
+
+        setCredentials(data.credentials);
+        setShowCredentialsModal(true);
       } else if (accountType === 'specialist') {
         // Validate specialist form
         if (!specialistData.first_name || !specialistData.last_name) {
@@ -288,7 +324,7 @@ export default function CreateAccountPage() {
     setShowCredentialsModal(false);
     setCredentials(null);
     // Redirect based on account type
-    if (accountType === 'specialist') {
+    if (accountType === 'specialist' || accountType === 'tech_admin') {
       router.push('/dashboard/admin');
     } else {
       router.push(returnHref);
@@ -356,6 +392,25 @@ export default function CreateAccountPage() {
                 <div className="font-semibold">Specialist</div>
                 <div className="text-xs mt-1">Resource specialist or service provider</div>
               </button>
+              {/* District-scoped role, so this option only exists for district
+                  admins — a site admin has no district to create one in. */}
+              {isDistrictAdmin && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setAccountType('tech_admin');
+                    setError(null);
+                  }}
+                  className={`flex-1 py-3 px-4 rounded-lg border-2 transition-all ${
+                    accountType === 'tech_admin'
+                      ? 'border-purple-500 bg-purple-50 text-purple-700'
+                      : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300'
+                  }`}
+                >
+                  <div className="font-semibold">District Tech Admin</div>
+                  <div className="text-xs mt-1">Sets up your SIS connection</div>
+                </button>
+              )}
             </div>
           </div>
 
@@ -617,6 +672,77 @@ export default function CreateAccountPage() {
                 <p className="ml-3 text-sm text-red-700">{error}</p>
               </div>
             </div>
+          )}
+
+          {accountType === 'tech_admin' && (
+            <>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label htmlFor="tech_first_name" className="block text-sm font-medium text-gray-700 mb-1">
+                    First Name <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    id="tech_first_name"
+                    required
+                    value={techAdminData.first_name}
+                    onChange={(e) => {
+                      setTechAdminData(prev => ({ ...prev, first_name: e.target.value }));
+                      setError(null);
+                    }}
+                    className="block w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
+                    placeholder="Jane"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="tech_last_name" className="block text-sm font-medium text-gray-700 mb-1">
+                    Last Name <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    id="tech_last_name"
+                    required
+                    value={techAdminData.last_name}
+                    onChange={(e) => {
+                      setTechAdminData(prev => ({ ...prev, last_name: e.target.value }));
+                      setError(null);
+                    }}
+                    className="block w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
+                    placeholder="Smith"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="tech_email" className="block text-sm font-medium text-gray-700 mb-1">
+                  Email Address <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="email"
+                  id="tech_email"
+                  required
+                  value={techAdminData.email}
+                  onChange={(e) => {
+                    setTechAdminData(prev => ({ ...prev, email: e.target.value }));
+                    setError(null);
+                  }}
+                  className="block w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
+                  placeholder="tech@district.edu"
+                />
+              </div>
+
+              <div className="rounded-lg bg-purple-50 border border-purple-200 p-4 text-sm text-purple-900">
+                <p className="font-medium mb-1">What this account can do</p>
+                <p>
+                  A District Tech Admin only sees the Integrations area, where they
+                  connect your student information system. They cannot see students,
+                  schedules, CARE, or any other part of Speddy.
+                </p>
+                <p className="mt-2">
+                  They&apos;ll be asked to choose a new password the first time they sign in.
+                </p>
+              </div>
+            </>
           )}
 
           {/* Action Buttons */}

--- a/app/(dashboard)/dashboard/admin/create-account/page.tsx
+++ b/app/(dashboard)/dashboard/admin/create-account/page.tsx
@@ -264,6 +264,12 @@ export default function CreateAccountPage() {
             first_name: techAdminData.first_name,
             last_name: techAdminData.last_name,
             email: techAdminData.email,
+            // Send the district this page is already scoped to. Without it, an
+            // admin holding more than one district grant gets a 400 from the
+            // route and cannot use this form at all. The route still validates
+            // the id against the caller's own grants, so this selects among
+            // them rather than widening anything.
+            district_id: districtId,
           }),
         });
 

--- a/app/(dashboard)/dashboard/admin/create-account/page.tsx
+++ b/app/(dashboard)/dashboard/admin/create-account/page.tsx
@@ -807,7 +807,9 @@ export default function CreateAccountPage() {
           teacherName={
             accountType === 'specialist'
               ? `${specialistData.first_name} ${specialistData.last_name}`
-              : `${formData.first_name} ${formData.last_name}`
+              : accountType === 'tech_admin'
+                ? `${techAdminData.first_name} ${techAdminData.last_name}`
+                : `${formData.first_name} ${formData.last_name}`
           }
         />
       )}

--- a/app/(internal)/internal/create-admin/page.tsx
+++ b/app/(internal)/internal/create-admin/page.tsx
@@ -33,7 +33,7 @@ interface CreatedAdmin {
   email: string;
   fullName: string;
   temporaryPassword: string;
-  adminType: 'district_admin' | 'site_admin';
+  adminType: 'district_admin' | 'site_admin' | 'district_tech';
 }
 
 export default function CreateAdminPage() {
@@ -42,7 +42,7 @@ export default function CreateAdminPage() {
   // Form state
   const [email, setEmail] = useState('');
   const [fullName, setFullName] = useState('');
-  const [adminType, setAdminType] = useState<'district_admin' | 'site_admin'>('district_admin');
+  const [adminType, setAdminType] = useState<'district_admin' | 'site_admin' | 'district_tech'>('district_admin');
   const [selectedState, setSelectedState] = useState('');
   const [selectedDistrict, setSelectedDistrict] = useState('');
   const [selectedSchool, setSelectedSchool] = useState('');
@@ -67,7 +67,7 @@ export default function CreateAdminPage() {
     const district = searchParams.get('district');
     const school = searchParams.get('school');
 
-    if (type === 'site_admin' || type === 'district_admin') {
+    if (type === 'site_admin' || type === 'district_admin' || type === 'district_tech') {
       setAdminType(type);
     }
     if (state) setSelectedState(state);
@@ -289,11 +289,24 @@ export default function CreateAdminPage() {
               />
               <span className="ml-2 text-slate-300">Site Admin</span>
             </label>
+            <label className="flex items-center">
+              <input
+                type="radio"
+                name="adminType"
+                value="district_tech"
+                checked={adminType === 'district_tech'}
+                onChange={() => setAdminType('district_tech')}
+                className="w-4 h-4 text-purple-600 bg-slate-700 border-slate-600 focus:ring-purple-500"
+              />
+              <span className="ml-2 text-slate-300">District Tech Admin</span>
+            </label>
           </div>
           <p className="mt-1 text-sm text-slate-500">
             {adminType === 'district_admin'
               ? 'Can manage all schools in the district'
-              : 'Can manage a single school'}
+              : adminType === 'district_tech'
+                ? 'SIS integrations only — no students, schedules or CARE'
+                : 'Can manage a single school'}
           </p>
         </div>
 

--- a/app/api/admin/district/tech-admin/route.ts
+++ b/app/api/admin/district/tech-admin/route.ts
@@ -1,0 +1,249 @@
+import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
+import { generateTemporaryPassword } from '@/lib/utils/password-generator';
+import { withRoute } from '@/lib/api/with-route';
+
+const log = logger.child({ module: 'district-admin-tech-admin' });
+
+/**
+ * POST /api/admin/district/tech-admin
+ *
+ * Create a District Tech Admin (`district_tech`) for the caller's district —
+ * the account a district's IT contact uses to connect Aeries / OneRoster.
+ *
+ * Mirrors ../site-admin/route.ts, with two deliberate differences:
+ *
+ *  1. NO SCHOOL. This role is district-scoped, so there is no school to resolve
+ *     the grant from. A caller holding several district grants must name the
+ *     target district explicitly; one grant is defaulted. The district is always
+ *     validated against the caller's own grants — the body never widens scope.
+ *  2. `must_change_password` is set at creation. The other admin-creation flows
+ *     hand out a temp password that is never force-rotated (SPE-190 / SPE-364);
+ *     this one does not inherit that gap.
+ */
+export const POST = withRoute({}, async ({ req: request, userId }) => {
+  try {
+    const supabase = await createClient();
+
+    // Holding more than one admin_permissions row is legal, so read the full
+    // set rather than .single(), which errors outright on 2+ rows and would 403
+    // a legitimately multi-district admin.
+    const { data: adminPermissions, error: permError } = await supabase
+      .from('admin_permissions')
+      .select('district_id, state_id')
+      .eq('admin_id', userId)
+      .eq('role', 'district_admin')
+      .not('district_id', 'is', null);
+
+    if (permError || !adminPermissions?.length) {
+      log.warn('Non-district-admin tried to create tech admin', { userId });
+      return NextResponse.json(
+        { error: 'Forbidden: District admin access required' },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json();
+    const { first_name, last_name, email, district_id } = body as {
+      first_name: string;
+      last_name: string;
+      email: string;
+      district_id?: string;
+    };
+
+    if (!first_name?.trim() || !last_name?.trim() || !email?.trim()) {
+      return NextResponse.json(
+        { error: 'Missing required fields: first_name, last_name, email' },
+        { status: 400 }
+      );
+    }
+
+    // Resolve which district this account belongs to. Only ever one of the
+    // caller's own grants — a district_id in the body selects among them, it
+    // never introduces a new one.
+    let grant;
+    if (district_id) {
+      grant = adminPermissions.find((p) => p.district_id === district_id);
+      if (!grant) {
+        log.warn('District admin tried to create tech admin outside their district', {
+          userId,
+          requestedDistrict: district_id,
+          adminDistricts: adminPermissions.map((p) => p.district_id),
+        });
+        return NextResponse.json(
+          { error: 'District is not one you administer' },
+          { status: 403 }
+        );
+      }
+    } else if (adminPermissions.length === 1) {
+      grant = adminPermissions[0];
+    } else {
+      return NextResponse.json(
+        { error: 'district_id is required when you administer multiple districts' },
+        { status: 400 }
+      );
+    }
+
+    const trimmedEmail = email.trim().toLowerCase();
+    const atIndex = trimmedEmail.indexOf('@');
+    const lastDotIndex = trimmedEmail.lastIndexOf('.');
+
+    if (
+      atIndex === -1 ||
+      atIndex === 0 ||
+      atIndex === trimmedEmail.length - 1 ||
+      lastDotIndex === -1 ||
+      lastDotIndex < atIndex ||
+      lastDotIndex === trimmedEmail.length - 1 ||
+      trimmedEmail.includes(' ') ||
+      trimmedEmail.length > 254
+    ) {
+      return NextResponse.json({ error: 'Invalid email format' }, { status: 400 });
+    }
+
+    const adminClient = createServiceClient();
+
+    const { data: district, error: districtError } = await adminClient
+      .from('districts')
+      .select('id, name, state_id')
+      .eq('id', grant.district_id!)
+      .single();
+
+    if (districtError || !district) {
+      log.error('District lookup failed for tech admin creation', districtError);
+      return NextResponse.json({ error: 'District not found' }, { status: 404 });
+    }
+
+    const { data: existingUsers } = await adminClient.auth.admin.listUsers();
+    const existingUser = existingUsers?.users?.find(
+      (u) => u.email?.toLowerCase() === trimmedEmail
+    );
+
+    if (existingUser) {
+      return NextResponse.json(
+        { error: 'An account with this email already exists' },
+        { status: 409 }
+      );
+    }
+
+    const temporaryPassword = generateTemporaryPassword();
+    const fullName = `${first_name.trim()} ${last_name.trim()}`;
+
+    log.info('District admin creating tech admin', {
+      districtId: district.id,
+      districtName: district.name,
+      email: trimmedEmail,
+      createdBy: userId,
+    });
+
+    const { data: authUser, error: createUserError } = await adminClient.auth.admin.createUser({
+      email: trimmedEmail,
+      password: temporaryPassword,
+      email_confirm: true,
+      user_metadata: {
+        full_name: fullName,
+        role: 'district_tech',
+        created_by_admin: true,
+      },
+    });
+
+    if (createUserError || !authUser.user) {
+      log.error('Failed to create auth user for tech admin', createUserError);
+      return NextResponse.json(
+        { error: createUserError?.message || 'Failed to create auth account' },
+        { status: 500 }
+      );
+    }
+
+    try {
+      const { error: profileError } = await adminClient.rpc('create_profile_for_new_user', {
+        user_id: authUser.user.id,
+        user_email: authUser.user.email!,
+        user_metadata: {
+          full_name: fullName,
+          role: 'district_tech',
+          school_site: '',
+          school_district: district.name,
+          state: '',
+          works_at_multiple_schools: false,
+          additional_schools: [],
+        },
+      });
+
+      if (profileError) {
+        throw new Error(`Profile creation failed: ${profileError.message}`);
+      }
+
+      // The RPC resolves scope by fuzzy NAME matching (find_school_ids_by_names).
+      // Pin the authoritative ids from the caller's grant instead of trusting
+      // that match, and force the temp password to be rotated at first login.
+      const { error: updateError } = await adminClient
+        .from('profiles')
+        .update({
+          district_id: grant.district_id,
+          state_id: grant.state_id,
+          school_id: null,
+          must_change_password: true,
+        })
+        .eq('id', authUser.user.id);
+
+      if (updateError) {
+        throw new Error(`Profile scoping update failed: ${updateError.message}`);
+      }
+
+      // Both CHECK constraints on admin_permissions must be satisfied:
+      // the role enum, and the pairing rule (district_tech => district_id NOT NULL).
+      const { error: permissionError } = await adminClient
+        .from('admin_permissions')
+        .insert({
+          admin_id: authUser.user.id,
+          role: 'district_tech',
+          school_id: null,
+          district_id: grant.district_id,
+          state_id: grant.state_id,
+        });
+
+      if (permissionError) {
+        throw new Error(`Admin permission creation failed: ${permissionError.message}`);
+      }
+
+      log.info('Tech admin created successfully', {
+        techAdminId: authUser.user.id,
+        districtId: district.id,
+        createdBy: userId,
+      });
+
+      return NextResponse.json({
+        success: true,
+        techAdmin: {
+          id: authUser.user.id,
+          email: trimmedEmail,
+          full_name: fullName,
+          district_id: grant.district_id,
+        },
+        credentials: {
+          email: trimmedEmail,
+          temporaryPassword,
+        },
+      });
+    } catch (rollbackError) {
+      log.error('Rolling back tech admin auth user creation', rollbackError);
+
+      await adminClient.auth.admin.deleteUser(authUser.user.id);
+
+      return NextResponse.json(
+        {
+          error:
+            rollbackError instanceof Error
+              ? rollbackError.message
+              : 'Failed to complete account creation',
+        },
+        { status: 500 }
+      );
+    }
+  } catch (error) {
+    log.error('Unexpected error in create tech admin', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+});

--- a/app/api/internal/create-admin-account/route.ts
+++ b/app/api/internal/create-admin-account/route.ts
@@ -181,6 +181,18 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
         })
         .eq('id', newUserId);
 
+      if (updateError && adminType === 'district_tech') {
+        // Fatal for this role only. Both things this update carries are
+        // load-bearing for district_tech and for nothing else here:
+        // `district_id` is what makes the account visible to its district admin
+        // (profiles_select's district branch, SPE-394), and
+        // `must_change_password` is the forced rotation. A district_tech that
+        // silently skipped this would exist, authorize correctly via
+        // admin_permissions, and still be invisible with an un-rotated temp
+        // password — the worst of both. Throwing rolls the auth user back.
+        throw new Error(`Profile scoping update failed: ${updateError.message}`);
+      }
+
       if (updateError) {
         log.warn('Failed to update profile with NCES IDs', { error: updateError });
         // Non-fatal - profile was still created

--- a/app/api/internal/create-admin-account/route.ts
+++ b/app/api/internal/create-admin-account/route.ts
@@ -62,9 +62,13 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
     // Normalize email to lowercase for consistency
     const normalizedEmail = email.toLowerCase().trim();
 
-    if (adminType !== 'district_admin' && adminType !== 'site_admin') {
+    if (
+      adminType !== 'district_admin' &&
+      adminType !== 'site_admin' &&
+      adminType !== 'district_tech'
+    ) {
       return NextResponse.json(
-        { error: 'Invalid admin type. Must be district_admin or site_admin' },
+        { error: 'Invalid admin type. Must be district_admin, site_admin or district_tech' },
         { status: 400 }
       );
     }
@@ -169,6 +173,11 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
           state_id: stateId,
           district_id: districtId,
           school_id: adminType === 'site_admin' ? schoolId : null,
+          // district_tech must behave identically however it is minted, so it
+          // gets the same forced rotation as the district-admin route (SPE-394).
+          // Deliberately not applied to the pre-existing admin types here —
+          // changing their behavior is SPE-364's call, not this ticket's.
+          ...(adminType === 'district_tech' ? { must_change_password: true } : {}),
         })
         .eq('id', newUserId);
 

--- a/app/components/internal/admin-credentials-modal.tsx
+++ b/app/components/internal/admin-credentials-modal.tsx
@@ -7,7 +7,7 @@ interface AdminCredentialsModalProps {
     email: string;
     fullName: string;
     temporaryPassword: string;
-    adminType: 'district_admin' | 'site_admin';
+    adminType: 'district_admin' | 'site_admin' | 'district_tech';
   };
   onClose: () => void;
 }
@@ -37,7 +37,12 @@ export function AdminCredentialsModal({ admin, onClose }: AdminCredentialsModalP
     }
   };
 
-  const adminTypeLabel = admin.adminType === 'district_admin' ? 'District Admin' : 'Site Admin';
+  const adminTypeLabel =
+    admin.adminType === 'district_admin'
+      ? 'District Admin'
+      : admin.adminType === 'district_tech'
+        ? 'District Tech Admin'
+        : 'Site Admin';
 
   return (
     <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -225,6 +225,33 @@ why SPE-320 shipped broken with three green test files.
 **Source of truth:** `supabase/migrations/20260724_fix_profiles_update_rls_recursion.sql`;
 live `profiles_update` policy + `profiles_guard_immutable_columns` trigger.
 
+### `profiles_select`: school-scoped, plus a district branch (SPE-394)
+
+Most branches of `profiles_select` find people by **school** — the school-ids
+union, providers-at-my-schools, the site-admin branch, and the district admin's
+"anyone at a school in my district" branch. That works for everyone who has a
+school, and silently fails for everyone who doesn't.
+
+`district_tech` has `school_id IS NULL` by design, so the district-admin branch
+(which joins `schools.id = profiles.school_id`) could never match it: a district
+admin could not see the tech admin they had just created. Verified live — 0 rows,
+against a control teacher in the same district returning 1. The same blind spot
+applied to `district_admin` profiles, which are equally school-less.
+
+A district branch now sits alongside the school one, matching
+`ap.district_id = profiles.district_id` for a `district_admin` caller. The
+widening is bounded to the caller's own grant rows, and the guard pins where it
+stops: a site admin still cannot see the tech admin, the tech admin gains no
+extra reads, and nothing crosses district lines.
+
+**Generalisation worth remembering:** a policy written in terms of `school_id` is
+invisible to district-scoped roles. When adding a role without a school, check
+every policy that identifies people by school — absence of a match reads exactly
+like "no permission", so it fails quietly rather than loudly.
+
+**Source of truth:** `supabase/migrations/20260806_spe394_profiles_select_district_scope.sql`;
+guarded by `npm run sim:verify-rls` ("district-scoped profile visibility").
+
 ### Route-guard matrix (from `middleware.ts`)
 
 | Path prefix | Who's allowed | Else → |
@@ -389,8 +416,21 @@ flowchart TD
   `app/(dashboard)/dashboard/admin/create-account/page.tsx` is the single UI
   entry point, and it picks its route by the admin's scope and the account type:
   `/api/admin/district/teachers`, `/api/admin/district/providers`, or
-  `/api/admin/create-teacher-account`. (`/api/admin/district/site-admin` and
-  `/api/internal/create-admin-account` cover the admin-creating-an-admin cases.)
+  `/api/admin/create-teacher-account`. (`/api/admin/district/site-admin`,
+  `/api/admin/district/tech-admin` and `/api/internal/create-admin-account`
+  cover the admin-creating-an-admin cases.)
+- **`district_tech` is the exception to the paragraph above (SPE-394).**
+  `/api/admin/district/tech-admin` **does** set `must_change_password: true` at
+  creation, so its temp password is force-rotated at first login — verified live:
+  the account is redirected to `/change-password`, cannot reach `/dashboard/tech`
+  until it rotates, and lands there once it does. The middleware ordering this
+  relies on is load-bearing: the `must_change_password` check (`middleware.ts`
+  ~line 107) runs **before** the `district_tech` route pinning (~line 149), so
+  the rotation wins over the role's portal redirect. `/internal` sets the same
+  flag for this role so it behaves identically however it is minted. The
+  pre-existing roles are deliberately unchanged here — that is SPE-364's call.
+  The creator is a **district admin**, not Speddy staff: the district's own admin
+  provisions their IT contact, with `/internal` as an onboarding fallback.
   **All of them** call `auth.admin.createUser` with `email_confirm: true`, so an
   admin-created user's email is pre-verified and they can use "Forgot password"
   on the sign-in page without ever having signed in — they don't need the temp

--- a/docs/CAPABILITIES_MATRIX.md
+++ b/docs/CAPABILITIES_MATRIX.md
@@ -324,12 +324,14 @@ The District tech column is an unbroken row of dashes by design, not by
 omission: the role's whole point is that connecting the SIS requires no access
 to anything the SIS is connected *for*.
 
-**Who creates the District tech account:** the district's own **district admin**,
-from the same "Create New Account" screen they already use for teachers and
-specialists — not Speddy staff, and not the tech person themselves. Site admins
-are not offered the option, because the role is district-wide and a site admin's
-authority stops at their school. The new account is handed a temporary password
-and must choose its own the first time it signs in.
+**Who creates the District tech account:** normally the district's own
+**district admin**, from the same "Create New Account" screen they already use
+for teachers and specialists — not the tech person themselves. Site admins are
+not offered the option, because the role is district-wide and a site admin's
+authority stops at their school. Speddy staff can also mint one from the
+internal onboarding tool as a fallback, which is how a district gets started
+before its own admin exists. Either way the new account is handed a temporary
+password and must choose its own the first time it signs in.
 
 ---
 

--- a/docs/CAPABILITIES_MATRIX.md
+++ b/docs/CAPABILITIES_MATRIX.md
@@ -324,6 +324,13 @@ The District tech column is an unbroken row of dashes by design, not by
 omission: the role's whole point is that connecting the SIS requires no access
 to anything the SIS is connected *for*.
 
+**Who creates the District tech account:** the district's own **district admin**,
+from the same "Create New Account" screen they already use for teachers and
+specialists — not Speddy staff, and not the tech person themselves. Site admins
+are not offered the option, because the role is district-wide and a site admin's
+authority stops at their school. The new account is handed a temporary password
+and must choose its own the first time it signs in.
+
 ---
 
 ## 4. Matrix — feature group × school level

--- a/scripts/sim-district/verify-profiles-rls.ts
+++ b/scripts/sim-district/verify-profiles-rls.ts
@@ -20,12 +20,17 @@
  *
  * Usage: npm run sim:verify-rls
  */
-import { requireEnv } from './lib';
+import { assertProjectRef, requireEnv } from './lib';
 import { DISTRICT, MAPLE, PERSONAS, derivePassword, simEmail } from './manifest';
 
 const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
 const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
 const secret = requireEnv('SIM_DISTRICT_PASSWORD');
+// Pin the Supabase host BEFORE reading the service-role key: assertProjectRef()
+// is what stops this credential being sent at some other project if the env is
+// wrong. createAdmin() calls it internally; this script sends the key over raw
+// fetch, so it has to assert explicitly first.
+assertProjectRef();
 const service = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
 
 interface Session {
@@ -226,15 +231,30 @@ async function main(): Promise<void> {
 
   // A site admin is school-scoped; the new branch is district_admin-only and
   // must not have handed them district-wide sight.
+  // status === 200 as well as the row count: readProfile returns rows: [] for
+  // ANY non-array body, so a 401 or 403 — an expired or never-established
+  // session — would satisfy a bare row-count assertion without the policy ever
+  // being consulted. Same false-pass class this file already guards for writes.
   const saSeesTech = await readProfile(siteAdmin, techId);
-  check(saSeesTech.rows.length === 0,
-    'site admin still cannot see the tech admin', `${saSeesTech.rows.length} row(s)`);
+  check(saSeesTech.status === 200 && saSeesTech.rows.length === 0,
+    'site admin still cannot see the tech admin',
+    `HTTP ${saSeesTech.status}, ${saSeesTech.rows.length} row(s)`);
 
   // The tech admin gains nothing: it holds a district grant, but with
   // role='district_tech', which no branch of the policy matches.
   const techSeesProvider = await readProfile(techAdmin, uid);
-  check(techSeesProvider.rows.length === 0,
-    'tech admin still cannot see other profiles', `${techSeesProvider.rows.length} row(s)`);
+  check(techSeesProvider.status === 200 && techSeesProvider.rows.length === 0,
+    'tech admin still cannot see a school-based profile',
+    `HTTP ${techSeesProvider.status}, ${techSeesProvider.rows.length} row(s)`);
+
+  // The provider above is school-scoped, so that check only proves the tech
+  // admin misses the SCHOOL branches. This one targets a school-less profile in
+  // its own district — the branch this PR actually added, and the one a district
+  // grant might plausibly have unlocked.
+  const techSeesDistrictAdmin = await readProfile(techAdmin, districtAdmin.user.id);
+  check(techSeesDistrictAdmin.status === 200 && techSeesDistrictAdmin.rows.length === 0,
+    'tech admin still cannot see a district-scoped profile',
+    `HTTP ${techSeesDistrictAdmin.status}, ${techSeesDistrictAdmin.rows.length} row(s)`);
 
   // Cross-district: the widening is pinned to the caller's own grant. This uses
   // a real, FK-valid foreign district — profiles.district_id is FK-constrained,
@@ -248,9 +268,9 @@ async function main(): Promise<void> {
   const foreignRows = (await foreign.json()) as Array<{ id: string }>;
   if (foreignRows?.length) {
     const crossRead = await readProfile(districtAdmin, foreignRows[0].id);
-    check(crossRead.rows.length === 0,
+    check(crossRead.status === 200 && crossRead.rows.length === 0,
       'district admin sees nothing in another district',
-      `${crossRead.rows.length} row(s) (target district=${FOREIGN_DISTRICT})`);
+      `HTTP ${crossRead.status}, ${crossRead.rows.length} row(s) (target district=${FOREIGN_DISTRICT})`);
   } else {
     check(false, 'fixture sanity: a profile exists in the foreign district',
       `none found in ${FOREIGN_DISTRICT} — check cannot run`);

--- a/scripts/sim-district/verify-profiles-rls.ts
+++ b/scripts/sim-district/verify-profiles-rls.ts
@@ -26,6 +26,7 @@ import { DISTRICT, MAPLE, PERSONAS, derivePassword, simEmail } from './manifest'
 const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
 const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
 const secret = requireEnv('SIM_DISTRICT_PASSWORD');
+const service = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
 
 interface Session {
   access_token: string;
@@ -76,6 +77,21 @@ async function patchProfile(
   };
 }
 
+/** Rows a session can SELECT from profiles for one target id. */
+async function readProfile(session: Session, targetId: string) {
+  const res = await fetch(`${url}/rest/v1/profiles?id=eq.${targetId}&select=id`, {
+    headers: { apikey: anon, Authorization: `Bearer ${session.access_token}` },
+  });
+  const text = await res.text();
+  let parsed: unknown = null;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    /* error bodies are not always JSON arrays */
+  }
+  return { status: res.status, rows: Array.isArray(parsed) ? parsed : [], body: text };
+}
+
 /**
  * Signature of a refusal from profiles_guard_immutable_columns: its SQLSTATE
  * plus the column list it names. Matching both proves the TRIGGER refused —
@@ -93,7 +109,7 @@ function check(ok: boolean, label: string, detail: string): void {
 }
 
 async function main(): Promise<void> {
-  const needed = ['rsp.willow', 'slp.itinerant', 'siteadmin.willow'];
+  const needed = ['rsp.willow', 'slp.itinerant', 'siteadmin.willow', 'district.admin', 'techadmin.district'];
   for (const local of needed) {
     if (!PERSONAS.some((p) => p.emailLocal === local)) {
       throw new Error(`persona '${local}' is no longer in the manifest — update this script`);
@@ -184,6 +200,60 @@ async function main(): Promise<void> {
     const byTrigger = !r.ok && refusedByTrigger(r.body);
     check(byTrigger, `site admin cannot set ${label}`,
       byTrigger ? `HTTP ${r.status} (trigger)` : `HTTP ${r.status} — ${r.body.slice(0, 90)}`);
+  }
+
+  // ---------------------------------------------------------------------
+  // SELECT visibility for DISTRICT-SCOPED staff (SPE-394).
+  //
+  // profiles_select's district-admin branch matches staff by SCHOOL. A
+  // `district_tech` has school_id IS NULL by design, so before SPE-394 that
+  // branch could never match and a district admin could not see the tech admin
+  // they had just created — verified live: 0 rows, against a control teacher
+  // returning 1. A district-scoped branch now covers school-less staff.
+  //
+  // The negatives below are the point: this widened what a district admin can
+  // read, so the guard has to pin where the widening STOPS.
+  // ---------------------------------------------------------------------
+  console.log('\ndistrict-scoped profile visibility:');
+
+  const districtAdmin = await signIn('district.admin');
+  const techAdmin = await signIn('techadmin.district');
+  const techId = techAdmin.user.id;
+
+  const daSeesTech = await readProfile(districtAdmin, techId);
+  check(daSeesTech.rows.length === 1,
+    'district admin sees the school-less tech admin', `${daSeesTech.rows.length} row(s)`);
+
+  // A site admin is school-scoped; the new branch is district_admin-only and
+  // must not have handed them district-wide sight.
+  const saSeesTech = await readProfile(siteAdmin, techId);
+  check(saSeesTech.rows.length === 0,
+    'site admin still cannot see the tech admin', `${saSeesTech.rows.length} row(s)`);
+
+  // The tech admin gains nothing: it holds a district grant, but with
+  // role='district_tech', which no branch of the policy matches.
+  const techSeesProvider = await readProfile(techAdmin, uid);
+  check(techSeesProvider.rows.length === 0,
+    'tech admin still cannot see other profiles', `${techSeesProvider.rows.length} row(s)`);
+
+  // Cross-district: the widening is pinned to the caller's own grant. This uses
+  // a real, FK-valid foreign district — profiles.district_id is FK-constrained,
+  // so an invented id silently lands NULL and a NULL district matches nothing,
+  // which would make this negative pass no matter what the policy said.
+  const FOREIGN_DISTRICT = '0618990'; // John Swett Unified
+  const foreign = await fetch(
+    `${url}/rest/v1/profiles?district_id=eq.${FOREIGN_DISTRICT}&select=id&limit=1`,
+    { headers: { apikey: service, Authorization: `Bearer ${service}` } },
+  );
+  const foreignRows = (await foreign.json()) as Array<{ id: string }>;
+  if (foreignRows?.length) {
+    const crossRead = await readProfile(districtAdmin, foreignRows[0].id);
+    check(crossRead.rows.length === 0,
+      'district admin sees nothing in another district',
+      `${crossRead.rows.length} row(s) (target district=${FOREIGN_DISTRICT})`);
+  } else {
+    check(false, 'fixture sanity: a profile exists in the foreign district',
+      `none found in ${FOREIGN_DISTRICT} — check cannot run`);
   }
 
   if (failures === 0) {

--- a/supabase/migrations/20260806_spe394_profiles_select_district_scope.sql
+++ b/supabase/migrations/20260806_spe394_profiles_select_district_scope.sql
@@ -80,7 +80,14 @@ USING (
         WHERE ap.admin_id = (SELECT auth.uid())
           AND ap.role = 'district_admin'
           AND ap.district_id IS NOT NULL
-          AND (ap.district_id)::text = (profiles.district_id)::text))
+          AND (ap.district_id)::text = (profiles.district_id)::text
+          -- school-less only. Staff WITH a school in this district are already
+          -- covered by the branch above, so without this the branch would also
+          -- match a profile whose district_id says one district while its
+          -- school_id points at another's school — inconsistent data nobody
+          -- should be granted sight of. Keeps the policy equal to its stated
+          -- intent rather than merely a superset of it. (CodeRabbit, PR #805.)
+          AND profiles.school_id IS NULL))
 
   -- site admin: my school, or a provider serving my school
   OR (EXISTS (

--- a/supabase/migrations/20260806_spe394_profiles_select_district_scope.sql
+++ b/supabase/migrations/20260806_spe394_profiles_select_district_scope.sql
@@ -39,10 +39,15 @@
 
 DROP POLICY IF EXISTS profiles_select ON public.profiles;
 
+-- TO authenticated, NOT public. 20260531_scope_public_select_policies_to_authenticated.sql
+-- deliberately narrowed this policy to `authenticated`; a DROP + CREATE without
+-- restating that silently reverts the hardening, because CREATE POLICY defaults
+-- to `public`. Caught in review (Codex, PR #805) after exactly that happened —
+-- the live policy had gone back to {public}.
 CREATE POLICY profiles_select
 ON public.profiles
 FOR SELECT
-TO public
+TO authenticated
 USING (
   -- own row
   (id = (SELECT auth.uid()))

--- a/supabase/migrations/20260806_spe394_profiles_select_district_scope.sql
+++ b/supabase/migrations/20260806_spe394_profiles_select_district_scope.sql
@@ -1,0 +1,92 @@
+-- SPE-394: let a district admin see the district-scoped staff in their own
+-- district — including the District Tech Admin they just created.
+--
+-- THE GAP. `profiles_select`'s district-admin branch matches staff by SCHOOL:
+--
+--   EXISTS (SELECT 1 FROM admin_permissions ap
+--             JOIN schools s ON s.district_id = ap.district_id
+--            WHERE ap.admin_id = auth.uid()
+--              AND ap.role = 'district_admin'
+--              AND s.id = profiles.school_id)
+--
+-- `district_tech` has `school_id IS NULL` by design, so `s.id = NULL` never
+-- matches and the account is invisible to the very admin who created it.
+-- Verified against live RLS before writing this: Dana (sim district admin) read
+-- 0 rows for Theo (district_tech, same district), while the control — a
+-- school-based teacher in that district — returned 1 row.
+--
+-- The same blind spot already applies to `district_admin` profiles, which are
+-- equally school-less; district admins cannot see each other today.
+--
+-- THE FIX. Add a branch that matches on the DISTRICT the caller administers,
+-- alongside the existing school branch rather than replacing it:
+--
+--   ap.role = 'district_admin' AND ap.district_id = profiles.district_id
+--
+-- Scope of the widening (owner-approved): a district admin additionally sees
+-- profiles in their OWN district that carry no school. Nothing crosses district
+-- lines — the predicate is pinned to the caller's own grant rows, and a NULL
+-- district_id on either side does not match.
+--
+-- No recursion risk: the new branch reads `admin_permissions`, not `profiles`.
+-- That is the same table the existing branches already consult, so this adds no
+-- new policy edge. (SPE-332 is the cautionary tale — `profiles_update` was
+-- recursive and silently broke every self-serve profile write for ~7 months.)
+--
+-- Everything else in the policy is carried over verbatim: self-read, the
+-- school-ids union, providers-at-my-schools, the original district-admin school
+-- branch, and the site-admin branch.
+
+DROP POLICY IF EXISTS profiles_select ON public.profiles;
+
+CREATE POLICY profiles_select
+ON public.profiles
+FOR SELECT
+TO public
+USING (
+  -- own row
+  (id = (SELECT auth.uid()))
+
+  -- anyone at a school I'm scoped to
+  OR ((school_id)::text IN (
+        SELECT get_my_school_ids.school_id
+        FROM get_my_school_ids() get_my_school_ids(school_id)))
+
+  -- providers serving my schools
+  OR (id IN (
+        SELECT get_providers_at_my_schools.provider_id
+        FROM get_providers_at_my_schools() get_providers_at_my_schools(provider_id)))
+
+  -- district admin: anyone at a school in a district I administer
+  OR (EXISTS (
+        SELECT 1
+        FROM admin_permissions ap
+          JOIN schools s ON ((s.district_id)::text = (ap.district_id)::text)
+        WHERE ap.admin_id = (SELECT auth.uid())
+          AND ap.role = 'district_admin'
+          AND (s.id)::text = (profiles.school_id)::text))
+
+  -- district admin: district-scoped staff in a district I administer (SPE-394).
+  -- This is the branch that school-less roles — district_tech, and fellow
+  -- district admins — fall through to.
+  OR (EXISTS (
+        SELECT 1
+        FROM admin_permissions ap
+        WHERE ap.admin_id = (SELECT auth.uid())
+          AND ap.role = 'district_admin'
+          AND ap.district_id IS NOT NULL
+          AND (ap.district_id)::text = (profiles.district_id)::text))
+
+  -- site admin: my school, or a provider serving my school
+  OR (EXISTS (
+        SELECT 1
+        FROM admin_permissions ap
+        WHERE ap.admin_id = (SELECT auth.uid())
+          AND ap.role = 'site_admin'
+          AND (((ap.school_id)::text = (profiles.school_id)::text)
+               OR (EXISTS (
+                     SELECT 1
+                     FROM provider_schools ps
+                     WHERE ps.provider_id = profiles.id
+                       AND (ps.school_id)::text = (ap.school_id)::text)))))
+);


### PR DESCRIPTION
Closes SPE-394 — third ticket of epic SPE-392, after SPE-393 (the role) and SPE-399 (the escalation fix found while auditing it).

Makes the role reachable in the real world. Until now a `district_tech` could only be minted by script — fine for the sim fixture, useless for JSUSD.

## What's here

**New route: `POST /api/admin/district/tech-admin`**, mirroring `../site-admin/route.ts`, with two deliberate differences:

1. **No school.** The role is district-scoped, so there's no school to resolve the grant from. A caller holding several district grants must name the target district; one grant is defaulted. The district is always matched against **the caller's own grants** — the body selects among them, it never introduces a new one.
2. **`must_change_password` is set at creation.** The other admin-creation flows hand out a temp password that is never force-rotated (SPE-190 / SPE-364); this one doesn't inherit that gap. `/internal` sets the same flag **for this role only**, so the account behaves identically however it's minted — the pre-existing admin types are deliberately untouched, that being SPE-364's call.

`create_profile_for_new_user` resolves scope by fuzzy **name** matching (`find_school_ids_by_names`), so the route pins `district_id` / `state_id` from the grant afterwards rather than trusting that match.

**UI** — "District Tech Admin" is a third account type on the existing create-account page, rendered **only** for district admins (a site admin's authority stops at their school). `/internal` gains the same option as an onboarding fallback.

## The RLS gap this surfaced

The ticket asked me to *verify* that district admins can see the new account in their staff listings. They couldn't.

Every branch of `profiles_select` identifies people by **school** — including the district admin's, which joins `schools.id = profiles.school_id`. `district_tech` has `school_id IS NULL` by design, so that branch can never match: **a district admin could not see the tech admin they had just created.** Confirmed live rather than by reading — 0 rows, against a control teacher in the same district returning 1. The same blind spot already hid `district_admin` profiles from each other.

A district branch now sits alongside the school one (`ap.district_id = profiles.district_id`, `district_admin` callers only), bounded to the caller's own grant rows. **Owner-approved**, since it widens what a district admin can read.

> **Generalisation worth keeping:** a policy written in terms of `school_id` is invisible to district-scoped roles. Absence of a match reads exactly like "no permission", so it fails *quietly* — the failure mode is a feature that looks shipped and isn't.

## Verification

**14/14 through the real UI**, with real signed-in sessions:
- Dana (district admin) sees the new account type, fills the form, creates the account;
- profile is `district_tech`, district-scoped with **no** school, `must_change_password: true`; the `admin_permissions` row carries `district_tech` + district;
- **she can now see it** (the RLS fix);
- the generated password is read **off the real credentials modal** — not injected — and used to sign in;
- first login is forced to `/change-password`; `/dashboard/tech` is **unreachable** until rotation; after rotating it lands there;
- a **site admin is never offered** the option.

That last chain depends on middleware ordering that is load-bearing: the `must_change_password` check (~line 107) runs **before** the `district_tech` route pinning (~line 149), so rotation wins over the role's portal redirect. Same class of ordering hazard as the CARE early-return in SPE-393.

**Permanent guard** — `sim:verify-rls` gains a "district-scoped profile visibility" section pinning where the widening stops: site admin still blind to the tech admin, tech admin gains nothing, nothing crosses district lines.

**Also green:** all six sim verifications (`sim:verify`, `verify-rls`, `provider-schools`, `multi-school`, `children`, `special-activities`), typecheck, lint, 713 unit tests.

## Two mistakes I made and corrected

Both are the same species — *a check that passes for the wrong reason* — and both are worth the reviewer's attention because neither was visible in the output:

1. **My walk's positive assertions passed against stale data.** Reusing a fixed email meant run 2 hit "account already exists", silently kept run 1's row, and every DB assertion passed against it. The account creation had actually **failed**. Now a unique email per run, and cleanup that is itself asserted.
2. **The cleanup was silently failing.** `deleteUser` errors were ignored — and it *was* erroring, because `profiles.id` references `auth.users(id)` with **no cascade**, so the profile row blocks the auth delete. Fixed by deleting `admin_permissions` → `profiles` → auth user, the order `teardown.ts` already uses.

The same trap bit the cross-district negative: `profiles.district_id` is FK-constrained, so my invented foreign district id landed `NULL`, and a NULL district matches nothing regardless of policy — the check was vacuous. It now uses a real district and asserts the fixture genuinely is foreign before trusting the negative.

## Reviewer notes

The two places where a plausible-looking change silently grants access: the district resolution in the new route (the body must never widen scope beyond the caller's grants), and the new `profiles_select` branch.

Not in scope, unchanged: admin accounts still have no edit/PATCH surface (SPE-365), and `must_change_password` on the pre-existing admin types (SPE-364).

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9wB9cKyt21z79WXbhyFtp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * District admins can create District Tech Admin accounts and view temporary credentials.
  * Added District Tech Admin as an account type for SIS integrations only.
  * New accounts must set a personal password on first sign-in.
  * District admins can view eligible tech-admin profiles within their district.
  * Site admins and tech users cannot create District Tech Admin accounts.

* **Documentation**
  * Updated account-creation, permissions, and profile-visibility documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->