### PR TITLE
SPE-384: scope an SEA to their caseload, not their whole school

### DIFF
--- a/scripts/sim-district/verify-multi-school-rls.ts
+++ b/scripts/sim-district/verify-multi-school-rls.ts
@@ -14,21 +14,26 @@
  *      primary school, while `teachers_select` already unioned
  *      `provider_schools`. So they saw teachers at every assigned school but
  *      could add at only one. The one path here with live impact.
- *   2. `students_select` (SEA branch) — a multi-school SEA saw school-wide
- *      students at their primary school alone.
- *   3. `children_select` (SEA branch) — the same gap on the child record.
+ *   2. `students_select` (SEA branch) — SPE-384 REMOVED this branch entirely.
+ *      It granted an SEA school-wide reads, which disagreed with the product:
+ *      the Students and Plan pages go through `get_sea_students()`, scoped by
+ *      session assignment. Assignment-scoped won, so the policy was narrowed to
+ *      match the UI rather than the UI widened to match the policy. This
+ *      supersedes SPE-362's widening of the same branch.
+ *   3. `children_select` (SEA branch) — the same branch, same removal.
  *
  * The contract asserted here:
  *   - a multi-school provider can create a teacher at a NON-primary assigned
  *     school, and still at their primary one;
  *   - and at NO school they are unassigned to — this widens to
  *     `provider_schools`, not to the district;
- *   - a multi-school SEA reads students and children at EVERY assigned school;
- *   - a single-school SEA is unchanged (no accidental widening of the common case);
- *   - and — the check that matters most — a multi-school NON-SEA provider does
- *     NOT pick up school-wide student reads. The SEA branch is gated on
- *     `role = 'sea'`; widening the school-id half of it must not leak the
- *     school-wide grant to everyone else assigned to that school.
+ *   - an SEA reads exactly their caseload — the students they are assigned to
+ *     through a session — and NOT the rest of their own school;
+ *   - an SEA assigned to nobody reads nothing, at any of their schools, which is
+ *     the cleanest read on the removed branch since it was their only route;
+ *   - and no other role loses anything: the removed branch was gated on
+ *     `role = 'sea'`, so a non-SEA must still read exactly what they read
+ *     before, via the provider and session branches.
  *
  * Three traps this deliberately avoids (CLAUDE.md):
  *   - assert the ROWS, not the HTTP status — an RLS-filtered write is a 2xx
@@ -118,6 +123,36 @@ function sameSet(a: Set<string>, b: Set<string>): boolean {
   return a.size === b.size && [...a].every(id => b.has(id));
 }
 
