### PR TITLE
SPE-395: per-district SIS credential store, encrypted at rest, behind a DPA gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,15 @@ SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 # openssl rand -base64 32
 # CALENDAR_TOKEN_ENCRYPTION_KEY=your-base64-32-byte-key
 
+# SIS Integration (Aeries / OneRoster)
+# App-layer AES-256-GCM key for district SIS credentials at rest (32 bytes,
+# base64): openssl rand -base64 32
+# Deliberately SEPARATE from CALENDAR_TOKEN_ENCRYPTION_KEY — these protect
+# different data classes with different blast radii, and either must be
+# rotatable without touching the other. Required before any district can
+# submit SIS credentials; credential intake fails closed without it.
+# SIS_CREDENTIAL_ENCRYPTION_KEY=your-base64-32-byte-key
+
 # AI Services (Optional)
 ANTHROPIC_API_KEY=your-anthropic-api-key
 OPENAI_API_KEY=your-openai-api-key

--- a/__tests__/unit/lib/sis/connections.test.ts
+++ b/__tests__/unit/lib/sis/connections.test.ts
@@ -1,0 +1,464 @@
+/**
+ * SPE-395 · lib/sis/connections — the credential store's app-layer gates.
+ *
+ * These tests deliberately do NOT claim anything about RLS or column grants:
+ * the Supabase client is mocked, so a mocked write "succeeds" whether or not
+ * the database would have permitted it. That half is covered by
+ * `npm run sim:verify-sis-rls` against a real signed-in session.
+ *
+ * What IS testable here is everything the module decides before the database
+ * sees it, and every one of these is a rule that only exists in this file:
+ *   - a credential is never stored without a recorded DPA;
+ *   - which column a secret lands in comes from the stored row, never the
+ *     caller;
+ *   - what reaches the database is ciphertext, and the hint is only a mask;
+ *   - a stored credential invalidates the previous test result;
+ *   - revoking a DPA takes the credentials with it.
+ */
+import { randomBytes } from 'crypto';
+
+const CONNECTION_ID = '33333333-3333-4333-8333-333333333333';
+const ACTOR_ID = '11111111-1111-4111-8111-111111111111';
+const DISTRICT_ID = '0618990';
+
+interface QueryRecord {
+  table: string;
+  op: 'select' | 'insert' | 'update';
+  select?: string;
+  values?: Record<string, unknown>;
+  eq?: [string, unknown];
+}
+
+const results: Array<{ data: unknown; error: unknown }> = [];
+const calls: QueryRecord[] = [];
+
+function nextResult() {
+  const result = results.shift();
+  if (!result) throw new Error('mock supabase: no result queued for this query');
+  return Promise.resolve(result);
+}
+
+function builder(record: QueryRecord): any {
+  const chain: any = {
+    select: (cols: string) => {
+      record.select = cols;
+      return chain;
+    },
+    insert: (values: Record<string, unknown>) => {
+      record.op = 'insert';
+      record.values = values;
+      return chain;
+    },
+    update: (values: Record<string, unknown>) => {
+      record.op = 'update';
+      record.values = values;
+      return chain;
+    },
+    eq: (col: string, val: unknown) => {
+      record.eq = [col, val];
+      return chain;
+    },
+    order: () => nextResult(),
+    single: () => nextResult(),
+    maybeSingle: () => nextResult(),
+    // `.update().eq()` is awaited directly, with no terminal method.
+    then: (resolve: any, reject: any) => nextResult().then(resolve, reject),
+  };
+  return chain;
+}
+
+jest.mock('@/lib/supabase/server', () => ({
+  createServiceClient: () => ({
+    from: (table: string) => {
+      const record: QueryRecord = { table, op: 'select' };
+      calls.push(record);
+      return builder(record);
+    },
+  }),
+}));
+
+const mockAudit = jest.fn(async () => {});
+jest.mock('@/lib/supabase/audit-log-server', () => ({
+  logServerAuditEvent: (...args: unknown[]) => mockAudit(...(args as [])),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+  },
+}));
+
+import {
+  disconnect,
+  getConnection,
+  listConnections,
+  recordTestResult,
+  setDpaCleared,
+  storeCredential,
+} from '@/lib/sis/connections';
+import { decryptSisCredential } from '@/lib/sis/credential-crypto';
+
+const CREDENTIAL_COLUMNS = [
+  'aeries_certificate_encrypted',
+  'oneroster_client_id_encrypted',
+  'oneroster_client_secret_encrypted',
+];
+
+const summaryRow = (over: Record<string, unknown> = {}) => ({
+  id: CONNECTION_ID,
+  district_id: DISTRICT_ID,
+  sis_type: 'aeries',
+  base_url: null,
+  token_url: null,
+  credential_hint: null,
+  status: 'testing',
+  dpa_cleared_at: '2026-08-01T00:00:00.000Z',
+  last_tested_at: null,
+  last_test_result: null,
+  created_by: ACTOR_ID,
+  created_at: '2026-08-01T00:00:00.000Z',
+  updated_at: '2026-08-01T00:00:00.000Z',
+  ...over,
+});
+
+describe('lib/sis/connections', () => {
+  const originalKey = process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+
+  beforeEach(() => {
+    results.length = 0;
+    calls.length = 0;
+    mockAudit.mockClear();
+    process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = randomBytes(32).toString('base64');
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+    else process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = originalKey;
+  });
+
+  describe('reads never ask for a credential column', () => {
+    it('listConnections selects only granted columns', async () => {
+      results.push({ data: [summaryRow()], error: null });
+      await listConnections(DISTRICT_ID);
+
+      expect(calls[0].select).toBeDefined();
+      for (const col of CREDENTIAL_COLUMNS) {
+        expect(calls[0].select).not.toContain(col);
+      }
+      // `*` would expand to columns the browser grant excludes, and would also
+      // pull ciphertext into server memory for a status read.
+      expect(calls[0].select).not.toBe('*');
+    });
+
+    it('getConnection selects only granted columns', async () => {
+      results.push({ data: summaryRow(), error: null });
+      await getConnection(CONNECTION_ID);
+
+      for (const col of CREDENTIAL_COLUMNS) {
+        expect(calls[0].select).not.toContain(col);
+      }
+    });
+  });
+
+  describe('storeCredential — the DPA gate', () => {
+    it('refuses when no DPA is recorded, without writing', async () => {
+      results.push({ data: summaryRow({ dpa_cleared_at: null }), error: null });
+
+      await expect(
+        storeCredential({
+          connectionId: CONNECTION_ID,
+          actorId: ACTOR_ID,
+          certificate: 'aeries-cert-value-1234',
+        })
+      ).rejects.toThrow(/no recorded DPA/i);
+
+      expect(calls.filter((c) => c.op === 'update')).toHaveLength(0);
+      expect(mockAudit).not.toHaveBeenCalled();
+    });
+
+    it('refuses when the connection does not exist', async () => {
+      results.push({ data: null, error: null });
+
+      await expect(
+        storeCredential({
+          connectionId: CONNECTION_ID,
+          actorId: ACTOR_ID,
+          certificate: 'aeries-cert-value-1234',
+        })
+      ).rejects.toThrow('SIS connection not found');
+
+      expect(calls.filter((c) => c.op === 'update')).toHaveLength(0);
+    });
+
+    it('refuses before touching the database when the key is unconfigured', async () => {
+      delete process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+
+      await expect(
+        storeCredential({
+          connectionId: CONNECTION_ID,
+          actorId: ACTOR_ID,
+          certificate: 'aeries-cert-value-1234',
+        })
+      ).rejects.toThrow(/SIS_CREDENTIAL_ENCRYPTION_KEY is not configured/);
+
+      // Not one query: a misconfigured environment must not leave a row in a
+      // half-written state.
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  describe('storeCredential — what reaches the database', () => {
+    it('writes ciphertext, never the plaintext secret', async () => {
+      const CERT = 'aeries-certificate-supersecret-a9f2';
+      results.push({ data: summaryRow(), error: null });
+      results.push({ data: summaryRow({ credential_hint: '••••a9f2' }), error: null });
+
+      await storeCredential({
+        connectionId: CONNECTION_ID,
+        actorId: ACTOR_ID,
+        certificate: CERT,
+      });
+
+      const write = calls.find((c) => c.op === 'update')!;
+      const stored = write.values!.aeries_certificate_encrypted as string;
+
+      expect(stored).not.toContain(CERT);
+      expect(stored).toMatch(/^v1\./);
+      expect(decryptSisCredential(stored)).toBe(CERT);
+
+      // The whole serialized patch must not carry the secret anywhere — a hint
+      // built from the wrong slice would leak it right past the ciphertext check.
+      expect(JSON.stringify(write.values)).not.toContain(CERT);
+      expect(write.values!.credential_hint).toBe('••••a9f2');
+    });
+
+    it('invalidates the previous test result', async () => {
+      // A rotation must not inherit "connected, tested last Tuesday" — that
+      // would vouch for a credential that has never been tried.
+      results.push({
+        data: summaryRow({ status: 'connected', credential_hint: '••••0000' }),
+        error: null,
+      });
+      results.push({ data: summaryRow(), error: null });
+
+      await storeCredential({
+        connectionId: CONNECTION_ID,
+        actorId: ACTOR_ID,
+        certificate: 'aeries-cert-value-1234',
+      });
+
+      const write = calls.find((c) => c.op === 'update')!;
+      expect(write.values!.status).toBe('testing');
+      expect(write.values!.last_tested_at).toBeNull();
+      expect(write.values!.last_test_result).toBeNull();
+    });
+
+    it('takes sis_type from the stored row, not the caller', async () => {
+      // The row is aeries. A caller sending OneRoster fields must be refused
+      // rather than having them written into OneRoster columns on an Aeries row.
+      results.push({ data: summaryRow({ sis_type: 'aeries' }), error: null });
+
+      await expect(
+        storeCredential({
+          connectionId: CONNECTION_ID,
+          actorId: ACTOR_ID,
+          clientId: 'client-id',
+          clientSecret: 'client-secret',
+        })
+      ).rejects.toThrow(/requires a certificate/i);
+
+      expect(calls.filter((c) => c.op === 'update')).toHaveLength(0);
+    });
+
+    it('requires both halves of a OneRoster pair', async () => {
+      results.push({ data: summaryRow({ sis_type: 'oneroster' }), error: null });
+
+      await expect(
+        storeCredential({
+          connectionId: CONNECTION_ID,
+          actorId: ACTOR_ID,
+          clientId: 'client-id-only',
+        })
+      ).rejects.toThrow(/client id and a client secret/i);
+
+      expect(calls.filter((c) => c.op === 'update')).toHaveLength(0);
+    });
+
+    it('hints from the OneRoster secret, and encrypts both halves', async () => {
+      const ID = 'oneroster-client-id-aaaa';
+      const SECRET = 'oneroster-client-secret-bbbb';
+      results.push({ data: summaryRow({ sis_type: 'oneroster' }), error: null });
+      results.push({ data: summaryRow({ sis_type: 'oneroster' }), error: null });
+
+      await storeCredential({
+        connectionId: CONNECTION_ID,
+        actorId: ACTOR_ID,
+        clientId: ID,
+        clientSecret: SECRET,
+      });
+
+      const write = calls.find((c) => c.op === 'update')!;
+      expect(decryptSisCredential(write.values!.oneroster_client_id_encrypted as string)).toBe(ID);
+      expect(
+        decryptSisCredential(write.values!.oneroster_client_secret_encrypted as string)
+      ).toBe(SECRET);
+      expect(write.values!.credential_hint).toBe('••••bbbb');
+      expect(JSON.stringify(write.values)).not.toContain(SECRET);
+    });
+  });
+
+  describe('storeCredential — audit trail', () => {
+    it('logs a first-time store as stored', async () => {
+      results.push({ data: summaryRow({ credential_hint: null }), error: null });
+      results.push({ data: summaryRow(), error: null });
+
+      await storeCredential({
+        connectionId: CONNECTION_ID,
+        actorId: ACTOR_ID,
+        certificate: 'aeries-cert-value-1234',
+      });
+
+      expect(mockAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'sis_credential_stored', user_id: ACTOR_ID })
+      );
+    });
+
+    it('logs a replacement as rotated', async () => {
+      results.push({ data: summaryRow({ credential_hint: '••••0000' }), error: null });
+      results.push({ data: summaryRow(), error: null });
+
+      await storeCredential({
+        connectionId: CONNECTION_ID,
+        actorId: ACTOR_ID,
+        certificate: 'aeries-cert-value-1234',
+      });
+
+      expect(mockAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'sis_credential_rotated' })
+      );
+    });
+
+    it('never puts a credential in the audit metadata', async () => {
+      const CERT = 'aeries-certificate-supersecret-a9f2';
+      results.push({ data: summaryRow(), error: null });
+      results.push({ data: summaryRow(), error: null });
+
+      await storeCredential({
+        connectionId: CONNECTION_ID,
+        actorId: ACTOR_ID,
+        certificate: CERT,
+      });
+
+      expect(JSON.stringify(mockAudit.mock.calls)).not.toContain(CERT);
+    });
+  });
+
+  describe('setDpaCleared', () => {
+    it('revoking takes the credentials and the test result with it', async () => {
+      results.push({ data: { id: CONNECTION_ID, status: 'connected' }, error: null });
+      results.push({ data: null, error: null });
+
+      await setDpaCleared({ connectionId: CONNECTION_ID, actorId: ACTOR_ID, cleared: false });
+
+      const write = calls.find((c) => c.op === 'update')!;
+      expect(write.values!.dpa_cleared_at).toBeNull();
+      for (const col of CREDENTIAL_COLUMNS) {
+        expect(write.values![col]).toBeNull();
+      }
+      expect(write.values!.credential_hint).toBeNull();
+      expect(write.values!.last_tested_at).toBeNull();
+      expect(write.values!.status).toBe('pending_dpa');
+      expect(mockAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'sis_dpa_revoked' })
+      );
+    });
+
+    it('recording a DPA lifts a pending_dpa row to awaiting_credentials', async () => {
+      results.push({ data: { id: CONNECTION_ID, status: 'pending_dpa' }, error: null });
+      results.push({ data: null, error: null });
+
+      await setDpaCleared({ connectionId: CONNECTION_ID, actorId: ACTOR_ID, cleared: true });
+
+      const write = calls.find((c) => c.op === 'update')!;
+      expect(write.values!.dpa_cleared_at).toEqual(expect.any(String));
+      expect(write.values!.status).toBe('awaiting_credentials');
+      expect(mockAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'sis_dpa_cleared' })
+      );
+    });
+
+    it('renewing a DPA on a live connection leaves its status alone', async () => {
+      // Otherwise a routine annual renewal would report a working integration
+      // as "waiting on credentials" that are, in fact, already stored.
+      results.push({ data: { id: CONNECTION_ID, status: 'connected' }, error: null });
+      results.push({ data: null, error: null });
+
+      await setDpaCleared({ connectionId: CONNECTION_ID, actorId: ACTOR_ID, cleared: true });
+
+      const write = calls.find((c) => c.op === 'update')!;
+      expect(write.values!.dpa_cleared_at).toEqual(expect.any(String));
+      expect(write.values).not.toHaveProperty('status');
+    });
+
+    it('refuses an unknown connection', async () => {
+      results.push({ data: null, error: null });
+
+      await expect(
+        setDpaCleared({ connectionId: CONNECTION_ID, actorId: ACTOR_ID, cleared: true })
+      ).rejects.toThrow('SIS connection not found');
+
+      expect(calls.filter((c) => c.op === 'update')).toHaveLength(0);
+      expect(mockAudit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disconnect', () => {
+    it('clears credentials and the stale test result, keeping the row', async () => {
+      results.push({ data: null, error: null });
+
+      await disconnect({ connectionId: CONNECTION_ID, actorId: ACTOR_ID });
+
+      const write = calls.find((c) => c.op === 'update')!;
+      for (const col of CREDENTIAL_COLUMNS) {
+        expect(write.values![col]).toBeNull();
+      }
+      expect(write.values!.credential_hint).toBeNull();
+      expect(write.values!.last_tested_at).toBeNull();
+      expect(write.values!.status).toBe('disabled');
+      // The DPA clearance and the provenance survive — that record is the
+      // reason the row is kept rather than deleted.
+      expect(write.values).not.toHaveProperty('dpa_cleared_at');
+      expect(write.values).not.toHaveProperty('created_by');
+    });
+  });
+
+  describe('recordTestResult', () => {
+    it('marks a failing test as error and audits the outcome', async () => {
+      results.push({ data: null, error: null });
+
+      await recordTestResult({
+        connectionId: CONNECTION_ID,
+        actorId: ACTOR_ID,
+        ok: false,
+        result: { message: 'HTTP 401' },
+      });
+
+      const write = calls.find((c) => c.op === 'update')!;
+      expect(write.values!.status).toBe('error');
+      expect(write.values!.last_tested_at).toEqual(expect.any(String));
+      expect(mockAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'sis_connection_tested', metadata: { ok: false } })
+      );
+    });
+
+    it('surfaces a write failure rather than reporting success', async () => {
+      results.push({ data: null, error: { message: 'permission denied' } });
+
+      await expect(
+        recordTestResult({ connectionId: CONNECTION_ID, actorId: ACTOR_ID, ok: true, result: {} })
+      ).rejects.toThrow(/permission denied/);
+
+      expect(mockAudit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/unit/lib/sis/connections.test.ts
+++ b/__tests__/unit/lib/sis/connections.test.ts
@@ -91,12 +91,13 @@ jest.mock('@/lib/logger', () => ({
 import {
   disconnect,
   getConnection,
+  getDecryptedCredential,
   listConnections,
   recordTestResult,
   setDpaCleared,
   storeCredential,
 } from '@/lib/sis/connections';
-import { decryptSisCredential } from '@/lib/sis/credential-crypto';
+import { decryptSisCredential, encryptSisCredential } from '@/lib/sis/credential-crypto';
 
 const CREDENTIAL_COLUMNS = [
   'aeries_certificate_encrypted',
@@ -412,9 +413,66 @@ describe('lib/sis/connections', () => {
     });
   });
 
-  describe('disconnect', () => {
-    it('clears credentials and the stale test result, keeping the row', async () => {
+  describe('getDecryptedCredential', () => {
+    it('returns the decrypted certificate for a populated aeries row', async () => {
+      const CERT = 'sim395fakecert0000000000000da9f2';
+      results.push({
+        data: { sis_type: 'aeries', aeries_certificate_encrypted: encryptSisCredential(CERT) },
+        error: null,
+      });
+
+      await expect(getDecryptedCredential(CONNECTION_ID)).resolves.toEqual({
+        sisType: 'aeries',
+        certificate: CERT,
+      });
+    });
+
+    it('returns null when the connection holds no credential yet', async () => {
+      // pending_dpa / awaiting_credentials is an ordinary state, not an error —
+      // callers must not have to distinguish "absent" from "failed".
+      results.push({
+        data: { sis_type: 'aeries', aeries_certificate_encrypted: null },
+        error: null,
+      });
+
+      await expect(getDecryptedCredential(CONNECTION_ID)).resolves.toBeNull();
+    });
+
+    it('returns null for a half-populated OneRoster pair rather than a partial credential', async () => {
+      results.push({
+        data: {
+          sis_type: 'oneroster',
+          oneroster_client_id_encrypted: encryptSisCredential('client-id'),
+          oneroster_client_secret_encrypted: null,
+        },
+        error: null,
+      });
+
+      await expect(getDecryptedCredential(CONNECTION_ID)).resolves.toBeNull();
+    });
+
+    it('returns null when the connection does not exist', async () => {
       results.push({ data: null, error: null });
+      await expect(getDecryptedCredential(CONNECTION_ID)).resolves.toBeNull();
+    });
+  });
+
+  describe('disconnect', () => {
+    it('refuses an unknown id instead of auditing a no-op', async () => {
+      // An UPDATE matching no row returns no error, so without a row check this
+      // would report success and write a disconnect audit record for a
+      // connection that never existed.
+      results.push({ data: null, error: null });
+
+      await expect(
+        disconnect({ connectionId: CONNECTION_ID, actorId: ACTOR_ID })
+      ).rejects.toThrow('SIS connection not found');
+
+      expect(mockAudit).not.toHaveBeenCalled();
+    });
+
+    it('clears credentials and the stale test result, keeping the row', async () => {
+      results.push({ data: { id: CONNECTION_ID }, error: null });
 
       await disconnect({ connectionId: CONNECTION_ID, actorId: ACTOR_ID });
 

--- a/__tests__/unit/lib/sis/credential-crypto.test.ts
+++ b/__tests__/unit/lib/sis/credential-crypto.test.ts
@@ -37,10 +37,19 @@ describe('SIS credential crypto', () => {
     expect(decryptSisCredential(encryptSisCredential(secret))).toBe(secret);
   });
 
-  it('round-trips a multi-line PEM-shaped certificate', () => {
-    // Aeries certificates are pasted by a human out of a web console, so they
-    // arrive with newlines and padding intact. Base64 of the ciphertext must
-    // survive that unchanged.
+  it('round-trips a real-shaped Aeries certificate', () => {
+    // The actual thing: a 32-char hex vendor certificate, sent as the
+    // AERIES-CERT header value (lib/integrations/aeries/config.ts).
+    const cert = '477abe9e7d27439681d62f4e0de1f5e1';
+    expect(decryptSisCredential(encryptSisCredential(cert))).toBe(cert);
+    expect(credentialHint(cert)).toBe('••••f5e1');
+  });
+
+  it('round-trips arbitrary UTF-8, including newlines', () => {
+    // Not a claim about how Aeries certificates arrive — they are 32 hex
+    // characters on a header line. This pins that the envelope is byte-faithful
+    // for any credential a future provider might use, so encryption never
+    // silently mutates what it was handed.
     const pem = [
       '-----BEGIN CERTIFICATE-----',
       randomBytes(48).toString('base64'),
@@ -71,6 +80,30 @@ describe('SIS credential crypto', () => {
     const parts = encryptSisCredential('secret').split('.');
     parts[3] = randomBytes(16).toString('base64');
     expect(() => decryptSisCredential(parts.join('.'))).toThrow();
+  });
+
+  it('rejects a truncated auth tag rather than accepting a weaker one', () => {
+    // Node accepts 4-, 8- and 12-to-15-byte GCM tags via setAuthTag, so without
+    // an explicit check a 4-byte tag verifies successfully — a full-width
+    // guarantee quietly replaced by a much narrower one.
+    const parts = encryptSisCredential('secret').split('.');
+    for (const shortLength of [4, 8, 12, 15]) {
+      const truncated = [...parts];
+      truncated[3] = Buffer.from(parts[3], 'base64')
+        .subarray(0, shortLength)
+        .toString('base64');
+      expect(() => decryptSisCredential(truncated.join('.'))).toThrow(
+        'Unrecognized encrypted SIS credential format'
+      );
+    }
+  });
+
+  it('rejects a wrong-length IV', () => {
+    const parts = encryptSisCredential('secret').split('.');
+    parts[1] = randomBytes(16).toString('base64');
+    expect(() => decryptSisCredential(parts.join('.'))).toThrow(
+      'Unrecognized encrypted SIS credential format'
+    );
   });
 
   it('rejects an envelope with extra fields appended', () => {
@@ -137,6 +170,11 @@ describe('SIS credential crypto', () => {
     });
 
     it('reports unconfigured when the key is the wrong length', () => {
+      // Rejected by the canonical-format regex (43 chars + '='), not by the
+      // byte-length check below it — a 16-byte key is 24 base64 characters, so
+      // it never reaches that branch. Named accurately because a test that
+      // claims to cover the length check while exercising the regex leaves the
+      // length check looking tested when it is not.
       process.env.SIS_CREDENTIAL_ENCRYPTION_KEY =
         randomBytes(16).toString('base64');
       expect(sisCredentialEncryptionConfigured()).toBe(false);

--- a/__tests__/unit/lib/sis/credential-crypto.test.ts
+++ b/__tests__/unit/lib/sis/credential-crypto.test.ts
@@ -9,12 +9,27 @@ import {
 describe('SIS credential crypto', () => {
   const key = randomBytes(32).toString('base64');
 
+  // Snapshot and restore BOTH keys. These tests mutate and delete process.env
+  // entries that later files in the same Jest worker may depend on, so leaving
+  // the environment modified would make an unrelated suite fail depending on
+  // file order — the kind of failure that looks like a real bug for an hour.
+  const original = {
+    sis: process.env.SIS_CREDENTIAL_ENCRYPTION_KEY,
+    calendar: process.env.CALENDAR_TOKEN_ENCRYPTION_KEY,
+  };
+
   beforeEach(() => {
     process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = key;
   });
 
-  afterAll(() => {
-    delete process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+  afterEach(() => {
+    for (const [name, value] of [
+      ['SIS_CREDENTIAL_ENCRYPTION_KEY', original.sis],
+      ['CALENDAR_TOKEN_ENCRYPTION_KEY', original.calendar],
+    ] as const) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
   });
 
   it('round-trips a credential', () => {
@@ -58,6 +73,22 @@ describe('SIS credential crypto', () => {
     expect(() => decryptSisCredential(parts.join('.'))).toThrow();
   });
 
+  it('rejects an envelope with extra fields appended', () => {
+    // The GCM tag authenticates the ciphertext, not the envelope, so trailing
+    // junk must be rejected structurally or it decrypts as if it were absent.
+    const encrypted = encryptSisCredential('secret');
+    expect(() => decryptSisCredential(`${encrypted}.junk`)).toThrow(
+      'Unrecognized encrypted SIS credential format'
+    );
+  });
+
+  it('rejects an envelope with too few fields', () => {
+    const parts = encryptSisCredential('secret').split('.');
+    expect(() => decryptSisCredential(parts.slice(0, 3).join('.'))).toThrow(
+      'Unrecognized encrypted SIS credential format'
+    );
+  });
+
   it('rejects unrecognized formats', () => {
     expect(() => decryptSisCredential('not-an-encrypted-credential')).toThrow(
       'Unrecognized encrypted SIS credential format'
@@ -80,7 +111,6 @@ describe('SIS credential crypto', () => {
     expect(() => decryptSisCredential(encrypted)).toThrow(
       'SIS_CREDENTIAL_ENCRYPTION_KEY is not set'
     );
-    delete process.env.CALENDAR_TOKEN_ENCRYPTION_KEY;
   });
 
   describe('configuration guard', () => {
@@ -90,6 +120,19 @@ describe('SIS credential crypto', () => {
 
     it('reports unconfigured when the key is absent', () => {
       delete process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+      expect(sisCredentialEncryptionConfigured()).toBe(false);
+    });
+
+    it('rejects a valid key with trailing junk', () => {
+      // Buffer.from ignores unrecognised base64 characters, so this decodes to
+      // a plausible 32 bytes. Only a canonical-format check catches it.
+      process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = `${key}!!!`;
+      expect(sisCredentialEncryptionConfigured()).toBe(false);
+      expect(() => encryptSisCredential('secret')).toThrow('canonical base64');
+    });
+
+    it('rejects a key with embedded whitespace or newlines', () => {
+      process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = `${key}\n`;
       expect(sisCredentialEncryptionConfigured()).toBe(false);
     });
 

--- a/__tests__/unit/lib/sis/credential-crypto.test.ts
+++ b/__tests__/unit/lib/sis/credential-crypto.test.ts
@@ -1,0 +1,124 @@
+import { randomBytes } from 'crypto';
+import {
+  credentialHint,
+  decryptSisCredential,
+  encryptSisCredential,
+  sisCredentialEncryptionConfigured,
+} from '@/lib/sis/credential-crypto';
+
+describe('SIS credential crypto', () => {
+  const key = randomBytes(32).toString('base64');
+
+  beforeEach(() => {
+    process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = key;
+  });
+
+  afterAll(() => {
+    delete process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+  });
+
+  it('round-trips a credential', () => {
+    const secret = 'aeries-cert-abc123-fake';
+    expect(decryptSisCredential(encryptSisCredential(secret))).toBe(secret);
+  });
+
+  it('round-trips a multi-line PEM-shaped certificate', () => {
+    // Aeries certificates are pasted by a human out of a web console, so they
+    // arrive with newlines and padding intact. Base64 of the ciphertext must
+    // survive that unchanged.
+    const pem = [
+      '-----BEGIN CERTIFICATE-----',
+      randomBytes(48).toString('base64'),
+      randomBytes(48).toString('base64'),
+      '-----END CERTIFICATE-----',
+    ].join('\n');
+    expect(decryptSisCredential(encryptSisCredential(pem))).toBe(pem);
+  });
+
+  it('uses a fresh IV per encryption', () => {
+    const secret = 'same-plaintext';
+    const a = encryptSisCredential(secret);
+    const b = encryptSisCredential(secret);
+    expect(a).not.toBe(b);
+    expect(decryptSisCredential(a)).toBe(secret);
+    expect(decryptSisCredential(b)).toBe(secret);
+  });
+
+  it('rejects tampered ciphertext', () => {
+    const parts = encryptSisCredential('secret').split('.');
+    parts[2] = randomBytes(Buffer.from(parts[2], 'base64').length).toString(
+      'base64'
+    );
+    expect(() => decryptSisCredential(parts.join('.'))).toThrow();
+  });
+
+  it('rejects a tampered auth tag', () => {
+    const parts = encryptSisCredential('secret').split('.');
+    parts[3] = randomBytes(16).toString('base64');
+    expect(() => decryptSisCredential(parts.join('.'))).toThrow();
+  });
+
+  it('rejects unrecognized formats', () => {
+    expect(() => decryptSisCredential('not-an-encrypted-credential')).toThrow(
+      'Unrecognized encrypted SIS credential format'
+    );
+  });
+
+  it('cannot decrypt with a different key', () => {
+    const encrypted = encryptSisCredential('secret');
+    process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = randomBytes(32).toString('base64');
+    expect(() => decryptSisCredential(encrypted)).toThrow();
+  });
+
+  it('does not fall back to the calendar key', () => {
+    // The two key spaces must stay independent — a SIS credential encrypted
+    // under the SIS key must not be readable just because the calendar key
+    // happens to be configured, and vice versa.
+    const encrypted = encryptSisCredential('secret');
+    delete process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+    process.env.CALENDAR_TOKEN_ENCRYPTION_KEY = key;
+    expect(() => decryptSisCredential(encrypted)).toThrow(
+      'SIS_CREDENTIAL_ENCRYPTION_KEY is not set'
+    );
+    delete process.env.CALENDAR_TOKEN_ENCRYPTION_KEY;
+  });
+
+  describe('configuration guard', () => {
+    it('reports configured with a valid key', () => {
+      expect(sisCredentialEncryptionConfigured()).toBe(true);
+    });
+
+    it('reports unconfigured when the key is absent', () => {
+      delete process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+      expect(sisCredentialEncryptionConfigured()).toBe(false);
+    });
+
+    it('reports unconfigured when the key is the wrong length', () => {
+      process.env.SIS_CREDENTIAL_ENCRYPTION_KEY =
+        randomBytes(16).toString('base64');
+      expect(sisCredentialEncryptionConfigured()).toBe(false);
+    });
+
+    it('encrypting without a key throws rather than storing plaintext', () => {
+      delete process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+      expect(() => encryptSisCredential('secret')).toThrow(
+        'SIS_CREDENTIAL_ENCRYPTION_KEY is not set'
+      );
+    });
+  });
+
+  describe('credentialHint', () => {
+    it('shows only the last 4 characters', () => {
+      expect(credentialHint('supersecretvalue9f2a')).toBe('••••9f2a');
+    });
+
+    it('masks a short secret entirely rather than mostly revealing it', () => {
+      expect(credentialHint('abc123')).toBe('••••');
+      expect(credentialHint('abc123')).not.toContain('123');
+    });
+
+    it('ignores surrounding whitespace from a paste', () => {
+      expect(credentialHint('  supersecretvalue9f2a \n')).toBe('••••9f2a');
+    });
+  });
+});

--- a/app/(internal)/internal/districts/[districtId]/page.tsx
+++ b/app/(internal)/internal/districts/[districtId]/page.tsx
@@ -8,6 +8,7 @@ import {
   getSchoolsByDistrict,
   getDistrictAdmins,
 } from '@/lib/supabase/queries/internal-admin';
+import SisConnectionsPanel from '@/app/components/internal/sis-connections-panel';
 
 interface District {
   id: string;
@@ -178,6 +179,9 @@ export default function DistrictDetailPage() {
           </div>
         </div>
       </div>
+
+      {/* SIS connections + the DPA gate (SPE-395) */}
+      <SisConnectionsPanel districtId={district.id} />
 
       {/* Existing admins */}
       {admins.length > 0 && (

--- a/app/api/internal/sis-connections/[connectionId]/dpa/route.ts
+++ b/app/api/internal/sis-connections/[connectionId]/dpa/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { withRoute } from '@/lib/api/with-route';
-import { requireSpeddyAdmin } from '@/lib/api/require-speddy-admin';
+import { speddyAdminDenialReason } from '@/lib/api/speddy-admin-denial-reason';
 import { logger } from '@/lib/logger';
-import { getConnection, setDpaCleared } from '@/lib/sis/connections';
+import { SIS_CONNECTION_NOT_FOUND, getConnection, setDpaCleared } from '@/lib/sis/connections';
 
 const log = logger.child({ module: 'internal-sis-dpa' });
 
@@ -22,7 +22,7 @@ const log = logger.child({ module: 'internal-sis-dpa' });
 export const PATCH = withRoute<{ connectionId: string }, { cleared: boolean }>(
   { body: z.object({ cleared: z.boolean() }) },
   async ({ userId, body, params }) => {
-    const denied = await requireSpeddyAdmin(userId);
+    const denied = await speddyAdminDenialReason(userId);
     if (denied) {
       log.warn('Non-speddy-admin tried to change a DPA', {
         userId,
@@ -47,8 +47,12 @@ export const PATCH = withRoute<{ connectionId: string }, { cleared: boolean }>(
         connectionId: params.connectionId,
         error: message,
       });
-      const status = message === 'SIS connection not found' ? 404 : 500;
-      return NextResponse.json({ error: message }, { status });
+      if (message === SIS_CONNECTION_NOT_FOUND) {
+        return NextResponse.json({ error: SIS_CONNECTION_NOT_FOUND }, { status: 404 });
+      }
+      // Fixed message, not `message`: a PostgREST error carries constraint,
+      // column and foreign-key names. The detail belongs in the log line above.
+      return NextResponse.json({ error: 'Failed to update DPA state' }, { status: 500 });
     }
 
     log.info('DPA state changed', {
@@ -59,7 +63,20 @@ export const PATCH = withRoute<{ connectionId: string }, { cleared: boolean }>(
 
     // Return the row the write produced rather than what the client assumed, so
     // the switch reflects the database instead of an optimistic guess.
-    const connection = await getConnection(params.connectionId);
-    return NextResponse.json({ connection });
+    //
+    // Guarded separately because the write has ALREADY committed here. Letting a
+    // failed read-back reject the request would report a successful DPA change
+    // as a failure, and the panel would keep showing the old state — the worst
+    // possible outcome on a control whose "off" position deletes credentials.
+    try {
+      const connection = await getConnection(params.connectionId);
+      return NextResponse.json({ connection });
+    } catch (err) {
+      log.error('DPA change committed but the read-back failed', {
+        connectionId: params.connectionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return NextResponse.json({ connection: null });
+    }
   }
 );

--- a/app/api/internal/sis-connections/[connectionId]/dpa/route.ts
+++ b/app/api/internal/sis-connections/[connectionId]/dpa/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withRoute } from '@/lib/api/with-route';
+import { requireSpeddyAdmin } from '@/lib/api/require-speddy-admin';
+import { logger } from '@/lib/logger';
+import { getConnection, setDpaCleared } from '@/lib/sis/connections';
+
+const log = logger.child({ module: 'internal-sis-dpa' });
+
+/**
+ * Record or revoke a district's signed DPA (SPE-395).
+ *
+ * This is the gate that opens credential intake: until a Speddy operator has
+ * the signed agreement on file and flips this, the database itself refuses to
+ * hold a credential for the district. Speddy staff only — a district's own
+ * admins must not be able to clear their own DPA.
+ *
+ * Revoking is destructive by design: it deletes the stored credentials, because
+ * leaving a live SIS certificate behind a gate that has just closed is the one
+ * outcome nobody wants. The UI confirms before calling this.
+ */
+export const PATCH = withRoute<{ connectionId: string }, { cleared: boolean }>(
+  { body: z.object({ cleared: z.boolean() }) },
+  async ({ userId, body, params }) => {
+    const denied = await requireSpeddyAdmin(userId);
+    if (denied) {
+      log.warn('Non-speddy-admin tried to change a DPA', {
+        userId,
+        connectionId: params.connectionId,
+        denied,
+      });
+      return NextResponse.json(
+        { error: 'Forbidden: Speddy admin access required' },
+        { status: 403 }
+      );
+    }
+
+    try {
+      await setDpaCleared({
+        connectionId: params.connectionId,
+        actorId: userId,
+        cleared: body.cleared,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update DPA state';
+      log.error('Failed to update DPA state', {
+        connectionId: params.connectionId,
+        error: message,
+      });
+      const status = message === 'SIS connection not found' ? 404 : 500;
+      return NextResponse.json({ error: message }, { status });
+    }
+
+    log.info('DPA state changed', {
+      connectionId: params.connectionId,
+      cleared: body.cleared,
+      actorId: userId,
+    });
+
+    // Return the row the write produced rather than what the client assumed, so
+    // the switch reflects the database instead of an optimistic guess.
+    const connection = await getConnection(params.connectionId);
+    return NextResponse.json({ connection });
+  }
+);

--- a/app/api/internal/sis-connections/route.ts
+++ b/app/api/internal/sis-connections/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { withRoute } from '@/lib/api/with-route';
-import { requireSpeddyAdmin } from '@/lib/api/require-speddy-admin';
+import { speddyAdminDenialReason } from '@/lib/api/speddy-admin-denial-reason';
 import { logger } from '@/lib/logger';
 import { createConnection, listConnections } from '@/lib/sis/connections';
 
@@ -14,7 +14,7 @@ const forbidden = () =>
 export const GET = withRoute(
   { query: z.object({ districtId: z.string().min(1) }) },
   async ({ userId, query }) => {
-    const denied = await requireSpeddyAdmin(userId);
+    const denied = await speddyAdminDenialReason(userId);
     if (denied) {
       log.warn('Non-speddy-admin tried to read SIS connections', { userId, denied });
       return forbidden();
@@ -42,7 +42,7 @@ export const POST = withRoute(
     }),
   },
   async ({ userId, body }) => {
-    const denied = await requireSpeddyAdmin(userId);
+    const denied = await speddyAdminDenialReason(userId);
     if (denied) {
       log.warn('Non-speddy-admin tried to create a SIS connection', { userId, denied });
       return forbidden();
@@ -72,7 +72,9 @@ export const POST = withRoute(
           { status: 409 }
         );
       }
-      return NextResponse.json({ error: message }, { status: 500 });
+      // Fixed message, not `message`: a PostgREST error carries constraint,
+      // column and foreign-key names. The detail belongs in the log line above.
+      return NextResponse.json({ error: 'Failed to create SIS connection' }, { status: 500 });
     }
   }
 );

--- a/app/api/internal/sis-connections/route.ts
+++ b/app/api/internal/sis-connections/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withRoute } from '@/lib/api/with-route';
+import { requireSpeddyAdmin } from '@/lib/api/require-speddy-admin';
+import { logger } from '@/lib/logger';
+import { createConnection, listConnections } from '@/lib/sis/connections';
+
+const log = logger.child({ module: 'internal-sis-connections' });
+
+const forbidden = () =>
+  NextResponse.json({ error: 'Forbidden: Speddy admin access required' }, { status: 403 });
+
+/** List a district's SIS connections. Status only — never credentials. */
+export const GET = withRoute(
+  { query: z.object({ districtId: z.string().min(1) }) },
+  async ({ userId, query }) => {
+    const denied = await requireSpeddyAdmin(userId);
+    if (denied) {
+      log.warn('Non-speddy-admin tried to read SIS connections', { userId, denied });
+      return forbidden();
+    }
+
+    const connections = await listConnections(query.districtId);
+    return NextResponse.json({ connections });
+  }
+);
+
+/**
+ * Create a connection shell for a district, in `pending_dpa`.
+ *
+ * Deliberately does not accept a DPA date or credentials: recording the DPA is
+ * a separate, separately-audited action, and credentials never come through
+ * /internal at all — the district's own tech admin enters those.
+ */
+export const POST = withRoute(
+  {
+    body: z.object({
+      districtId: z.string().min(1),
+      sisType: z.enum(['aeries', 'oneroster']),
+      baseUrl: z.string().url().optional(),
+      tokenUrl: z.string().url().optional(),
+    }),
+  },
+  async ({ userId, body }) => {
+    const denied = await requireSpeddyAdmin(userId);
+    if (denied) {
+      log.warn('Non-speddy-admin tried to create a SIS connection', { userId, denied });
+      return forbidden();
+    }
+
+    try {
+      const connection = await createConnection({
+        districtId: body.districtId,
+        sisType: body.sisType,
+        actorId: userId,
+        baseUrl: body.baseUrl,
+        tokenUrl: body.tokenUrl,
+      });
+      return NextResponse.json({ connection });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create SIS connection';
+      log.error('Failed to create SIS connection', {
+        districtId: body.districtId,
+        sisType: body.sisType,
+        error: message,
+      });
+      // The unique constraint is the one failure a staff member can trigger by
+      // double-clicking, so name it rather than returning a raw Postgres string.
+      if (message.includes('district_sis_connections_district_sis_key')) {
+        return NextResponse.json(
+          { error: 'This district already has a connection for that SIS.' },
+          { status: 409 }
+        );
+      }
+      return NextResponse.json({ error: message }, { status: 500 });
+    }
+  }
+);

--- a/app/components/internal/sis-connections-panel.tsx
+++ b/app/components/internal/sis-connections-panel.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * Speddy-staff control for a district's SIS connections (SPE-395).
+ *
+ * Its one job is the DPA switch. Credentials are never entered, shown, or
+ * touched here — the district's own tech admin does that in the tech portal
+ * (SPE-396/397). All this page can say about a credential is whether one exists
+ * and its last four characters.
+ */
+
+type SisType = 'aeries' | 'oneroster';
+
+interface SisConnection {
+  id: string;
+  district_id: string;
+  sis_type: SisType;
+  base_url: string | null;
+  token_url: string | null;
+  credential_hint: string | null;
+  status: string;
+  dpa_cleared_at: string | null;
+  last_tested_at: string | null;
+  created_at: string;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  pending_dpa: 'Waiting on DPA',
+  awaiting_credentials: 'Waiting on district credentials',
+  testing: 'Saved, not yet tested',
+  connected: 'Connected',
+  error: 'Last test failed',
+  disabled: 'Disconnected',
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  pending_dpa: 'bg-amber-500/10 text-amber-300 border-amber-500/30',
+  awaiting_credentials: 'bg-blue-500/10 text-blue-300 border-blue-500/30',
+  testing: 'bg-slate-500/10 text-slate-300 border-slate-500/30',
+  connected: 'bg-emerald-500/10 text-emerald-300 border-emerald-500/30',
+  error: 'bg-red-500/10 text-red-300 border-red-500/30',
+  disabled: 'bg-slate-600/10 text-slate-400 border-slate-600/30',
+};
+
+const SIS_LABELS: Record<SisType, string> = {
+  aeries: 'Aeries',
+  oneroster: 'OneRoster',
+};
+
+function formatDate(value: string | null): string {
+  if (!value) return '—';
+  return new Date(value).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export default function SisConnectionsPanel({ districtId }: { districtId: string }) {
+  const [connections, setConnections] = useState<SisConnection[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [creating, setCreating] = useState<SisType | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/internal/sis-connections?districtId=${encodeURIComponent(districtId)}`
+      );
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || 'Failed to load SIS connections');
+      setConnections(json.connections || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load SIS connections');
+    } finally {
+      setLoading(false);
+    }
+  }, [districtId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const createConnection = async (sisType: SisType) => {
+    setCreating(sisType);
+    setError(null);
+    try {
+      const res = await fetch('/api/internal/sis-connections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ districtId, sisType }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || 'Failed to create connection');
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create connection');
+    } finally {
+      setCreating(null);
+    }
+  };
+
+  const setDpa = async (connection: SisConnection, cleared: boolean) => {
+    // Revoking destroys the stored credential, so it is confirmed rather than
+    // being one misplaced click away from cutting a district's integration.
+    if (!cleared) {
+      const confirmed = window.confirm(
+        `Revoke the DPA for ${SIS_LABELS[connection.sis_type]}?\n\n` +
+          'This deletes the stored credentials. The district will have to re-enter them ' +
+          'after a new DPA is recorded.'
+      );
+      if (!confirmed) return;
+    }
+
+    setBusyId(connection.id);
+    setError(null);
+    try {
+      const res = await fetch(`/api/internal/sis-connections/${connection.id}/dpa`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cleared }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || 'Failed to update the DPA');
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update the DPA');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const existingTypes = new Set(connections.map((c) => c.sis_type));
+  const addableTypes = (['aeries', 'oneroster'] as SisType[]).filter(
+    (t) => !existingTypes.has(t)
+  );
+
+  return (
+    <div className="bg-slate-800 rounded-lg border border-slate-700 p-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-white">SIS Connections</h2>
+          <p className="mt-1 text-sm text-slate-400">
+            Record the signed data privacy agreement here. Until it is recorded, the
+            district cannot enter SIS credentials.
+          </p>
+        </div>
+        {addableTypes.length > 0 && (
+          <div className="flex gap-2">
+            {addableTypes.map((type) => (
+              <button
+                key={type}
+                type="button"
+                onClick={() => createConnection(type)}
+                disabled={creating !== null}
+                className="px-3 py-2 text-sm bg-slate-600 hover:bg-slate-500 disabled:opacity-50 text-white rounded-md transition-colors"
+              >
+                {creating === type ? 'Adding…' : `Add ${SIS_LABELS[type]}`}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className="mt-4 rounded-md border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <p className="mt-6 text-sm text-slate-400">Loading…</p>
+      ) : connections.length === 0 ? (
+        <p className="mt-6 text-sm text-slate-400">
+          No SIS connection set up for this district yet.
+        </p>
+      ) : (
+        <ul className="mt-6 space-y-4">
+          {connections.map((connection) => {
+            const dpaCleared = Boolean(connection.dpa_cleared_at);
+            const busy = busyId === connection.id;
+            return (
+              <li
+                key={connection.id}
+                className="rounded-lg border border-slate-700 bg-slate-800/50 p-4"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <div>
+                    <div className="flex items-center gap-3">
+                      <span className="font-medium text-white">
+                        {SIS_LABELS[connection.sis_type]}
+                      </span>
+                      <span
+                        className={`rounded-full border px-2 py-0.5 text-xs ${
+                          STATUS_STYLES[connection.status] ||
+                          'bg-slate-500/10 text-slate-300 border-slate-500/30'
+                        }`}
+                      >
+                        {STATUS_LABELS[connection.status] || connection.status}
+                      </span>
+                    </div>
+                    <dl className="mt-2 flex flex-wrap gap-x-6 gap-y-1 text-sm text-slate-400">
+                      <div className="flex gap-2">
+                        <dt>DPA:</dt>
+                        <dd className="text-slate-300">
+                          {dpaCleared ? formatDate(connection.dpa_cleared_at) : 'Not recorded'}
+                        </dd>
+                      </div>
+                      <div className="flex gap-2">
+                        <dt>Credential:</dt>
+                        <dd className="font-mono text-slate-300">
+                          {connection.credential_hint || 'None stored'}
+                        </dd>
+                      </div>
+                      <div className="flex gap-2">
+                        <dt>Last tested:</dt>
+                        <dd className="text-slate-300">
+                          {formatDate(connection.last_tested_at)}
+                        </dd>
+                      </div>
+                    </dl>
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={() => setDpa(connection, !dpaCleared)}
+                    disabled={busy}
+                    className={`px-4 py-2 text-sm rounded-md transition-colors disabled:opacity-50 ${
+                      dpaCleared
+                        ? 'bg-slate-700 hover:bg-slate-600 text-slate-200'
+                        : 'bg-purple-600 hover:bg-purple-700 text-white'
+                    }`}
+                  >
+                    {busy ? 'Saving…' : dpaCleared ? 'Revoke DPA' : 'Record signed DPA'}
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/components/internal/sis-connections-panel.tsx
+++ b/app/components/internal/sis-connections-panel.tsx
@@ -167,7 +167,10 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
       </div>
 
       {error && (
-        <div className="mt-4 rounded-md border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+        <div
+          role="alert"
+          className="mt-4 rounded-md border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300"
+        >
           {error}
         </div>
       )}

--- a/docs/data-inventory.md
+++ b/docs/data-inventory.md
@@ -126,6 +126,50 @@ Two qualifications, so the "no personal data" label is exact:
 Listed so the sweep is complete and future reviewers can see these were
 considered and excluded, rather than missed.
 
+## E. Integration credentials (no personal data; highest sensitivity)
+
+_Entry: **provided by the district's own IT staff**, through the tech portal._
+
+| Element | Source |
+|---|---|
+| District SIS connection config (SIS type, base URL, OAuth token URL) | `district_sis_connections` |
+| District SIS credentials — Aeries certificate; OneRoster client id + secret | `district_sis_connections` (**ciphertext only**) |
+| Masked credential hint (last 4 characters) | `district_sis_connections.credential_hint` |
+| Connection lifecycle — status, DPA-cleared timestamp, last test time and per-area diagnostics | `district_sis_connections` |
+
+Filed as its own class rather than under §D, and the distinction is not
+cosmetic. This table holds **no personal data** — but it holds the keys to a
+district's entire student information system, which makes it the most sensitive
+row in the database by consequence even though it is the least sensitive by
+content. Listing it beside bell schedules under "no personal data" would be
+true and misleading in the same sentence.
+
+How it is protected, so the NDPA answer is exact rather than reassuring:
+
+- **Encrypted at rest at the application layer**, AES-256-GCM, under
+  `SIS_CREDENTIAL_ENCRYPTION_KEY` — a key held in the environment and never in
+  the database, and deliberately separate from the calendar-token key so either
+  can be rotated without the other. Database-level encryption at rest (Supabase)
+  sits underneath this, not instead of it.
+- **Never returned to a browser.** Row-level security cannot hide a column, so
+  the credential columns are additionally withheld by **column-level grants**:
+  an authenticated session cannot name them and is refused outright. Only the
+  masked hint is client-readable.
+- **No plaintext column exists**, and CHECK constraints reject any value in a
+  credential column that is not a well-formed ciphertext envelope — so a bug
+  that skipped encryption is refused by the database rather than stored.
+- **Not writable from a browser at all**; every mutation runs server-side.
+- **Credentials cannot be stored before the district's DPA is recorded** — also
+  a CHECK constraint, not only an application rule.
+
+`created_by` is a staff-attribution stamp, as in §D; the identity it points at
+is disclosed in §B.
+
+**Not student data, and not a subprocessor disclosure.** Speddy stores the
+credential; the SIS vendor (Aeries, or the district's OneRoster provider) is the
+district's own system, not a Speddy subprocessor. What flows *back* through that
+connection becomes §A student data and is disclosed there.
+
 ---
 
 ## Where each element flows (see [`subprocessors.md`](./subprocessors.md))

--- a/lib/api/require-speddy-admin.ts
+++ b/lib/api/require-speddy-admin.ts
@@ -1,0 +1,29 @@
+import { createServiceClient } from '@/lib/supabase/server';
+
+/**
+ * Verify a caller holds the Speddy-staff flag.
+ *
+ * `is_speddy_admin` is checked through the service client on purpose: the flag
+ * gates the /internal surface, so reading it must not itself depend on what the
+ * caller's own session is permitted to select. Middleware already redirects
+ * non-staff away from /internal pages, but middleware guards navigation, not
+ * fetch() — an API route has to check for itself.
+ *
+ * Returns null when the caller is staff, or a reason string when they are not.
+ * Callers turn that into a 403; the reason is for logs, not for the response.
+ */
+export async function requireSpeddyAdmin(userId: string): Promise<string | null> {
+  if (!userId) return 'no authenticated user';
+
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('is_speddy_admin')
+    .eq('id', userId)
+    .maybeSingle();
+
+  if (error) return `profile lookup failed: ${error.message}`;
+  if (!data) return 'profile not found';
+  if (!data.is_speddy_admin) return 'not a speddy admin';
+  return null;
+}

--- a/lib/api/speddy-admin-denial-reason.ts
+++ b/lib/api/speddy-admin-denial-reason.ts
@@ -1,7 +1,12 @@
 import { createServiceClient } from '@/lib/supabase/server';
 
 /**
- * Verify a caller holds the Speddy-staff flag.
+ * Why a caller may NOT act as Speddy staff — or null if they may.
+ *
+ * Named for what it RETURNS, not what it enforces. `requireSpeddyAdmin` read as
+ * a boolean guard, but null means allowed and a string means denied, so
+ * `if (await requireSpeddyAdmin(id)) return forbidden()` — the obvious reading —
+ * would have inverted it and let everyone through, silently.
  *
  * `is_speddy_admin` is checked through the service client on purpose: the flag
  * gates the /internal surface, so reading it must not itself depend on what the
@@ -12,7 +17,7 @@ import { createServiceClient } from '@/lib/supabase/server';
  * Returns null when the caller is staff, or a reason string when they are not.
  * Callers turn that into a 403; the reason is for logs, not for the response.
  */
-export async function requireSpeddyAdmin(userId: string): Promise<string | null> {
+export async function speddyAdminDenialReason(userId: string): Promise<string | null> {
   if (!userId) return 'no authenticated user';
 
   const supabase = createServiceClient();

--- a/lib/sis/connections.ts
+++ b/lib/sis/connections.ts
@@ -1,0 +1,420 @@
+/**
+ * Server-side access to `district_sis_connections` (SPE-395).
+ *
+ * This is the ONLY place credentials are encrypted, decrypted, or written. The
+ * tech-portal flows (SPE-396 Aeries, SPE-397 OneRoster) and the exploration
+ * tooling (SPE-398) call in here rather than touching the table, so there is a
+ * single audited path and a single place holding the key.
+ *
+ * Why a module rather than "just query the table":
+ *   - browsers cannot write this table at all (every write policy is `false`),
+ *     so every mutation is server-side by construction;
+ *   - the credential columns are withheld from `authenticated` by column-level
+ *     grants, so reads of them must come through the service role;
+ *   - every mutation is an auditable event on a district's SIS access, and
+ *     routing them through one module is what makes an audit trail something
+ *     the code guarantees rather than something each caller remembers.
+ *
+ * Server-only: uses the service-role client and the encryption key. Never
+ * import from a client component. (The repo has no `server-only` package, so
+ * this is a convention, same as lib/calendar/token-crypto.ts — but it fails
+ * closed in practice: SUPABASE_SERVICE_ROLE_KEY is not in the client bundle,
+ * so createServiceClient() throws if this ever runs in a browser.)
+ */
+import { createServiceClient } from '@/lib/supabase/server';
+import { logServerAuditEvent } from '@/lib/supabase/audit-log-server';
+import { logger } from '@/lib/logger';
+import {
+  credentialHint,
+  decryptSisCredential,
+  encryptSisCredential,
+  sisCredentialEncryptionConfigured,
+} from './credential-crypto';
+
+const log = logger.child({ module: 'sis-connections' });
+
+export type SisType = 'aeries' | 'oneroster';
+
+export type SisConnectionStatus =
+  | 'pending_dpa'
+  | 'awaiting_credentials'
+  | 'testing'
+  | 'connected'
+  | 'error'
+  | 'disabled';
+
+/** Everything a client may see. Deliberately has no credential fields. */
+export interface SisConnectionSummary {
+  id: string;
+  district_id: string;
+  sis_type: SisType;
+  base_url: string | null;
+  token_url: string | null;
+  credential_hint: string | null;
+  status: SisConnectionStatus;
+  dpa_cleared_at: string | null;
+  last_tested_at: string | null;
+  last_test_result: unknown | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * The exact column list a client may read. Mirrors the GRANT in the migration.
+ *
+ * Named explicitly rather than using `*`: `select('*')` is REFUSED for a
+ * browser session (it expands to columns it may not read), and a server-side
+ * `*` would quietly pull credentials into memory in places that have no
+ * business holding them.
+ */
+const SUMMARY_COLUMNS =
+  'id, district_id, sis_type, base_url, token_url, credential_hint, status, dpa_cleared_at, last_tested_at, last_test_result, created_by, created_at, updated_at';
+
+/** Connections for a district — status only, never credentials. */
+export async function listConnections(
+  districtId: string
+): Promise<SisConnectionSummary[]> {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from('district_sis_connections')
+    .select(SUMMARY_COLUMNS)
+    .eq('district_id', districtId)
+    .order('sis_type');
+
+  if (error) throw new Error(`Failed to load SIS connections: ${error.message}`);
+  return (data ?? []) as SisConnectionSummary[];
+}
+
+/** A single connection by id — status only, never credentials. */
+export async function getConnection(
+  connectionId: string
+): Promise<SisConnectionSummary | null> {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from('district_sis_connections')
+    .select(SUMMARY_COLUMNS)
+    .eq('id', connectionId)
+    .maybeSingle();
+
+  if (error) throw new Error(`Failed to load SIS connection: ${error.message}`);
+  return (data as SisConnectionSummary | null) ?? null;
+}
+
+/**
+ * Decrypt a stored credential for server-side use — a connection test, or a
+ * real SIS call.
+ *
+ * Returns null when the connection has no credential yet, which is an ordinary
+ * state (pending_dpa / awaiting_credentials), not an error. Callers must treat
+ * the result as short-lived: use it for the request at hand and let it go.
+ */
+export async function getDecryptedCredential(
+  connectionId: string
+): Promise<
+  | { sisType: 'aeries'; certificate: string }
+  | { sisType: 'oneroster'; clientId: string; clientSecret: string }
+  | null
+> {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from('district_sis_connections')
+    .select(
+      'sis_type, aeries_certificate_encrypted, oneroster_client_id_encrypted, oneroster_client_secret_encrypted'
+    )
+    .eq('id', connectionId)
+    .maybeSingle();
+
+  if (error) throw new Error(`Failed to load SIS credential: ${error.message}`);
+  if (!data) return null;
+
+  if (data.sis_type === 'aeries') {
+    if (!data.aeries_certificate_encrypted) return null;
+    return {
+      sisType: 'aeries',
+      certificate: decryptSisCredential(data.aeries_certificate_encrypted),
+    };
+  }
+
+  if (!data.oneroster_client_id_encrypted || !data.oneroster_client_secret_encrypted) {
+    return null;
+  }
+  return {
+    sisType: 'oneroster',
+    clientId: decryptSisCredential(data.oneroster_client_id_encrypted),
+    clientSecret: decryptSisCredential(data.oneroster_client_secret_encrypted),
+  };
+}
+
+/** Create a connection shell in `pending_dpa`, before any DPA or credentials. */
+export async function createConnection(params: {
+  districtId: string;
+  sisType: SisType;
+  actorId: string;
+  baseUrl?: string;
+  tokenUrl?: string;
+}): Promise<SisConnectionSummary> {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from('district_sis_connections')
+    .insert({
+      district_id: params.districtId,
+      sis_type: params.sisType,
+      base_url: params.baseUrl ?? null,
+      token_url: params.tokenUrl ?? null,
+      status: 'pending_dpa',
+      created_by: params.actorId,
+    })
+    .select(SUMMARY_COLUMNS)
+    .single();
+
+  if (error) throw new Error(`Failed to create SIS connection: ${error.message}`);
+
+  const created = data as SisConnectionSummary;
+  await logServerAuditEvent({
+    user_id: params.actorId,
+    action: 'sis_connection_created',
+    resource_type: 'district_sis_connection',
+    resource_id: created.id,
+    metadata: { district_id: params.districtId, sis_type: params.sisType },
+  });
+
+  return created;
+}
+
+export interface StoreCredentialInput {
+  connectionId: string;
+  actorId: string;
+  baseUrl?: string;
+  tokenUrl?: string;
+  /** Aeries */
+  certificate?: string;
+  /** OneRoster */
+  clientId?: string;
+  clientSecret?: string;
+}
+
+/**
+ * Encrypt and store a district's credential on an existing connection.
+ *
+ * Deliberately NOT an upsert. The connection must already exist and its DPA
+ * must already be recorded, because the database refuses a credential on a row
+ * with a null `dpa_cleared_at` — an upsert would create the row and then be
+ * rejected by that CHECK, surfacing the DPA gate as a constraint-violation
+ * string instead of a clear "the DPA isn't signed yet". Order of operations is
+ * createConnection -> setDpaCleared -> storeCredential.
+ *
+ * `sisType` comes from the stored row, never the caller: it decides which
+ * column the secret lands in, and letting a request pick that is how an Aeries
+ * certificate ends up in a OneRoster field.
+ *
+ * Fails closed if the encryption key is missing or malformed, BEFORE touching
+ * the database, so a misconfigured environment cannot half-write a connection.
+ */
+export async function storeCredential(
+  input: StoreCredentialInput
+): Promise<SisConnectionSummary> {
+  if (!sisCredentialEncryptionConfigured()) {
+    throw new Error(
+      'SIS_CREDENTIAL_ENCRYPTION_KEY is not configured — refusing to store a credential'
+    );
+  }
+
+  const supabase = createServiceClient();
+  const { data: existing, error: loadError } = await supabase
+    .from('district_sis_connections')
+    .select('id, district_id, sis_type, dpa_cleared_at, credential_hint')
+    .eq('id', input.connectionId)
+    .maybeSingle();
+
+  if (loadError) {
+    throw new Error(`Failed to load SIS connection: ${loadError.message}`);
+  }
+  if (!existing) throw new Error('SIS connection not found');
+  if (!existing.dpa_cleared_at) {
+    throw new Error(
+      'This district has no recorded DPA — credentials cannot be stored until one is on file'
+    );
+  }
+
+  // A stored credential invalidates whatever the last test said. Leaving a
+  // stale `connected` + `last_tested_at` in place would claim the credential
+  // just pasted in is known-good, which is exactly backwards after a rotation.
+  const patch: Record<string, unknown> = {
+    status: 'testing',
+    last_tested_at: null,
+    last_test_result: null,
+  };
+  if (input.baseUrl !== undefined) patch.base_url = input.baseUrl;
+  if (input.tokenUrl !== undefined) patch.token_url = input.tokenUrl;
+
+  if (existing.sis_type === 'aeries') {
+    if (!input.certificate) throw new Error('Aeries connection requires a certificate');
+    patch.aeries_certificate_encrypted = encryptSisCredential(input.certificate);
+    patch.credential_hint = credentialHint(input.certificate);
+  } else {
+    if (!input.clientId || !input.clientSecret) {
+      throw new Error('OneRoster connection requires both a client id and a client secret');
+    }
+    patch.oneroster_client_id_encrypted = encryptSisCredential(input.clientId);
+    patch.oneroster_client_secret_encrypted = encryptSisCredential(input.clientSecret);
+    patch.credential_hint = credentialHint(input.clientSecret);
+  }
+
+  const { data, error } = await supabase
+    .from('district_sis_connections')
+    .update(patch)
+    .eq('id', input.connectionId)
+    .select(SUMMARY_COLUMNS)
+    .single();
+
+  if (error) {
+    // The message can carry a constraint name but never a credential — the
+    // patch values are ciphertext and PostgREST does not echo them here.
+    log.error('Failed to store SIS credential', {
+      connectionId: input.connectionId,
+      error: error.message,
+    });
+    throw new Error(`Failed to store SIS credential: ${error.message}`);
+  }
+
+  // Rotation and first-time storage are materially different events during an
+  // incident review, so they are logged as different actions.
+  await logServerAuditEvent({
+    user_id: input.actorId,
+    action: existing.credential_hint ? 'sis_credential_rotated' : 'sis_credential_stored',
+    resource_type: 'district_sis_connection',
+    resource_id: input.connectionId,
+    metadata: {
+      district_id: existing.district_id,
+      sis_type: existing.sis_type,
+    },
+  });
+
+  return data as SisConnectionSummary;
+}
+
+/** Record the outcome of a connection test. Never stores anything sensitive. */
+export async function recordTestResult(params: {
+  connectionId: string;
+  actorId: string;
+  ok: boolean;
+  result: unknown;
+}): Promise<void> {
+  const supabase = createServiceClient();
+  const { error } = await supabase
+    .from('district_sis_connections')
+    .update({
+      status: params.ok ? 'connected' : 'error',
+      last_tested_at: new Date().toISOString(),
+      last_test_result: params.result,
+    })
+    .eq('id', params.connectionId);
+
+  if (error) throw new Error(`Failed to record test result: ${error.message}`);
+
+  await logServerAuditEvent({
+    user_id: params.actorId,
+    action: 'sis_connection_tested',
+    resource_type: 'district_sis_connection',
+    resource_id: params.connectionId,
+    metadata: { ok: params.ok },
+  });
+}
+
+/**
+ * Disconnect: clear the credentials, keep the connection row.
+ *
+ * The row is retained deliberately — it carries the DPA clearance and the
+ * record of who connected what and when, which is exactly what someone asks
+ * for after a disconnection. Deleting it would destroy that record to save a
+ * row.
+ */
+export async function disconnect(params: {
+  connectionId: string;
+  actorId: string;
+}): Promise<void> {
+  const supabase = createServiceClient();
+  const { error } = await supabase
+    .from('district_sis_connections')
+    .update({
+      aeries_certificate_encrypted: null,
+      oneroster_client_id_encrypted: null,
+      oneroster_client_secret_encrypted: null,
+      credential_hint: null,
+      last_tested_at: null,
+      last_test_result: null,
+      status: 'disabled',
+    })
+    .eq('id', params.connectionId);
+
+  if (error) throw new Error(`Failed to disconnect: ${error.message}`);
+
+  await logServerAuditEvent({
+    user_id: params.actorId,
+    action: 'sis_connection_disconnected',
+    resource_type: 'district_sis_connection',
+    resource_id: params.connectionId,
+  });
+}
+
+/**
+ * Record or revoke a district's signed DPA. Speddy-staff only — the caller is
+ * responsible for that check; this module does not know who is asking.
+ *
+ * Revoking is intentionally supported: a DPA can lapse. Because the CHECK
+ * constraint refuses to leave credentials behind an un-cleared DPA, revoking
+ * clears them in the same statement rather than leaving a live certificate
+ * sitting behind a gate that has just closed.
+ */
+export async function setDpaCleared(params: {
+  connectionId: string;
+  actorId: string;
+  cleared: boolean;
+}): Promise<void> {
+  const supabase = createServiceClient();
+
+  const { data: existing, error: loadError } = await supabase
+    .from('district_sis_connections')
+    .select('id, status')
+    .eq('id', params.connectionId)
+    .maybeSingle();
+
+  if (loadError) {
+    throw new Error(`Failed to load SIS connection: ${loadError.message}`);
+  }
+  if (!existing) throw new Error('SIS connection not found');
+
+  // Recording a DPA lifts the entry state and nothing else. A DPA renewal on a
+  // live connection must not knock it back to `awaiting_credentials` — the
+  // credentials are still there — and must not un-disable a disabled one.
+  const patch: Record<string, unknown> = params.cleared
+    ? {
+        dpa_cleared_at: new Date().toISOString(),
+        ...(existing.status === 'pending_dpa' ? { status: 'awaiting_credentials' } : {}),
+      }
+    : {
+        dpa_cleared_at: null,
+        aeries_certificate_encrypted: null,
+        oneroster_client_id_encrypted: null,
+        oneroster_client_secret_encrypted: null,
+        credential_hint: null,
+        last_tested_at: null,
+        last_test_result: null,
+        status: 'pending_dpa',
+      };
+
+  const { error } = await supabase
+    .from('district_sis_connections')
+    .update(patch)
+    .eq('id', params.connectionId);
+
+  if (error) throw new Error(`Failed to update DPA state: ${error.message}`);
+
+  await logServerAuditEvent({
+    user_id: params.actorId,
+    action: params.cleared ? 'sis_dpa_cleared' : 'sis_dpa_revoked',
+    resource_type: 'district_sis_connection',
+    resource_id: params.connectionId,
+  });
+}

--- a/lib/sis/connections.ts
+++ b/lib/sis/connections.ts
@@ -294,7 +294,17 @@ export async function storeCredential(
   return data as SisConnectionSummary;
 }
 
-/** Record the outcome of a connection test. Never stores anything sensitive. */
+/**
+ * Record the outcome of a connection test. Never stores anything sensitive.
+ *
+ * NOTE for SPE-396/397, which will be the first real callers: `last_test_result`
+ * is one of the columns granted to `authenticated`, so whatever lands here is
+ * readable by the district's own staff. Assemble it from named fields (status,
+ * area, message) — never spread a raw provider response into it. A failing SIS
+ * call can echo the submitted credential back in its body, which is why
+ * lib/integrations/aeries/client.ts already discards the body and keeps only
+ * status and path.
+ */
 export async function recordTestResult(params: {
   connectionId: string;
   actorId: string;

--- a/lib/sis/connections.ts
+++ b/lib/sis/connections.ts
@@ -35,6 +35,33 @@ const log = logger.child({ module: 'sis-connections' });
 
 export type SisType = 'aeries' | 'oneroster';
 
+/**
+ * Thrown when an operation names a connection that does not exist.
+ *
+ * Exported so routes can map it to a 404 by identity. Matching on the message
+ * text instead would silently degrade to a 500 the day someone rewords the
+ * string, and nothing would link the two files to warn them.
+ */
+export const SIS_CONNECTION_NOT_FOUND = 'SIS connection not found';
+
+/**
+ * What may be recorded about a connection test.
+ *
+ * Deliberately narrow rather than `unknown`. `last_test_result` is one of the
+ * columns granted to `authenticated`, so anything written here is readable by
+ * that district's staff — and a failing SIS call can echo the submitted
+ * credential back in its response body. A type is the only thing that stops a
+ * future caller spreading a raw provider response into it: Postgres cannot tell
+ * a certificate from a diagnostics blob, and a doc comment does not fail a
+ * build. (lib/integrations/aeries/client.ts already discards response bodies
+ * for the same reason.)
+ */
+export interface SisTestResult {
+  status?: number;
+  area?: string;
+  message?: string;
+}
+
 export type SisConnectionStatus =
   | 'pending_dpa'
   | 'awaiting_credentials'
@@ -230,7 +257,7 @@ export async function storeCredential(
   if (loadError) {
     throw new Error(`Failed to load SIS connection: ${loadError.message}`);
   }
-  if (!existing) throw new Error('SIS connection not found');
+  if (!existing) throw new Error(SIS_CONNECTION_NOT_FOUND);
   if (!existing.dpa_cleared_at) {
     throw new Error(
       'This district has no recorded DPA — credentials cannot be stored until one is on file'
@@ -309,7 +336,7 @@ export async function recordTestResult(params: {
   connectionId: string;
   actorId: string;
   ok: boolean;
-  result: unknown;
+  result: SisTestResult;
 }): Promise<void> {
   const supabase = createServiceClient();
   const { error } = await supabase
@@ -345,7 +372,13 @@ export async function disconnect(params: {
   actorId: string;
 }): Promise<void> {
   const supabase = createServiceClient();
-  const { error } = await supabase
+  // `.select().maybeSingle()` so a bogus id is a genuine failure. An UPDATE
+  // matching no row returns no error, so without this a disconnect against a
+  // connection that does not exist would report success AND write an
+  // `sis_connection_disconnected` audit record for it — a false entry in the
+  // one log someone reads during an incident. The other mutations check
+  // existence up front; this was the only one that did not.
+  const { data, error } = await supabase
     .from('district_sis_connections')
     .update({
       aeries_certificate_encrypted: null,
@@ -356,9 +389,12 @@ export async function disconnect(params: {
       last_test_result: null,
       status: 'disabled',
     })
-    .eq('id', params.connectionId);
+    .eq('id', params.connectionId)
+    .select('id')
+    .maybeSingle();
 
   if (error) throw new Error(`Failed to disconnect: ${error.message}`);
+  if (!data) throw new Error(SIS_CONNECTION_NOT_FOUND);
 
   await logServerAuditEvent({
     user_id: params.actorId,
@@ -393,7 +429,7 @@ export async function setDpaCleared(params: {
   if (loadError) {
     throw new Error(`Failed to load SIS connection: ${loadError.message}`);
   }
-  if (!existing) throw new Error('SIS connection not found');
+  if (!existing) throw new Error(SIS_CONNECTION_NOT_FOUND);
 
   // Recording a DPA lifts the entry state and nothing else. A DPA renewal on a
   // live connection must not knock it back to `awaiting_credentials` — the

--- a/lib/sis/credential-crypto.ts
+++ b/lib/sis/credential-crypto.ts
@@ -88,12 +88,18 @@ export function decryptSisCredential(encrypted: string): string {
   if (version !== VERSION || !ivB64 || !dataB64 || !tagB64) {
     throw new Error('Unrecognized encrypted SIS credential format');
   }
-  const decipher = createDecipheriv(
-    'aes-256-gcm',
-    getKey(),
-    Buffer.from(ivB64, 'base64')
-  );
-  decipher.setAuthTag(Buffer.from(tagB64, 'base64'));
+  const iv = Buffer.from(ivB64, 'base64');
+  const tag = Buffer.from(tagB64, 'base64');
+  // Node's setAuthTag accepts 4, 8, and 12-15 byte GCM tags as well as 16, so
+  // a truncated tag decrypts happily on a value that still looks like a valid
+  // envelope. Nothing we write produces one — encrypt always emits 12/16 — so
+  // pinning the lengths costs nothing and keeps the tag's guarantee full-width
+  // rather than whatever a stored value happens to claim.
+  if (iv.length !== 12 || tag.length !== 16) {
+    throw new Error('Unrecognized encrypted SIS credential format');
+  }
+  const decipher = createDecipheriv('aes-256-gcm', getKey(), iv);
+  decipher.setAuthTag(tag);
   return Buffer.concat([
     decipher.update(Buffer.from(dataB64, 'base64')),
     decipher.final(),

--- a/lib/sis/credential-crypto.ts
+++ b/lib/sis/credential-crypto.ts
@@ -26,6 +26,16 @@ function getKey(): Buffer {
   if (!raw) {
     throw new Error('SIS_CREDENTIAL_ENCRYPTION_KEY is not set');
   }
+  // Canonical base64, checked BEFORE decoding. Buffer.from(x, 'base64')
+  // silently discards characters it doesn't recognise, so a good 32-byte key
+  // with junk appended ("…=!!!") decodes to a valid-looking 32 bytes and would
+  // sail past a length check alone. A key that is subtly not the key you think
+  // it is fails at decrypt time, long after the ciphertext was written.
+  if (!/^[A-Za-z0-9+/]{43}=$/.test(raw)) {
+    throw new Error(
+      'SIS_CREDENTIAL_ENCRYPTION_KEY must be canonical base64 of 32 bytes (openssl rand -base64 32)'
+    );
+  }
   const key = Buffer.from(raw, 'base64');
   if (key.length !== 32) {
     throw new Error(
@@ -67,7 +77,14 @@ export function encryptSisCredential(plaintext: string): string {
 }
 
 export function decryptSisCredential(encrypted: string): string {
-  const [version, ivB64, dataB64, tagB64] = encrypted.split('.');
+  // Exactly four parts. Destructuring alone ignores extras, so
+  // `<valid-envelope>.junk` would decrypt happily — the GCM tag covers the
+  // ciphertext, not the envelope around it.
+  const parts = encrypted.split('.');
+  if (parts.length !== 4) {
+    throw new Error('Unrecognized encrypted SIS credential format');
+  }
+  const [version, ivB64, dataB64, tagB64] = parts;
   if (version !== VERSION || !ivB64 || !dataB64 || !tagB64) {
     throw new Error('Unrecognized encrypted SIS credential format');
   }

--- a/lib/sis/credential-crypto.ts
+++ b/lib/sis/credential-crypto.ts
@@ -1,0 +1,98 @@
+/**
+ * App-layer encryption for stored SIS credentials (SPE-395).
+ *
+ * `district_sis_connections` holds ciphertext only — an Aeries certificate, or
+ * a OneRoster client id/secret. The key lives in the
+ * SIS_CREDENTIAL_ENCRYPTION_KEY env var (32 bytes, base64 — generate with
+ * `openssl rand -base64 32`) and never touches the database. AES-256-GCM,
+ * fresh IV per encryption, auth tag verified on decrypt.
+ *
+ * Deliberately a SEPARATE key from CALENDAR_TOKEN_ENCRYPTION_KEY rather than a
+ * shared "app secret": these protect different data classes with different
+ * blast radii — a calendar token reaches one user's calendar, a district's SIS
+ * certificate reaches every student record in that district. Separate keys mean
+ * either can be rotated without touching the other, and a leak of one does not
+ * decrypt the other.
+ *
+ * Server-only: uses Node crypto and a secret env var. Never import from client
+ * components.
+ */
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+const VERSION = 'v1';
+
+function getKey(): Buffer {
+  const raw = process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+  if (!raw) {
+    throw new Error('SIS_CREDENTIAL_ENCRYPTION_KEY is not set');
+  }
+  const key = Buffer.from(raw, 'base64');
+  if (key.length !== 32) {
+    throw new Error(
+      'SIS_CREDENTIAL_ENCRYPTION_KEY must decode to 32 bytes (openssl rand -base64 32)'
+    );
+  }
+  return key;
+}
+
+/**
+ * Whether the key is present and well-formed. Callers use this to fail a
+ * credential-intake request up front with a clear operator error, rather than
+ * throwing mid-write and leaving a half-built connection row behind.
+ */
+export function sisCredentialEncryptionConfigured(): boolean {
+  try {
+    getKey();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Returns `v1.<iv>.<ciphertext>.<tag>`, each part base64. */
+export function encryptSisCredential(plaintext: string): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', getKey(), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return [
+    VERSION,
+    iv.toString('base64'),
+    ciphertext.toString('base64'),
+    tag.toString('base64'),
+  ].join('.');
+}
+
+export function decryptSisCredential(encrypted: string): string {
+  const [version, ivB64, dataB64, tagB64] = encrypted.split('.');
+  if (version !== VERSION || !ivB64 || !dataB64 || !tagB64) {
+    throw new Error('Unrecognized encrypted SIS credential format');
+  }
+  const decipher = createDecipheriv(
+    'aes-256-gcm',
+    getKey(),
+    Buffer.from(ivB64, 'base64')
+  );
+  decipher.setAuthTag(Buffer.from(tagB64, 'base64'));
+  return Buffer.concat([
+    decipher.update(Buffer.from(dataB64, 'base64')),
+    decipher.final(),
+  ]).toString('utf8');
+}
+
+/**
+ * Last 4 characters, for display next to a stored credential ("…a9f2").
+ *
+ * This is the ONLY part of a credential that may be persisted in the clear or
+ * shown to a client. Short secrets are masked entirely rather than largely
+ * revealed — a 6-character secret would otherwise have two thirds of it printed
+ * next to the connection it unlocks.
+ */
+export function credentialHint(plaintext: string): string {
+  const trimmed = plaintext.trim();
+  if (trimmed.length < 8) return '••••';
+  return `••••${trimmed.slice(-4)}`;
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "sim:verify-special-activities-rls": "tsx scripts/sim-district/verify-special-activities-rls.ts",
     "sim:verify-multi-school-rls": "tsx scripts/sim-district/verify-multi-school-rls.ts",
     "sim:verify-provider-schools-rls": "tsx scripts/sim-district/verify-provider-schools-rls.ts",
-    "sim:verify-sis-rls": "tsx scripts/sim-district/verify-sis-connections-rls.ts"
+    "sim:verify-sis-rls": "tsx scripts/sim-district/verify-sis-connections-rls.ts",
+    "sim:verify-sis-lifecycle": "tsx scripts/sim-district/verify-sis-lifecycle.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "sim:verify-child-link": "tsx scripts/sim-district/verify-child-link.ts",
     "sim:verify-special-activities-rls": "tsx scripts/sim-district/verify-special-activities-rls.ts",
     "sim:verify-multi-school-rls": "tsx scripts/sim-district/verify-multi-school-rls.ts",
-    "sim:verify-provider-schools-rls": "tsx scripts/sim-district/verify-provider-schools-rls.ts"
+    "sim:verify-provider-schools-rls": "tsx scripts/sim-district/verify-provider-schools-rls.ts",
+    "sim:verify-sis-rls": "tsx scripts/sim-district/verify-sis-connections-rls.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -708,6 +708,12 @@ export const DECLARED_UNSEEDED_TABLES: string[] = [
   'rotation_group_members', 'rotation_activity_pairs', 'rotation_week_assignments',
   'activity_type_availability', 'activated_school_years', 'school_year_config',
   'holidays',
+  // SIS integration (SPE-395). Not seeded: a connection row is created live by
+  // the feature under test, and holds encrypted district credentials, so the
+  // fixture should never carry one at rest. Swept bespoke in teardown by
+  // district_id — SWEPT_TABLES only keys on user/student/school identities,
+  // and this table is district-scoped.
+  'district_sis_connections',
   // Personal / auxiliary:
   'documents', 'curriculum_tracking', 'calendar_connections', 'calendar_events',
   'api_keys', 'teams', 'team_members', 'material_constraints',

--- a/scripts/sim-district/teardown.ts
+++ b/scripts/sim-district/teardown.ts
@@ -85,6 +85,20 @@ export async function teardown(admin: Admin): Promise<Record<string, number>> {
     deleted['debug_signup_log (swept)'] = await deleteWhereIn(admin, 'debug_signup_log', 'user_id', [...debugIds]);
   }
 
+  // district_sis_connections: district-scoped, so it has no user/student/school
+  // sweep key. Deleting the sim profiles would only NULL its created_by (the FK
+  // is ON DELETE SET NULL), leaving an orphaned row holding encrypted
+  // credentials behind — the one kind of residue least acceptable to leave in a
+  // shared fixture. Swept explicitly by the sim district id.
+  {
+    const { error, count } = await admin
+      .from('district_sis_connections')
+      .delete({ count: 'exact' })
+      .eq('district_id', DISTRICT.id);
+    if (error) throw new Error(`district_sis_connections sweep failed: ${error.message}`);
+    deleted['district_sis_connections (swept)'] = count ?? 0;
+  }
+
   // 3. School-scoped schedule scaffolding (school_id match catches all seeded
   //    rows; provider_id match catches any strays created by sim providers).
   for (const table of ['special_activities', 'bell_schedules', 'school_hours'] as const) {

--- a/scripts/sim-district/verify-sis-connections-rls.ts
+++ b/scripts/sim-district/verify-sis-connections-rls.ts
@@ -122,8 +122,14 @@ async function main(): Promise<void> {
     // kind of check that looks green for the wrong reason.
     check(stored!.credential_hint === credentialHint(CERT),
       'hint stored masked', String(stored!.credential_hint));
-    check(!stored!.credential_hint!.includes(CERT.slice(0, -4)),
-      'hint reveals nothing but the last 4');
+    // Asserted by SHAPE, not by containment. The obvious
+    // `!hint.includes(CERT.slice(0, -4))` cannot fail: the hint is 8 characters
+    // and that prefix is 38, so an 8-character string can never contain it —
+    // the check stayed green no matter what the hint held.
+    const hint = String(stored!.credential_hint);
+    check(
+      hint.length === 8 && hint.startsWith('••••') && hint.slice(4) === CERT.slice(-4),
+      'hint is the mask plus exactly the last 4, nothing more', hint);
 
     console.log('\ndistrict staff — status readable, credentials NOT:');
     for (const [persona, label] of [['theo', 'district_tech (Theo)'], ['dana', 'district_adm (Dana)']] as const) {
@@ -145,11 +151,16 @@ async function main(): Promise<void> {
         `HTTP ${star.status} code=${star.code ?? 'none'}`);
 
       // Browser writes denied outright — every mutation is server-side.
+      // Assert WHY it was refused. `!wErr ? count === 0 : true` passed for ANY
+      // error — a renamed column, a bad payload, a dropped connection — which
+      // is exactly the trap this file's header says it avoids. An RLS-denied
+      // UPDATE is either 0 rows affected (policy filtered it) or 42501 (the
+      // column grant refused first); nothing else counts.
       const { error: wErr, count } = await client
         .from('district_sis_connections')
         .update({ status: 'disabled' }, { count: 'exact' })
         .eq('id', connectionId);
-      check(!wErr ? count === 0 : true,
+      check(wErr ? wErr.code === '42501' : count === 0,
         `${label}: cannot modify the connection from a browser`,
         wErr ? `err=${wErr.code}` : `${count} row(s) affected`);
 

--- a/scripts/sim-district/verify-sis-connections-rls.ts
+++ b/scripts/sim-district/verify-sis-connections-rls.ts
@@ -1,0 +1,187 @@
+/**
+ * SPE-395 — `district_sis_connections` must expose connection STATUS to the
+ * district's own staff while never exposing a credential to any browser.
+ *
+ * Same reason this is a script and not a jest test as its siblings: our unit
+ * tests mock the Supabase client, so they cannot see RLS or column grants at
+ * all — they pass identically whether a credential is readable or not.
+ *
+ * WHY THIS TABLE IS DIFFERENT. Row-level security cannot hide a COLUMN. A
+ * policy that lets a district_tech read their connection row would also hand
+ * them the ciphertext, which is what `calendar_connections` does. A district's
+ * Aeries certificate unlocks every student record in that district, so this
+ * table additionally uses column-level grants: `authenticated` holds SELECT on
+ * the non-secret columns only and cannot name a credential column.
+ *
+ * The contract asserted here:
+ *   - the district's tech admin and district admin CAN read connection status;
+ *   - neither can read any credential column — refused with 42501, asserted by
+ *     CODE, not merely "the request failed";
+ *   - `select('*')` fails too, since `*` expands to columns they may not read;
+ *   - a site admin, and another district's staff, see nothing at all;
+ *   - browser writes are refused even for the district's own tech admin;
+ *   - the service role CAN round-trip a credential, so the app path works.
+ *
+ * Traps deliberately avoided (CLAUDE.md):
+ *   - assert WHY a read was refused (42501), so a row simply not matching RLS
+ *     cannot masquerade as a column-grant refusal;
+ *   - assert status AND rows, so a dead session cannot pass a negative;
+ *   - every write is undone on the way out, pass or fail, and the cleanup is
+ *     itself asserted.
+ *
+ * Requires a seeded sim district and SIS_CREDENTIAL_ENCRYPTION_KEY.
+ * Usage: npm run sim:verify-sis-rls
+ */
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { assertProjectRef, createAdmin, requireEnv } from './lib';
+import { DISTRICT, derivePassword, personaEmail } from './manifest';
+import {
+  credentialHint,
+  decryptSisCredential,
+  encryptSisCredential,
+} from '../../lib/sis/credential-crypto';
+
+const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+const secret = requireEnv('SIM_DISTRICT_PASSWORD');
+assertProjectRef();
+
+const admin = createAdmin();
+const CREDENTIAL_COLUMNS = [
+  'aeries_certificate_encrypted',
+  'oneroster_client_id_encrypted',
+  'oneroster_client_secret_encrypted',
+];
+const SAFE_COLUMNS = 'id,district_id,sis_type,status,credential_hint,dpa_cleared_at';
+
+let failures = 0;
+function check(ok: boolean, label: string, detail = ''): void {
+  if (!ok) failures++;
+  console.log(`  [${ok ? 'ok  ' : 'FAIL'}] ${label.padEnd(60)} ${detail}`);
+}
+
+async function signIn(personaKey: string): Promise<{ client: SupabaseClient; token: string }> {
+  const email = personaEmail(personaKey);
+  const client = createClient(url, anon, { auth: { persistSession: false, autoRefreshToken: false } });
+  const { error } = await client.auth.signInWithPassword({
+    email, password: derivePassword(secret, email),
+  });
+  if (error) throw new Error(`sim login failed for ${email} — is the district seeded? (${error.message})`);
+  const token = (await client.auth.getSession()).data.session!.access_token;
+  return { client, token };
+}
+
+/** Raw PostgREST read, so the HTTP status and PostgREST error code are visible. */
+async function read(token: string, select: string) {
+  const res = await fetch(
+    `${url}/rest/v1/district_sis_connections?select=${encodeURIComponent(select)}`,
+    { headers: { apikey: anon, Authorization: `Bearer ${token}` } },
+  );
+  const text = await res.text();
+  let parsed: unknown = null;
+  try { parsed = JSON.parse(text); } catch { /* error bodies are not always arrays */ }
+  const code = parsed && !Array.isArray(parsed) ? (parsed as { code?: string }).code : undefined;
+  return { status: res.status, code, rows: Array.isArray(parsed) ? parsed : [], body: text.slice(0, 140) };
+}
+
+async function main(): Promise<void> {
+  const CERT = 'FAKE-AERIES-CERT-FOR-SIM-VERIFICATION-a9f2';
+  let connectionId: string | null = null;
+
+  try {
+    // Service-role write: the path the real API routes use.
+    const { data: created, error: createErr } = await admin
+      .from('district_sis_connections')
+      .insert({
+        district_id: DISTRICT.id,
+        sis_type: 'aeries',
+        base_url: 'https://sim.aeries.test',
+        status: 'connected',
+        dpa_cleared_at: new Date().toISOString(),
+        aeries_certificate_encrypted: encryptSisCredential(CERT),
+        credential_hint: credentialHint(CERT),
+      })
+      .select('id')
+      .single();
+    check(!createErr, 'service role can create a connection (the app write path)',
+      createErr ? createErr.message : 'created');
+    if (createErr) throw new Error('cannot continue without a connection row');
+    connectionId = created!.id;
+
+    // Round-trip through the DB, proving what we stored is what we get back.
+    const { data: stored } = await admin
+      .from('district_sis_connections')
+      .select('aeries_certificate_encrypted, credential_hint')
+      .eq('id', connectionId).single();
+    check(decryptSisCredential(stored!.aeries_certificate_encrypted!) === CERT,
+      'credential round-trips through the database');
+    check(!stored!.aeries_certificate_encrypted!.includes(CERT),
+      'stored value is ciphertext, not the plaintext');
+    // Derived, not hardcoded — a literal copied from another fixture passes or
+    // fails on whether the two happened to share a suffix, which is exactly the
+    // kind of check that looks green for the wrong reason.
+    check(stored!.credential_hint === credentialHint(CERT),
+      'hint stored masked', String(stored!.credential_hint));
+    check(!stored!.credential_hint!.includes(CERT.slice(0, -4)),
+      'hint reveals nothing but the last 4');
+
+    console.log('\ndistrict staff — status readable, credentials NOT:');
+    for (const [persona, label] of [['theo', 'district_tech (Theo)'], ['dana', 'district_adm (Dana)']] as const) {
+      const { client, token } = await signIn(persona);
+
+      const safe = await read(token, SAFE_COLUMNS);
+      check(safe.status === 200 && safe.rows.length === 1,
+        `${label}: reads connection status`, `HTTP ${safe.status}, ${safe.rows.length} row(s)`);
+
+      for (const col of CREDENTIAL_COLUMNS) {
+        const r = await read(token, col);
+        check(r.status === 403 && r.code === '42501',
+          `${label}: refused ${col}`, `HTTP ${r.status} code=${r.code ?? 'none'}`);
+      }
+
+      const star = await read(token, '*');
+      check(star.status === 403 && star.code === '42501',
+        `${label}: select('*') refused (expands to denied columns)`,
+        `HTTP ${star.status} code=${star.code ?? 'none'}`);
+
+      // Browser writes denied outright — every mutation is server-side.
+      const { error: wErr, count } = await client
+        .from('district_sis_connections')
+        .update({ status: 'disabled' }, { count: 'exact' })
+        .eq('id', connectionId);
+      check(!wErr ? count === 0 : true,
+        `${label}: cannot modify the connection from a browser`,
+        wErr ? `err=${wErr.code}` : `${count} row(s) affected`);
+
+      await client.auth.signOut();
+    }
+
+    console.log('\nnegative space — nobody else sees it at all:');
+    const site = await signIn('priya');
+    const siteRead = await read(site.token, SAFE_COLUMNS);
+    check(siteRead.status === 200 && siteRead.rows.length === 0,
+      'site admin sees no connection', `HTTP ${siteRead.status}, ${siteRead.rows.length} row(s)`);
+    await site.client.auth.signOut();
+
+    const provider = await signIn('rachel');
+    const provRead = await read(provider.token, SAFE_COLUMNS);
+    check(provRead.status === 200 && provRead.rows.length === 0,
+      'a provider sees no connection', `HTTP ${provRead.status}, ${provRead.rows.length} row(s)`);
+    await provider.client.auth.signOut();
+  } finally {
+    if (connectionId) {
+      const { error } = await admin.from('district_sis_connections').delete().eq('id', connectionId);
+      check(!error, 'cleanup: connection row removed', error?.message ?? 'deleted');
+    }
+    const { count } = await admin
+      .from('district_sis_connections')
+      .select('id', { count: 'exact', head: true })
+      .eq('district_id', DISTRICT.id);
+    check(count === 0, 'no SIS connection residue left in the fixture', `${count} row(s)`);
+  }
+
+  console.log(`\n${failures === 0 ? 'All checks passed.' : `${failures} check(s) FAILED.`}`);
+  process.exit(failures > 0 ? 1 : 0);
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/scripts/sim-district/verify-sis-lifecycle.ts
+++ b/scripts/sim-district/verify-sis-lifecycle.ts
@@ -215,12 +215,12 @@ async function main(): Promise<void> {
     const decrypted = await getDecryptedCredential(shell.id);
     check(
       decrypted?.sisType === 'aeries' && decrypted.certificate === AERIES_CERT,
-      'certificate decrypts to the exact multi-line original',
+      'certificate decrypts to the exact original',
       decrypted?.sisType === 'aeries' ? `${decrypted.certificate.length} chars` : 'MISMATCH'
     );
 
     console.log('\nrecord a test, then rotate:');
-    await recordTestResult({ connectionId: shell.id, actorId, ok: true, result: { http: 200 } });
+    await recordTestResult({ connectionId: shell.id, actorId, ok: true, result: { status: 200, area: 'students', message: 'ok' } });
     const tested = await readRaw(shell.id);
     check(tested?.status === 'connected', 'a passing test marks it connected', String(tested?.status));
     check(!!tested?.last_tested_at, 'last_tested_at persisted', String(tested?.last_tested_at));

--- a/scripts/sim-district/verify-sis-lifecycle.ts
+++ b/scripts/sim-district/verify-sis-lifecycle.ts
@@ -53,16 +53,13 @@ requireEnv('SIS_CREDENTIAL_ENCRYPTION_KEY');
 
 const admin = createAdmin();
 
-// Realistic shapes. The Aeries value is a pasted multi-line PEM (newlines and
-// '=' padding are exactly what a hand-written ciphertext regex gets wrong), and
-// the OneRoster secret is URL-safe-ish with punctuation.
-const AERIES_CERT = [
-  '-----BEGIN CERTIFICATE-----',
-  'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsim+fake/cert+data==',
-  'Zm9yU1BFLTM5NXZlcmlmaWNhdGlvbk9ubHkK/not+a+real+key+a9f2',
-  '-----END CERTIFICATE-----',
-].join('\n');
-const AERIES_CERT_ROTATED = AERIES_CERT.replace('a9f2', 'b7c1');
+// Realistic shapes. An Aeries certificate is 32 hex characters sent as the
+// AERIES-CERT header value (lib/integrations/aeries/config.ts) — NOT a PEM. It
+// matters here: a PEM ends '-----END CERTIFICATE-----', so every PEM masks to
+// the same '••••----' and any assertion comparing hints would pass whether or
+// not the value changed. The OneRoster secret carries punctuation.
+const AERIES_CERT = 'sim395fakecert0000000000000da9f2';
+const AERIES_CERT_ROTATED = 'sim395fakecert0000000000000db7c1';
 const OR_CLIENT_ID = 'sim-oneroster-client-id-0001';
 const OR_CLIENT_SECRET = 'sim~oneroster~secret!value.7f3e';
 
@@ -198,7 +195,7 @@ async function main(): Promise<void> {
       String(storedRaw?.aeries_certificate_encrypted).slice(0, 24) + '…'
     );
     check(
-      !String(storedRaw?.aeries_certificate_encrypted).includes('BEGIN CERTIFICATE'),
+      !String(storedRaw?.aeries_certificate_encrypted).includes(AERIES_CERT),
       'stored value is not the plaintext certificate'
     );
     check(storedRaw?.credential_hint === credentialHint(AERIES_CERT),
@@ -231,10 +228,9 @@ async function main(): Promise<void> {
     const beforeRotation = String(storedRaw?.aeries_certificate_encrypted);
     await storeCredential({ connectionId: shell.id, actorId, certificate: AERIES_CERT_ROTATED });
     const rotated = await readRaw(shell.id);
-    // Comparing the hint alone would be vacuous here: every PEM ends in
-    // "-----END CERTIFICATE-----", so both certs mask to the same '••••----'
-    // and the check would pass even if the rotation never happened. The
-    // substantive assertion is that the stored secret is now the new one.
+    // The hint check below is real now that the fixtures are hex certs ending
+    // in different characters, but it is still the weaker assertion: the
+    // substantive one is that the stored secret itself changed.
     check(
       String(rotated?.aeries_certificate_encrypted) !== beforeRotation,
       'rotation replaced the stored ciphertext'
@@ -365,7 +361,10 @@ async function main(): Promise<void> {
       check(actions.has(expected), `audited: ${expected}`);
     }
     const auditBlob = JSON.stringify(events ?? []);
-    check(!auditBlob.includes('BEGIN CERTIFICATE'), 'no certificate in the audit trail');
+    check(
+      !auditBlob.includes(AERIES_CERT) && !auditBlob.includes(AERIES_CERT_ROTATED),
+      'no certificate in the audit trail'
+    );
     check(!auditBlob.includes(OR_CLIENT_SECRET), 'no client secret in the audit trail');
   } finally {
     console.log('\ncleanup:');

--- a/scripts/sim-district/verify-sis-lifecycle.ts
+++ b/scripts/sim-district/verify-sis-lifecycle.ts
@@ -1,0 +1,395 @@
+/**
+ * SPE-395 — drive `lib/sis/connections.ts` against the REAL database.
+ *
+ * Its sibling `verify-sis-connections-rls.ts` proves a browser cannot read a
+ * credential. This proves the other half: that the server-side path the app
+ * actually uses works, and that every rule the migration claims to enforce is
+ * enforced by the database rather than only by the module.
+ *
+ * Why this cannot be a jest test. The unit suite mocks the Supabase client, so
+ * a mocked write "succeeds" whether or not Postgres would have taken it. Every
+ * assertion below is one a mock would have gotten wrong:
+ *
+ *   - the ciphertext_shape CHECK is a regex written by hand against a sample.
+ *     If it disagrees with what encryptSisCredential() actually emits — one
+ *     stray padding character — every credential write in production fails.
+ *     Nothing but a real INSERT can tell us.
+ *   - same for hint_shape and the multi-byte '••••' mask.
+ *   - the DPA gate exists twice, in the module and in a CHECK. The module's
+ *     copy is tested by jest; only this can show the database's copy is real,
+ *     which is what makes the gate survive a future route that forgets it.
+ *   - `created_by` -> profiles, `district_id` -> districts: FK shape and width
+ *     (the varchar(20)/varchar(36) bug) only show up against real rows.
+ *
+ * Traps deliberately avoided (CLAUDE.md):
+ *   - every negative check asserts WHY it was refused — the constraint name or
+ *     the specific message — so a write rejected for some incidental reason
+ *     cannot keep a check green after the guard it tests is gone;
+ *   - every negative check runs against a FRESH fixture in the state that makes
+ *     the guard meaningful, never one already in the target state;
+ *   - persistence is asserted by reading the row back, never by a status code.
+ *
+ * Writes only to the sim district, and removes everything it wrote.
+ * Requires a seeded sim district and SIS_CREDENTIAL_ENCRYPTION_KEY.
+ * Usage: npm run sim:verify-sis-lifecycle
+ */
+import { createAdmin, requireEnv } from './lib';
+import { DISTRICT, personaEmail } from './manifest';
+import { credentialHint } from '../../lib/sis/credential-crypto';
+import {
+  disconnect,
+  getConnection,
+  getDecryptedCredential,
+  listConnections,
+  recordTestResult,
+  setDpaCleared,
+  storeCredential,
+  createConnection,
+} from '../../lib/sis/connections';
+
+// Fail fast and loudly: without the key, storeCredential refuses by design and
+// every credential check below would "pass" by never running.
+requireEnv('SIS_CREDENTIAL_ENCRYPTION_KEY');
+
+const admin = createAdmin();
+
+// Realistic shapes. The Aeries value is a pasted multi-line PEM (newlines and
+// '=' padding are exactly what a hand-written ciphertext regex gets wrong), and
+// the OneRoster secret is URL-safe-ish with punctuation.
+const AERIES_CERT = [
+  '-----BEGIN CERTIFICATE-----',
+  'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsim+fake/cert+data==',
+  'Zm9yU1BFLTM5NXZlcmlmaWNhdGlvbk9ubHkK/not+a+real+key+a9f2',
+  '-----END CERTIFICATE-----',
+].join('\n');
+const AERIES_CERT_ROTATED = AERIES_CERT.replace('a9f2', 'b7c1');
+const OR_CLIENT_ID = 'sim-oneroster-client-id-0001';
+const OR_CLIENT_SECRET = 'sim~oneroster~secret!value.7f3e';
+
+let failures = 0;
+function check(ok: boolean, label: string, detail = ''): void {
+  if (!ok) failures++;
+  console.log(`  [${ok ? 'ok  ' : 'FAIL'}] ${label.padEnd(52)}${detail}`);
+}
+
+/** Read a row with the service role, including the columns clients cannot see. */
+async function readRaw(id: string) {
+  const { data, error } = await admin
+    .from('district_sis_connections')
+    .select(
+      'id, sis_type, status, dpa_cleared_at, credential_hint, last_tested_at, last_test_result, ' +
+        'aeries_certificate_encrypted, oneroster_client_id_encrypted, oneroster_client_secret_encrypted'
+    )
+    .eq('id', id)
+    .maybeSingle();
+  if (error) throw new Error(`readRaw failed: ${error.message}`);
+  return data as Record<string, any> | null;
+}
+
+/** Run a thunk and return the error message, or null if it unexpectedly passed. */
+async function refusedWith(fn: () => Promise<unknown>): Promise<string | null> {
+  try {
+    await fn();
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+async function main(): Promise<void> {
+  console.log(`\nSPE-395 · SIS connection lifecycle against the real database`);
+  console.log(`district: ${DISTRICT.id} (${DISTRICT.name})\n`);
+
+  // A real profile id — created_by is a live FK to profiles.
+  const { data: actor, error: actorError } = await admin
+    .from('profiles')
+    .select('id, email')
+    .eq('email', personaEmail('theo'))
+    .single();
+  if (actorError || !actor) {
+    console.error(`Could not resolve the sim district tech admin: ${actorError?.message}`);
+    console.error('Run `npm run sim:reset -- --yes` first.');
+    process.exit(1);
+  }
+  const actorId = (actor as { id: string }).id;
+
+  const created: string[] = [];
+
+  try {
+    // Guard against a stale fixture silently satisfying later assertions.
+    const preexisting = await listConnections(DISTRICT.id);
+    check(preexisting.length === 0, 'fixture starts with no SIS connection',
+      `${preexisting.length} row(s)`);
+
+    console.log('\ncreate — a connection shell, before any DPA:');
+    const shell = await createConnection({
+      districtId: DISTRICT.id,
+      sisType: 'aeries',
+      actorId,
+      baseUrl: 'https://sim.aeries.example.test',
+    });
+    created.push(shell.id);
+    check(shell.status === 'pending_dpa', 'new connection enters pending_dpa', shell.status);
+    check(shell.dpa_cleared_at === null, 'new connection has no DPA', String(shell.dpa_cleared_at));
+    check(shell.credential_hint === null, 'new connection has no credential', String(shell.credential_hint));
+    check(shell.district_id === DISTRICT.id, 'district_id round-trips', shell.district_id);
+
+    // The sim district's id is short, so the round-trip above says nothing
+    // about the varchar(20) -> varchar(36) fix. Districts created through
+    // /api/internal/create-district get a 36-char UUID, and a narrow column
+    // would reject them with value-too-long. Assert the declared width itself.
+    // A 36-char id that is deliberately not a real district: if the column were
+    // still varchar(20) this fails on length (22001) BEFORE the FK is consulted,
+    // so "rejected by the FK" is precisely the evidence that the width is right.
+    const probeId = '01234567-89ab-cdef-0123-456789abcdef';
+    const { error: wideError } = await admin
+      .from('district_sis_connections')
+      .insert({ district_id: probeId, sis_type: 'aeries' });
+    check(
+      !!wideError && /foreign key|violates foreign key constraint/i.test(wideError.message),
+      'district_id column accepts a 36-char id (fails on the FK, not on width)',
+      wideError?.message?.slice(0, 90) ?? 'UNEXPECTEDLY INSERTED'
+    );
+
+    console.log('\nthe DPA gate — asserted on a fixture that has no DPA yet:');
+    const moduleRefusal = await refusedWith(() =>
+      storeCredential({ connectionId: shell.id, actorId, certificate: AERIES_CERT })
+    );
+    check(
+      moduleRefusal !== null && /no recorded DPA/i.test(moduleRefusal),
+      'module refuses a credential before the DPA',
+      moduleRefusal ?? 'NOT REFUSED'
+    );
+    // And independently of the module: the database refuses it too. This is
+    // what makes the gate survive a future writer that skips this module.
+    const { error: dbGate } = await admin
+      .from('district_sis_connections')
+      .update({ aeries_certificate_encrypted: 'v1.aaaa.bbbb.cccc' })
+      .eq('id', shell.id);
+    check(
+      !!dbGate && /no_credentials_before_dpa/.test(dbGate.message),
+      'database refuses it too, by CHECK constraint',
+      dbGate?.message?.slice(0, 90) ?? 'NOT REFUSED'
+    );
+    const stillEmpty = await readRaw(shell.id);
+    check(stillEmpty?.aeries_certificate_encrypted === null,
+      'no credential landed despite two attempts', String(stillEmpty?.aeries_certificate_encrypted));
+
+    console.log('\nrecord the DPA:');
+    await setDpaCleared({ connectionId: shell.id, actorId, cleared: true });
+    const cleared = await readRaw(shell.id);
+    check(!!cleared?.dpa_cleared_at, 'dpa_cleared_at persisted', String(cleared?.dpa_cleared_at));
+    check(cleared?.status === 'awaiting_credentials',
+      'pending_dpa lifts to awaiting_credentials', String(cleared?.status));
+
+    console.log('\nstore a credential — the shapes the CHECK constraints police:');
+    const stored = await storeCredential({
+      connectionId: shell.id,
+      actorId,
+      certificate: AERIES_CERT,
+    });
+    const storedRaw = await readRaw(shell.id);
+    // The headline assertion: real ciphertext from real code satisfied the
+    // hand-written ciphertext_shape regex.
+    check(
+      typeof storedRaw?.aeries_certificate_encrypted === 'string' &&
+        storedRaw.aeries_certificate_encrypted.startsWith('v1.'),
+      'ciphertext_shape accepts real encryptSisCredential output',
+      String(storedRaw?.aeries_certificate_encrypted).slice(0, 24) + '…'
+    );
+    check(
+      !String(storedRaw?.aeries_certificate_encrypted).includes('BEGIN CERTIFICATE'),
+      'stored value is not the plaintext certificate'
+    );
+    check(storedRaw?.credential_hint === credentialHint(AERIES_CERT),
+      'hint_shape accepts the real mask', String(storedRaw?.credential_hint));
+    // Derived, not copied from a fixture: a hardcoded expectation here would
+    // assert my arithmetic rather than the code's.
+    const hint = String(storedRaw?.credential_hint);
+    check(
+      hint.length === 8 && hint.startsWith('••••') && hint.slice(4) === AERIES_CERT.trim().slice(-4),
+      'hint is the mask plus exactly 4 characters',
+      hint
+    );
+    check(stored.status === 'testing', 'status moves to testing', stored.status);
+    check(storedRaw?.last_tested_at === null, 'no test result is implied by storing');
+
+    console.log('\ndecrypt — the round trip the connection test depends on:');
+    const decrypted = await getDecryptedCredential(shell.id);
+    check(
+      decrypted?.sisType === 'aeries' && decrypted.certificate === AERIES_CERT,
+      'certificate decrypts to the exact multi-line original',
+      decrypted?.sisType === 'aeries' ? `${decrypted.certificate.length} chars` : 'MISMATCH'
+    );
+
+    console.log('\nrecord a test, then rotate:');
+    await recordTestResult({ connectionId: shell.id, actorId, ok: true, result: { http: 200 } });
+    const tested = await readRaw(shell.id);
+    check(tested?.status === 'connected', 'a passing test marks it connected', String(tested?.status));
+    check(!!tested?.last_tested_at, 'last_tested_at persisted', String(tested?.last_tested_at));
+
+    const beforeRotation = String(storedRaw?.aeries_certificate_encrypted);
+    await storeCredential({ connectionId: shell.id, actorId, certificate: AERIES_CERT_ROTATED });
+    const rotated = await readRaw(shell.id);
+    // Comparing the hint alone would be vacuous here: every PEM ends in
+    // "-----END CERTIFICATE-----", so both certs mask to the same '••••----'
+    // and the check would pass even if the rotation never happened. The
+    // substantive assertion is that the stored secret is now the new one.
+    check(
+      String(rotated?.aeries_certificate_encrypted) !== beforeRotation,
+      'rotation replaced the stored ciphertext'
+    );
+    const rotatedPlain = await getDecryptedCredential(shell.id);
+    check(
+      rotatedPlain?.sisType === 'aeries' && rotatedPlain.certificate === AERIES_CERT_ROTATED,
+      'the rotated certificate is what decrypts now'
+    );
+    check(rotated?.credential_hint === credentialHint(AERIES_CERT_ROTATED),
+      'hint matches the rotated credential', String(rotated?.credential_hint));
+    check(rotated?.last_tested_at === null,
+      'rotation clears the stale test result', String(rotated?.last_tested_at));
+    check(rotated?.status === 'testing',
+      'a rotated credential is no longer claimed connected', String(rotated?.status));
+
+    console.log('\ncredential_shape — an Aeries row cannot hold OneRoster fields:');
+    const { error: crossType } = await admin
+      .from('district_sis_connections')
+      .update({ oneroster_client_id_encrypted: 'v1.aaaa.bbbb.cccc' })
+      .eq('id', shell.id);
+    check(
+      !!crossType && /credential_shape/.test(crossType.message),
+      'database rejects a OneRoster secret on an Aeries row',
+      crossType?.message?.slice(0, 90) ?? 'NOT REFUSED'
+    );
+
+    console.log('\nhint_shape — a full secret cannot be written to the one public column:');
+    const { error: fatHint } = await admin
+      .from('district_sis_connections')
+      .update({ credential_hint: OR_CLIENT_SECRET })
+      .eq('id', shell.id);
+    check(
+      !!fatHint && /hint_shape/.test(fatHint.message),
+      'database rejects an unmasked hint',
+      fatHint?.message?.slice(0, 90) ?? 'NOT REFUSED'
+    );
+
+    console.log('\nOneRoster — the paired-credential path:');
+    const orShell = await createConnection({
+      districtId: DISTRICT.id,
+      sisType: 'oneroster',
+      actorId,
+      baseUrl: 'https://sim.oneroster.example.test/ims/oneroster/v1p1',
+      tokenUrl: 'https://sim.oneroster.example.test/token',
+    });
+    created.push(orShell.id);
+    await setDpaCleared({ connectionId: orShell.id, actorId, cleared: true });
+
+    // All-or-nothing, asserted on a row that currently has NEITHER half — the
+    // state where the constraint is actually load-bearing.
+    const { error: halfPair } = await admin
+      .from('district_sis_connections')
+      .update({ oneroster_client_id_encrypted: 'v1.aaaa.bbbb.cccc' })
+      .eq('id', orShell.id);
+    check(
+      !!halfPair && /credential_shape/.test(halfPair.message),
+      'database rejects a client id with no secret',
+      halfPair?.message?.slice(0, 90) ?? 'NOT REFUSED'
+    );
+
+    const orModuleRefusal = await refusedWith(() =>
+      storeCredential({ connectionId: orShell.id, actorId, clientId: OR_CLIENT_ID })
+    );
+    check(
+      orModuleRefusal !== null && /client id and a client secret/i.test(orModuleRefusal),
+      'module refuses a half pair too',
+      orModuleRefusal ?? 'NOT REFUSED'
+    );
+
+    await storeCredential({
+      connectionId: orShell.id,
+      actorId,
+      clientId: OR_CLIENT_ID,
+      clientSecret: OR_CLIENT_SECRET,
+    });
+    const orDecrypted = await getDecryptedCredential(orShell.id);
+    check(
+      orDecrypted?.sisType === 'oneroster' &&
+        orDecrypted.clientId === OR_CLIENT_ID &&
+        orDecrypted.clientSecret === OR_CLIENT_SECRET,
+      'both halves decrypt to their originals'
+    );
+    const orRaw = await readRaw(orShell.id);
+    check(orRaw?.credential_hint === credentialHint(OR_CLIENT_SECRET),
+      'hint comes from the secret, not the id', String(orRaw?.credential_hint));
+
+    console.log('\nrevoke the DPA — the credentials must go with it:');
+    await setDpaCleared({ connectionId: orShell.id, actorId, cleared: false });
+    const revoked = await readRaw(orShell.id);
+    check(revoked?.dpa_cleared_at === null, 'dpa_cleared_at cleared', String(revoked?.dpa_cleared_at));
+    check(
+      revoked?.oneroster_client_id_encrypted === null &&
+        revoked?.oneroster_client_secret_encrypted === null &&
+        revoked?.credential_hint === null,
+      'no credential survives a revoked DPA'
+    );
+    check(revoked?.status === 'pending_dpa', 'status returns to pending_dpa', String(revoked?.status));
+    const afterRevoke = await getDecryptedCredential(orShell.id);
+    check(afterRevoke === null, 'nothing left to decrypt', String(afterRevoke));
+
+    console.log('\ndisconnect — credentials go, the record stays:');
+    await disconnect({ connectionId: shell.id, actorId });
+    const disconnected = await readRaw(shell.id);
+    check(disconnected?.aeries_certificate_encrypted === null, 'certificate cleared');
+    check(disconnected?.credential_hint === null, 'hint cleared');
+    check(disconnected?.status === 'disabled', 'status is disabled', String(disconnected?.status));
+    check(!!disconnected?.dpa_cleared_at, 'the DPA record survives the disconnect',
+      String(disconnected?.dpa_cleared_at));
+
+    console.log('\nthe audit trail — written, and free of secrets:');
+    const { data: events, error: auditError } = await admin
+      .from('audit_logs')
+      .select('action, resource_id, metadata')
+      .eq('resource_type', 'district_sis_connection')
+      .in('resource_id', created);
+    check(!auditError, 'audit rows readable', auditError?.message ?? '');
+    const actions = new Set((events ?? []).map((e: any) => e.action));
+    for (const expected of [
+      'sis_connection_created',
+      'sis_dpa_cleared',
+      'sis_dpa_revoked',
+      'sis_credential_stored',
+      'sis_credential_rotated',
+      'sis_connection_tested',
+      'sis_connection_disconnected',
+    ]) {
+      check(actions.has(expected), `audited: ${expected}`);
+    }
+    const auditBlob = JSON.stringify(events ?? []);
+    check(!auditBlob.includes('BEGIN CERTIFICATE'), 'no certificate in the audit trail');
+    check(!auditBlob.includes(OR_CLIENT_SECRET), 'no client secret in the audit trail');
+  } finally {
+    console.log('\ncleanup:');
+    for (const id of created) {
+      const { error } = await admin.from('district_sis_connections').delete().eq('id', id);
+      check(!error, `cleanup: connection ${id.slice(0, 8)} removed`, error?.message ?? 'deleted');
+    }
+    if (created.length > 0) {
+      const { error: auditCleanup } = await admin
+        .from('audit_logs')
+        .delete()
+        .eq('resource_type', 'district_sis_connection')
+        .in('resource_id', created);
+      check(!auditCleanup, 'cleanup: audit rows removed', auditCleanup?.message ?? 'deleted');
+    }
+    const { count } = await admin
+      .from('district_sis_connections')
+      .select('id', { count: 'exact', head: true })
+      .eq('district_id', DISTRICT.id);
+    check(count === 0, 'no SIS connection residue left in the fixture', `${count} row(s)`);
+  }
+
+  console.log(`\n${failures === 0 ? 'All checks passed.' : `${failures} check(s) FAILED.`}`);
+  process.exit(failures > 0 ? 1 : 0);
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/supabase/migrations/20260806_spe395_district_sis_connections.sql
+++ b/supabase/migrations/20260806_spe395_district_sis_connections.sql
@@ -1,0 +1,157 @@
+-- SPE-395: per-district SIS credential store, encrypted at rest.
+--
+-- Today the Aeries client is env-var-only — one global connection for the whole
+-- platform. This gives each district its own stored connection, which is what
+-- the tech portal (SPE-396 Aeries / SPE-397 OneRoster) and the exploration
+-- tooling (SPE-398) both read.
+--
+-- ---------------------------------------------------------------------------
+-- HOW CREDENTIALS ARE KEPT AWAY FROM CLIENTS
+-- ---------------------------------------------------------------------------
+-- RLS is ROW-level: it cannot hide a column. A policy that lets a district_tech
+-- read "their" connection row lets them read every column of it, ciphertext
+-- included. `calendar_connections` accepts that — its owner can select
+-- `access_token_encrypted` — on the grounds that ciphertext without the key is
+-- inert.
+--
+-- That is not good enough here. A district's Aeries certificate unlocks every
+-- student record in the district, it is long-lived, and it would sit in a
+-- browser's memory and network log on every page that reads connection status.
+-- Ciphertext is a second line of defence, not a reason to hand it out.
+--
+-- So this table uses COLUMN-level grants on top of row-level RLS:
+--
+--   REVOKE SELECT ON district_sis_connections FROM authenticated;
+--   GRANT  SELECT (<non-credential columns>) TO authenticated;
+--
+-- `authenticated` therefore cannot name a credential column at all — PostgREST
+-- refuses with 42501 rather than returning it. The service role, which the API
+-- routes use for the encrypt/decrypt paths, is unaffected (it bypasses both RLS
+-- and column grants).
+--
+-- Consequence worth knowing: `select('*')` on this table FAILS for a browser
+-- session, because `*` expands to columns it may not read. That is deliberate —
+-- a loud, immediate error is a better failure mode than silently shipping a
+-- certificate to the client because someone reached for the usual shorthand.
+-- Callers must name the columns they want.
+--
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.district_sis_connections (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  district_id varchar(20) NOT NULL REFERENCES public.districts(id),
+  sis_type text NOT NULL CHECK (sis_type IN ('aeries', 'oneroster')),
+
+  -- Connection config (non-secret).
+  base_url text,
+  token_url text,  -- OneRoster only
+
+  -- Credentials. Ciphertext ONLY, produced by lib/sis/credential-crypto.ts
+  -- (AES-256-GCM, `v1.<iv>.<ct>.<tag>`). There is deliberately no plaintext
+  -- column to "temporarily" write to.
+  aeries_certificate_encrypted text,
+  oneroster_client_id_encrypted text,
+  oneroster_client_secret_encrypted text,
+
+  -- Last 4 of the credential, for display. The only part ever shown to a client.
+  credential_hint text,
+
+  -- Lifecycle. pending_dpa is the entry state: credential intake stays closed
+  -- until a Speddy operator records the signed DPA.
+  status text NOT NULL DEFAULT 'pending_dpa'
+    CHECK (status IN ('pending_dpa', 'awaiting_credentials', 'testing',
+                      'connected', 'error', 'disabled')),
+  dpa_cleared_at timestamptz,
+
+  last_tested_at timestamptz,
+  last_test_result jsonb,
+
+  created_by uuid REFERENCES public.profiles(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  -- One connection per SIS per district.
+  CONSTRAINT district_sis_connections_district_sis_key UNIQUE (district_id, sis_type),
+
+  -- Credentials cannot exist before the DPA is recorded. Enforced here rather
+  -- than only in the API, so the rule survives a future route that forgets it.
+  CONSTRAINT district_sis_connections_no_credentials_before_dpa CHECK (
+    dpa_cleared_at IS NOT NULL
+    OR (aeries_certificate_encrypted IS NULL
+        AND oneroster_client_id_encrypted IS NULL
+        AND oneroster_client_secret_encrypted IS NULL)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS district_sis_connections_district_idx
+  ON public.district_sis_connections (district_id);
+
+COMMENT ON TABLE public.district_sis_connections IS
+  'Per-district SIS connection + app-layer-encrypted credentials (SPE-395). Credential columns are readable only by the service role — authenticated holds column-level SELECT on the non-secret columns only. Never add a plaintext credential column.';
+
+-- ---------------------------------------------------------------------------
+-- Row-level policies: scope a caller to their OWN district.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.district_sis_connections ENABLE ROW LEVEL SECURITY;
+
+-- Read: the district's tech admin and its district admin(s). Writes are NOT
+-- granted to browser sessions at all — every mutation runs server-side through
+-- an API route, because every mutation involves crypto. Same reasoning as
+-- provider_schools in SPE-399: this table is an integration control surface,
+-- and "it's my district's row" is not a reason to let a browser write it.
+CREATE POLICY district_sis_connections_select
+ON public.district_sis_connections
+FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM admin_permissions ap
+    WHERE ap.admin_id = (SELECT auth.uid())
+      AND ap.role IN ('district_tech', 'district_admin')
+      AND ap.district_id IS NOT NULL
+      AND (ap.district_id)::text = (district_sis_connections.district_id)::text
+  )
+);
+
+CREATE POLICY district_sis_connections_insert
+ON public.district_sis_connections
+FOR INSERT
+TO authenticated
+WITH CHECK (false);
+
+CREATE POLICY district_sis_connections_update
+ON public.district_sis_connections
+FOR UPDATE
+TO authenticated
+USING (false)
+WITH CHECK (false);
+
+CREATE POLICY district_sis_connections_delete
+ON public.district_sis_connections
+FOR DELETE
+TO authenticated
+USING (false);
+
+-- ---------------------------------------------------------------------------
+-- Column-level grants: the part that actually hides the credentials.
+-- ---------------------------------------------------------------------------
+REVOKE ALL ON public.district_sis_connections FROM authenticated, anon;
+
+GRANT SELECT (
+  id,
+  district_id,
+  sis_type,
+  base_url,
+  token_url,
+  credential_hint,
+  status,
+  dpa_cleared_at,
+  last_tested_at,
+  last_test_result,
+  created_by,
+  created_at,
+  updated_at
+) ON public.district_sis_connections TO authenticated;
+
+-- anon gets nothing at all: this table has no logged-out surface.

--- a/supabase/migrations/20260806_spe395_district_sis_connections.sql
+++ b/supabase/migrations/20260806_spe395_district_sis_connections.sql
@@ -98,6 +98,33 @@ CREATE TABLE IF NOT EXISTS public.district_sis_connections (
         AND oneroster_client_secret_encrypted IS NULL)
   ),
 
+  -- Ciphertext-shaped or nothing. The module is the only intended writer, but
+  -- "there is deliberately no plaintext column" is a comment, not a rule — this
+  -- makes it one. A privileged writer that skipped encryption, or wrote the raw
+  -- paste into the wrong column, is rejected by the database instead of sitting
+  -- there looking like a stored credential.
+  --
+  -- Regexes checked against real values before being written here: a genuine
+  -- `v1.<iv>.<ct>.<tag>` passes with or without base64 padding; a PEM
+  -- certificate, a raw secret, a v2 envelope, and 3- or 5-part envelopes all
+  -- fail.
+  CONSTRAINT district_sis_connections_ciphertext_shape CHECK (
+    (aeries_certificate_encrypted IS NULL
+      OR aeries_certificate_encrypted ~ '^v1\.[A-Za-z0-9+/]+={0,2}\.[A-Za-z0-9+/]+={0,2}\.[A-Za-z0-9+/]+={0,2}$')
+    AND (oneroster_client_id_encrypted IS NULL
+      OR oneroster_client_id_encrypted ~ '^v1\.[A-Za-z0-9+/]+={0,2}\.[A-Za-z0-9+/]+={0,2}\.[A-Za-z0-9+/]+={0,2}$')
+    AND (oneroster_client_secret_encrypted IS NULL
+      OR oneroster_client_secret_encrypted ~ '^v1\.[A-Za-z0-9+/]+={0,2}\.[A-Za-z0-9+/]+={0,2}\.[A-Za-z0-9+/]+={0,2}$')
+  ),
+
+  -- credential_hint is the ONE column on this table a browser can read, so it
+  -- is the one place a leak would actually reach a client. Pin it to exactly
+  -- what credentialHint() produces: the mask alone, or the mask plus four
+  -- characters. A full secret written here by mistake is rejected.
+  CONSTRAINT district_sis_connections_hint_shape CHECK (
+    credential_hint IS NULL OR credential_hint ~ '^••••(.{4})?$'
+  ),
+
   -- Credentials must match the row's sis_type, and a OneRoster pair is
   -- all-or-nothing. Without this the table would accept an Aeries certificate
   -- on a oneroster row, or a client id with no secret — shapes no server-side

--- a/supabase/migrations/20260806_spe395_district_sis_connections.sql
+++ b/supabase/migrations/20260806_spe395_district_sis_connections.sql
@@ -29,17 +29,28 @@
 -- routes use for the encrypt/decrypt paths, is unaffected (it bypasses both RLS
 -- and column grants).
 --
--- Consequence worth knowing: `select('*')` on this table FAILS for a browser
--- session, because `*` expands to columns it may not read. That is deliberate —
--- a loud, immediate error is a better failure mode than silently shipping a
--- certificate to the client because someone reached for the usual shorthand.
+-- VERIFIED, not assumed. Against a throwaway probe table on this project, with
+-- a real signed-in session and the same grant shape:
+--
+--   select=id,safe_col    -> HTTP 200, row returned
+--   select=secret_col     -> HTTP 403, {"code":"42501"} permission denied
+--   select=*              -> HTTP 403, {"code":"42501"} permission denied
+--   select=id,secret_col  -> HTTP 403, {"code":"42501"} permission denied
+--
+-- So `select('*')` FAILS for a browser session rather than silently returning
+-- a narrowed row. That is deliberate: a loud, immediate error beats silently
+-- shipping a certificate because someone reached for the usual shorthand.
 -- Callers must name the columns they want.
 --
 -- ---------------------------------------------------------------------------
 
 CREATE TABLE IF NOT EXISTS public.district_sis_connections (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  district_id varchar(20) NOT NULL REFERENCES public.districts(id),
+  -- varchar(36), matching districts.id and every other district FK in the
+  -- schema. Was varchar(20) — districts created through /api/internal/
+  -- create-district get a 36-char UUID id, so a narrower column would have
+  -- rejected them with value-too-long before the FK was even consulted.
+  district_id varchar(36) NOT NULL REFERENCES public.districts(id),
   sis_type text NOT NULL CHECK (sis_type IN ('aeries', 'oneroster')),
 
   -- Connection config (non-secret).
@@ -66,7 +77,12 @@ CREATE TABLE IF NOT EXISTS public.district_sis_connections (
   last_tested_at timestamptz,
   last_test_result jsonb,
 
-  created_by uuid REFERENCES public.profiles(id),
+  -- ON DELETE SET NULL: this is provenance, not a dependency. Without it,
+  -- deleting the admin who set up a connection would fail on this FK — the
+  -- provider-deletion flow nulls known nullable references, but cannot know
+  -- about one added later. Losing the attribution beats blocking the delete
+  -- or cascading away a live district connection.
+  created_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now(),
 
@@ -80,8 +96,36 @@ CREATE TABLE IF NOT EXISTS public.district_sis_connections (
     OR (aeries_certificate_encrypted IS NULL
         AND oneroster_client_id_encrypted IS NULL
         AND oneroster_client_secret_encrypted IS NULL)
+  ),
+
+  -- Credentials must match the row's sis_type, and a OneRoster pair is
+  -- all-or-nothing. Without this the table would accept an Aeries certificate
+  -- on a oneroster row, or a client id with no secret — shapes no server-side
+  -- reader should have to defend against, and which would surface as a
+  -- confusing runtime failure at connection-test time rather than at write time.
+  CONSTRAINT district_sis_connections_credential_shape CHECK (
+    (sis_type = 'aeries'
+      AND oneroster_client_id_encrypted IS NULL
+      AND oneroster_client_secret_encrypted IS NULL)
+    OR
+    (sis_type = 'oneroster'
+      AND aeries_certificate_encrypted IS NULL
+      AND ((oneroster_client_id_encrypted IS NULL
+            AND oneroster_client_secret_encrypted IS NULL)
+        OR (oneroster_client_id_encrypted IS NOT NULL
+            AND oneroster_client_secret_encrypted IS NOT NULL)))
   )
 );
+
+-- updated_at maintained in the DB, not by convention. Credential rotations,
+-- connection tests, DPA changes and status transitions all come from
+-- different writers; relying on each to remember would leave the column
+-- reading as the creation time forever. Same trigger calendar_connections uses.
+DROP TRIGGER IF EXISTS district_sis_connections_set_updated_at
+  ON public.district_sis_connections;
+CREATE TRIGGER district_sis_connections_set_updated_at
+  BEFORE UPDATE ON public.district_sis_connections
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
 
 CREATE INDEX IF NOT EXISTS district_sis_connections_district_idx
   ON public.district_sis_connections (district_id);


### PR DESCRIPTION
The per-district SIS credential store that SPE-396 (Aeries), SPE-397 (OneRoster) and SPE-398 (exploration tooling) all read from.

> **The migration is applied** to the production database (owner-approved), and `SIS_CREDENTIAL_ENCRYPTION_KEY` is set in Vercel.

## What's here

**`lib/sis/credential-crypto.ts`** — the AES-256-GCM pattern from `lib/calendar/token-crypto.ts` (`v1.<iv>.<ct>.<tag>`, fresh IV per encryption, config guard) under its own key.

Separate key on purpose, not a shared app secret: a calendar token reaches one user's calendar; a district's Aeries certificate reaches **every student record in that district**. Different blast radius, and either must be rotatable without touching the other.

The key is validated as *canonical* base64 before decoding. `Buffer.from(x, 'base64')` silently discards characters it doesn't recognise, so a good key with junk appended decodes to a plausible 32 bytes and sails past a length check — then fails at decrypt time, long after the ciphertext was written.

IV and auth-tag lengths are pinned on decrypt. Node's `setAuthTag` accepts 4-, 8- and 12-to-15-byte GCM tags, so without that a truncated tag decrypts happily on a value that still looks like a valid envelope — a full-width integrity guarantee quietly replaced by a narrower one.

**`lib/sis/connections.ts`** — the only place credentials are encrypted, decrypted, or written. Reads name their columns explicitly; `select('*')` is refused for a browser session by the column grants, and a server-side `*` would pull ciphertext into memory for what is only a status read. Every mutation is audited, with rotation and first-time storage as distinct actions.

Rules that live here because nothing else can enforce them:

- **`storeCredential` is not an upsert.** The connection must already exist with its DPA recorded. An upsert would create the row and then be rejected by the CHECK constraint, surfacing the DPA gate as a constraint-violation string instead of a clear refusal.
- **`sis_type` comes from the stored row, never the caller.** It decides which column a secret lands in, and letting a request pick that is how an Aeries certificate ends up in a OneRoster field.
- **Storing a credential clears the previous test result.** Inheriting "connected, tested Tuesday" would vouch for a credential that has never been tried.
- **`recordTestResult` takes a narrow `SisTestResult`, not `unknown`.** `last_test_result` is granted to `authenticated`, so anything written there is readable by that district's staff — and a failing SIS call can echo the submitted credential back in its body. A doc comment does not fail a build; a type does.

**The `/internal` DPA switch** — a panel on the district page to record or revoke the signed agreement per connection. Credentials are never entered or shown there; all it can say about one is whether it exists and its last four characters. Revoking deletes the stored credentials, so it confirms first.

**The migration** — `district_sis_connections`: one row per district per SIS, ciphertext-only credential columns, `credential_hint`, lifecycle status, `dpa_cleared_at`, test diagnostics, and five CHECK constraints.

## The decision worth reviewing

**RLS is row-level and cannot hide a column.** A policy that lets a `district_tech` read "their" connection row lets them read every column of it, ciphertext included. That's what `calendar_connections` does today — its owner can select `access_token_encrypted` — on the reasoning that ciphertext without the key is inert.

I did not copy that here. A district's SIS certificate is long-lived, unlocks an entire district's student data, and would sit in browser memory and network logs on every page rendering connection status. Ciphertext is a second line of defence, not a reason to hand it out.

So this table adds **column-level grants** on top of row-level RLS:

```sql
REVOKE ALL ON district_sis_connections FROM authenticated, anon;
GRANT SELECT (id, district_id, sis_type, ..., status, ...) TO authenticated;
```

`authenticated` cannot *name* a credential column — PostgREST refuses with `42501` rather than returning it.

**Known consequence, deliberate:** `select('*')` on this table **fails** for a browser session. A loud immediate error beats silently shipping a certificate because someone reached for the usual shorthand.

Browser **writes** are denied outright (`WITH CHECK (false)`) — every mutation involves crypto, so every mutation is server-side. Same reasoning as `provider_schools` in SPE-399.

The DPA gate exists **twice**: in the module, and as a CHECK constraint, so it survives a future route that forgets it.

## Verification

**Unit — 47 tests, every security-relevant one mutation-tested.** Removing the DPA gate, trusting the caller's `sis_type`, storing plaintext, keeping a stale test result, leaving credentials behind on revoke, widening the hint, dropping the IV/tag length pins, and removing the disconnect row check each fail *exactly* the test that claims to cover them. A test that cannot fail is not coverage.

**`npm run sim:verify-sis-rls`** — real signed-in sessions. District tech and district admin read status; both are refused every credential column and `select('*')` with HTTP 403 / `42501` (asserted by *code*, so a row simply not matching RLS cannot masquerade as a column-grant refusal). Site admin and provider see nothing. Browser writes refused with `42501` specifically.

**`npm run sim:verify-sis-lifecycle`** (new) — 51 checks driving the real module against the real database. This is the only thing that can show the hand-written `ciphertext_shape` and `hint_shape` regexes accept what the code actually emits — one stray padding character and every credential write in production fails — and that the DPA gate exists in the database and not just in the module.

### Five assertions in this PR were passing for the wrong reason

Listed in full because every one of them looked green, and three were in files written specifically to avoid this failure mode:

1. the rotation check compared credential hints, but the fixture was a PEM and every PEM ends `-----END CERTIFICATE-----`, so both certificates masked to the same `••••----` and the check would have passed had the rotation never happened. Fixtures are now real-shaped 32-char hex certs (`••••a9f2` → `••••b7c1`), and the substantive assertion is that the stored ciphertext changed and decrypts to the new value.
2. the `district_id` width check round-tripped the sim district's 8-character id, saying nothing about the `varchar(20)` → `varchar(36)` fix. It now inserts a 36-character id and asserts it is refused by the *foreign key* rather than by length — a narrow column would fail on `22001` first.
3. the "wrong length" key test never reached the length check it named; a 16-byte key is 24 base64 characters and is rejected by the canonical-format regex first. That branch is unreachable by construction, and the test now says so.
4. the hint-leak check asked whether an 8-character hint contained a 38-character prefix of the certificate. It cannot, so the check was green regardless of what the hint held — including the entire certificate. Now asserted by shape: exactly 8 characters, the mask, and the last four of the plaintext.
5. the browser-write check was `!wErr ? count === 0 : true`, which passes for **any** error — a renamed column, a malformed payload, a dropped connection. Now: 0 rows affected, or `42501` specifically. Confirmed live; both personas report `err=42501`.

Also green: typecheck, lint, the full 772-test suite, and `next build`.

## Review rounds

**Codex** caught the `varchar(20)`/`varchar(36)` width bug — a real defect that would have made SIS connections impossible for every internally-created district, and would have looked like a mysterious integration failure rather than a schema mistake. Also the missing `updated_at` trigger and the `ON DELETE SET NULL` on `created_by`. All fixed.

**A 49-agent adversarial design review** over the crypto and the migration. Two findings survived verification: the PEM rationale (which turned out to be load-bearing for finding 1 above) and the GCM tag length. The sim-manifest classification it flagged was already fixed in `7aba6ed`.

**CodeRabbit** (after its rate limit lifted and it reviewed the full surface) found 7 actionable items plus 4 nitpicks, all verified against the source and all taken. Beyond findings 4 and 5 above:

- `disconnect()` reported success and wrote an `sis_connection_disconnected` audit record for an id matching no row — a false entry in the one log someone reads during an incident. It was the only mutation not checking existence first.
- both routes returned the raw PostgREST error string to the client, carrying constraint, column and foreign-key names. Fixed messages now; detail stays in the log line.
- the DPA route's read-back ran outside the `try`, so a failed read after a **committed** write reported the change as failed and left the panel showing the old state — the worst outcome on a control whose "off" position deletes credentials.
- `SIS_CONNECTION_NOT_FOUND` is now an exported sentinel; the 404 mapping previously compared a message string duplicated across two files.
- `requireSpeddyAdmin` → `speddyAdminDenialReason`. It returns `null` for **allowed** and a string for **denied**, so `if (await requireSpeddyAdmin(id)) return forbidden()` — the obvious reading of the old name — inverts the guard and lets everyone through, silently.
- `role="alert"` on the error banner; `getDecryptedCredential`'s null paths covered.

## Not covered, stated plainly

- **The `/internal` DPA switch has not been exercised in a browser.** `/internal` is gated on `is_speddy_admin`, and the sim district has no Speddy-admin persona (SPE-401). The API routes and the store beneath the panel are covered by the lifecycle checks above; the panel itself is not.
- **The deep self-review (`/code-review`) did not run** — it is reserved for explicit user invocation.
- **GitHub Actions is down.** Runs on this branch have been queued for over an hour; the ones that completed failed with `Failed to resolve action download info. Error: Service Unavailable`, before checking out any code. Even the run-cancellation API returns 500s. **Nothing here has been verified by CI** — every gate above was run locally. (Filed SPE-405: no workflow declares a `concurrency` group, so superseded runs never auto-cancel.)

## Operator note

`SIS_CREDENTIAL_ENCRYPTION_KEY` must be set (`openssl rand -base64 32`) before any district can submit credentials. Intake fails closed without it — nothing else breaks. `.env.example` documents it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added district SIS connection management for Aeries and OneRoster integrations.
  - Internal district staff can view connections, add integrations, monitor status, and manage signed DPAs.
  - Added credential submission, testing, masking, rotation, revocation, and disconnection workflows.
  - Added connection statuses, DPA dates, credential hints, and test-result details.
- **Security**
  - SIS credentials are encrypted and protected from browser access.
  - Revoking a DPA or disconnecting removes stored credentials.
- **Documentation**
  - Documented SIS credential handling, protection controls, and data classification.
- **Tests**
  - Added comprehensive encryption, access-control, lifecycle, and integration verification coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->