### PR TITLE
SPE-396: Aeries connection flow — per-area diagnostics and credential intake

### DIFF
--- a/__tests__/unit/app/api/internal/sis-connections-schema.test.ts
+++ b/__tests__/unit/app/api/internal/sis-connections-schema.test.ts
@@ -1,0 +1,48 @@
+/**
+ * SPE-396 · /api/internal/sis-connections must not accept an http:// base.
+ *
+ * This route is the only way an http:// SIS address can reach the table — the
+ * district-facing path normalizes through `normalizeAeriesBaseUrl`, which
+ * refuses one. A stored http:// base is not an SSRF problem; it is a credential
+ * problem, because every probe against that row would send the district's SIS
+ * certificate in cleartext.
+ *
+ * The real schema is imported rather than reconstructed here. A local copy
+ * would keep passing after someone deleted the constraint from the route.
+ */
+import { createSisConnectionBody } from '@/app/api/internal/sis-connections/route';
+
+const valid = { districtId: 'SIM-D001', sisType: 'aeries' as const };
+
+describe('createSisConnectionBody', () => {
+  it('accepts an https base and token url', () => {
+    const r = createSisConnectionBody.safeParse({
+      ...valid,
+      baseUrl: 'https://demo.aeries.net/aeries/api/v5',
+      tokenUrl: 'https://demo.aeries.net/token',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts the row with neither url — both are optional', () => {
+    expect(createSisConnectionBody.safeParse(valid).success).toBe(true);
+  });
+
+  it.each([
+    ['baseUrl', { baseUrl: 'http://demo.aeries.net/aeries/api/v5' }],
+    ['tokenUrl', { tokenUrl: 'http://demo.aeries.net/token' }],
+  ])('refuses an http:// %s', (field, patch) => {
+    const r = createSisConnectionBody.safeParse({ ...valid, ...patch });
+    expect(r.success).toBe(false);
+    // Assert WHY it was refused. `.url()` rejects plenty of strings on its own,
+    // so "it failed" would stay green with the https constraint deleted.
+    expect(r.success === false && JSON.stringify(r.error.issues)).toContain(
+      `${field} must start with https://`,
+    );
+  });
+
+  it('still refuses a string that is not a url at all', () => {
+    const r = createSisConnectionBody.safeParse({ ...valid, baseUrl: 'not a url' });
+    expect(r.success).toBe(false);
+  });
+});

--- a/__tests__/unit/lib/api/district-sis-caller.test.ts
+++ b/__tests__/unit/lib/api/district-sis-caller.test.ts
@@ -1,0 +1,123 @@
+/**
+ * SPE-396 · resolveDistrictSisCaller — who may write a SIS credential.
+ *
+ * This decides who can store a district's SIS certificate and who can make our
+ * servers probe a district's SIS. It had no tests; review flagged that, and it
+ * is the right call for an authorization primitive whose failure modes are all
+ * silent.
+ *
+ * The branch that matters most is the multi-district one. Picking a district
+ * for a caller who holds several grants would write one district's credential
+ * into another district's row, and nothing downstream would notice.
+ */
+const mockIn = jest.fn();
+const mockNot = jest.fn();
+let result: { data: unknown; error: unknown } = { data: [], error: null };
+
+jest.mock('@/lib/supabase/server', () => ({
+  createServiceClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          in: (...a: unknown[]) => {
+            mockIn(...a);
+            return {
+              not: (...b: unknown[]) => {
+                mockNot(...b);
+                return Promise.resolve(result);
+              },
+            };
+          },
+        }),
+      }),
+    }),
+  }),
+}));
+
+import { resolveDistrictSisCaller } from '@/lib/api/district-sis-caller';
+
+const USER = '11111111-1111-4111-8111-111111111111';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  result = { data: [], error: null };
+});
+
+describe('resolveDistrictSisCaller', () => {
+  it('refuses an empty user id without querying', async () => {
+    await expect(resolveDistrictSisCaller('')).resolves.toEqual({
+      ok: false,
+      denied: 'no authenticated user',
+    });
+    expect(mockIn).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the permission lookup itself fails', async () => {
+    // Fail closed: a database hiccup must not read as "allowed".
+    result = { data: null, error: { message: 'connection reset' } };
+    const r = await resolveDistrictSisCaller(USER);
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.denied).toMatch(/lookup failed/);
+  });
+
+  it('refuses a caller with no district grant', async () => {
+    result = { data: [], error: null };
+    const r = await resolveDistrictSisCaller(USER);
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.denied).toMatch(/no district_tech or district_admin/);
+  });
+
+  it('resolves a district_tech to their district', async () => {
+    result = { data: [{ district_id: 'SIM-D001', role: 'district_tech' }], error: null };
+    await expect(resolveDistrictSisCaller(USER)).resolves.toEqual({
+      ok: true,
+      districtId: 'SIM-D001',
+      role: 'district_tech',
+    });
+  });
+
+  it('resolves a district_admin too', async () => {
+    result = { data: [{ district_id: 'SIM-D001', role: 'district_admin' }], error: null };
+    await expect(resolveDistrictSisCaller(USER)).resolves.toEqual({
+      ok: true,
+      districtId: 'SIM-D001',
+      role: 'district_admin',
+    });
+  });
+
+  it('prefers the tech role when the caller holds both in one district', async () => {
+    result = {
+      data: [
+        { district_id: 'SIM-D001', role: 'district_admin' },
+        { district_id: 'SIM-D001', role: 'district_tech' },
+      ],
+      error: null,
+    };
+    const r = await resolveDistrictSisCaller(USER);
+    expect(r).toEqual({ ok: true, districtId: 'SIM-D001', role: 'district_tech' });
+  });
+
+  it('refuses rather than guessing when grants span several districts', async () => {
+    // The one that would be silent: picking either would write this district's
+    // certificate into the other district's connection row.
+    result = {
+      data: [
+        { district_id: 'SIM-D001', role: 'district_admin' },
+        { district_id: '0618990', role: 'district_admin' },
+      ],
+      error: null,
+    };
+    const r = await resolveDistrictSisCaller(USER);
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.denied).toMatch(/2 districts/);
+  });
+
+  it('only ever asks for the two roles that may manage SIS connections', async () => {
+    result = { data: [{ district_id: 'SIM-D001', role: 'district_tech' }], error: null };
+    await resolveDistrictSisCaller(USER);
+    // Pinned so widening the query is a deliberate act: adding a role here
+    // would silently hand SIS credential access to that role.
+    expect(mockIn).toHaveBeenCalledWith('role', ['district_tech', 'district_admin']);
+    expect(mockNot).toHaveBeenCalledWith('district_id', 'is', null);
+  });
+});

--- a/__tests__/unit/lib/api/district-sis-caller.test.ts
+++ b/__tests__/unit/lib/api/district-sis-caller.test.ts
@@ -10,6 +10,7 @@
  * for a caller who holds several grants would write one district's credential
  * into another district's row, and nothing downstream would notice.
  */
+const mockEq = jest.fn();
 const mockIn = jest.fn();
 const mockNot = jest.fn();
 let result: { data: unknown; error: unknown } = { data: [], error: null };