+function intersect(a: Set<string>, b: Set<string>): Set<string> {
+  return new Set([...a].filter(id => b.has(id)));
+}
+
+async function profileIdFor(personaKey: string): Promise<string> {
+  const { data, error } = await admin
+    .from('profiles').select('id').eq('email', personaEmail(personaKey)).single();
+  if (error) throw new Error(`profile lookup failed for ${personaKey}: ${error.message}`);
+  return data.id as string;
+}
+
+/**
+ * An SEA's caseload per the service client: the students they are actually
+ * assigned to through a session. After SPE-384 this is their whole world.
+ */
+async function caseloadStudentIds(seaId: string): Promise<Set<string>> {
+  const { data, error } = await admin
+    .from('schedule_sessions').select('student_id').eq('assigned_to_sea_id', seaId);
+  if (error) throw new Error(`caseload lookup failed for ${seaId}: ${error.message}`);
+  return new Set((data ?? []).map(r => r.student_id as string));
+}
+
+async function childIdsForStudents(studentIds: Set<string>): Promise<Set<string>> {
+  if (studentIds.size === 0) return new Set();
+  const { data, error } = await admin
+    .from('students').select('child_id').in('id', [...studentIds]).not('child_id', 'is', null);
+  if (error) throw new Error(`child link lookup failed: ${error.message}`);
+  return new Set((data ?? []).map(r => r.child_id as string));
+}
+
 /** A fully-populated teacher row: see the header note on 23502 vs 42501. */
 function teacherRow(schoolId: string, tag: string): Record<string, unknown> {
   return {
@@ -187,62 +222,66 @@ async function main(): Promise<void> {
       'and no Maple teacher row was created');
   }
 
-  console.log('students_select — a multi-school SEA reads every assigned school:');
+  console.log('students_select — an SEA sees their CASELOAD, not their school (SPE-384):');
   {
     const willow = await fixtureStudentIds(WILLOW);
     const juniper = await fixtureStudentIds(JUNIPER);
-    const maple = await fixtureStudentIds(MAPLE);
 
-    const omarWillow = await visibleStudentIds(omar, WILLOW);
-    check(sameSet(omarWillow, willow), 'Omar sees Willow students (his primary — worked before)',
-      `${omarWillow.size}/${willow.size}`);
-
-    // Before the fix this was 0.
-    const omarJuniper = await visibleStudentIds(omar, JUNIPER);
-    check(sameSet(omarJuniper, juniper), 'Omar sees Juniper students (assigned, NOT primary)',
-      `${omarJuniper.size}/${juniper.size}`);
-
-    const omarMaple = await visibleStudentIds(omar, MAPLE);
-    check(omarMaple.size === 0, 'Omar sees NO Maple students (not assigned)',
-      `count=${omarMaple.size}/${maple.size}`);
+    // Leah is assigned to a handful of Willow students. The contract is that she
+    // sees exactly those — not the other ~40 at the same school.
+    const leahCaseload = await caseloadStudentIds(await profileIdFor('leah'));
+    const expected = intersect(leahCaseload, willow);
+    check(expected.size > 0 && expected.size < willow.size,
+      'fixture is non-vacuous: Leah has a caseload smaller than her school',
+      `caseload ${expected.size} of ${willow.size} at Willow`);
 
     const leahWillow = await visibleStudentIds(leah, WILLOW);
-    const leahJuniper = await visibleStudentIds(leah, JUNIPER);
-    check(sameSet(leahWillow, willow) && leahJuniper.size === 0,
-      'single-school SEA unchanged: Willow only',
-      `willow ${leahWillow.size}/${willow.size}, juniper ${leahJuniper.size}`);
+    // Before the narrowing this was all 43 — the whole school.
+    check(sameSet(leahWillow, expected),
+      'Leah sees exactly her caseload at Willow, not the school',
+      `${leahWillow.size}/${willow.size} (caseload ${expected.size})`);
+
+    // Omar is assigned to nobody, so for him the school-wide grant was the ONLY
+    // thing making students visible. He is the cleanest read on its removal.
+    const omarWillow = await visibleStudentIds(omar, WILLOW);
+    const omarJuniper = await visibleStudentIds(omar, JUNIPER);
+    check(omarWillow.size === 0 && omarJuniper.size === 0,
+      'unassigned SEA sees NO students at either assigned school',
+      `willow ${omarWillow.size}/${willow.size}, juniper ${omarJuniper.size}/${juniper.size}`);
   }
 
-  console.log('...but the school-wide grant stays SEA-only:');
+  console.log('...and no other role loses anything:');
   {
-    // The SEA branch is `school_id IN (my schools) AND role = 'sea'`. Widening
-    // the school-id half must not hand school-wide reads to a non-SEA who is
-    // also assigned to that school. Tomás should see only students he is
-    // actually tied to at Juniper — as provider, or via a session.
+    // The removed branch was gated on `role = 'sea'`, so a non-SEA must read
+    // exactly what they read before: their own students, via provider or session.
     const juniper = await fixtureStudentIds(JUNIPER);
     const tomasJuniper = await visibleStudentIds(tomas, JUNIPER);
     check(tomasJuniper.size > 0 && tomasJuniper.size < juniper.size,
-      'non-SEA at Juniper sees only their OWN students, not school-wide',
+      'non-SEA at Juniper still sees their OWN students (unchanged)',
       `${tomasJuniper.size}/${juniper.size}`);
   }
 
-  console.log('children_select — same SEA branch, through students:');
+  console.log('children_select — same narrowing, through students:');
   {
     const willowKids = await fixtureChildIds(WILLOW);
     const juniperKids = await fixtureChildIds(JUNIPER);
 
+    // Leah's caseload children only — not every child at Willow.
+    const leahCaseload = await caseloadStudentIds(await profileIdFor('leah'));
+    const expectedKids = await childIdsForStudents(leahCaseload);
+    const leahWillowKids = await visibleChildIds(leah, willowKids);
+    check(expectedKids.size > 0 && expectedKids.size < willowKids.size,
+      'fixture is non-vacuous: Leah\'s caseload children are fewer than the school\'s',
+      `${expectedKids.size} of ${willowKids.size}`);
+    check(sameSet(leahWillowKids, intersect(expectedKids, willowKids)),
+      'Leah sees only her caseload\'s children at Willow',
+      `${leahWillowKids.size}/${willowKids.size}`);
+
     const omarWillowKids = await visibleChildIds(omar, willowKids);
-    check(sameSet(omarWillowKids, willowKids), 'Omar sees Willow children (primary)',
-      `${omarWillowKids.size}/${willowKids.size}`);
-
-    // Before the fix this was 0.
     const omarJuniperKids = await visibleChildIds(omar, juniperKids);
-    check(sameSet(omarJuniperKids, juniperKids), 'Omar sees Juniper children (assigned, NOT primary)',
-      `${omarJuniperKids.size}/${juniperKids.size}`);
-
-    const leahJuniperKids = await visibleChildIds(leah, juniperKids);
-    check(leahJuniperKids.size === 0, 'single-school SEA sees NO Juniper children',
-      `count=${leahJuniperKids.size}/${juniperKids.size}`);
+    check(omarWillowKids.size === 0 && omarJuniperKids.size === 0,
+      'unassigned SEA sees NO children at either assigned school',
+      `willow ${omarWillowKids.size}/${willowKids.size}, juniper ${omarJuniperKids.size}/${juniperKids.size}`);
   }
 
   if (failures === 0) {

--- a/scripts/sim-district/verify-multi-school-rls.ts
+++ b/scripts/sim-district/verify-multi-school-rls.ts
@@ -135,12 +135,19 @@ async function profileIdFor(personaKey: string): Promise<string> {
 }
 
 /**
- * An SEA's caseload per the service client: the students they are actually
- * assigned to through a session. After SPE-384 this is their whole world.
+ * An SEA's caseload per the service client: the students they are assigned to
+ * through an SEA-DELIVERED session. After SPE-384 this is their whole world.
+ *
+ * `delivered_by` is filtered here for the same reason the policy filters it —
+ * the column is nullable, so a CHECK constraint cannot guarantee that an
+ * `assigned_to_sea_id` row is SEA-delivered. Deriving the expectation the same
+ * way the policy does is what keeps this a real check rather than a tautology.
  */
 async function caseloadStudentIds(seaId: string): Promise<Set<string>> {
   const { data, error } = await admin
-    .from('schedule_sessions').select('student_id').eq('assigned_to_sea_id', seaId);
+    .from('schedule_sessions').select('student_id')
+    .eq('assigned_to_sea_id', seaId)
+    .eq('delivered_by', 'sea');
   if (error) throw new Error(`caseload lookup failed for ${seaId}: ${error.message}`);
   return new Set((data ?? []).map(r => r.student_id as string));
 }

--- a/supabase/migrations/20260806_spe384_narrow_sea_student_scope.sql
+++ b/supabase/migrations/20260806_spe384_narrow_sea_student_scope.sql
@@ -20,10 +20,22 @@
 -- already present directly above it:
 --
 --     EXISTS (SELECT 1 FROM schedule_sessions
---             WHERE student_id = students.id AND assigned_to_sea_id = auth.uid())
+--             WHERE student_id = students.id
+--               AND assigned_to_sea_id = auth.uid()
+--               AND delivered_by = 'sea')
 --
--- which is the same grant the RPC gives, minus the `delivered_by` filter — an
--- SEA assigned to a session can still read that student either way.
+-- which is exactly the grant the RPC gives: an SEA reads a student when they
+-- are assigned to an SEA-DELIVERED session for that student, and not otherwise.
+--
+-- The `delivered_by = 'sea'` half looks redundant next to
+-- `schedule_sessions_delivered_by_assignee_integrity`, which forces
+-- `assigned_to_sea_id` to NULL when `delivered_by` is 'provider' or
+-- 'specialist'. It is not: `delivered_by` is nullable, and a CHECK constraint
+-- is satisfied when its expression evaluates to NULL, so a row with a NULL
+-- `delivered_by` and an SEA assigned passes the constraint and would otherwise
+-- be readable through RLS while `get_sea_students()` skipped it. No such row
+-- exists today (all 3,184 SEA-assigned sessions carry 'sea'), so this closes
+-- the gap without removing anyone's access.
 --
 -- This SUPERSEDES the SEA half of SPE-362 (20260805): that migration widened
 -- this branch from primary-school-only to all assigned schools. The branch is
@@ -59,6 +71,7 @@ CREATE POLICY "students_select" ON students
       SELECT 1 FROM schedule_sessions
       WHERE schedule_sessions.student_id = students.id
         AND schedule_sessions.assigned_to_sea_id = (SELECT auth.uid())
+        AND schedule_sessions.delivered_by = 'sea'
     )
     OR EXISTS (
       SELECT 1 FROM admin_permissions
@@ -93,6 +106,7 @@ CREATE POLICY "children_select" ON children
             SELECT 1 FROM schedule_sessions ss
             WHERE ss.student_id = s.id
               AND ss.assigned_to_sea_id = (SELECT auth.uid())
+              AND ss.delivered_by = 'sea'
           )
           OR EXISTS (
             SELECT 1 FROM admin_permissions ap

--- a/supabase/migrations/20260806_spe384_narrow_sea_student_scope.sql
+++ b/supabase/migrations/20260806_spe384_narrow_sea_student_scope.sql
@@ -1,0 +1,105 @@
+-- SPE-384: scope an SEA to their own caseload, not to the whole school.
+--
+-- `students_select` and `children_select` each carried an SEA branch granting
+-- school-wide reads:
+--
+--     school_id IN (SELECT school_id FROM get_my_school_ids())
+--     AND auth.uid() IN (SELECT id FROM profiles WHERE role = 'sea')
+--
+-- That disagreed with how the product actually behaves. The Students and Plan
+-- pages read through `get_sea_students()`, a SECURITY DEFINER function scoped by
+-- session assignment (`ss.assigned_to_sea_id = auth.uid() AND ss.delivered_by =
+-- 'sea'`), and `lib/supabase/queries/sea-students.ts` uses that result whenever
+-- the RPC succeeds — falling back to the RLS-backed query only on error. So the
+-- school-wide grant was invisible in the main UI while still being live on the
+-- table underneath it.
+--
+-- Of the two, assignment-scoped is the intended behaviour, so the policy is
+-- narrowed to match rather than the UI widened to match the policy. Removing
+-- the branch outright leaves the SEA with the session-assignment branch that is
+-- already present directly above it:
+--
+--     EXISTS (SELECT 1 FROM schedule_sessions
+--             WHERE student_id = students.id AND assigned_to_sea_id = auth.uid())
+--
+-- which is the same grant the RPC gives, minus the `delivered_by` filter — an
+-- SEA assigned to a session can still read that student either way.
+--
+-- This SUPERSEDES the SEA half of SPE-362 (20260805): that migration widened
+-- this branch from primary-school-only to all assigned schools. The branch is
+-- now gone, so the widening is moot. SPE-362's `teachers_insert` change — the
+-- one with live users behind it — is untouched.
+--
+-- Blast radius, measured against prod before applying: this removes visibility
+-- of students at an SEA's own school whom they are not assigned to — 18 students
+-- for one real SEA, 5 for another, 0 for the rest. None of it was reachable
+-- through the SEA UI, which has always gone through the assignment-scoped RPC.
+--
+-- Non-SEA callers are unaffected: the removed branch was gated on
+-- `role = 'sea'`. Every other branch of both policies is reproduced verbatim.
+
+-- 1. students_select -------------------------------------------------------
+
+DROP POLICY IF EXISTS "students_select" ON students;
+
+CREATE POLICY "students_select" ON students
+  FOR SELECT TO authenticated
+  USING (
+    provider_id = (SELECT auth.uid())
+    OR teacher_id IN (
+      SELECT teachers.id FROM teachers WHERE teachers.account_id = (SELECT auth.uid())
+    )
+    OR EXISTS (
+      SELECT 1 FROM schedule_sessions
+      WHERE schedule_sessions.student_id = students.id
+        AND schedule_sessions.assigned_to_specialist_id = (SELECT auth.uid())
+    )
+    OR EXISTS (
+      -- The SEA's caseload: this is now their ONLY route to a student record.
+      SELECT 1 FROM schedule_sessions
+      WHERE schedule_sessions.student_id = students.id
+        AND schedule_sessions.assigned_to_sea_id = (SELECT auth.uid())
+    )
+    OR EXISTS (
+      SELECT 1 FROM admin_permissions
+      WHERE admin_permissions.admin_id = (SELECT auth.uid())
+        AND admin_permissions.role = 'site_admin'
+        AND admin_permissions.school_id::text = students.school_id::text
+    )
+  );
+
+-- 2. children_select -------------------------------------------------------
+-- Mirrors students_select through the `students s` join; same branch removed.
+
+DROP POLICY IF EXISTS "children_select" ON children;
+
+CREATE POLICY "children_select" ON children
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM students s
+      WHERE s.child_id = children.id
+        AND (
+          s.provider_id = (SELECT auth.uid())
+          OR s.teacher_id IN (
+            SELECT t.id FROM teachers t WHERE t.account_id = (SELECT auth.uid())
+          )
+          OR EXISTS (
+            SELECT 1 FROM schedule_sessions ss
+            WHERE ss.student_id = s.id
+              AND ss.assigned_to_specialist_id = (SELECT auth.uid())
+          )
+          OR EXISTS (
+            SELECT 1 FROM schedule_sessions ss
+            WHERE ss.student_id = s.id
+              AND ss.assigned_to_sea_id = (SELECT auth.uid())
+          )
+          OR EXISTS (
+            SELECT 1 FROM admin_permissions ap
+            WHERE ap.admin_id = (SELECT auth.uid())
+              AND ap.role = 'site_admin'
+              AND ap.school_id::text = s.school_id::text
+          )
+        )
+    )
+  );


### PR DESCRIPTION
Closes SPE-384.

## What was wrong

An SEA's student access was defined twice, differently:

| Path | Scope |
| -- | -- |
| `students_select` / `children_select` RLS, SEA branch | **School-wide** — every student at a school they're assigned to |
| `get_sea_students()` RPC (SECURITY DEFINER) | **Assignment-scoped** — only students with a session where `assigned_to_sea_id = auth.uid()` |

The Students and Plan pages go through the RPC, and `lib/supabase/queries/sea-students.ts:70` uses that result whenever the call *succeeds* — including a zero-row result — falling back to the RLS-backed query only on **error**. So the school-wide grant was invisible in the product while still live on the table underneath it.

## The fix, and why this direction

Assignment-scoped is the intended behaviour, so the **policy is narrowed to match the UI** rather than the UI widened to match the policy. Widening would have changed what all 5 existing SEAs see today, from "my assigned students" to "every student at my school" — a real expansion of access to solve a problem nobody has yet.

Removing the branch leaves the SEA with the session-assignment branch already sitting directly above it, which is the same grant the RPC gives:

```sql
EXISTS (SELECT 1 FROM schedule_sessions
        WHERE student_id = students.id AND assigned_to_sea_id = auth.uid())
```

Non-SEA callers are unaffected — the removed branch was gated on `role = 'sea'`. Every other branch of both policies is reproduced verbatim.