@@ -18,17 +19,24 @@ jest.mock('@/lib/supabase/server', () => ({
   createServiceClient: () => ({
     from: () => ({
       select: () => ({
-        eq: () => ({
-          in: (...a: unknown[]) => {
-            mockIn(...a);
-            return {
-              not: (...b: unknown[]) => {
-                mockNot(...b);
-                return Promise.resolve(result);
-              },
-            };
-          },
-        }),
+        // `.eq()` is RECORDED, not ignored. Without this the suite passes even
+        // if `.eq('admin_id', userId)` is dropped — and that regression returns
+        // another administrator's grants, which is the whole thing this
+        // function exists to prevent.
+        eq: (...e: unknown[]) => {
+          mockEq(...e);
+          return {
+            in: (...a: unknown[]) => {
+              mockIn(...a);
+              return {
+                not: (...b: unknown[]) => {
+                  mockNot(...b);
+                  return Promise.resolve(result);
+                },
+              };
+            },
+          };
+        },
       }),
     }),
   }),
@@ -110,6 +118,13 @@ describe('resolveDistrictSisCaller', () => {
     const r = await resolveDistrictSisCaller(USER);
     expect(r.ok).toBe(false);
     expect(r.ok === false && r.denied).toMatch(/2 districts/);
+  });
+
+  it('scopes the lookup to the CALLER, not just to the roles', async () => {
+    result = { data: [{ district_id: 'SIM-D001', role: 'district_tech' }], error: null };
+    await resolveDistrictSisCaller(USER);
+    // The predicate that keeps one admin from resolving another's grants.
+    expect(mockEq).toHaveBeenCalledWith('admin_id', USER);
   });
 
   it('only ever asks for the two roles that may manage SIS connections', async () => {

--- a/__tests__/unit/lib/sis/aeries-setup.guard-wiring.test.ts
+++ b/__tests__/unit/lib/sis/aeries-setup.guard-wiring.test.ts
@@ -92,6 +92,32 @@ describe('runAeriesConnectionTest calls the resolving guard', () => {
     expect(mockGetSchools).not.toHaveBeenCalled();
   });
 
+  it('makes NO request for an http:// base, even to a perfectly public host', async () => {
+    // The host here is fine — the scheme is the whole problem. Probing it would
+    // put the district's Aeries certificate on the wire in cleartext.
+    //
+    // Nothing can store such a row today: both write paths refuse http:// and
+    // the table is empty. This is the last checkpoint before the AERIES-CERT
+    // header is sent, and the only one that sees the URL a probe will really
+    // dial rather than the one somebody typed into a form.
+    mockLookup.mockResolvedValue([{ address: '104.16.0.1', family: 4 }]);
+
+    const report = await runAeriesConnectionTest({
+      baseUrl: 'http://demo.aeries.net/aeries/api/v5',
+      certificate: CERT,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.areas[0].message).toMatch(/https:\/\//);
+    expect(mockGetSchools).not.toHaveBeenCalled();
+  });
+
+  it('makes NO request for a baseUrl that is not a url at all', async () => {
+    const report = await runAeriesConnectionTest({ baseUrl: 'not a url', certificate: CERT });
+    expect(report.ok).toBe(false);
+    expect(mockGetSchools).not.toHaveBeenCalled();
+  });
+
   it('proceeds normally when the name resolves publicly', async () => {
     // The other half: a guard that refused everything would pass the two tests
     // above while breaking every real district.

--- a/__tests__/unit/lib/sis/aeries-setup.guard-wiring.test.ts
+++ b/__tests__/unit/lib/sis/aeries-setup.guard-wiring.test.ts
@@ -1,0 +1,107 @@
+/**
+ * SPE-396 · the SSRF guard is actually WIRED IN — not merely correct.
+ *
+ * WHY THIS FILE IS SEPARATE. `ssrf-guard.test.ts` has 60-odd tests proving the
+ * guard classifies addresses correctly, and `aeries-setup.test.ts` stubs
+ * `assertPublicAeriesHost` to pass so it can test the diagnostics without DNS.
+ * Between them they leave the one thing that matters unpinned: whether anything
+ * CALLS the guard. Deleting both call sites in `aeries-setup.ts` left the whole
+ * suite green — 86 suites, 866 tests, typecheck and lint clean — with the
+ * control entirely gone. A security check nothing invokes is decoration.
+ *
+ * So these tests deliberately do NOT mock the guard. They mock DNS underneath
+ * it, which is the only part that needs to be deterministic, and assert on the
+ * observable consequence: a private address means no request is ever made.
+ */
+const mockLookup = jest.fn();
+jest.mock('dns/promises', () => ({ lookup: (...a: unknown[]) => mockLookup(...a) }));
+
+const mockGetSchools = jest.fn();
+jest.mock('@/lib/integrations/aeries', () => {
+  const actual = jest.requireActual('@/lib/integrations/aeries');
+  return {
+    ...actual,
+    AeriesClient: class {
+      getSchools = (...a: unknown[]) => mockGetSchools(...a);
+      getSchoolStudents = jest.fn();
+      getSchoolTeachers = jest.fn();
+      getStudentPrograms = jest.fn();
+    },
+  };
+});
+
+import { normalizeAeriesBaseUrl, runAeriesConnectionTest } from '@/lib/sis/aeries-setup';
+
+const CERT = '477abe9e7d27439681d62f4e0de1f5e1';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetSchools.mockResolvedValue([{ SchoolCode: 1, Name: 'Sim High' }]);
+});
+
+describe('normalizeAeriesBaseUrl calls the syntactic guard', () => {
+  // Each of these is refused ONLY by assertPublicAeriesHostSyntax — nothing
+  // else in the normalizer would reject them. Remove that one line and every
+  // case here fails, which is the point.
+  it.each([
+    ['https://127.0.0.1/', 'an IPv4 literal'],
+    ['https://127.0.0.1../', 'an IPv4 literal wearing two trailing dots'],
+    ['https://localhost/', 'localhost'],
+    ['https://sis.internal/', 'an internal-only name'],
+    ['https://aeries/', 'a single-label intranet name'],
+  ])('refuses %s (%s)', (url) => {
+    expect(() => normalizeAeriesBaseUrl(url)).toThrow();
+  });
+
+  it('still accepts a real district address', () => {
+    expect(normalizeAeriesBaseUrl('https://demo.aeries.net')).toBe(
+      'https://demo.aeries.net/aeries/api/v5',
+    );
+  });
+});
+
+describe('runAeriesConnectionTest calls the resolving guard', () => {
+  it('makes NO request when the name resolves to a private address', async () => {
+    // The scenario the syntactic half cannot catch: a perfectly ordinary
+    // hostname whose A record points inside the network.
+    mockLookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+
+    const report = await runAeriesConnectionTest({
+      baseUrl: 'https://sis.example.com/aeries/api/v5',
+      certificate: CERT,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.areas[0].message).toMatch(/private network/i);
+    // The assertion that actually pins the wiring. Reporting an error while
+    // still dialling the address would satisfy every other check here.
+    expect(mockGetSchools).not.toHaveBeenCalled();
+  });
+
+  it('makes NO request when a name resolves to a NAT64-encoded internal address', async () => {
+    // Same wiring, but through the IPv6 classifier — which allowed this exact
+    // address until the deny-list became an allow-list.
+    mockLookup.mockResolvedValue([{ address: '64:ff9b::a9fe:a9fe', family: 6 }]);
+
+    const report = await runAeriesConnectionTest({
+      baseUrl: 'https://sis.example.com/aeries/api/v5',
+      certificate: CERT,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(mockGetSchools).not.toHaveBeenCalled();
+  });
+
+  it('proceeds normally when the name resolves publicly', async () => {
+    // The other half: a guard that refused everything would pass the two tests
+    // above while breaking every real district.
+    mockLookup.mockResolvedValue([{ address: '104.16.0.1', family: 4 }]);
+
+    await runAeriesConnectionTest({
+      baseUrl: 'https://demo.aeries.net/aeries/api/v5',
+      certificate: CERT,
+    });
+
+    expect(mockGetSchools).toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/lib/sis/aeries-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/aeries-setup.http.test.ts
@@ -18,15 +18,19 @@
  *     permission area rather than 401, or a 200 with an empty array. No mock
  *     can settle that; only the real service can.
  *
- * The guard is stubbed because these servers are on 127.0.0.1, which it
- * correctly refuses. ssrf-guard.test.ts covers the guard itself.
+ * The guard is stubbed because these servers are on 127.0.0.1 over plain http,
+ * both of which it correctly refuses. That is the point of stubbing the whole
+ * of `assertSafeAeriesUrl` rather than half of it: this suite is about
+ * transport, and URL policy is proven elsewhere — ssrf-guard.test.ts for the
+ * classification, aeries-setup.guard-wiring.test.ts for the fact that
+ * runAeriesConnectionTest actually calls the guard and refuses an http:// base.
  */
 import { createServer, type Server } from 'http';
 import type { AddressInfo } from 'net';
 
 jest.mock('@/lib/sis/ssrf-guard', () => ({
   ...jest.requireActual('@/lib/sis/ssrf-guard'),
-  assertPublicAeriesHost: jest.fn().mockResolvedValue(undefined),
+  assertSafeAeriesUrl: jest.fn().mockResolvedValue(undefined),
 }));
 
 import { runAeriesConnectionTest } from '@/lib/sis/aeries-setup';

--- a/__tests__/unit/lib/sis/aeries-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/aeries-setup.http.test.ts
@@ -1,0 +1,154 @@
+/**
+ * SPE-396 · the Aeries diagnostics against a REAL HTTP server.
+ *
+ * The sibling suite mocks `AeriesClient`'s methods, so it proves the reporting
+ * logic and nothing about the transport. This one starts an actual server and
+ * lets the real `fetch` in `AeriesClient` talk to it, so what is exercised is
+ * the whole path: request construction, real HTTP status codes, real JSON
+ * parsing, `AeriesApiError` mapping, and the redirect policy.
+ *
+ * WHY THIS EXISTS. `demo.aeries.net` is blocked by this sandbox's egress policy,
+ * so the flow has never run against a real Aeries instance. This closes most of
+ * that gap — everything except Aeries' own behaviour. Stated precisely:
+ *
+ *   - PROVEN HERE: given a 403, our code says "tick that box"; given a 401, it
+ *     says "re-copy the certificate"; a redirect is refused; a non-array body
+ *     is not reported as a network failure.
+ *   - STILL ASSUMED: that Aeries actually returns 403 for an unticked
+ *     permission area rather than 401, or a 200 with an empty array. No mock
+ *     can settle that; only the real service can.
+ *
+ * The guard is stubbed because these servers are on 127.0.0.1, which it
+ * correctly refuses. ssrf-guard.test.ts covers the guard itself.
+ */
+import { createServer, type Server } from 'http';
+import type { AddressInfo } from 'net';
+
+jest.mock('@/lib/sis/ssrf-guard', () => ({
+  ...jest.requireActual('@/lib/sis/ssrf-guard'),
+  assertPublicAeriesHost: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { runAeriesConnectionTest } from '@/lib/sis/aeries-setup';
+
+const CERT = '477abe9e7d27439681d62f4e0de1f5e1';
+
+/** Route table keyed by the path segment the probe hits. */
+type Handler = (path: string) => { status: number; body?: unknown; headers?: Record<string, string> };
+
+let server: Server;
+let baseUrl: string;
+let handler: Handler;
+let seenCertHeaders: (string | undefined)[] = [];
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    seenCertHeaders.push(req.headers['aeries-cert'] as string | undefined);
+    const { status, body, headers } = handler(req.url ?? '');
+    res.writeHead(status, { 'Content-Type': 'application/json', ...(headers ?? {}) });
+    res.end(body === undefined ? '' : JSON.stringify(body));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}/aeries/api/v5`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  seenCertHeaders = [];
+});
+
+const run = () => runAeriesConnectionTest({ baseUrl, certificate: CERT });
+const area = (r: Awaited<ReturnType<typeof run>>, key: string) => r.areas.find((a) => a.key === key)!;
+
+/** Everything granted; each endpoint returns a plausible Aeries-shaped body. */
+const allGranted: Handler = (path) => {
+  if (path.includes('/programs')) return { status: 200, body: [{ ProgramCode: '144' }] };
+  if (path.includes('/teachers')) return { status: 200, body: [{ TeacherNumber: 7 }] };
+  if (path.includes('/students')) return { status: 200, body: [{ StudentID: 1 }] };
+  return { status: 200, body: [{ SchoolCode: 1, Name: 'Sim High' }] };
+};
+
+describe('runAeriesConnectionTest over real HTTP', () => {
+  it('reports every area granted, and sends the certificate as a header', async () => {
+    handler = allGranted;
+    const report = await run();
+
+    expect(report.ok).toBe(true);
+    expect(report.summary).toMatch(/ready/i);
+    // The transport detail the mocked suite cannot see: the credential travels
+    // as AERIES-CERT on every request, not in a query string where it would
+    // land in the district's access logs.
+    expect(seenCertHeaders.length).toBeGreaterThan(0);
+    expect(new Set(seenCertHeaders)).toEqual(new Set([CERT]));
+  });
+
+  it('a real 403 on Student Programs produces "tick that box", not a cert error', async () => {
+    handler = (path) =>
+      path.includes('/programs') ? { status: 403, body: { message: 'forbidden' } } : allGranted(path);
+
+    const report = await run();
+    expect(report.ok).toBe(false);
+    expect(area(report, 'programs').status).toBe('denied');
+    expect(area(report, 'programs').message).toMatch(/read-only box/);
+    expect(report.summary).toMatch(/special education/i);
+  });
+
+  it('a real 401 produces "re-copy the certificate", and stops before the other probes', async () => {
+    handler = () => ({ status: 401, body: { message: 'unauthorized' } });
+
+    const report = await run();
+    expect(area(report, 'connection').message).toMatch(/certificate/i);
+    // One request, not four: probing on with a certificate Aeries just rejected
+    // would produce three more misleading failures.
+    expect(seenCertHeaders).toHaveLength(1);
+  });
+
+  it('a real 404 blames the address rather than a permission', async () => {
+    handler = () => ({ status: 404, body: { message: 'not found' } });
+    const report = await run();
+    expect(area(report, 'connection').message).toMatch(/address/i);
+    expect(area(report, 'connection').message).not.toMatch(/read-only box/);
+  });
+
+  it('a 200 with a non-array body is not reported as unreachable', async () => {
+    // The failure CodeRabbit flagged: `.map` throws a TypeError, which the
+    // network branch would otherwise swallow into "could not reach Aeries" for
+    // an instance that answered perfectly well.
+    handler = () => ({ status: 200, body: { error: 'unexpected shape' } });
+    const report = await run();
+    expect(area(report, 'connection').message).not.toMatch(/Could not reach/i);
+  });
+
+  it('REFUSES a redirect instead of following it — with the certificate unsent', async () => {
+    // The escape that defeated the whole SSRF guard before `redirect: 'error'`:
+    // a public host answering 302 towards an internal address. This asserts the
+    // policy actually takes effect in this Node runtime rather than trusting
+    // that the option is honoured.
+    let redirectTarget = '';
+    handler = (path) => {
+      if (path.includes('/elsewhere')) return { status: 200, body: [{ SchoolCode: 99 }] };
+      redirectTarget = `${baseUrl}/elsewhere`;
+      return { status: 302, headers: { Location: redirectTarget } };
+    };
+
+    const report = await run();
+    expect(report.ok).toBe(false);
+    // Exactly one request: the redirect was refused, not followed. If fetch had
+    // followed it there would be a second request carrying AERIES-CERT to a
+    // destination the guard never validated.
+    expect(seenCertHeaders).toHaveLength(1);
+    expect(area(report, 'connection').status).not.toBe('ok');
+  });
+
+  it('surfaces a dead server as unreachable, not as a permission problem', async () => {
+    const report = await runAeriesConnectionTest({
+      // Port 1 is reserved and nothing listens there.
+      baseUrl: 'http://127.0.0.1:1/aeries/api/v5',
+      certificate: CERT,
+    });
+    expect(area(report, 'connection').message).toMatch(/Could not reach/i);
+  });
+});

--- a/__tests__/unit/lib/sis/aeries-setup.test.ts
+++ b/__tests__/unit/lib/sis/aeries-setup.test.ts
@@ -1,0 +1,258 @@
+/**
+ * SPE-396 · Aeries connection setup — URL normalization and per-area diagnostics.
+ *
+ * These tests carry more weight than usual: `demo.aeries.net` is blocked by
+ * this sandbox's network policy, so the diagnostics cannot currently be
+ * exercised against a real Aeries instance. Everything asserted here is
+ * therefore pinned against the failure shapes the client actually produces
+ * (`AeriesApiError` with a real HTTP status), not against a hand-waved mock —
+ * and the gap is stated plainly on the PR rather than implied away.
+ *
+ * The two properties worth the most:
+ *   - 401 and 403 must NOT produce the same advice. One means the certificate
+ *     is wrong, the other means a checkbox was never ticked. Collapsing them
+ *     is what causes the support round-trips this feature exists to remove.
+ *   - no probe may surface a student name, an ID, or the certificate.
+ */
+import { AeriesApiError } from '@/lib/integrations/aeries';
+
+const mockGetSchools = jest.fn();
+const mockGetSchoolStudents = jest.fn();
+const mockGetSchoolTeachers = jest.fn();
+const mockGetStudentPrograms = jest.fn();
+let lastClientConfig: { baseUrl: string; certificate: string } | null = null;
+
+jest.mock('@/lib/integrations/aeries', () => {
+  const actual = jest.requireActual('@/lib/integrations/aeries');
+  return {
+    ...actual,
+    AeriesClient: class {
+      constructor(config: { baseUrl: string; certificate: string }) {
+        lastClientConfig = config;
+      }
+      getSchools = (...a: unknown[]) => mockGetSchools(...a);
+      getSchoolStudents = (...a: unknown[]) => mockGetSchoolStudents(...a);
+      getSchoolTeachers = (...a: unknown[]) => mockGetSchoolTeachers(...a);
+      getStudentPrograms = (...a: unknown[]) => mockGetStudentPrograms(...a);
+    },
+  };
+});
+
+import {
+  AERIES_API_PATH,
+  normalizeAeriesBaseUrl,
+  runAeriesConnectionTest,
+  toStoredTestResult,
+} from '@/lib/sis/aeries-setup';
+
+const CERT = '477abe9e7d27439681d62f4e0de1f5e1';
+const grantAll = () => {
+  mockGetSchools.mockResolvedValue([{ SchoolCode: 1, Name: 'Sim High' }]);
+  mockGetSchoolStudents.mockResolvedValue([{ StudentID: 1 }]);
+  mockGetSchoolTeachers.mockResolvedValue([{ TeacherNumber: 1 }]);
+  mockGetStudentPrograms.mockResolvedValue([{ StudentID: 1, ProgramCode: '144' }]);
+};
+const run = () => runAeriesConnectionTest({ baseUrl: 'https://x.aeries.net' + AERIES_API_PATH, certificate: CERT });
+const area = (r: Awaited<ReturnType<typeof run>>, key: string) => r.areas.find((a) => a.key === key)!;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  lastClientConfig = null;
+});
+
+describe('normalizeAeriesBaseUrl', () => {
+  // Every one of these is a shape a district administrator will actually
+  // paste, because it is what their browser was showing them.
+  it.each([
+    ['https://demo.aeries.net', 'bare host'],
+    ['https://demo.aeries.net/', 'trailing slash'],
+    ['https://demo.aeries.net/admin', 'the admin page they were on'],
+    ['https://demo.aeries.net/admin/', 'admin with a slash'],
+    ['https://demo.aeries.net/aeries/api/v5', 'already correct'],
+    ['demo.aeries.net', 'no scheme at all'],
+    ['  https://demo.aeries.net/admin  ', 'padded by the copy/paste'],
+  ])('normalizes %s (%s)', (input) => {
+    expect(normalizeAeriesBaseUrl(input)).toBe('https://demo.aeries.net/aeries/api/v5');
+  });
+
+  it('never doubles the api path when one is already present', () => {
+    expect(normalizeAeriesBaseUrl('https://d.aeries.net/aeries/api/v5')).not.toContain(
+      '/aeries/api/v5/aeries',
+    );
+  });
+
+  it('preserves a non-default port', () => {
+    expect(normalizeAeriesBaseUrl('https://sis.district.org:8443/admin')).toBe(
+      'https://sis.district.org:8443/aeries/api/v5',
+    );
+  });
+
+  it('refuses http rather than silently upgrading it', () => {
+    // Silently upgrading would hide that the district gave us a cleartext
+    // address; the certificate would ride that URL on every request.
+    expect(() => normalizeAeriesBaseUrl('http://demo.aeries.net')).toThrow(/https:\/\//);
+  });
+
+  it('refuses empty input with an instruction, not a stack trace', () => {
+    expect(() => normalizeAeriesBaseUrl('   ')).toThrow(/Enter your district/);
+  });
+
+  it('refuses something that cannot be a URL', () => {
+    expect(() => normalizeAeriesBaseUrl('not a url at all')).toThrow(/look like/);
+  });
+});
+
+describe('runAeriesConnectionTest', () => {
+  it('reports every area granted on a healthy connection', async () => {
+    grantAll();
+    const report = await run();
+
+    expect(report.ok).toBe(true);
+    expect(report.summary).toMatch(/ready/i);
+    for (const key of ['connection', 'schools', 'students', 'teachers', 'programs']) {
+      expect(area(report, key).status).toBe('ok');
+    }
+  });
+
+  it('passes the supplied credential to the client, not the env default', async () => {
+    grantAll();
+    await run();
+    expect(lastClientConfig).toEqual({
+      baseUrl: `https://x.aeries.net${AERIES_API_PATH}`,
+      certificate: CERT,
+    });
+  });
+
+  describe('401 vs 403 — the distinction the whole feature turns on', () => {
+    it('401 blames the certificate and says where to re-copy it', async () => {
+      mockGetSchools.mockRejectedValue(new AeriesApiError('unauthorized', 401, 'schools'));
+      const report = await run();
+
+      expect(report.ok).toBe(false);
+      expect(area(report, 'connection').message).toMatch(/certificate/i);
+      expect(area(report, 'connection').message).toMatch(/API Security/);
+      // Must NOT tell them to tick a permission box — that would send them to
+      // the wrong screen entirely.
+      expect(area(report, 'connection').message).not.toMatch(/tick the read-only box/);
+    });
+
+    it('403 names the exact checkbox, and does not blame the certificate', async () => {
+      grantAll();
+      mockGetStudentPrograms.mockRejectedValue(new AeriesApiError('forbidden', 403, 'programs'));
+      const report = await run();
+
+      const programs = area(report, 'programs');
+      expect(programs.status).toBe('denied');
+      expect(programs.message).toContain('Student Programs');
+      expect(programs.message).toMatch(/read-only box/);
+      expect(programs.message).not.toMatch(/certificate/i);
+    });
+  });
+
+  it('calls out a lone Student Programs denial as the consequential one', async () => {
+    // The half-success that matters: everything looks connected, but no
+    // special-education data will ever arrive. It must not read as "fine".
+    grantAll();
+    mockGetStudentPrograms.mockRejectedValue(new AeriesApiError('forbidden', 403, 'programs'));
+    const report = await run();
+
+    expect(report.ok).toBe(false);
+    expect(report.summary).toMatch(/special education/i);
+  });
+
+  it('distinguishes a wrong address from a permission problem', async () => {
+    mockGetSchools.mockRejectedValue(new AeriesApiError('not found', 404, 'schools'));
+    const report = await run();
+    expect(area(report, 'connection').message).toMatch(/address/i);
+    expect(area(report, 'connection').message).not.toMatch(/read-only box/);
+  });
+
+  it('reports a network failure as unreachable rather than as a permission denial', async () => {
+    mockGetSchools.mockRejectedValue(new Error('getaddrinfo ENOTFOUND'));
+    const report = await run();
+    expect(area(report, 'connection').message).toMatch(/Could not reach/i);
+  });
+
+  it('reports a timeout as a timeout', async () => {
+    mockGetSchools.mockRejectedValue(new AeriesApiError('timed out', 408, 'schools'));
+    const report = await run();
+    expect(area(report, 'connection').message).toMatch(/did not respond in time/i);
+  });
+
+  it('marks downstream areas untested when the connection fails, rather than guessing', async () => {
+    mockGetSchools.mockRejectedValue(new AeriesApiError('unauthorized', 401, 'schools'));
+    const report = await run();
+
+    for (const key of ['students', 'teachers', 'programs']) {
+      expect(area(report, key).message).toMatch(/Not checked/);
+    }
+    // And it must not have called them — probing with a cert Aeries just
+    // rejected produces three more misleading failures.
+    expect(mockGetSchoolStudents).not.toHaveBeenCalled();
+    expect(mockGetSchoolTeachers).not.toHaveBeenCalled();
+    expect(mockGetStudentPrograms).not.toHaveBeenCalled();
+  });
+
+  it('handles an authorized connection that returns no schools', async () => {
+    mockGetSchools.mockResolvedValue([]);
+    const report = await run();
+    expect(report.ok).toBe(false);
+    expect(report.summary).toMatch(/no schools/i);
+  });
+
+  describe('aggregate-only — the tech admin has no right to student data', () => {
+    it('requests one non-identifying field and a single row per probe', async () => {
+      grantAll();
+      await run();
+
+      const studentOpts = mockGetSchoolStudents.mock.calls[0][1];
+      expect(studentOpts.fields).toEqual(['StudentID']);
+      expect(studentOpts.endingRecord).toBe(1);
+
+      const teacherOpts = mockGetSchoolTeachers.mock.calls[0][1];
+      expect(teacherOpts.endingRecord).toBe(1);
+    });
+
+    it('never surfaces a student name or the certificate in any message', async () => {
+      mockGetSchools.mockResolvedValue([{ SchoolCode: 1, Name: 'Sim High' }]);
+      // A hostile-shaped payload: if any probe echoed records into its output,
+      // this name and id would appear in the report.
+      mockGetSchoolStudents.mockResolvedValue([
+        { StudentID: 98765, FirstName: 'Jordan', LastName: 'Rivera' },
+      ]);
+      mockGetSchoolTeachers.mockResolvedValue([{ TeacherNumber: 7, LastName: 'Nakamura' }]);
+      mockGetStudentPrograms.mockResolvedValue([{ StudentID: 98765, ProgramCode: '144' }]);
+
+      const blob = JSON.stringify(await run());
+      for (const leak of ['Jordan', 'Rivera', 'Nakamura', '98765', CERT]) {
+        expect(blob).not.toContain(leak);
+      }
+    });
+  });
+});
+
+describe('toStoredTestResult', () => {
+  it('keeps outcomes and drops the counts', async () => {
+    grantAll();
+    const stored = toStoredTestResult(await run());
+    // Counts are aggregate, but the connection log has no need to remember how
+    // many students a district has.
+    expect(JSON.stringify(stored)).not.toMatch(/count/);
+    expect(stored.area).toBe('all');
+  });
+
+  it('names the failing areas', async () => {
+    grantAll();
+    mockGetStudentPrograms.mockRejectedValue(new AeriesApiError('forbidden', 403, 'programs'));
+    const stored = toStoredTestResult(await run());
+    expect(stored.area).toContain('Student Programs');
+  });
+
+  it('never carries a credential into the stored result', async () => {
+    mockGetSchools.mockRejectedValue(new AeriesApiError(`bad cert ${CERT}`, 401, 'schools'));
+    const stored = toStoredTestResult(await run());
+    // AeriesApiError messages can carry the submitted cert; nothing may copy
+    // one into a column the district's staff can read.
+    expect(JSON.stringify(stored)).not.toContain(CERT);
+  });
+});

--- a/__tests__/unit/lib/sis/aeries-setup.test.ts
+++ b/__tests__/unit/lib/sis/aeries-setup.test.ts
@@ -21,7 +21,7 @@ import { AeriesApiError } from '@/lib/integrations/aeries';
 // pass here; ssrf-guard.test.ts covers the guard itself.
 jest.mock('@/lib/sis/ssrf-guard', () => ({
   ...jest.requireActual('@/lib/sis/ssrf-guard'),
-  assertPublicAeriesHost: jest.fn().mockResolvedValue(undefined),
+  assertSafeAeriesUrl: jest.fn().mockResolvedValue(undefined),
 }));
 
 const mockGetSchools = jest.fn();

--- a/__tests__/unit/lib/sis/aeries-setup.test.ts
+++ b/__tests__/unit/lib/sis/aeries-setup.test.ts
@@ -16,11 +16,19 @@
  */
 import { AeriesApiError } from '@/lib/integrations/aeries';
 
+// The setup module now resolves the host before probing (SSRF guard). Tests of
+// the DIAGNOSTICS must not depend on DNS, so the resolved check is stubbed to
+// pass here; ssrf-guard.test.ts covers the guard itself.
+jest.mock('@/lib/sis/ssrf-guard', () => ({
+  ...jest.requireActual('@/lib/sis/ssrf-guard'),
+  assertPublicAeriesHost: jest.fn().mockResolvedValue(undefined),
+}));
+
 const mockGetSchools = jest.fn();
 const mockGetSchoolStudents = jest.fn();
 const mockGetSchoolTeachers = jest.fn();
 const mockGetStudentPrograms = jest.fn();
-let lastClientConfig: { baseUrl: string; certificate: string } | null = null;
+let mockClientConfig: { baseUrl: string; certificate: string } | null = null;
 
 jest.mock('@/lib/integrations/aeries', () => {
   const actual = jest.requireActual('@/lib/integrations/aeries');
@@ -28,7 +36,7 @@ jest.mock('@/lib/integrations/aeries', () => {
     ...actual,
     AeriesClient: class {
       constructor(config: { baseUrl: string; certificate: string }) {
-        lastClientConfig = config;
+        mockClientConfig = config;
       }
       getSchools = (...a: unknown[]) => mockGetSchools(...a);
       getSchoolStudents = (...a: unknown[]) => mockGetSchoolStudents(...a);
@@ -57,7 +65,7 @@ const area = (r: Awaited<ReturnType<typeof run>>, key: string) => r.areas.find((
 
 beforeEach(() => {
   jest.clearAllMocks();
-  lastClientConfig = null;
+  mockClientConfig = null;
 });
 
 describe('normalizeAeriesBaseUrl', () => {
@@ -117,7 +125,7 @@ describe('runAeriesConnectionTest', () => {
   it('passes the supplied credential to the client, not the env default', async () => {
     grantAll();
     await run();
-    expect(lastClientConfig).toEqual({
+    expect(mockClientConfig).toEqual({
       baseUrl: `https://x.aeries.net${AERIES_API_PATH}`,
       certificate: CERT,
     });
@@ -146,6 +154,17 @@ describe('runAeriesConnectionTest', () => {
       expect(programs.message).toContain('Student Programs');
       expect(programs.message).toMatch(/read-only box/);
       expect(programs.message).not.toMatch(/certificate/i);
+    });
+
+    it('403 on Schools reports a denial, not an unreachable instance', async () => {
+      // The district granted the certificate but never ticked Schools. Nothing
+      // downstream can be probed, but the cause is a checkbox, not the network.
+      mockGetSchools.mockRejectedValue(new AeriesApiError('forbidden', 403, 'schools'));
+      const report = await run();
+
+      expect(area(report, 'schools').status).toBe('denied');
+      expect(area(report, 'schools').message).toContain('Schools');
+      expect(report.summary).toMatch(/Could not connect/i);
     });
   });
 
@@ -185,6 +204,10 @@ describe('runAeriesConnectionTest', () => {
 
     for (const key of ['students', 'teachers', 'programs']) {
       expect(area(report, key).message).toMatch(/Not checked/);
+      // 'untested', not 'error' — the UI colours by status, and three red
+      // permission failures for areas nobody probed sends the district off to
+      // fix checkboxes that may already be correct.
+      expect(area(report, key).status).toBe('untested');
     }
     // And it must not have called them — probing with a cert Aeries just
     // rejected produces three more misleading failures.
@@ -211,6 +234,12 @@ describe('runAeriesConnectionTest', () => {
 
       const teacherOpts = mockGetSchoolTeachers.mock.calls[0][1];
       expect(teacherOpts.endingRecord).toBe(1);
+
+      // ProgramCode only: asking for StudentID too would pull an identifiable
+      // program-membership record into memory on an aggregate-only flow.
+      const programOpts = mockGetStudentPrograms.mock.calls[0][3];
+      expect(programOpts.fields).toEqual(['ProgramCode']);
+      expect(programOpts.fields).not.toContain('StudentID');
     });
 
     it('never surfaces a student name or the certificate in any message', async () => {

--- a/__tests__/unit/lib/sis/connections.test.ts
+++ b/__tests__/unit/lib/sis/connections.test.ts
@@ -158,6 +158,14 @@ describe('lib/sis/connections', () => {
       for (const col of CREDENTIAL_COLUMNS) {
         expect(calls[0].select).not.toContain(col);
       }
+      // The `not.toBe('*')` guard matters MORE here than on listConnections:
+      // getConnection's row is serialized straight to the browser by the DPA
+      // route, so a `select('*')` would ship credential ciphertext into a staff
+      // browser. Without this line the test passes on `'*'` — the string
+      // contains none of the column names above. (Caught by mutation: switching
+      // to `select('*')` left all 25 tests green.)
+      expect(calls[0].select).not.toBe('*');
+      expect(calls[0].select).toContain('credential_hint');
     });
   });
 

--- a/__tests__/unit/lib/sis/ssrf-guard.test.ts
+++ b/__tests__/unit/lib/sis/ssrf-guard.test.ts
@@ -35,6 +35,17 @@ describe('isPrivateAddress', () => {
     ['0.0.0.0', 'this network'],
     ['224.0.0.1', 'multicast'],
     ['255.255.255.255', 'broadcast'],
+    // These three arms were each deletable with the suite green.
+    ['198.18.0.1', 'benchmarking range, low edge'],
+    ['198.19.255.254', 'benchmarking range, high edge'],
+    ['192.0.0.1', 'IETF protocol assignments'],
+    ['192.0.2.5', 'TEST-NET-1, inside the same 192.0/16 arm'],
+    // Fail closed on anything that is not four valid octets: a classifier that
+    // returned "not private" for input it could not parse would be worse than
+    // no classifier, because the caller reads false as a positive clearance.
+    ['not.an.ip.at.all', 'unparseable'],
+    ['10.0.0', 'too few octets'],
+    ['999.0.0.1', 'octet out of range'],
   ])('rejects %s (%s)', (addr) => {
     expect(isPrivateAddress(addr, 4)).toBe(true);
   });
@@ -64,8 +75,36 @@ describe('isPrivateAddress', () => {
     expect(isPrivateAddress(addr, 6)).toBe(true);
   });
 
-  it('allows a public IPv6 address', () => {
-    expect(isPrivateAddress('2606:4700::1111', 6)).toBe(false);
+  // Every one of these was ALLOWED by the deny-list this replaced, and every
+  // one is a different spelling of an address the IPv4 side already refuses.
+  // They are listed out rather than summarised because the failure they guard
+  // against is precisely "we only thought of four spellings".
+  it.each([
+    ['64:ff9b::a9fe:a9fe', 'NAT64 — reaches 169.254.169.254 on any DNS64 network'],
+    ['64:ff9b::a00:5', 'NAT64 — reaches 10.0.0.5'],
+    ['::169.254.169.254', 'IPv4-compatible metadata endpoint'],
+    ['::127.0.0.1', 'IPv4-compatible loopback'],
+    ['::ffff:7f00:1', 'IPv4-mapped loopback written in hex, not dotted quad'],
+    ['fec0::1', 'site-local — one nibble outside the old fe[89ab] arm'],
+    ['2002:a9fe:a9fe::', '6to4-encoded metadata endpoint'],
+    ['2002:7f00:1::', '6to4-encoded loopback'],
+    ['2001::7f00:1', 'Teredo'],
+    ['fe80::1%eth0', 'link-local carrying a zone id'],
+  ])('rejects IPv6 %s (%s)', (addr) => {
+    expect(isPrivateAddress(addr, 6)).toBe(true);
+  });
+
+  // The other half of an allow-list: it must not lock a real district out.
+  // Rejecting a genuine Aeries host is the expensive failure — there is no
+  // workaround for the district, whereas a missed private range is defence in
+  // depth we still have other layers for.
+  it.each([
+    ['2606:4700:4700::1111', 'Cloudflare'],
+    ['2a00:1450:4001:80e::200e', 'Google, 2a00::/12'],
+    ['2001:4860:4860::8888', 'Google DNS — 2001::/16 but NOT Teredo'],
+    ['3fff::1', 'top of the 2000::/3 global unicast range'],
+  ])('allows public IPv6 %s (%s)', (addr) => {
+    expect(isPrivateAddress(addr, 6)).toBe(false);
   });
 });
 

--- a/__tests__/unit/lib/sis/ssrf-guard.test.ts
+++ b/__tests__/unit/lib/sis/ssrf-guard.test.ts
@@ -58,6 +58,8 @@ describe('isPrivateAddress', () => {
     ['fe80::1', 'link-local'],
     ['::ffff:10.0.0.1', 'IPv4-mapped private address'],
     ['::ffff:169.254.169.254', 'IPv4-mapped metadata endpoint'],
+    ['ff02::1', 'multicast — all nodes on the link'],
+    ['ff05::1:3', 'multicast — site-local DHCP servers'],
   ])('rejects IPv6 %s (%s)', (addr) => {
     expect(isPrivateAddress(addr, 6)).toBe(true);
   });

--- a/__tests__/unit/lib/sis/ssrf-guard.test.ts
+++ b/__tests__/unit/lib/sis/ssrf-guard.test.ts
@@ -78,9 +78,19 @@ describe('assertPublicAeriesHostSyntax', () => {
     expect(() => assertPublicAeriesHostSyntax(host)).toThrow(/not an IP address/i);
   });
 
-  it.each(['localhost', 'sub.localhost'])('refuses %s', (host) => {
+  it.each(['localhost', 'sub.localhost', 'localhost.'])('refuses %s', (host) => {
     expect(() => assertPublicAeriesHostSyntax(host)).toThrow(/this server/i);
   });
+
+  it.each(['localhost.', 'sis.internal.', 'aeries.local.'])(
+    'refuses the fully-qualified trailing-dot form %s',
+    (host) => {
+      // Found by probing the guard rather than reading it: a trailing dot is
+      // the fully-qualified form of the same name and resolves identically,
+      // but `endsWith('.internal')` and `=== 'localhost'` both miss it.
+      expect(() => assertPublicAeriesHostSyntax(host)).toThrow();
+    },
+  );
 
   it.each(['sis.internal', 'aeries.local', 'server.corp', 'box.lan'])(
     'refuses the internal-only name %s',

--- a/__tests__/unit/lib/sis/ssrf-guard.test.ts
+++ b/__tests__/unit/lib/sis/ssrf-guard.test.ts
@@ -1,0 +1,139 @@
+/**
+ * SPE-396 · the SSRF guard on district-supplied Aeries addresses.
+ *
+ * Found by review, and confirmed against the code before it was written: the
+ * original normalizer accepted `https://127.0.0.1:8443`, `https://10.0.0.5`,
+ * and — worst — `https://169.254.169.254`, the cloud metadata endpoint. The
+ * connection test then makes authenticated requests to whatever is stored and
+ * reports, per HTTP status, what answered. That is a port scanner running from
+ * our production egress, aimed by a customer.
+ *
+ * `isPrivateAddress` is tested directly rather than only through DNS, because a
+ * range that is wrong there is invisible until someone actually points a name
+ * at it.
+ */
+import {
+  assertPublicAeriesHost,
+  assertPublicAeriesHostSyntax,
+  isPrivateAddress,
+} from '@/lib/sis/ssrf-guard';
+
+const mockLookup = jest.fn();
+jest.mock('dns/promises', () => ({ lookup: (...a: unknown[]) => mockLookup(...a) }));
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('isPrivateAddress', () => {
+  it.each([
+    ['127.0.0.1', 'loopback'],
+    ['10.0.0.5', 'private class A'],
+    ['172.16.0.1', 'private class B, low edge'],
+    ['172.31.255.254', 'private class B, high edge'],
+    ['192.168.1.1', 'private class C'],
+    ['169.254.169.254', 'link-local — the cloud metadata endpoint'],
+    ['100.64.0.1', 'carrier-grade NAT'],
+    ['0.0.0.0', 'this network'],
+    ['224.0.0.1', 'multicast'],
+    ['255.255.255.255', 'broadcast'],
+  ])('rejects %s (%s)', (addr) => {
+    expect(isPrivateAddress(addr, 4)).toBe(true);
+  });
+
+  it.each([
+    ['8.8.8.8', 'public resolver'],
+    ['104.16.0.1', 'public CDN'],
+    ['172.15.0.1', 'just below the private class B block'],
+    ['172.32.0.1', 'just above the private class B block'],
+    ['100.63.255.255', 'just below carrier-grade NAT'],
+    ['100.128.0.1', 'just above carrier-grade NAT'],
+  ])('allows %s (%s)', (addr) => {
+    expect(isPrivateAddress(addr, 4)).toBe(false);
+  });
+
+  it.each([
+    ['::1', 'IPv6 loopback'],
+    ['::', 'unspecified'],
+    ['fc00::1', 'unique local'],
+    ['fd12:3456::1', 'unique local'],
+    ['fe80::1', 'link-local'],
+    ['::ffff:10.0.0.1', 'IPv4-mapped private address'],
+    ['::ffff:169.254.169.254', 'IPv4-mapped metadata endpoint'],
+  ])('rejects IPv6 %s (%s)', (addr) => {
+    expect(isPrivateAddress(addr, 6)).toBe(true);
+  });
+
+  it('allows a public IPv6 address', () => {
+    expect(isPrivateAddress('2606:4700::1111', 6)).toBe(false);
+  });
+});
+
+describe('assertPublicAeriesHostSyntax', () => {
+  it.each([
+    ['127.0.0.1', 'loopback literal'],
+    ['10.0.0.5', 'private literal'],
+    ['169.254.169.254', 'metadata literal'],
+    ['::1', 'IPv6 literal'],
+    ['[::1]', 'bracketed IPv6 literal'],
+  ])('refuses the IP literal %s (%s)', (host) => {
+    expect(() => assertPublicAeriesHostSyntax(host)).toThrow(/not an IP address/i);
+  });
+
+  it.each(['localhost', 'sub.localhost'])('refuses %s', (host) => {
+    expect(() => assertPublicAeriesHostSyntax(host)).toThrow(/this server/i);
+  });
+
+  it.each(['sis.internal', 'aeries.local', 'server.corp', 'box.lan'])(
+    'refuses the internal-only name %s',
+    (host) => {
+      expect(() => assertPublicAeriesHostSyntax(host)).toThrow(/inside your network/i);
+    },
+  );
+
+  it('refuses a single-label intranet shortcut', () => {
+    expect(() => assertPublicAeriesHostSyntax('aeries')).toThrow(/internal shortcut/i);
+  });
+
+  it('accepts a real district hostname', () => {
+    expect(() => assertPublicAeriesHostSyntax('jsusd.aeries.net')).not.toThrow();
+    expect(() => assertPublicAeriesHostSyntax('sis.somedistrict.k12.ca.us')).not.toThrow();
+  });
+});
+
+describe('assertPublicAeriesHost', () => {
+  it('accepts a name that resolves publicly', async () => {
+    mockLookup.mockResolvedValue([{ address: '104.16.0.1', family: 4 }]);
+    await expect(assertPublicAeriesHost('demo.aeries.net')).resolves.toBeUndefined();
+  });
+
+  it('refuses a public-looking name that resolves to a private address', async () => {
+    // The attack the syntax check alone cannot stop: nothing prevents a
+    // district from pointing sis.example.com at 10.0.0.5.
+    mockLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+    await expect(assertPublicAeriesHost('sis.example.com')).rejects.toThrow(/private network/i);
+  });
+
+  it('refuses when ANY resolved address is private, not just the first', async () => {
+    // A name with one public and one private record would otherwise pass the
+    // check and then be dialled at whichever the resolver happened to pick.
+    mockLookup.mockResolvedValue([
+      { address: '104.16.0.1', family: 4 },
+      { address: '192.168.1.10', family: 4 },
+    ]);
+    await expect(assertPublicAeriesHost('sis.example.com')).rejects.toThrow(/private network/i);
+  });
+
+  it('refuses a name that resolves to nothing', async () => {
+    mockLookup.mockResolvedValue([]);
+    await expect(assertPublicAeriesHost('sis.example.com')).rejects.toThrow(/private network/i);
+  });
+
+  it('reports an unresolvable name as a typo, not a security refusal', async () => {
+    mockLookup.mockRejectedValue(new Error('ENOTFOUND'));
+    await expect(assertPublicAeriesHost('typo.aeries.net')).rejects.toThrow(/couldn't find/i);
+  });
+
+  it('applies the syntax check before spending a DNS lookup', async () => {
+    await expect(assertPublicAeriesHost('127.0.0.1')).rejects.toThrow(/not an IP address/i);
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+});

--- a/app/(dashboard)/dashboard/tech/page.tsx
+++ b/app/(dashboard)/dashboard/tech/page.tsx
@@ -1,17 +1,31 @@
 'use client';
 
 /**
- * District Tech Admin portal home (SPE-393).
+ * District Tech Admin portal (SPE-393 shell, SPE-396 Aeries flow).
  *
- * The shell only: it establishes the route the role is pinned to and explains
- * what will live here. The actual connection surfaces arrive with SPE-396
- * (Aeries API) and SPE-397 (OneRoster); SPE-395 adds the credential store they
- * both write to.
+ * The connection row is read straight from Supabase rather than through an API
+ * route: `district_sis_connections` grants a district's own tech/district admin
+ * SELECT on exactly the non-secret columns (SPE-395), so this read is governed
+ * by the same policy that protects the credentials.
+ *
+ * Columns are named explicitly and MUST stay that way. `select('*')` on this
+ * table is REFUSED for a browser session — `*` expands to columns the grant
+ * excludes, and PostgREST returns 42501 rather than a narrowed row. That is
+ * deliberate: a loud error beats silently shipping a certificate because
+ * someone reached for the usual shorthand.
  */
 
 import { useCallback, useEffect, useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import { Card, CardHeader, CardTitle, CardBody } from '../../../components/ui/card';
+import AeriesSetupGuide from '../../../components/tech/aeries-setup-guide';
+import AeriesConnectionCard, {
+  type ConnectionSummary,
+} from '../../../components/tech/aeries-connection-card';
+
+/** Mirrors the GRANT in 20260806_spe395_district_sis_connections.sql. */
+const CONNECTION_COLUMNS =
+  'id, sis_type, base_url, credential_hint, status, dpa_cleared_at, last_tested_at';
 
 interface TechProfile {
   full_name: string | null;
@@ -20,31 +34,45 @@ interface TechProfile {
 
 export default function TechPortalPage() {
   const [profile, setProfile] = useState<TechProfile | null>(null);
+  const [connections, setConnections] = useState<ConnectionSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const supabase = createClient();
 
-  const loadProfile = useCallback(async () => {
+  const load = useCallback(async () => {
     try {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return;
 
-      const { data } = await supabase
-        .from('profiles')
-        .select('full_name, school_district')
-        .eq('id', user.id)
-        .single();
+      const [{ data: prof }, { data: conns, error: connError }] = await Promise.all([
+        supabase.from('profiles').select('full_name, school_district').eq('id', user.id).single(),
+        supabase
+          .from('district_sis_connections')
+          .select(CONNECTION_COLUMNS)
+          .order('sis_type'),
+      ]);
 
-      setProfile(data);
+      setProfile(prof);
+      if (connError) {
+        // Surfaced rather than swallowed: if the column grant ever drifts, this
+        // is where it shows up, and a silent empty state would look identical
+        // to "no connection set up yet".
+        setLoadError('Could not load your integration status. Please refresh.');
+        console.error('Failed to load SIS connections:', connError.message);
+      } else {
+        setConnections((conns ?? []) as unknown as ConnectionSummary[]);
+      }
     } catch (error) {
-      console.error('Error loading tech portal profile:', error);
+      console.error('Error loading tech portal:', error);
+      setLoadError('Could not load your integration status. Please refresh.');
     } finally {
       setLoading(false);
     }
   }, [supabase]);
 
   useEffect(() => {
-    loadProfile();
-  }, [loadProfile]);
+    load();
+  }, [load]);
 
   if (loading) {
     return (
@@ -57,62 +85,95 @@ export default function TechPortalPage() {
     );
   }
 
+  const aeries = connections.find((c) => c.sis_type === 'aeries');
+  const districtName = profile?.school_district || 'your district';
+
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900">Integrations</h1>
           <p className="mt-2 text-gray-600">
-            Connect {profile?.school_district || 'your district'}&apos;s student
-            information system to Speddy.
+            Connect {districtName}&apos;s student information system to Speddy.
           </p>
         </div>
 
+        {loadError && (
+          <div
+            role="alert"
+            className="mb-6 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+          >
+            {loadError}
+          </div>
+        )}
+
         <div className="space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>No connection yet</CardTitle>
-            </CardHeader>
-            <CardBody>
-              <p className="text-sm text-gray-600">
-                Your district doesn&apos;t have a student information system
-                connected. Setup runs with help from the Speddy team — we&apos;ll
-                walk you through it and confirm the connection works before
-                anything syncs.
-              </p>
-              <p className="mt-4 text-sm text-gray-600">
-                Setup can begin once your district&apos;s data privacy agreement
-                is signed. Your Speddy contact will let you know when it&apos;s
-                time.
-              </p>
-            </CardBody>
-          </Card>
+          {!aeries ? (
+            <Card>
+              <CardHeader>
+                <CardTitle>No connection yet</CardTitle>
+              </CardHeader>
+              <CardBody>
+                <p className="text-sm text-gray-600">
+                  Your district doesn&apos;t have a student information system connected yet.
+                  Setup runs with help from the Speddy team — we&apos;ll walk you through it and
+                  confirm the connection works before anything syncs.
+                </p>
+                <p className="mt-4 text-sm text-gray-600">
+                  Setup can begin once your district&apos;s data privacy agreement is signed. Your
+                  Speddy contact will let you know when it&apos;s time.
+                </p>
+              </CardBody>
+            </Card>
+          ) : !aeries.dpa_cleared_at ? (
+            // The DPA gate. Nothing they can do about it from here, so the copy
+            // says who moves it forward instead of offering a dead control.
+            <Card>
+              <CardHeader>
+                <CardTitle>Waiting on your data privacy agreement</CardTitle>
+              </CardHeader>
+              <CardBody>
+                <p className="text-sm text-gray-600">
+                  Before {districtName} can share student data with Speddy, your signed data
+                  privacy agreement needs to be on file. Your Speddy contact is handling that —
+                  they&apos;ll let you know as soon as this page opens up.
+                </p>
+                <p className="mt-4 text-sm text-gray-600">
+                  Nothing is needed from you yet. If you want to get a head start, you can ask
+                  whoever manages your Aeries security settings to be ready.
+                </p>
+              </CardBody>
+            </Card>
+          ) : (
+            <>
+              <AeriesConnectionCard connection={aeries} onChanged={load} />
+              <AeriesSetupGuide />
+            </>
+          )}
 
           <Card>
             <CardHeader>
-              <CardTitle>What you&apos;ll need</CardTitle>
+              <CardTitle>What Speddy does with this access</CardTitle>
             </CardHeader>
             <CardBody>
               <ul className="space-y-3 text-sm text-gray-600">
                 <li>
-                  <span className="font-medium text-gray-900">
-                    Access to your SIS admin settings.
-                  </span>{' '}
-                  For Aeries that&apos;s the API Security page; for OneRoster
-                  it&apos;s wherever your vendor issues API credentials.
+                  <span className="font-medium text-gray-900">Read-only, always.</span> Speddy
+                  never writes anything back to your student information system.
                 </li>
                 <li>
                   <span className="font-medium text-gray-900">
-                    Permission to create an API account.
+                    Your certificate is encrypted and never shown again.
                   </span>{' '}
-                  Speddy only ever reads — we never write back to your SIS.
+                  Not to us in a support screen, and not back to you here — only its last four
+                  characters.
                 </li>
                 <li>
                   <span className="font-medium text-gray-900">
-                    A few minutes to test the connection.
+                    We check each area separately.
                   </span>{' '}
-                  We check each piece separately and tell you in plain language
-                  what&apos;s working and what isn&apos;t.
+                  If something isn&apos;t granted, we tell you exactly which box to tick in
+                  Aeries rather than just saying it failed.
                 </li>
               </ul>
             </CardBody>

--- a/app/api/internal/sis-connections/[connectionId]/dpa/route.ts
+++ b/app/api/internal/sis-connections/[connectionId]/dpa/route.ts
@@ -43,9 +43,8 @@ export const PATCH = withRoute<{ connectionId: string }, { cleared: boolean }>(
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to update DPA state';
-      log.error('Failed to update DPA state', {
+      log.error('Failed to update DPA state', err, {
         connectionId: params.connectionId,
-        error: message,
       });
       if (message === SIS_CONNECTION_NOT_FOUND) {
         return NextResponse.json({ error: SIS_CONNECTION_NOT_FOUND }, { status: 404 });
@@ -72,9 +71,8 @@ export const PATCH = withRoute<{ connectionId: string }, { cleared: boolean }>(
       const connection = await getConnection(params.connectionId);
       return NextResponse.json({ connection });
     } catch (err) {
-      log.error('DPA change committed but the read-back failed', {
+      log.error('DPA change committed but the read-back failed', err, {
         connectionId: params.connectionId,
-        error: err instanceof Error ? err.message : String(err),
       });
       return NextResponse.json({ connection: null });
     }

--- a/app/api/internal/sis-connections/route.ts
+++ b/app/api/internal/sis-connections/route.ts
@@ -32,15 +32,38 @@ export const GET = withRoute(
  * a separate, separately-audited action, and credentials never come through
  * /internal at all — the district's own tech admin enters those.
  */
+/**
+ * Exported so it can be tested as the real thing. The https constraint below is
+ * the sort of rule that is silently deleted in a refactor, and a copy of the
+ * schema in a test file would keep passing after that happened.
+ */
+export const createSisConnectionBody = z.object({
+  districtId: z.string().min(1),
+  sisType: z.enum(['aeries', 'oneroster']),
+  // https only, on both. A bare `.url()` accepts http://, and this route is the
+  // one way an http:// base can reach the table — the district-facing path goes
+  // through normalizeAeriesBaseUrl, which refuses it. A stored http:// base
+  // would put the district's SIS credential on the wire in cleartext on every
+  // probe, so it is refused at the boundary rather than re-checked wherever the
+  // row is later read.
+  baseUrl: z
+    .string()
+    .url()
+    .refine((u) => u.startsWith('https://'), {
+      message: 'baseUrl must start with https:// so credentials stay encrypted',
+    })
+    .optional(),
+  tokenUrl: z
+    .string()
+    .url()
+    .refine((u) => u.startsWith('https://'), {
+      message: 'tokenUrl must start with https:// so credentials stay encrypted',
+    })
+    .optional(),
+});
+
 export const POST = withRoute(
-  {
-    body: z.object({
-      districtId: z.string().min(1),
-      sisType: z.enum(['aeries', 'oneroster']),
-      baseUrl: z.string().url().optional(),
-      tokenUrl: z.string().url().optional(),
-    }),
-  },
+  { body: createSisConnectionBody },
   async ({ userId, body }) => {
     const denied = await speddyAdminDenialReason(userId);
     if (denied) {

--- a/app/api/internal/sis-connections/route.ts
+++ b/app/api/internal/sis-connections/route.ts
@@ -59,10 +59,9 @@ export const POST = withRoute(
       return NextResponse.json({ connection });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to create SIS connection';
-      log.error('Failed to create SIS connection', {
+      log.error('Failed to create SIS connection', err, {
         districtId: body.districtId,
         sisType: body.sisType,
-        error: message,
       });
       // The unique constraint is the one failure a staff member can trigger by
       // double-clicking, so name it rather than returning a raw Postgres string.

--- a/app/api/tech/sis/aeries/route.ts
+++ b/app/api/tech/sis/aeries/route.ts
@@ -32,10 +32,13 @@ export const POST = withRoute(
       certificate: z
         .string()
         .trim()
-        // Aeries vendor certificates are 32 hex characters. Checking the shape
-        // here turns the single most common paste error (grabbing the wrong
-        // field off the API Security page) into an immediate, specific message
-        // instead of a failed connection test minutes later.
+        // 32 alphanumerics, matching the error text. Deliberately NOT tightened
+        // to hex, even though every certificate we have seen is hex and the docs
+        // say "32-char": the costs are asymmetric. Rejecting a valid certificate
+        // locks a district out with no workaround; accepting a malformed one
+        // costs one connection test that fails with a clear message. Aeries' own
+        // docs call it "case-sensitive", which hex would not need to be — so the
+        // character set is not certain enough to refuse on.
         .regex(/^[A-Za-z0-9]{32}$/, 'An Aeries certificate is 32 letters and numbers'),
     }),
     rateLimit: { requests: 10, windowSeconds: 60, name: 'tech-sis-aeries-store' },
@@ -65,7 +68,19 @@ export const POST = withRoute(
       );
     }
 
-    const connections = await listConnections(caller.districtId);
+    // Wrapped rather than left to the route wrapper: withRoute's catch echoes
+    // error.message to the client when NODE_ENV=development, and a Supabase
+    // error names tables and constraints.
+    let connections;
+    try {
+      connections = await listConnections(caller.districtId);
+    } catch (err) {
+      log.error('Failed to load SIS connections', {
+        districtId: caller.districtId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return NextResponse.json({ error: 'Could not load your connection.' }, { status: 500 });
+    }
     const connection = connections.find((c) => c.sis_type === 'aeries');
     if (!connection) {
       return NextResponse.json(

--- a/app/api/tech/sis/aeries/route.ts
+++ b/app/api/tech/sis/aeries/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withRoute } from '@/lib/api/with-route';
+import { resolveDistrictSisCaller } from '@/lib/api/district-sis-caller';
+import { logger } from '@/lib/logger';
+import { listConnections, storeCredential } from '@/lib/sis/connections';
+import { normalizeAeriesBaseUrl } from '@/lib/sis/aeries-setup';
+
+const log = logger.child({ module: 'tech-sis-aeries' });
+
+/**
+ * POST /api/tech/sis/aeries — a district submits its Aeries credential.
+ *
+ * This is the only route in the app that accepts a SIS certificate. Three
+ * things are true of it by construction:
+ *
+ *  - the district comes from the caller's own grants, never the request body,
+ *    so a tech admin cannot write a credential into another district's row;
+ *  - the certificate is encrypted before it reaches the database and is never
+ *    echoed back — the response carries connection status only;
+ *  - the DPA gate is enforced beneath this, in `storeCredential` and again by a
+ *    CHECK constraint, so this route cannot bypass it even by mistake.
+ *
+ * Rate-limited: this is an unauthenticated-adjacent secret-submission endpoint
+ * in the sense that matters — a bug here is expensive, and there is no
+ * legitimate reason to call it in a loop.
+ */
+export const POST = withRoute(
+  {
+    body: z.object({
+      baseUrl: z.string().min(1, 'Enter your Aeries web address'),
+      certificate: z
+        .string()
+        .trim()
+        // Aeries vendor certificates are 32 hex characters. Checking the shape
+        // here turns the single most common paste error (grabbing the wrong
+        // field off the API Security page) into an immediate, specific message
+        // instead of a failed connection test minutes later.
+        .regex(/^[A-Za-z0-9]{32}$/, 'An Aeries certificate is 32 letters and numbers'),
+    }),
+    rateLimit: { requests: 10, windowSeconds: 60, name: 'tech-sis-aeries-store' },
+  },
+  async ({ userId, body }) => {
+    const caller = await resolveDistrictSisCaller(userId);
+    if (!caller.ok) {
+      log.warn('Non-district-tech tried to store an Aeries credential', {
+        userId,
+        denied: caller.denied,
+      });
+      return NextResponse.json(
+        { error: 'Forbidden: district tech admin access required' },
+        { status: 403 },
+      );
+    }
+
+    let baseUrl: string;
+    try {
+      baseUrl = normalizeAeriesBaseUrl(body.baseUrl);
+    } catch (err) {
+      // These messages are written for the district administrator and contain
+      // nothing sensitive — passing them through is the point.
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : 'That Aeries address is not valid.' },
+        { status: 400 },
+      );
+    }
+
+    const connections = await listConnections(caller.districtId);
+    const connection = connections.find((c) => c.sis_type === 'aeries');
+    if (!connection) {
+      return NextResponse.json(
+        {
+          error:
+            'Aeries setup has not been opened for your district yet. Your Speddy contact will enable it.',
+        },
+        { status: 409 },
+      );
+    }
+    if (!connection.dpa_cleared_at) {
+      // The gate, stated in the district's terms rather than as a constraint
+      // violation. They cannot fix this themselves — say who can.
+      return NextResponse.json(
+        {
+          error:
+            "Your district's data privacy agreement is not on file yet. Your Speddy contact will let you know when setup can begin.",
+        },
+        { status: 409 },
+      );
+    }
+
+    try {
+      const updated = await storeCredential({
+        connectionId: connection.id,
+        actorId: userId,
+        baseUrl,
+        certificate: body.certificate,
+      });
+      log.info('Aeries credential stored', {
+        districtId: caller.districtId,
+        connectionId: connection.id,
+      });
+      return NextResponse.json({ connection: updated });
+    } catch (err) {
+      log.error('Failed to store Aeries credential', {
+        districtId: caller.districtId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // Fixed message: the underlying error can name constraints and columns.
+      return NextResponse.json({ error: 'Could not save the credential.' }, { status: 500 });
+    }
+  },
+);

--- a/app/api/tech/sis/aeries/test/route.ts
+++ b/app/api/tech/sis/aeries/test/route.ts
@@ -22,7 +22,7 @@ const log = logger.child({ module: 'tech-sis-aeries-test' });
  * used for the probes, and dropped; the response carries diagnostics only, and
  * what is persisted is narrower still (`toStoredTestResult` drops the counts).
  *
- * Rate-limited harder than the credential write: each call fans out to five
+ * Rate-limited harder than the credential write: each call fans out to four
  * requests against the district's SIS, and hammering a school district's
  * production server from our side is not acceptable behaviour.
  */
@@ -47,7 +47,19 @@ export const POST = withRoute(
       return NextResponse.json({ error: 'No Aeries connection to test.' }, { status: 404 });
     }
 
-    const credential = await getDecryptedCredential(connection.id);
+    // Decryption throws when the ciphertext can't be opened — most plausibly
+    // after an encryption-key rotation. That reads to the district exactly like
+    // "no credential stored", and the fix is the same, so say so rather than
+    // returning a 500 they can do nothing with.
+    let credential: Awaited<ReturnType<typeof getDecryptedCredential>> = null;
+    try {
+      credential = await getDecryptedCredential(connection.id);
+    } catch (err) {
+      log.error('Could not decrypt the stored Aeries credential', {
+        connectionId: connection.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
     if (!credential || credential.sisType !== 'aeries') {
       // Not an error state: a connection can legitimately exist with no
       // credential yet. Say what to do rather than reporting a failure.
@@ -68,12 +80,22 @@ export const POST = withRoute(
       certificate: credential.certificate,
     });
 
-    await recordTestResult({
-      connectionId: connection.id,
-      actorId: userId,
-      ok: report.ok,
-      result: toStoredTestResult(report),
-    });
+    try {
+      await recordTestResult({
+        connectionId: connection.id,
+        actorId: userId,
+        ok: report.ok,
+        result: toStoredTestResult(report),
+      });
+    } catch (err) {
+      // Every probe already ran. Turning a bookkeeping failure into a 500 would
+      // hide a completed report AND invite the district to run it again, sending
+      // four more requests at their SIS to learn what we already know.
+      log.error('Failed to record Aeries test result', {
+        connectionId: connection.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
 
     log.info('Aeries connection tested', {
       districtId: caller.districtId,

--- a/app/api/tech/sis/aeries/test/route.ts
+++ b/app/api/tech/sis/aeries/test/route.ts
@@ -55,9 +55,8 @@ export const POST = withRoute(
     try {
       credential = await getDecryptedCredential(connection.id);
     } catch (err) {
-      log.error('Could not decrypt the stored Aeries credential', {
+      log.error('Could not decrypt the stored Aeries credential', err, {
         connectionId: connection.id,
-        error: err instanceof Error ? err.message : String(err),
       });
     }
     if (!credential || credential.sisType !== 'aeries') {
@@ -91,9 +90,8 @@ export const POST = withRoute(
       // Every probe already ran. Turning a bookkeeping failure into a 500 would
       // hide a completed report AND invite the district to run it again, sending
       // four more requests at their SIS to learn what we already know.
-      log.error('Failed to record Aeries test result', {
+      log.error('Failed to record Aeries test result', err, {
         connectionId: connection.id,
-        error: err instanceof Error ? err.message : String(err),
       });
     }
 

--- a/app/api/tech/sis/aeries/test/route.ts
+++ b/app/api/tech/sis/aeries/test/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server';
+import { withRoute } from '@/lib/api/with-route';
+import { resolveDistrictSisCaller } from '@/lib/api/district-sis-caller';
+import { logger } from '@/lib/logger';
+import {
+  getDecryptedCredential,
+  listConnections,
+  recordTestResult,
+} from '@/lib/sis/connections';
+import { runAeriesConnectionTest, toStoredTestResult } from '@/lib/sis/aeries-setup';
+
+const log = logger.child({ module: 'tech-sis-aeries-test' });
+
+/**
+ * POST /api/tech/sis/aeries/test — check the stored credential, area by area.
+ *
+ * The feature that removes most onboarding back-and-forth: instead of "it
+ * didn't work", the district gets a list of the exact permission boxes that
+ * are and aren't ticked, in Aeries' own wording.
+ *
+ * The decrypted certificate exists only inside this request. It is fetched,
+ * used for the probes, and dropped; the response carries diagnostics only, and
+ * what is persisted is narrower still (`toStoredTestResult` drops the counts).
+ *
+ * Rate-limited harder than the credential write: each call fans out to five
+ * requests against the district's SIS, and hammering a school district's
+ * production server from our side is not acceptable behaviour.
+ */
+export const POST = withRoute(
+  { rateLimit: { requests: 6, windowSeconds: 60, name: 'tech-sis-aeries-test' } },
+  async ({ userId }) => {
+    const caller = await resolveDistrictSisCaller(userId);
+    if (!caller.ok) {
+      log.warn('Non-district-tech tried to test an Aeries connection', {
+        userId,
+        denied: caller.denied,
+      });
+      return NextResponse.json(
+        { error: 'Forbidden: district tech admin access required' },
+        { status: 403 },
+      );
+    }
+
+    const connections = await listConnections(caller.districtId);
+    const connection = connections.find((c) => c.sis_type === 'aeries');
+    if (!connection) {
+      return NextResponse.json({ error: 'No Aeries connection to test.' }, { status: 404 });
+    }
+
+    const credential = await getDecryptedCredential(connection.id);
+    if (!credential || credential.sisType !== 'aeries') {
+      // Not an error state: a connection can legitimately exist with no
+      // credential yet. Say what to do rather than reporting a failure.
+      return NextResponse.json(
+        { error: 'Enter your Aeries certificate first, then run the test.' },
+        { status: 409 },
+      );
+    }
+    if (!connection.base_url) {
+      return NextResponse.json(
+        { error: 'This connection has no Aeries web address saved. Re-enter it and save again.' },
+        { status: 409 },
+      );
+    }
+
+    const report = await runAeriesConnectionTest({
+      baseUrl: connection.base_url,
+      certificate: credential.certificate,
+    });
+
+    await recordTestResult({
+      connectionId: connection.id,
+      actorId: userId,
+      ok: report.ok,
+      result: toStoredTestResult(report),
+    });
+
+    log.info('Aeries connection tested', {
+      districtId: caller.districtId,
+      connectionId: connection.id,
+      ok: report.ok,
+    });
+
+    // The full per-area report goes back to the caller for this one response —
+    // it is the whole point of the feature — while the stored copy stays
+    // narrow. Nothing here carries a record or the certificate; that is pinned
+    // by tests in __tests__/unit/lib/sis/aeries-setup.test.ts.
+    return NextResponse.json({ report });
+  },
+);

--- a/app/components/tech/aeries-connection-card.tsx
+++ b/app/components/tech/aeries-connection-card.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardHeader, CardTitle, CardBody } from '../ui/card';
+import type { AeriesAreaResult, AeriesTestReport } from '@/lib/sis/aeries-setup';
+
+/**
+ * Credential entry and the per-area test result (SPE-396).
+ *
+ * The certificate field is write-only by design: once stored, all this screen
+ * can say about it is the last four characters, because that is all the server
+ * will ever return (SPE-395's column grants). Replacing it means typing a new
+ * one — there is no "reveal", and there is nothing to reveal.
+ */
+
+export interface ConnectionSummary {
+  id: string;
+  sis_type: string;
+  base_url: string | null;
+  credential_hint: string | null;
+  status: string;
+  dpa_cleared_at: string | null;
+  last_tested_at: string | null;
+}
+
+// 'untested' is deliberately neutral. Those areas were never probed, and
+// colouring them red would send a district off to fix checkboxes that may well
+// already be correct.
+const AREA_STYLES: Record<AeriesAreaResult['status'], string> = {
+  ok: 'border-emerald-200 bg-emerald-50',
+  denied: 'border-amber-200 bg-amber-50',
+  error: 'border-red-200 bg-red-50',
+  untested: 'border-gray-200 bg-gray-50',
+};
+
+const AREA_MARK: Record<AeriesAreaResult['status'], string> = {
+  ok: 'text-emerald-600',
+  denied: 'text-amber-600',
+  error: 'text-red-600',
+  untested: 'text-gray-400',
+};
+
+const AREA_GLYPH: Record<AeriesAreaResult['status'], string> = {
+  ok: '\u2713',
+  denied: '!',
+  error: '!',
+  untested: '\u2013',
+};
+
+function AreaRow({ area }: { area: AeriesAreaResult }) {
+  return (
+    <li className={`rounded-md border p-3 ${AREA_STYLES[area.status]}`}>
+      <div className="flex items-start gap-2">
+        <span className={`mt-0.5 text-sm font-bold ${AREA_MARK[area.status]}`}>
+          {AREA_GLYPH[area.status]}
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-gray-900">{area.label}</p>
+          <p className="mt-0.5 text-sm text-gray-700">{area.message}</p>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export default function AeriesConnectionCard({
+  connection,
+  onChanged,
+}: {
+  connection: ConnectionSummary;
+  onChanged: () => void | Promise<void>;
+}) {
+  const [baseUrl, setBaseUrl] = useState(connection.base_url ?? '');
+  const [certificate, setCertificate] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [report, setReport] = useState<AeriesTestReport | null>(null);
+
+  const hasCredential = Boolean(connection.credential_hint);
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    setReport(null);
+    try {
+      const res = await fetch('/api/tech/sis/aeries', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ baseUrl, certificate }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || 'Could not save the credential.');
+      // Clear it from component state the moment it is stored. It is already
+      // unrecoverable from the server; there is no reason to keep the plaintext
+      // sitting in the page.
+      setCertificate('');
+      await onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save the credential.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const test = async () => {
+    setTesting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/tech/sis/aeries/test', { method: 'POST' });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || 'Could not test the connection.');
+      setReport(json.report as AeriesTestReport);
+      await onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not test the connection.');
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{hasCredential ? 'Your Aeries connection' : 'Enter your Aeries details'}</CardTitle>
+      </CardHeader>
+      <CardBody>
+        {error && (
+          <div
+            role="alert"
+            className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="aeries-url" className="block text-sm font-medium text-gray-900">
+              Your Aeries web address
+            </label>
+            <input
+              id="aeries-url"
+              type="text"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              placeholder="https://yourdistrict.aeries.net"
+              autoComplete="off"
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+            <p className="mt-1 text-xs text-gray-500">
+              Paste the address you use to sign in to Aeries. We&apos;ll sort out the rest.
+            </p>
+          </div>
+
+          <div>
+            <label htmlFor="aeries-cert" className="block text-sm font-medium text-gray-900">
+              Certificate
+            </label>
+            <input
+              id="aeries-cert"
+              // `password` so it is masked, excluded from autofill, and not
+              // read aloud by screen readers in the clear.
+              type="password"
+              value={certificate}
+              onChange={(e) => setCertificate(e.target.value)}
+              placeholder={hasCredential ? 'Enter a new certificate to replace the saved one' : '32 letters and numbers'}
+              autoComplete="off"
+              spellCheck={false}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+            {hasCredential ? (
+              <p className="mt-1 text-xs text-gray-500">
+                A certificate ending{' '}
+                <span className="font-mono">{connection.credential_hint?.slice(-4)}</span> is saved.
+                It can&apos;t be shown again — leave this blank unless you&apos;re replacing it.
+              </p>
+            ) : (
+              <p className="mt-1 text-xs text-gray-500">
+                From <span className="font-medium">Display Certificate Details</span> in Aeries.
+                It&apos;s stored encrypted and never shown again.
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-center gap-3 border-t border-gray-200 pt-4">
+          <button
+            type="button"
+            onClick={save}
+            disabled={saving || !baseUrl.trim() || !certificate.trim()}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : hasCredential ? 'Replace certificate' : 'Save and continue'}
+          </button>
+
+          {hasCredential && (
+            <button
+              type="button"
+              onClick={test}
+              disabled={testing}
+              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
+            >
+              {testing ? 'Checking…' : 'Test connection'}
+            </button>
+          )}
+
+          {connection.last_tested_at && !report && (
+            <span className="text-xs text-gray-500">
+              Last checked {new Date(connection.last_tested_at).toLocaleString()}
+            </span>
+          )}
+        </div>
+
+        {report && (
+          <div className="mt-6 border-t border-gray-200 pt-5">
+            <p
+              className={`text-sm font-medium ${report.ok ? 'text-emerald-700' : 'text-amber-700'}`}
+            >
+              {report.summary}
+            </p>
+            <ul className="mt-3 space-y-2">
+              {report.areas.map((a) => (
+                <AreaRow key={a.key} area={a} />
+              ))}
+            </ul>
+            {!report.ok && (
+              <p className="mt-4 text-xs text-gray-600">
+                Fix the areas above in Aeries, then run the test again. Nothing needs to be
+                re-entered here.
+              </p>
+            )}
+          </div>
+        )}
+      </CardBody>
+    </Card>
+  );
+}

--- a/app/components/tech/aeries-connection-card.tsx
+++ b/app/components/tech/aeries-connection-card.tsx
@@ -213,7 +213,7 @@ export default function AeriesConnectionCard({
         </div>
 
         {report && (
-          <div className="mt-6 border-t border-gray-200 pt-5">
+          <div role="status" aria-live="polite" className="mt-6 border-t border-gray-200 pt-5">
             <p
               className={`text-sm font-medium ${report.ok ? 'text-emerald-700' : 'text-amber-700'}`}
             >

--- a/app/components/tech/aeries-setup-guide.tsx
+++ b/app/components/tech/aeries-setup-guide.tsx
@@ -18,7 +18,17 @@ import { Card, CardHeader, CardTitle, CardBody } from '../ui/card';
  * publishes exactly this artifact.
  */
 
-/** Exactly the areas `runAeriesConnectionTest` probes — keep the two in step. */
+/**
+ * The boxes a district must tick. `probed: false` marks one the connection test
+ * does not yet check.
+ *
+ * That distinction is load-bearing rather than cosmetic: the test reports "All
+ * areas granted", and if the guide asks for five boxes while the test checks
+ * four, that sentence quietly vouches for a permission nobody verified. Classes
+ * is needed for secondary student-teacher links (SPE-342) and is requested now
+ * so the district only visits Aeries once — but it is labelled honestly until
+ * there is a probe behind it.
+ */
 export const AERIES_PERMISSION_AREAS = [
   {
     label: 'Student Data',
@@ -35,6 +45,7 @@ export const AERIES_PERMISSION_AREAS = [
   {
     label: 'Classes/Master Schedule',
     why: 'Which teacher a secondary student actually sees, period by period.',
+    probed: false,
   },
   {
     label: 'Student Programs',
@@ -116,6 +127,11 @@ export default function AeriesSetupGuide() {
                 {AERIES_PERMISSION_AREAS.map((a) => (
                   <li key={a.label} className="rounded-md border border-gray-200 bg-gray-50 p-3">
                     <span className="font-medium text-gray-900">{a.label}</span>
+                    {'probed' in a && a.probed === false && (
+                      <span className="ml-2 rounded bg-gray-200 px-1.5 py-0.5 text-[11px] text-gray-600">
+                        not checked by the test yet
+                      </span>
+                    )}
                     <p className="mt-0.5 text-xs text-gray-600">{a.why}</p>
                   </li>
                 ))}

--- a/app/components/tech/aeries-setup-guide.tsx
+++ b/app/components/tech/aeries-setup-guide.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Card, CardHeader, CardTitle, CardBody } from '../ui/card';
 
 /**
@@ -66,18 +66,28 @@ const COPYABLE = [
 ].join('\n');
 
 export default function AeriesSetupGuide() {
-  const [copied, setCopied] = useState(false);
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear any pending reset on unmount, and before scheduling a new one: two
+  // clicks inside the reset window would otherwise have the first timer wipe
+  // the second confirmation.
+  useEffect(() => () => {
+    if (resetTimer.current) clearTimeout(resetTimer.current);
+  }, []);
 
   const copy = async () => {
+    if (resetTimer.current) clearTimeout(resetTimer.current);
     try {
       await navigator.clipboard.writeText(COPYABLE);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2500);
+      setCopyState('copied');
     } catch {
-      // Clipboard can be blocked by permissions policy. The steps are all on
-      // screen anyway, so this is a convenience, not the only path.
-      setCopied(false);
+      // Clipboard access can be denied by permissions policy. Say so — the
+      // silent version leaves the button reading "Copy these steps" and the
+      // user believing it worked. The steps are all on screen either way.
+      setCopyState('failed');
     }
+    resetTimer.current = setTimeout(() => setCopyState('idle'), 2500);
   };
 
   return (
@@ -156,11 +166,14 @@ export default function AeriesSetupGuide() {
             onClick={copy}
             className="rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200"
           >
-            {copied ? 'Copied' : 'Copy these steps'}
+            {copyState === 'copied' ? 'Copied' : 'Copy these steps'}
           </button>
-          <span className="text-xs text-gray-500">
-            Sending this to whoever manages Aeries security? Copy the steps and paste them into
-            an email.
+          <span role="status" aria-live="polite" className="text-xs text-gray-500">
+            {copyState === 'copied'
+              ? 'Steps copied.'
+              : copyState === 'failed'
+                ? 'Copy failed — select the steps above and copy them manually.'
+                : 'Sending this to whoever manages Aeries security? Copy the steps and paste them into an email.'}
           </span>
         </div>
       </CardBody>

--- a/app/components/tech/aeries-setup-guide.tsx
+++ b/app/components/tech/aeries-setup-guide.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardHeader, CardTitle, CardBody } from '../ui/card';
+
+/**
+ * The district-side instructions for issuing Speddy an Aeries certificate
+ * (SPE-396).
+ *
+ * Written for someone who has Aeries admin rights and has never opened the API
+ * Security page. That means exact click paths and the exact box labels — not
+ * "grant the necessary permissions", which is the sentence that generates a
+ * support call.
+ *
+ * The permission list is copyable as a block because this person very often
+ * isn't the one who will do the clicking: they forward it to a site tech or to
+ * the county office. Every vendor who does this well (SIRAS, Xello, Clever)
+ * publishes exactly this artifact.
+ */
+
+/** Exactly the areas `runAeriesConnectionTest` probes — keep the two in step. */
+export const AERIES_PERMISSION_AREAS = [
+  {
+    label: 'Student Data',
+    why: 'Names and grade levels, so we can match your students to the caseloads providers already entered.',
+  },
+  {
+    label: 'Schools',
+    why: 'The list of your schools, so services land at the right site.',
+  },
+  {
+    label: 'Teacher/Staff Data',
+    why: 'So a provider can pick a real teacher instead of typing a name.',
+  },
+  {
+    label: 'Classes/Master Schedule',
+    why: 'Which teacher a secondary student actually sees, period by period.',
+  },
+  {
+    label: 'Student Programs',
+    why: 'Where the special education flag lives. Without this one, Speddy cannot tell which students have an IEP.',
+  },
+] as const;
+
+const COPYABLE = [
+  'Aeries API Security setup for Speddy',
+  '',
+  '1. In Aeries: Security -> API Security -> Add New Record',
+  '2. Product Name: Speddy',
+  '3. Tick the READ-ONLY box for each of these areas:',
+  ...AERIES_PERMISSION_AREAS.map((a) => `   - ${a.label}`),
+  '4. Save, then click "Display Certificate Details" and copy the certificate.',
+  '',
+  'Speddy only ever reads. We never write anything back to Aeries.',
+].join('\n');
+
+export default function AeriesSetupGuide() {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(COPYABLE);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    } catch {
+      // Clipboard can be blocked by permissions policy. The steps are all on
+      // screen anyway, so this is a convenience, not the only path.
+      setCopied(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>How to create the Aeries credential</CardTitle>
+      </CardHeader>
+      <CardBody>
+        <p className="text-sm text-gray-600">
+          You&apos;ll do this inside Aeries, not here. It takes about five minutes. If
+          someone else manages your Aeries security settings, send them these steps.
+        </p>
+
+        <ol className="mt-5 space-y-4 text-sm text-gray-700">
+          <li className="flex gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-blue-100 text-xs font-semibold text-blue-700">
+              1
+            </span>
+            <span>
+              In Aeries, go to{' '}
+              <span className="font-medium text-gray-900">
+                Security → API Security → Add New Record
+              </span>
+              .
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-blue-100 text-xs font-semibold text-blue-700">
+              2
+            </span>
+            <span>
+              Set <span className="font-medium text-gray-900">Product Name</span> to{' '}
+              <span className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs">Speddy</span>.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-blue-100 text-xs font-semibold text-blue-700">
+              3
+            </span>
+            <div className="min-w-0">
+              <p>
+                Tick the <span className="font-medium text-gray-900">read-only</span> box for
+                each area below. Read-only is the only access Speddy needs — we never write
+                anything back to Aeries.
+              </p>
+              <ul className="mt-3 space-y-2">
+                {AERIES_PERMISSION_AREAS.map((a) => (
+                  <li key={a.label} className="rounded-md border border-gray-200 bg-gray-50 p-3">
+                    <span className="font-medium text-gray-900">{a.label}</span>
+                    <p className="mt-0.5 text-xs text-gray-600">{a.why}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-blue-100 text-xs font-semibold text-blue-700">
+              4
+            </span>
+            <span>
+              Save the record, then click{' '}
+              <span className="font-medium text-gray-900">Display Certificate Details</span> and
+              copy the certificate. It&apos;s 32 letters and numbers.
+            </span>
+          </li>
+        </ol>
+
+        <div className="mt-6 flex flex-wrap items-center gap-3 border-t border-gray-200 pt-4">
+          <button
+            type="button"
+            onClick={copy}
+            className="rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200"
+          >
+            {copied ? 'Copied' : 'Copy these steps'}
+          </button>
+          <span className="text-xs text-gray-500">
+            Sending this to whoever manages Aeries security? Copy the steps and paste them into
+            an email.
+          </span>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,8 +46,10 @@
 - **Org scoping uses two parallel systems** on `profiles`/`provider_schools`:
   legacy free-text (`school_district`, `school_site`) **and** structured FK ids
   (`state_id`, `district_id`, `school_id`). Both coexist today.
-- **Audit logging is scaffolded but unwired** (`audit_logs` table is empty;
-  `logAccess()` is never called) — SPE-169.
+- **Audit logging covers SIS credentials only.** `audit_logs` is written by
+  `lib/sis/connections.ts` (SPE-395) and by nothing else; the older
+  `logAccess()` helper is still never called, and no student-data access is
+  audited — SPE-169.
 - **Elementary-first.** A school is *elementary* or *secondary* (`isSecondarySchool`,
   by `school_type` / `grade_span_low ≥ 6`); on a **secondary** site the scheduling
   surfaces (Schedule, Bell Schedules, Special Activities, Plan) are hidden for
@@ -199,6 +201,69 @@ flowchart TD
 3. **RLS** — the authoritative layer. Domain tables (students, sessions, CARE,
    etc.) carry policies scoped to the user's school(s) and/or ownership. Admin
    scope is granted via `admin_permissions` (§3).
+
+### Column-level grants — when RLS is not enough (SPE-395)
+
+**RLS is row-level and cannot hide a column.** A policy that lets someone read
+a row lets them read *every column of it*. For most tables that is fine. For
+`district_sis_connections` — which holds each district's encrypted SIS
+credentials — it is not: a district's Aeries certificate unlocks every student
+record in that district, and it would otherwise sit in a browser's memory and
+network log on every page that renders connection status.
+
+So that table layers **column-level `GRANT`s** on top of row-level RLS:
+
+```sql
+REVOKE ALL ON district_sis_connections FROM authenticated, anon;
+GRANT SELECT (id, district_id, sis_type, base_url, token_url, credential_hint,
+              status, dpa_cleared_at, last_tested_at, last_test_result,
+              created_by, created_at, updated_at)
+  ON district_sis_connections TO authenticated;
+```
+
+`authenticated` therefore cannot *name* a credential column — PostgREST refuses
+with **HTTP 403 / `42501`** rather than returning it. The service role is
+unaffected and is how the server-side encrypt/decrypt paths read them.
+
+**Consequence that will bite you:** `select('*')` on this table **fails** for a
+browser session, because `*` expands to columns the grant excludes. That is
+deliberate — a loud error beats silently shipping a certificate because someone
+reached for the usual shorthand. Callers name their columns; see
+`CONNECTION_COLUMNS` in `app/(dashboard)/dashboard/tech/page.tsx` and
+`SUMMARY_COLUMNS` in `lib/sis/connections.ts`, both of which mirror the GRANT.
+
+Browser **writes** are denied outright (`WITH CHECK (false)` on insert/update,
+`USING (false)` on delete) — every mutation involves crypto and runs
+server-side. Same reasoning as `provider_schools` after SPE-399.
+
+Verified against a real signed-in session, not assumed:
+`npm run sim:verify-sis-rls`.
+
+**Source of truth:**
+`supabase/migrations/20260806_spe395_district_sis_connections.sql`;
+`lib/sis/connections.ts`; `scripts/sim-district/verify-sis-connections-rls.ts`.
+
+### SIS credentials: encryption, the DPA gate, and egress (SPE-395/396)
+
+- **Encrypted app-side**, never in plaintext: AES-256-GCM, envelope
+  `v1.<iv>.<ct>.<tag>`, under `SIS_CREDENTIAL_ENCRYPTION_KEY` — deliberately a
+  *separate* key from `CALENDAR_TOKEN_ENCRYPTION_KEY`, because the blast radii
+  differ by orders of magnitude. Only `credential_hint` (the mask plus the last
+  four characters) is ever readable by a client.
+- **The DPA gate exists twice.** `storeCredential()` refuses a credential when
+  `dpa_cleared_at IS NULL`, and a CHECK constraint refuses it again — so the
+  rule survives a future route that forgets it. Speddy staff set the flag from
+  the `/internal` district page; districts cannot.
+- **Outbound requests are guarded** (`lib/sis/ssrf-guard.ts`). The district
+  supplies the address we then dial with their credential, so IP literals,
+  internal-only names and any host resolving into private/loopback/link-local/
+  CGNAT/multicast space are refused, and redirects are refused outright. The
+  remaining hole — DNS rebinding between the check and the connection — is
+  documented in that file and tracked as **SPE-406**.
+
+**Source of truth:** `lib/sis/credential-crypto.ts`; `lib/sis/connections.ts`;
+`lib/sis/ssrf-guard.ts`; `lib/sis/aeries-setup.ts`;
+`app/api/tech/sis/aeries/`; `app/api/internal/sis-connections/`.
 
 ### `profiles` self-updates: policy + trigger (SPE-332)
 
@@ -951,16 +1016,33 @@ All cron routes authenticate with a shared `CRON_SECRET` (header
      and deleted via `app/api/admin/care-referrals/[referralId]`, never
      auto-deleted (a name match can be ambiguous).
 
-### Audit logging — scaffolded but unwired
-> **Known gap — SPE-169 (security, High).** An `audit_logs` table exists in the
-> DB (columns `id, user_id, action, resource_type, resource_id, metadata,
-> timestamp, created_at`) but holds **0 rows**, and the helper
-> `lib/supabase/audit-log.ts` (`logAccess()`, fire-and-forget insert) is **never
-> imported or called anywhere**. So there is no functioning audit trail today.
-> The FERPA page wording was softened to the truthful interim language (RLS +
-> auth) under **SPE-134**; SPE-169 is the "build real audit logging" ticket and
-> should restore the wording once shipped. Whoever builds it should decide
-> whether to wire up / replace this existing scaffold.
+### Audit logging — wired for SIS credentials only (SPE-395)
+
+The `audit_logs` table (`id, user_id, action, resource_type, resource_id,
+metadata, timestamp, created_at`) now has exactly **one** real writer:
+`lib/sis/connections.ts`, via `logServerAuditEvent()`
+(`lib/supabase/audit-log-server.ts`). Every mutation of a district's SIS
+connection is recorded — `sis_connection_created`, `sis_credential_stored`,
+`sis_credential_rotated`, `sis_connection_tested`, `sis_dpa_cleared`,
+`sis_dpa_revoked`, `sis_connection_disconnected`. Rotation and first-time
+storage are separate actions on purpose: during an incident review they mean
+different things.
+
+Two properties worth knowing before relying on it:
+
+- **It is best-effort.** `logServerAuditEvent` catches and logs its own
+  failures rather than breaking the action being audited, so a mutation can
+  succeed with no audit row. Fine for a diagnostic trail; not sufficient if
+  the trail ever needs to be evidential.
+- **Nothing else writes it.** Student-data access is still unaudited.
+
+> **Known gap — SPE-169 (security, High).** The older helper
+> `lib/supabase/audit-log.ts` (`logAccess()`) remains **unused**, and no
+> student-data access is logged anywhere. The FERPA page wording was softened
+> to truthful interim language (RLS + auth) under **SPE-134**; SPE-169 is the
+> "build real audit logging" ticket and should restore the wording once
+> shipped. It should also decide whether to fold the unused `audit-log.ts`
+> scaffold into the `audit-log-server.ts` path SPE-395 established.
 
 **Source of truth:** `app/api/cron/cleanup-uploads/route.ts`;
 `app/api/cron/cleanup-worksheet-images/route.ts`;
@@ -1124,7 +1206,7 @@ Re-check Linear for current state.
 | Ticket | Pri | Area | Summary |
 |---|---|---|---|
 | **SPE-111** | High | Cleanup / Security | ✅ App-level self-signup removed (PR #678); production Supabase Auth `enable_signup` **disabled in the dashboard 2026-07-20** → direct `/auth/v1/signup` no longer creates an account; admin-only enforced. No real billing remnants existed. |
-| **SPE-169** | High | Security/FERPA | Build real audit logging; `audit_logs` table + `logAccess()` exist but are unwired/empty. |
+| **SPE-169** | High | Security/FERPA | Build real audit logging. `audit_logs` is now written for SIS-credential mutations only (SPE-395); student-data access is still unaudited and the older `logAccess()` helper remains unused. |
 | **SPE-187** | Medium | Security | AI generation routes have no role authz; `withRoute` has no `roles` option. Not live (AI off). |
 | **SPE-188** | Low | Security | Idle logout is client-side only; no server-side session-lifetime backstop. |
 | **SPE-190** | Low | Security | Admin-created teachers get a temp password that's never force-rotated (no `must_change_password` on creation). |

--- a/lib/api/district-sis-caller.ts
+++ b/lib/api/district-sis-caller.ts
@@ -1,0 +1,52 @@
+import { createServiceClient } from '@/lib/supabase/server';
+
+/**
+ * Resolve which district a caller may manage SIS connections for (SPE-396).
+ *
+ * The tech portal is for `district_tech`; `district_admin` is included because
+ * the district admin creates that account and needs to be able to finish the
+ * job themselves when the tech contact is unavailable — the same pair the
+ * table's SELECT policy already admits (SPE-395).
+ *
+ * Named for what it RETURNS: a districtId when the caller is entitled to one,
+ * or a denial reason. It never accepts a district from the request — the whole
+ * point is that scope comes from the caller's own grants, so a request body
+ * cannot widen it.
+ *
+ * Read through the service client on purpose: this decides authorization, and
+ * must not itself depend on what the caller's session is permitted to select.
+ */
+export type DistrictSisCaller =
+  | { ok: true; districtId: string; role: 'district_tech' | 'district_admin' }
+  | { ok: false; denied: string };
+
+export async function resolveDistrictSisCaller(userId: string): Promise<DistrictSisCaller> {
+  if (!userId) return { ok: false, denied: 'no authenticated user' };
+
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from('admin_permissions')
+    .select('district_id, role')
+    .eq('admin_id', userId)
+    .in('role', ['district_tech', 'district_admin'])
+    .not('district_id', 'is', null);
+
+  if (error) return { ok: false, denied: `permission lookup failed: ${error.message}` };
+  if (!data?.length) return { ok: false, denied: 'no district_tech or district_admin grant' };
+
+  // Holding several grants is legal. Rather than guess, refuse — silently
+  // picking one would let a multi-district admin write a credential to a
+  // district they did not mean to touch. SPE-403 tracks the picker that makes
+  // this a real choice instead of an error.
+  const districts = [...new Set(data.map((p) => String(p.district_id)))];
+  if (districts.length > 1) {
+    return {
+      ok: false,
+      denied: `caller holds grants in ${districts.length} districts; district selection is not implemented (SPE-403)`,
+    };
+  }
+
+  // Prefer the tech role in the reported value when the caller holds both.
+  const role = data.some((p) => p.role === 'district_tech') ? 'district_tech' : 'district_admin';
+  return { ok: true, districtId: districts[0], role };
+}

--- a/lib/integrations/aeries/client.ts
+++ b/lib/integrations/aeries/client.ts
@@ -86,6 +86,14 @@ export class AeriesClient {
         signal: controller.signal,
         // Never cache SIS responses (student PII, changing data).
         cache: 'no-store',
+        // Refuse redirects outright (SPE-396). The base URL is district-supplied
+        // and validated against private-network ranges before we dial it, but
+        // that check covers the host WE resolve — following a 302 would hand the
+        // destination back to the remote server, letting a public host bounce an
+        // authenticated request into an internal address and defeat the guard
+        // entirely. The Aeries API does not redirect; if it ever starts, this
+        // fails loudly rather than silently.
+        redirect: 'error',
       });
 
       if (!res.ok) {

--- a/lib/sis/aeries-setup.ts
+++ b/lib/sis/aeries-setup.ts
@@ -22,7 +22,7 @@
  * Server-only: reaches an external SIS with a decrypted credential.
  */
 import { AeriesApiError, AeriesClient } from '@/lib/integrations/aeries';
-import { assertPublicAeriesHost, assertPublicAeriesHostSyntax } from './ssrf-guard';
+import { assertPublicAeriesHostSyntax, assertSafeAeriesUrl } from './ssrf-guard';
 import type { SisTestResult } from './connections';
 
 export const AERIES_API_PATH = '/aeries/api/v5';
@@ -170,7 +170,7 @@ export async function runAeriesConnectionTest(params: {
   // Re-checked here, not just at write time: the stored row could predate the
   // guard, and a name's addresses can change after it was saved.
   try {
-    await assertPublicAeriesHost(new URL(params.baseUrl).hostname);
+    await assertSafeAeriesUrl(params.baseUrl);
   } catch (err) {
     const message = err instanceof Error ? err.message : 'That address cannot be used.';
     return {

--- a/lib/sis/aeries-setup.ts
+++ b/lib/sis/aeries-setup.ts
@@ -1,0 +1,280 @@
+/**
+ * Aeries connection setup: URL normalization and per-area diagnostics (SPE-396).
+ *
+ * The persona this exists for is a district generalist who has Aeries admin
+ * rights but has never opened the API Security page. Everything here is built
+ * around one goal: when their connection doesn't work, tell them exactly which
+ * checkbox to fix, in words they can act on — instead of an HTTP status they
+ * have to forward to us.
+ *
+ * TWO RULES THAT SHAPE THIS FILE
+ *
+ * 1. Aggregate-only. The tech admin has NO right to student data (SPE-393 —
+ *    the role sees integrations and nothing else). Every probe therefore
+ *    reports a COUNT and an area name, never a record. `fields` is pinned to a
+ *    single non-identifying column and pagination to one row wherever the API
+ *    allows it, so we don't even pull PII into memory to count it.
+ *
+ * 2. Never echo the certificate. Aeries error bodies can contain the submitted
+ *    cert; `AeriesClient` already discards bodies and keeps status + path, and
+ *    nothing here re-introduces them.
+ *
+ * Server-only: reaches an external SIS with a decrypted credential.
+ */
+import { AeriesApiError, AeriesClient } from '@/lib/integrations/aeries';
+import type { SisTestResult } from './connections';
+
+export const AERIES_API_PATH = '/aeries/api/v5';
+
+/**
+ * Turn whatever a district administrator pasted into the base URL the client
+ * needs.
+ *
+ * They will paste what they see in their browser. Observed and handled:
+ *   https://demo.aeries.net                      (bare host)
+ *   https://demo.aeries.net/                     (trailing slash)
+ *   https://demo.aeries.net/admin                (the admin UI they were just in)
+ *   https://demo.aeries.net/aeries/api/v5        (already correct)
+ *   demo.aeries.net                              (no scheme at all)
+ *
+ * Rejecting these instead would produce a support ticket for a typo, which is
+ * exactly the back-and-forth this ticket exists to remove.
+ *
+ * @throws with an actionable message when the input cannot be a URL at all.
+ */
+export function normalizeAeriesBaseUrl(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) throw new Error("Enter your district's Aeries web address.");
+
+  // A pasted host with no scheme is the single most common shape; assume https
+  // rather than failing. Aeries is HTTPS-only in practice.
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+
+  let url: URL;
+  try {
+    url = new URL(withScheme);
+  } catch {
+    throw new Error(
+      `"${trimmed}" doesn't look like a web address. It should look like https://yourdistrict.aeries.net`,
+    );
+  }
+
+  if (url.protocol !== 'https:') {
+    // An http:// base would put the certificate on the wire in cleartext on
+    // every request. Refuse rather than silently upgrading, so the district
+    // fixes the address they actually gave us.
+    throw new Error('The Aeries address must start with https:// so credentials stay encrypted.');
+  }
+
+  // Strip whatever path they landed on and append the API path ourselves.
+  // /admin, /student, a deep link — none of it is the API root, and guessing
+  // from their path is how you end up with .../admin/aeries/api/v5.
+  return `${url.origin}${AERIES_API_PATH}`;
+}
+
+/** One probed permission area, in the district's terms — not Aeries' URLs. */
+export interface AeriesAreaResult {
+  /** Stable key for the UI. */
+  key: 'connection' | 'schools' | 'students' | 'teachers' | 'programs';
+  /** The label as it appears on the Aeries API Security page. */
+  label: string;
+  status: 'ok' | 'denied' | 'error';
+  /** Plain-English outcome. Never contains a name, an ID, or the certificate. */
+  message: string;
+  /** Aggregate only — how many records the area returned, when it succeeded. */
+  count?: number;
+}
+
+export interface AeriesTestReport {
+  ok: boolean;
+  areas: AeriesAreaResult[];
+  /** One-line summary for the connection row and the status chip. */
+  summary: string;
+}
+
+/**
+ * Map an Aeries failure to something the district can act on.
+ *
+ * The mapping that matters most is 401 vs 403. Aeries returns 401 when the
+ * certificate itself is wrong and 403 when the certificate is valid but that
+ * permission box was never checked — completely different fixes, and telling
+ * them apart is most of this feature's value.
+ */
+function explain(err: unknown, area: string): { status: 'denied' | 'error'; message: string } {
+  if (err instanceof AeriesApiError) {
+    if (err.status === 401) {
+      return {
+        status: 'error',
+        message:
+          'Aeries rejected the certificate. Re-copy it from Security → API Security → Display Certificate Details.',
+      };
+    }
+    if (err.status === 403) {
+      return {
+        status: 'denied',
+        message: `Not granted. In Aeries, tick the read-only box for "${area}" on the Speddy API Security record.`,
+      };
+    }
+    if (err.status === 404) {
+      return {
+        status: 'error',
+        message:
+          'Not found at that address. Check the Aeries web address — it should look like https://yourdistrict.aeries.net',
+      };
+    }
+    if (err.status === 408) {
+      return { status: 'error', message: 'Aeries did not respond in time. Try again in a moment.' };
+    }
+    return { status: 'error', message: `Aeries returned an unexpected error (${err.status}).` };
+  }
+  // Network-level: DNS, TLS, refused connection. No status to report.
+  return {
+    status: 'error',
+    message: 'Could not reach Aeries at that address. Check the web address and that it is publicly reachable.',
+  };
+}
+
+/** Probe one area, converting any failure into a reportable result. */
+async function probe(
+  key: AeriesAreaResult['key'],
+  label: string,
+  run: () => Promise<number>,
+): Promise<AeriesAreaResult> {
+  try {
+    const count = await run();
+    return { key, label, status: 'ok', message: 'Granted.', count };
+  } catch (err) {
+    return { key, label, ...explain(err, label) };
+  }
+}
+
+/**
+ * Run the full connection test and report per area.
+ *
+ * Ordering is deliberate: connection and Schools first, because everything
+ * downstream needs a school code, and because "we can't reach you at all" and
+ * "one checkbox is missing" should never be reported as the same failure. If
+ * Schools fails there is nothing to probe the other areas against, so they are
+ * reported as untested rather than guessed at.
+ */
+export async function runAeriesConnectionTest(params: {
+  baseUrl: string;
+  certificate: string;
+}): Promise<AeriesTestReport> {
+  const client = new AeriesClient({
+    baseUrl: params.baseUrl,
+    certificate: params.certificate,
+  });
+
+  const areas: AeriesAreaResult[] = [];
+
+  // 1. Reachability + certificate. `schools` doubles as the auth check: it is
+  // the smallest endpoint that requires a valid cert, and it carries no
+  // student data, so a failed connection never touches PII.
+  let schoolCodes: number[] = [];
+  const schools = await probe('schools', 'Schools', async () => {
+    const list = await client.getSchools({ fields: ['SchoolCode', 'Name'] });
+    schoolCodes = list.map((s) => s.SchoolCode).filter((c) => Number.isFinite(c));
+    return list.length;
+  });
+  areas.push(
+    schools.status === 'ok'
+      ? { key: 'connection', label: 'Connection', status: 'ok', message: 'Speddy can reach your Aeries instance.' }
+      : { key: 'connection', label: 'Connection', status: schools.status, message: schools.message },
+    schools,
+  );
+
+  if (schools.status !== 'ok' || schoolCodes.length === 0) {
+    const blocked: AeriesAreaResult['status'] = 'error';
+    const why =
+      schools.status === 'ok'
+        ? 'No schools were returned, so the remaining areas could not be checked.'
+        : 'Not checked — the connection has to work first.';
+    for (const [key, label] of [
+      ['students', 'Student Data'],
+      ['teachers', 'Teacher/Staff Data'],
+      ['programs', 'Student Programs'],
+    ] as const) {
+      areas.push({ key, label, status: blocked, message: why });
+    }
+    return {
+      ok: false,
+      areas,
+      summary:
+        schools.status === 'ok'
+          ? 'Connected, but Aeries returned no schools.'
+          : 'Could not connect to Aeries.',
+    };
+  }
+
+  // Probe against the first school only. This is a permission check, not a
+  // sync: one school proves the box is ticked, and walking every school would
+  // pull thousands of student records to learn nothing more.
+  const school = schoolCodes[0];
+
+  areas.push(
+    await probe('students', 'Student Data', async () => {
+      // One record, one non-identifying field. Enough to prove access without
+      // pulling a name into memory.
+      const rows = await client.getSchoolStudents(school, {
+        fields: ['StudentID'],
+        startingRecord: 1,
+        endingRecord: 1,
+      });
+      return rows.length;
+    }),
+    await probe('teachers', 'Teacher/Staff Data', async () => {
+      const rows = await client.getSchoolTeachers(school, {
+        fields: ['TeacherNumber'],
+        startingRecord: 1,
+        endingRecord: 1,
+      });
+      return rows.length;
+    }),
+    await probe('programs', 'Student Programs', async () => {
+      // The one that carries special education (program 144/144x). If this is
+      // the only area denied, the connection still "works" — which is exactly
+      // the confusing half-success worth naming explicitly.
+      const rows = await client.getStudentPrograms(school, 0, undefined, {
+        fields: ['StudentID', 'ProgramCode'],
+        startingRecord: 1,
+        endingRecord: 1,
+      });
+      return rows.length;
+    }),
+  );
+
+  const failed = areas.filter((a) => a.status !== 'ok');
+  const programsDenied = areas.some((a) => a.key === 'programs' && a.status !== 'ok');
+
+  let summary: string;
+  if (failed.length === 0) {
+    summary = 'All areas granted. Aeries is ready.';
+  } else if (failed.length === 1 && programsDenied) {
+    // Named specially because it is the likeliest single miss and the most
+    // consequential: everything appears to work, but no special-education data
+    // ever arrives.
+    summary =
+      'Connected, but Student Programs is not granted — Speddy cannot see special education records without it.';
+  } else {
+    summary = `${failed.length} of ${areas.length} areas need attention in Aeries.`;
+  }
+
+  return { ok: failed.length === 0, areas, summary };
+}
+
+/**
+ * Reduce a report to what may be persisted in `last_test_result`.
+ *
+ * That column is readable by the district's own staff (SPE-395), so this
+ * deliberately drops the counts and keeps only area names and outcomes. A
+ * count is aggregate, but "how many special-education students this district
+ * has" is not something the connection log needs to remember.
+ */
+export function toStoredTestResult(report: AeriesTestReport): SisTestResult {
+  const failed = report.areas.filter((a) => a.status !== 'ok').map((a) => a.label);
+  return {
+    area: failed.length ? failed.join(', ') : 'all',
+    message: report.summary,
+  };
+}

--- a/lib/sis/aeries-setup.ts
+++ b/lib/sis/aeries-setup.ts
@@ -22,6 +22,7 @@
  * Server-only: reaches an external SIS with a decrypted credential.
  */
 import { AeriesApiError, AeriesClient } from '@/lib/integrations/aeries';
+import { assertPublicAeriesHost, assertPublicAeriesHostSyntax } from './ssrf-guard';
 import type { SisTestResult } from './connections';
 
 export const AERIES_API_PATH = '/aeries/api/v5';
@@ -66,6 +67,11 @@ export function normalizeAeriesBaseUrl(input: string): string {
     throw new Error('The Aeries address must start with https:// so credentials stay encrypted.');
   }
 
+  // Refuse anything that could point our server at a private network. This is
+  // the syntactic half; assertPublicAeriesHost() resolves the name too, and is
+  // what the store and test paths actually await.
+  assertPublicAeriesHostSyntax(url.hostname);
+
   // Strip whatever path they landed on and append the API path ourselves.
   // /admin, /student, a deep link — none of it is the API root, and guessing
   // from their path is how you end up with .../admin/aeries/api/v5.
@@ -78,7 +84,7 @@ export interface AeriesAreaResult {
   key: 'connection' | 'schools' | 'students' | 'teachers' | 'programs';
   /** The label as it appears on the Aeries API Security page. */
   label: string;
-  status: 'ok' | 'denied' | 'error';
+  status: 'ok' | 'denied' | 'error' | 'untested';
   /** Plain-English outcome. Never contains a name, an ID, or the certificate. */
   message: string;
   /** Aggregate only — how many records the area returned, when it succeeded. */
@@ -161,6 +167,19 @@ export async function runAeriesConnectionTest(params: {
   baseUrl: string;
   certificate: string;
 }): Promise<AeriesTestReport> {
+  // Re-checked here, not just at write time: the stored row could predate the
+  // guard, and a name's addresses can change after it was saved.
+  try {
+    await assertPublicAeriesHost(new URL(params.baseUrl).hostname);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'That address cannot be used.';
+    return {
+      ok: false,
+      areas: [{ key: 'connection', label: 'Connection', status: 'error', message }],
+      summary: 'Could not connect to Aeries.',
+    };
+  }
+
   const client = new AeriesClient({
     baseUrl: params.baseUrl,
     certificate: params.certificate,
@@ -174,6 +193,12 @@ export async function runAeriesConnectionTest(params: {
   let schoolCodes: number[] = [];
   const schools = await probe('schools', 'Schools', async () => {
     const list = await client.getSchools({ fields: ['SchoolCode', 'Name'] });
+    // Without this, a non-array body makes `.map` throw a TypeError, which
+    // `explain` reads as a network failure — telling a district their reachable
+    // instance is unreachable.
+    if (!Array.isArray(list)) {
+      throw new AeriesApiError('Aeries returned an unexpected response for Schools.', 502, 'schools');
+    }
     schoolCodes = list.map((s) => s.SchoolCode).filter((c) => Number.isFinite(c));
     return list.length;
   });
@@ -185,7 +210,10 @@ export async function runAeriesConnectionTest(params: {
   );
 
   if (schools.status !== 'ok' || schoolCodes.length === 0) {
-    const blocked: AeriesAreaResult['status'] = 'error';
+    // 'untested', not 'error': these areas were never probed, and rendering
+    // three red permission failures for checkboxes we never looked at sends the
+    // district to fix things that may be perfectly fine.
+    const blocked: AeriesAreaResult['status'] = 'untested';
     const why =
       schools.status === 'ok'
         ? 'No schools were returned, so the remaining areas could not be checked.'
@@ -236,7 +264,10 @@ export async function runAeriesConnectionTest(params: {
       // the only area denied, the connection still "works" — which is exactly
       // the confusing half-success worth naming explicitly.
       const rows = await client.getStudentPrograms(school, 0, undefined, {
-        fields: ['StudentID', 'ProgramCode'],
+        // ProgramCode only. Asking for StudentID too would pull an identifiable
+        // program-membership record into memory on a flow whose whole contract
+        // is that it never touches student data.
+        fields: ['ProgramCode'],
         startingRecord: 1,
         endingRecord: 1,
       });
@@ -244,20 +275,23 @@ export async function runAeriesConnectionTest(params: {
     }),
   );
 
-  const failed = areas.filter((a) => a.status !== 'ok');
-  const programsDenied = areas.some((a) => a.key === 'programs' && a.status !== 'ok');
+  // `connection` mirrors the Schools outcome, so counting it would report one
+  // failure as two to a district trying to work out how much is left to fix.
+  const permissionAreas = areas.filter((a) => a.key !== 'connection');
+  const failed = permissionAreas.filter((a) => a.status !== 'ok');
+  const programsNotOk = areas.some((a) => a.key === 'programs' && a.status !== 'ok');
 
   let summary: string;
   if (failed.length === 0) {
     summary = 'All areas granted. Aeries is ready.';
-  } else if (failed.length === 1 && programsDenied) {
+  } else if (failed.length === 1 && programsNotOk) {
     // Named specially because it is the likeliest single miss and the most
     // consequential: everything appears to work, but no special-education data
     // ever arrives.
     summary =
       'Connected, but Student Programs is not granted — Speddy cannot see special education records without it.';
   } else {
-    summary = `${failed.length} of ${areas.length} areas need attention in Aeries.`;
+    summary = `${failed.length} of ${permissionAreas.length} areas need attention in Aeries.`;
   }
 
   return { ok: failed.length === 0, areas, summary };

--- a/lib/sis/connections.ts
+++ b/lib/sis/connections.ts
@@ -298,9 +298,8 @@ export async function storeCredential(
   if (error) {
     // The message can carry a constraint name but never a credential — the
     // patch values are ciphertext and PostgREST does not echo them here.
-    log.error('Failed to store SIS credential', {
+    log.error('Failed to store SIS credential', error, {
       connectionId: input.connectionId,
-      error: error.message,
     });
     throw new Error(`Failed to store SIS credential: ${error.message}`);
   }

--- a/lib/sis/ssrf-guard.ts
+++ b/lib/sis/ssrf-guard.ts
@@ -28,11 +28,17 @@ import { lookup } from 'dns/promises';
 
 /** Reject any literal IP address, and names that cannot be public. */
 export function assertPublicAeriesHostSyntax(hostname: string): void {
-  // Strip a single trailing dot before ANY comparison. `localhost.` and
-  // `sis.internal.` are the fully-qualified forms of exactly the names below,
-  // resolve identically, and would otherwise sail past both checks — found by
-  // probing this guard rather than by reading it.
-  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '');
+  // Strip ALL trailing dots before ANY comparison. `localhost.` is the
+  // fully-qualified form of `localhost`, resolves identically, and would
+  // otherwise sail past every check below.
+  //
+  // `\.+$`, not `\.$`: the first version of this stripped exactly one dot, and
+  // `127.0.0.1..` then defeated the whole function — the IP-literal regex is
+  // anchored, so a leftover dot means it no longer matches, and every name
+  // check falls through the same way. The write path accepted it and stored
+  // `https://127.0.0.1../aeries/api/v5`. Fixing one spelling of a trailing dot
+  // and leaving the next is how the IPv6 branch below went wrong too.
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '').replace(/\.+$/, '');
 
   // No district hands out a bare IP for their SIS; every real instance is a
   // hostname. Refusing literals removes the whole IPv4/IPv6 literal surface
@@ -84,16 +90,35 @@ export function isPrivateAddress(address: string, family: number): boolean {
     );
   }
 
-  const v6 = address.toLowerCase();
-  if (v6 === '::1' || v6 === '::') return true;
-  // IPv4-mapped (::ffff:10.0.0.1) — judge the embedded v4 address.
-  const mapped = v6.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
-  if (mapped) return isPrivateAddress(mapped[1], 4);
-  // fc00::/7 unique-local, fe80::/10 link-local, ff00::/8 multicast. The
-  // multicast arm matters because the IPv4 side already blocks 224/4 — without
-  // it the two families disagree, and a AAAA record is all it takes to pick the
-  // permissive one.
-  return /^f[cd]/.test(v6) || /^fe[89ab]/.test(v6) || /^ff/.test(v6);
+  // IPv6 is an ALLOW-list, deliberately, and this is the one place the two
+  // families are treated differently.
+  //
+  // It started as a deny-list — ::1, ::ffff:<v4>, fc00::/7, fe80::/10, ff00::/8
+  // — and that was wrong in nine ways at once, every one of them a spelling of
+  // an address the IPv4 side already refused: NAT64 (64:ff9b::a9fe:a9fe reaches
+  // 169.254.169.254 on any DNS64 network), 6to4 (2002:a9fe:a9fe::), the
+  // IPv4-compatible form (::169.254.169.254), site-local fec0::/10 — which
+  // `fe[89ab]` misses by one nibble — and even ::ffff:7f00:1, the plain hex
+  // spelling of the IPv4-mapped address the deny-list was built to catch.
+  // Enumerating the ways to write "loopback" in IPv6 is not a winnable game.
+  //
+  // So: the only globally routable IPv6 is 2000::/3. Everything outside it is
+  // special-purpose by IANA assignment and cannot be a district's Aeries host.
+  // One rule, and every encoding above is refused by construction rather than
+  // by having been thought of.
+  const v6 = address.toLowerCase().split('%')[0]; // drop any zone id (fe80::1%eth0)
+  const head = parseInt(v6.split(':')[0], 16); // NaN for '::1', '::ffff:…' — refused
+  if (!(head >= 0x2000 && head <= 0x3fff)) return true;
+
+  // The two IPv4-embedding tunnels that live INSIDE global unicast, and so are
+  // the only ways back through the rule above. Both are effectively dead
+  // (RFC 7526 withdrew the 6to4 relay); refusing them outright is simpler and
+  // safer than decoding the address they carry.
+  const second = parseInt(v6.split(':')[1] || '0', 16);
+  if (head === 0x2002) return true; // 6to4
+  if (head === 0x2001 && second === 0) return true; // Teredo, 2001::/32
+
+  return false;
 }
 
 /**

--- a/lib/sis/ssrf-guard.ts
+++ b/lib/sis/ssrf-guard.ts
@@ -1,0 +1,116 @@
+/**
+ * Keep district-supplied SIS addresses pointed at the public internet (SPE-396).
+ *
+ * WHY THIS EXISTS. A district tech admin types the address their SIS lives at,
+ * and our server then makes authenticated requests to it and reports, per
+ * status code, what answered. Without a guard that is a host-and-port scanner
+ * running from our production egress, driven by a customer: point it at
+ * `https://10.0.0.5:8443` or `https://169.254.169.254` (the cloud metadata
+ * endpoint) and the diagnostics distinguish "connected", "denied", "not found"
+ * and "unreachable" for you.
+ *
+ * Two layers, because either alone is bypassable:
+ *   - syntactic (`assertPublicAeriesHostSyntax`): reject IP literals and
+ *     obviously-internal names before anything is stored;
+ *   - resolved (`assertPublicAeriesHost`): resolve the name and reject if it
+ *     lands on a private, loopback, link-local, or carrier-NAT address —
+ *     because `sis.example.com` is free to be an A record for 10.0.0.5.
+ *
+ * KNOWN LIMIT, stated rather than papered over: this does not close DNS
+ * rebinding. A name that resolves public at check time and private at fetch
+ * time would still be followed, because Node's fetch resolves again itself.
+ * Closing that needs a pinned-IP dialer. The residual risk is bounded — the
+ * caller is authenticated, is a named district's tech admin, and no response
+ * body is ever returned to them — so it is accepted here and noted for
+ * whoever raises the ceiling later.
+ */
+import { lookup } from 'dns/promises';
+
+/** Reject any literal IP address, and names that cannot be public. */
+export function assertPublicAeriesHostSyntax(hostname: string): void {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+
+  // No district hands out a bare IP for their SIS; every real instance is a
+  // hostname. Refusing literals removes the whole IPv4/IPv6 literal surface
+  // before it needs picking apart.
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host) || host.includes(':')) {
+    throw new Error(
+      'Enter your Aeries web address as a name (for example https://yourdistrict.aeries.net), not an IP address.',
+    );
+  }
+
+  if (host === 'localhost' || host.endsWith('.localhost')) {
+    throw new Error('That address points at this server rather than your Aeries instance.');
+  }
+
+  // Names that only resolve inside a private network. Speddy runs in the cloud
+  // and could never reach these, so accepting one guarantees a confusing
+  // failure later even in the innocent case.
+  if (/\.(local|internal|intranet|lan|home|corp|localdomain)$/.test(host)) {
+    throw new Error(
+      'That address is only reachable inside your network. Speddy connects over the public internet, so Aeries needs a publicly reachable address.',
+    );
+  }
+
+  // A single label ("aeries", "sis") is an intranet short name.
+  if (!host.includes('.')) {
+    throw new Error(
+      'That address looks like an internal shortcut. Use the full public address, for example https://yourdistrict.aeries.net',
+    );
+  }
+}
+
+/** True when an IPv4/IPv6 address is one we must never dial on a caller's behalf. */
+export function isPrivateAddress(address: string, family: number): boolean {
+  if (family === 4) {
+    const p = address.split('.').map(Number);
+    if (p.length !== 4 || p.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return true;
+    const [a, b] = p;
+    return (
+      a === 0 || // "this network"
+      a === 10 || // private
+      a === 127 || // loopback
+      (a === 100 && b >= 64 && b <= 127) || // carrier-grade NAT
+      (a === 169 && b === 254) || // link-local — includes cloud metadata
+      (a === 172 && b >= 16 && b <= 31) || // private
+      (a === 192 && b === 168) || // private
+      (a === 192 && b === 0) || // protocol assignments / IETF
+      (a === 198 && (b === 18 || b === 19)) || // benchmarking
+      a >= 224 // multicast + reserved
+    );
+  }
+
+  const v6 = address.toLowerCase();
+  if (v6 === '::1' || v6 === '::') return true;
+  // IPv4-mapped (::ffff:10.0.0.1) — judge the embedded v4 address.
+  const mapped = v6.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
+  if (mapped) return isPrivateAddress(mapped[1], 4);
+  // fc00::/7 unique-local, fe80::/10 link-local.
+  return /^f[cd]/.test(v6) || /^fe[89ab]/.test(v6);
+}
+
+/**
+ * Resolve the host and refuse anything that lands inside a private network.
+ *
+ * Checks EVERY address the name resolves to, not just the first: a name with
+ * one public and one private A record would otherwise pass and then be dialled
+ * at whichever the resolver picked.
+ */
+export async function assertPublicAeriesHost(hostname: string): Promise<void> {
+  assertPublicAeriesHostSyntax(hostname);
+
+  let addresses: { address: string; family: number }[];
+  try {
+    addresses = await lookup(hostname, { all: true });
+  } catch {
+    throw new Error(
+      `We couldn't find ${hostname}. Check the address — it should look like https://yourdistrict.aeries.net`,
+    );
+  }
+
+  if (!addresses.length || addresses.some((a) => isPrivateAddress(a.address, a.family))) {
+    throw new Error(
+      'That address resolves to a private network address, so Speddy cannot use it. Aeries needs to be reachable over the public internet.',
+    );
+  }
+}

--- a/lib/sis/ssrf-guard.ts
+++ b/lib/sis/ssrf-guard.ts
@@ -89,8 +89,11 @@ export function isPrivateAddress(address: string, family: number): boolean {
   // IPv4-mapped (::ffff:10.0.0.1) — judge the embedded v4 address.
   const mapped = v6.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
   if (mapped) return isPrivateAddress(mapped[1], 4);
-  // fc00::/7 unique-local, fe80::/10 link-local.
-  return /^f[cd]/.test(v6) || /^fe[89ab]/.test(v6);
+  // fc00::/7 unique-local, fe80::/10 link-local, ff00::/8 multicast. The
+  // multicast arm matters because the IPv4 side already blocks 224/4 — without
+  // it the two families disagree, and a AAAA record is all it takes to pick the
+  // permissive one.
+  return /^f[cd]/.test(v6) || /^fe[89ab]/.test(v6) || /^ff/.test(v6);
 }
 
 /**

--- a/lib/sis/ssrf-guard.ts
+++ b/lib/sis/ssrf-guard.ts
@@ -146,3 +146,36 @@ export async function assertPublicAeriesHost(hostname: string): Promise<void> {
     );
   }
 }
+
+/**
+ * The whole question — "is it safe to send a district's certificate here?" —
+ * answered in one place: scheme, then host syntax, then resolved addresses.
+ *
+ * The scheme belongs here rather than only at the write paths. Both of those
+ * already refuse http:// (`normalizeAeriesBaseUrl` for the district's own form,
+ * a zod refine on /api/internal/sis-connections), so nothing can store one
+ * today — the table is empty and there is no third writer. But this is the last
+ * point before the AERIES-CERT header goes on the wire, and it is the only one
+ * that sees the URL a probe will actually dial rather than the one someone
+ * typed. A future writer, a restored backup, or a hand-edited row would all
+ * arrive here and nowhere else.
+ *
+ * Callers get one function so the two halves cannot drift apart, and so a test
+ * that stubs the guard stubs all of it rather than silently keeping half.
+ */
+export async function assertSafeAeriesUrl(baseUrl: string): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new Error(
+      'That does not look like a web address. It should look like https://yourdistrict.aeries.net',
+    );
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new Error('The Aeries address must start with https:// so credentials stay encrypted.');
+  }
+
+  await assertPublicAeriesHost(parsed.hostname);
+}

--- a/lib/sis/ssrf-guard.ts
+++ b/lib/sis/ssrf-guard.ts
@@ -28,7 +28,11 @@ import { lookup } from 'dns/promises';
 
 /** Reject any literal IP address, and names that cannot be public. */
 export function assertPublicAeriesHostSyntax(hostname: string): void {
-  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  // Strip a single trailing dot before ANY comparison. `localhost.` and
+  // `sis.internal.` are the fully-qualified forms of exactly the names below,
+  // resolve identically, and would otherwise sail past both checks — found by
+  // probing this guard rather than by reading it.
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '');
 
   // No district hands out a bare IP for their SIS; every real instance is a
   // hostname. Refusing literals removes the whole IPv4/IPv6 literal surface

--- a/scripts/sim-district/verify-sis-connections-rls.ts
+++ b/scripts/sim-district/verify-sis-connections-rls.ts
@@ -84,9 +84,18 @@ async function read(token: string, select: string) {
   return { status: res.status, code, rows: Array.isArray(parsed) ? parsed : [], body: text.slice(0, 140) };
 }
 
+// A real district that is NOT the sim district. The policy's district clause is
+// only load-bearing if a foreign row exists for the in-district personas to be
+// refused — without one, "nobody else sees it" is proven entirely by personas
+// the ROLE clause already excludes, and dropping the district match from the
+// policy would leave this script fully green while every district_admin on the
+// platform could read every district's connection.
+const FOREIGN_DISTRICT = '0618990';
+
 async function main(): Promise<void> {
   const CERT = 'FAKE-AERIES-CERT-FOR-SIM-VERIFICATION-a9f2';
   let connectionId: string | null = null;
+  let foreignConnectionId: string | null = null;
 
   try {
     // Service-role write: the path the real API routes use.
@@ -107,6 +116,29 @@ async function main(): Promise<void> {
       createErr ? createErr.message : 'created');
     if (createErr) throw new Error('cannot continue without a connection row');
     connectionId = created!.id;
+
+    // The foreign-tenant row. Deliberately a different district so the district
+    // half of the SELECT policy has to do work.
+    // String()-wrapped so this is a RUNTIME check. Comparing the literals
+    // directly is a compile error ("no overlap") — TypeScript already proves
+    // them different today, but that proof evaporates the moment the manifest
+    // changes, which is exactly when this check earns its place.
+    check(String(FOREIGN_DISTRICT) !== String(DISTRICT.id),
+      'the foreign district is genuinely a different district',
+      `${FOREIGN_DISTRICT} vs ${DISTRICT.id}`);
+    const { data: foreign, error: foreignErr } = await admin
+      .from('district_sis_connections')
+      .insert({
+        district_id: FOREIGN_DISTRICT,
+        sis_type: 'aeries',
+        base_url: 'https://other.aeries.test',
+        status: 'connected',
+      })
+      .select('id')
+      .single();
+    check(!foreignErr, 'seeded a connection for another district',
+      foreignErr ? foreignErr.message : 'created');
+    if (!foreignErr) foreignConnectionId = foreign!.id;
 
     // Round-trip through the DB, proving what we stored is what we get back.
     const { data: stored } = await admin
@@ -138,6 +170,14 @@ async function main(): Promise<void> {
       const safe = await read(token, SAFE_COLUMNS);
       check(safe.status === 200 && safe.rows.length === 1,
         `${label}: reads connection status`, `HTTP ${safe.status}, ${safe.rows.length} row(s)`);
+      // EXACTLY one row, and it must be their own district's. This is the check
+      // that makes the policy's district clause load-bearing: drop it and this
+      // read returns 2 rows and fails, instead of quietly passing because the
+      // only other personas are excluded on role.
+      check(
+        safe.rows.length === 1 && safe.rows[0]?.district_id === DISTRICT.id,
+        `${label}: sees ONLY their own district's connection`,
+        `${safe.rows.length} row(s), district=${safe.rows[0]?.district_id ?? 'none'}`);
 
       for (const col of CREDENTIAL_COLUMNS) {
         const r = await read(token, col);
@@ -184,6 +224,18 @@ async function main(): Promise<void> {
       const { error } = await admin.from('district_sis_connections').delete().eq('id', connectionId);
       check(!error, 'cleanup: connection row removed', error?.message ?? 'deleted');
     }
+    if (foreignConnectionId) {
+      const { error } = await admin
+        .from('district_sis_connections')
+        .delete()
+        .eq('id', foreignConnectionId);
+      check(!error, 'cleanup: foreign-district row removed', error?.message ?? 'deleted');
+    }
+    const { count: foreignLeft } = await admin
+      .from('district_sis_connections')
+      .select('id', { count: 'exact', head: true })
+      .eq('district_id', FOREIGN_DISTRICT);
+    check(foreignLeft === 0, 'no residue left in the foreign district', `${foreignLeft} row(s)`);
     const { count } = await admin
       .from('district_sis_connections')
       .select('id', { count: 'exact', head: true })


### PR DESCRIPTION
The Aeries connection flow from SPE-392. Consumes the credential store merged in #806 (SPE-395).

> **Status:** ready. The adversarial pass on the SSRF guard landed and found three more real holes; all fixed below.

## What this is for

The person on the other end is a district IT generalist who has Aeries admin rights but has never opened the API Security page. The whole value of this feature is that when their connection doesn't work, we tell them **which checkbox to tick**, rather than an HTTP status they have to forward to us.

## The distinction the feature turns on

Aeries returns **401 when the certificate is wrong** and **403 when the certificate is fine but a permission box was never ticked**. Different screens, different fixes. Collapsing them into "connection failed" is what generates the onboarding round-trips this ticket exists to remove.

One case is called out by name: **a lone Student Programs denial**. Everything else looks connected, the district thinks they're done — and no special-education data will ever arrive, because program 144/144x lives behind that one box.

Areas that were never probed report as `untested`, not `error`. The UI colours by status, and painting three red permission failures for checkboxes nobody looked at sends a district off to fix things that are already fine.

## Aggregate-only, by construction

`district_tech` has no right to student data at all (SPE-393). Every probe pins `fields` to a single non-identifying column and pagination to one row, reports a count and an area name, and drops the counts before persisting. A test feeds the probes a deliberately hostile payload (names, IDs, the certificate) and checks none of it reaches the report or the stored result.

## SSRF: the hole this PR opened, and the seven ways it was closed

The original normalizer accepted any host that parsed as `https`. Verified against that code, it accepted `https://127.0.0.1:8443`, `https://10.0.0.5`, `https://sis.internal`, and `https://169.254.169.254` — **the cloud metadata endpoint**. The test route then makes authenticated requests to whatever is stored and reports, per status, what answered: a host-and-port scanner running from our production egress, aimed by a customer.

Both Codex and CodeRabbit flagged it independently. `lib/sis/ssrf-guard.ts` closes it in two layers — syntactic (no IP literals, no `localhost`, no internal-only suffixes, no single-label shortcuts) and resolved (refuse if **any** resolved address is not publicly routable). Applied at write time and before every probe.

**Then the guard itself was attacked rather than re-read**, which found four more:

- **Redirects defeated the whole control.** `AeriesClient` left fetch's default `redirect: 'follow'`, so a public host could 302 an authenticated request into an internal address — the guard only ever validated the host *we* resolved. Now `redirect: 'error'`.
- **A trailing dot** slipped both name checks — and the fix for it was itself incomplete: stripping one dot meant **`127.0.0.1..` defeated the function entirely**, because the anchored IP regex stops matching and every name check falls through. The write path accepted it and stored `https://127.0.0.1../aeries/api/v5`. Now strips all trailing dots.
- **The IPv6 branch was a deny-list, and was wrong in nine ways** — every one a different spelling of an address the IPv4 side already refused: NAT64 (`64:ff9b::a9fe:a9fe`, which reaches `169.254.169.254` on any DNS64 network), 6to4, the IPv4-compatible form (`::169.254.169.254`), site-local `fec0::/10` (one nibble outside the old `fe[89ab]` arm), and `::ffff:7f00:1` — the plain hex spelling of the IPv4-mapped form the deny-list was built to catch. Replaced with the allow-list that actually holds: **global unicast is `2000::/3`**, minus the 6to4 and Teredo tunnels inside it. Every encoding is now refused by construction rather than by having been thought of. The reverse is tested too — Cloudflare, Google, and `2001:4860:4860::8888` (2001::/16 but *not* Teredo) must all still be allowed, because an allow-list that locks out a real district is worse than the bug.
- **Both call sites were pinned by no test at all.** Deleting them left 86 suites and 866 tests green with the entire control gone — one suite tests the guard in isolation, the other stubs it out to test the diagnostics, and nothing asserted anything *called* it. `aeries-setup.guard-wiring.test.ts` now leaves the guard live, mocks DNS underneath it, and asserts the observable consequence: a private address means no request is made.

**Also closed:** `runAeriesConnectionTest` checked the host but not the scheme, so an `http://` base would have sent `AERIES-CERT` in cleartext (CodeRabbit, Major). Both halves now live in one guard, `assertSafeAeriesUrl`. Nothing can store such a row today — both write paths refuse `http://` and `district_sis_connections` is empty, queried rather than assumed — so this is the last checkpoint before the header goes on the wire rather than a live leak.

**Known limit, written into the file:** this does not close DNS rebinding, which needs a pinned-IP dialer. Tracked as **SPE-406** with both implementation routes and the trade-offs; deferred because each means either a new dependency or rewriting the shared client's transport. Discussed in-thread with CodeRabbit, which accepted the deferral.

**Deliberately left open: SPE-407.** The port is taken from district input and never constrained, so the test can probe arbitrary ports on public hosts. Bounded (authenticated district tech admin, public hosts only, no response body returned) but real. Not fixed here because restricting it can lock out a district running Aeries on a non-standard port, and picking the allowed set needs someone who knows how Aeries is deployed in the field — a product call, not a bug fix.

## Also fixed here, from the SPE-395 audit of already-merged code

A 49-agent audit produced 16 candidates; 13 refuted, 3 real:

- **`getConnection selects only granted columns` could not fail.** Proved by mutation: switching to `.select('*')` left all 25 tests green, because `'*'` contains none of the credential column names the test loops over. That row goes straight to the browser via the DPA route.
- **The RLS verification never exercised the policy's district clause.** One district in the fixture meant "nobody else sees it" was proven entirely by personas the *role* clause already excludes. Fixed with a foreign-district row — then **proved**: with the table at 0 rows, I dropped the district clause from the live policy, watched the script fail 4 checks with both personas reading 2 rows, and restored it, verifying it came back `TO authenticated` rather than the `TO public` that `CREATE POLICY` defaults to.
- **`log.error` was called as `(message, context)`** against a `(message, error, meta)` signature, so Sentry recorded a message with no stack instead of an exception.

## Verification

**889 tests green, 88 suites.** Every SSRF fix is mutation-tested — reverted, confirmed the new tests fail, restored. The IPv6 rewrite fails exactly the 9 encoding tests; deleting the guard call sites fails 7 wiring tests while the two "must still work" cases stay green; removing the scheme check fails exactly 1.

**Real HTTP, not just mocked methods** (`aeries-setup.http.test.ts`). The other suite stubs `AeriesClient`'s methods, so it proved the reporting logic and nothing about the transport. This one starts an actual server and lets the real `fetch` talk to it, establishing two things that were previously claims: **redirects are refused** (exactly one request, and the certificate never reaches the redirect target), and **the certificate travels as the `AERIES-CERT` header** and nowhere else — not in a query string, where it would land in the district's own access logs.

**Portal walked with real signed-in sessions** — 19 checks. The credential form is *absent* (not merely hidden) before the DPA is recorded; `https://169.254.169.254` is refused through the actual UI with nothing stored; a provider is bounced from the portal and refused by both routes with 403 **and the guard's own message**, not a 401 that a dead session would also produce.

`sim:verify`, `sim:verify-sis-rls`, `sim:verify-sis-lifecycle` green against the real database; lifecycle closed clean (teardown → expect-empty → reseed → verify). Typecheck, lint, `next build`.

## Not covered, stated precisely

- **Aeries' own behaviour is still assumed.** `demo.aeries.net` is blocked by the build sandbox's egress policy — an organization network policy, not something routable around. So: *proven* — given a 403, our code says "tick that box"; given a 401, "re-copy the certificate". *Still assumed* — that Aeries actually returns 403 for an unticked box rather than 401 or an empty 200. No local server can settle that. If the assumption is wrong, the diagnostics give confident wrong advice, and we would find out on the first real district.
- **Production is unaffected by that block** — connection tests run from Vercel, which makes its own outbound calls.
- **GitHub Actions has been down for this entire PR.** No CI run exists; every gate above was run locally. (SPE-405 covers the missing `concurrency` groups found while diagnosing.)

## A judgment call made against a review suggestion

Codex asked to tighten the certificate regex to hex. Every certificate we've seen is hex, but Aeries' docs call it "case-sensitive" — odd phrasing for hex, which is case-insensitive by definition. The costs are asymmetric: rejecting a valid certificate locks a district out with no workaround, while accepting a malformed one costs one connection test that fails with clear advice. Kept alphanumeric, corrected the comment that disagreed with it, and explained in-thread.

## Summary by CodeRabbit

- **New Features**
  - Added Aeries SIS connection setup for district technology administrators.
  - Added secure credential entry, replacement, masking, and connection testing.
  - Added area-by-area diagnostics for connectivity, permissions, schools, students, teachers, and programs.
  - Added connection-aware technology dashboard states for setup, DPA approval, and configured connections.
- **Security**
  - Added HTTPS and public-host validation, redirect blocking, rate limits, and sensitive-data protections.
  - Restricted connection data to authorized callers within their district.
- **Bug Fixes**
  - Improved validation and clearer diagnostics for authentication, network, timeout, and permission failures.