### This supersedes the SEA half of SPE-362

PR #801 widened this same branch from primary-school-only to all assigned schools. The branch is now gone, so that widening is moot. **SPE-362's `teachers_insert` change — the one with live users behind it — is untouched**, and its checks still pass in the probe here.

### Blast radius, measured before applying

This removes visibility of students at an SEA's own school whom they are not assigned to:

| SEA | saw school-wide | caseload | loses visibility of |
| -- | -- | -- | -- |
| (real, MDUSD) | 39 | 21 | 18 |
| (real, MDUSD) | 25 | 20 | 5 |
| others | — | — | 0 |

None of it was reachable through the SEA UI, which has always gone through the assignment-scoped RPC — confirmed by the walk below.

## Verification

Unit tests mock the Supabase client and cannot see RLS, so they are not evidence. Verified with **real signed-in sessions**, at both layers.

**Policy —** `npm run sim:verify-multi-school-rls` fails 4 checks against the old policies and passes all 13 against the new ones:

```
BEFORE                                                    AFTER
[FAIL] Leah sees exactly her caseload      43/43       → [ok] 2/43 (caseload 2)
[FAIL] unassigned SEA sees NO students     43+49       → [ok] 0/43, 0/49
[FAIL] Leah sees only caseload children    41/41       → [ok] 2/41
[FAIL] unassigned SEA sees NO children     41+49       → [ok] 0/41, 0/49
```

Guards that hold in **both** runs: `non-SEA at Juniper still sees their OWN students` (15/49, unchanged) and every `teachers_insert` check from SPE-362. The fixture is also asserted non-vacuous — Leah's caseload must be smaller than her school, or the checks would pass trivially.

**UI —** a Playwright walk of every SEA-reachable surface (SEA dashboard, Students, Plan) for both personas, 21 checks:

- Leah's Students page shows exactly her 2 caseload students, 2 table rows
- Omar (assigned to nobody) degrades to a clean empty state — no crash, no spinner
- Neither falls back to the RLS query path (no `[loadStudentsForUser] RPC failed`)
- Nav is Dashboard/Students/Plan, no Schedule/Chat/CARE/Meetings, and `/dashboard/admin` bounces

**Control —** a resource specialist, whose branches this doesn't touch, still shows all 28 of her students. This also reproduced the sandbox's console noise (Help Scout beacon blocked, aborted RSC prefetch, auth fetch cancelled on teardown) identically, which is how that noise was ruled out as a regression rather than assumed to be one.

Sibling suites `sim:verify-rls`, `sim:verify-children-rls`, `sim:verify-special-activities-rls`, `sim:verify-child-link`, `sim:verify-provider-schools-rls` all pass. Full lifecycle close: teardown → `sim:verify --expect-empty` all zeros → reset → green. Typecheck, lint, and the unit suite (80 files, 713 passing) are green.

Applied policies were also read back from `pg_policies` and checked branch-by-branch: school-wide branch and its `role = 'sea'` test gone from both, specialist / SEA-session / site-admin branches all retained.

## Probe changes

`verify-multi-school-rls.ts` previously asserted the SEA *could* read school-wide at every assigned school — the contract SPE-362 shipped. Those assertions are inverted to the narrowed contract and the header rewritten, so the file now pins caseload-scoping. Its `teachers_insert` half is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBQpZtN31mhpK4W2HEGZHQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Access**
  * Narrowed SEA access to students associated with their assigned sessions.
  * Applied the same scoped access rules to related child records.
  * Removed broad school-wide visibility for SEA users.
  * Preserved existing access for providers, teachers, specialists, and site administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->