### PR TITLE
SPE-397: OneRoster connection flow — client, guided setup, credential intake, step-wise test

### DIFF
--- a/__tests__/unit/lib/sis/aeries-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/aeries-setup.http.test.ts
@@ -20,7 +20,7 @@
  *
  * The guard is stubbed because these servers are on 127.0.0.1 over plain http,
  * both of which it correctly refuses. That is the point of stubbing the whole
- * of `assertSafeAeriesUrl` rather than half of it: this suite is about
+ * of `assertSafeSisUrl` rather than half of it: this suite is about
  * transport, and URL policy is proven elsewhere — ssrf-guard.test.ts for the
  * classification, aeries-setup.guard-wiring.test.ts for the fact that
  * runAeriesConnectionTest actually calls the guard and refuses an http:// base.
@@ -30,7 +30,7 @@ import type { AddressInfo } from 'net';
 
 jest.mock('@/lib/sis/ssrf-guard', () => ({
   ...jest.requireActual('@/lib/sis/ssrf-guard'),
-  assertSafeAeriesUrl: jest.fn().mockResolvedValue(undefined),
+  assertSafeSisUrl: jest.fn().mockResolvedValue(undefined),
 }));
 
 import { runAeriesConnectionTest } from '@/lib/sis/aeries-setup';

--- a/__tests__/unit/lib/sis/aeries-setup.test.ts
+++ b/__tests__/unit/lib/sis/aeries-setup.test.ts
@@ -21,7 +21,7 @@ import { AeriesApiError } from '@/lib/integrations/aeries';
 // pass here; ssrf-guard.test.ts covers the guard itself.
 jest.mock('@/lib/sis/ssrf-guard', () => ({
   ...jest.requireActual('@/lib/sis/ssrf-guard'),
-  assertSafeAeriesUrl: jest.fn().mockResolvedValue(undefined),
+  assertSafeSisUrl: jest.fn().mockResolvedValue(undefined),
 }));
 
 const mockGetSchools = jest.fn();

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -1,0 +1,273 @@
+/**
+ * SPE-397 · the OneRoster exchange against a REAL HTTP server.
+ *
+ * OneRoster's auth is two steps — POST credentials for a bearer token, then use
+ * the token — and the properties worth the most are about WHICH credential
+ * travels WHERE. A mocked client cannot see that at all: it would pass whether
+ * the consumer secret went in a header, a query string, or on every subsequent
+ * request. So this suite starts a real server and inspects what actually
+ * arrives.
+ *
+ * WHY THIS MATTERS HERE MORE THAN FOR AERIES. Aeries sends one static header to
+ * one host. OneRoster sends a long-lived district secret to one endpoint and a
+ * short-lived token to another. Leaking the first onto the second — or into a
+ * query string, where it lands in the district's own access logs — is a silent
+ * credential disclosure that every mocked test in the suite would still pass.
+ *
+ * The guard is stubbed because these servers are on 127.0.0.1 over plain http,
+ * which it correctly refuses. ssrf-guard.test.ts covers the guard itself and
+ * oneroster-setup.test.ts covers that this module actually calls it.
+ */
+import { createServer, type Server } from 'http';
+import type { AddressInfo } from 'net';
+
+jest.mock('@/lib/sis/ssrf-guard', () => ({
+  ...jest.requireActual('@/lib/sis/ssrf-guard'),
+  assertSafeSisUrl: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { runOneRosterConnectionTest } from '@/lib/sis/oneroster-setup';
+
+const CLIENT_ID = 'speddy-consumer-id';
+const CLIENT_SECRET = 'sup3r-s3cret-consumer-key';
+const TOKEN = 'bearer-token-abc123';
+
+interface Seen {
+  url: string;
+  method: string;
+  auth?: string;
+  /** EVERY header, not just Authorization — see the secret-placement test. */
+  headers: Record<string, string>;
+  body: string;
+}
+
+/** Flatten a request to one string, so a secret cannot hide in a field nobody checked. */
+const everything = (r: Seen) =>
+  [r.url, r.body, ...Object.entries(r.headers).map(([k, v]) => `${k}: ${v}`)].join('\n');
+
+type Handler = (req: Seen) => { status: number; body?: unknown };
+
+let server: Server;
+let origin: string;
+let handler: Handler;
+let seen: Seen[] = [];
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      const entry: Seen = {
+        url: req.url ?? '',
+        method: req.method ?? '',
+        auth: req.headers.authorization,
+        headers: Object.fromEntries(
+          Object.entries(req.headers).map(([k, v]) => [k, Array.isArray(v) ? v.join(',') : String(v ?? '')]),
+        ),
+        body,
+      };
+      seen.push(entry);
+      const { status, body: out } = handler(entry);
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(out === undefined ? '' : JSON.stringify(out));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  seen = [];
+});
+
+const run = () =>
+  runOneRosterConnectionTest({
+    baseUrl: `${origin}/admin`,
+    tokenUrl: `${origin}/admin/token/`,
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+  });
+
+const stepOf = (r: Awaited<ReturnType<typeof run>>, key: string) =>
+  r.steps.find((s) => s.key === key)!;
+
+/** Everything works: a token, then both collections. */
+const allGood: Handler = (req) => {
+  if (req.url.includes('/token')) {
+    return { status: 200, body: { access_token: TOKEN, token_type: 'bearer', expires_in: 3600 } };
+  }
+  return { status: 200, body: { orgs: [{ sourcedId: 'org-1', name: 'Sim USD', type: 'district' }] } };
+};
+
+describe('the OneRoster exchange over real HTTP', () => {
+  it('reports every step working', async () => {
+    handler = allGood;
+    const report = await run();
+
+    expect(report.ok).toBe(true);
+    expect(report.summary).toMatch(/ready/i);
+    expect(report.steps.map((s) => s.status)).toEqual(['ok', 'ok', 'ok']);
+  });
+
+  it('sends the consumer secret ONLY to the token endpoint, and only as a Basic header', async () => {
+    handler = allGood;
+    await run();
+
+    const tokenReqs = seen.filter((r) => r.url.includes('/token'));
+    const dataReqs = seen.filter((r) => !r.url.includes('/token'));
+    expect(tokenReqs).toHaveLength(1);
+    expect(dataReqs.length).toBeGreaterThan(0);
+
+    // The secret is in the Basic header of the token request...
+    const basic = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64');
+    expect(tokenReqs[0].auth).toBe(`Basic ${basic}`);
+
+    // ...and NOWHERE else.
+    //
+    // Asserted over the WHOLE request — every header, the body, and the URL —
+    // not just Authorization. The narrower version of this test passed while a
+    // mutant leaked the secret in an `X-Secret:` header on every data request,
+    // which is exactly the disclosure this test exists to catch.
+    expect(tokenReqs[0].body).not.toContain(CLIENT_SECRET);
+    for (const r of dataReqs) {
+      expect(r.auth).toBe(`Bearer ${TOKEN}`);
+      expect(everything(r)).not.toContain(CLIENT_SECRET);
+      expect(everything(r)).not.toContain(CLIENT_ID);
+    }
+    // A URL is the worst place of all: it lands in the district's own access
+    // logs and in any proxy between us and them.
+    for (const r of seen) {
+      expect(r.url).not.toContain(CLIENT_SECRET);
+      expect(r.url).not.toContain(CLIENT_ID);
+    }
+  });
+
+  it('asks for client_credentials and only the roster-core scope', async () => {
+    handler = allGood;
+    await run();
+
+    const body = seen.find((r) => r.url.includes('/token'))!.body;
+    expect(body).toContain('grant_type=client_credentials');
+    expect(decodeURIComponent(body)).toContain(
+      'https://purl.imsglobal.org/spec/or/v1p1/scope/roster-core.readonly',
+    );
+    // Demographics carries birthdate, sex and race. This flow has no use for
+    // any of it, and a district reviewing the grant should see that.
+    expect(decodeURIComponent(body)).not.toContain('demographics');
+  });
+
+  it('fetches the token once and reuses it across both collections', async () => {
+    handler = allGood;
+    await run();
+    expect(seen.filter((r) => r.url.includes('/token'))).toHaveLength(1);
+  });
+
+  it('a 401 at the token step blames the credential MIX-UP, not the network', async () => {
+    // The most common real failure: the certificate pasted where the Consumer
+    // ID and Secret belong. Same Aeries page, adjacent fields.
+    handler = (req) =>
+      req.url.includes('/token') ? { status: 401, body: { error: 'invalid_client' } } : allGood(req);
+
+    const report = await run();
+    expect(report.ok).toBe(false);
+    expect(stepOf(report, 'token').message).toMatch(/Consumer ID and Consumer Secret/i);
+    expect(stepOf(report, 'token').message).toMatch(/not the certificate/i);
+  });
+
+  it('stops after a failed token — no data request is attempted', async () => {
+    handler = (req) =>
+      req.url.includes('/token') ? { status: 401, body: {} } : allGood(req);
+
+    const report = await run();
+    // Exactly one request total. Probing on without a token would produce two
+    // more failures that say nothing about the actual problem.
+    expect(seen).toHaveLength(1);
+    expect(stepOf(report, 'orgs').status).toBe('untested');
+    expect(stepOf(report, 'schools').status).toBe('untested');
+  });
+
+  it('a 403 AFTER a good token reads as "not shared", not as a bad credential', async () => {
+    handler = (req) => {
+      if (req.url.includes('/token')) return { status: 200, body: { access_token: TOKEN } };
+      return { status: 403, body: { error: 'forbidden' } };
+    };
+
+    const report = await run();
+    expect(stepOf(report, 'token').status).toBe('ok');
+    expect(stepOf(report, 'orgs').status).toBe('denied');
+    expect(stepOf(report, 'orgs').message).toMatch(/credentials work/i);
+    expect(stepOf(report, 'orgs').message).not.toMatch(/not the certificate/i);
+  });
+
+  it('a 200 token response with no access_token is not reported as unreachable', async () => {
+    // A real OneRoster failure mode. Reporting it as a network problem sends
+    // the district to look at a firewall that is working perfectly.
+    handler = (req) =>
+      req.url.includes('/token') ? { status: 200, body: { token_type: 'bearer' } } : allGood(req);
+
+    const report = await run();
+    expect(stepOf(report, 'token').status).toBe('error');
+    expect(stepOf(report, 'token').message).not.toMatch(/Could not reach/i);
+  });
+
+  it('REFUSES a redirect from the token endpoint — with the secret unsent', async () => {
+    // The escape `redirect: 'error'` exists to close: a public host answering
+    // 302 toward an internal address. Following it would carry the district's
+    // consumer secret to a destination the guard never validated.
+    let redirected = false;
+    handler = (req) => {
+      if (req.url.includes('/elsewhere')) {
+        redirected = true;
+        return { status: 200, body: { access_token: TOKEN } };
+      }
+      return { status: 302, body: {} };
+    };
+    // 302 needs a Location header; add one via a bespoke handler.
+    server.removeAllListeners('request');
+    server.on('request', (req, res) => {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        seen.push({
+          url: req.url ?? '',
+          method: req.method ?? '',
+          auth: req.headers.authorization,
+          headers: Object.fromEntries(
+            Object.entries(req.headers).map(([k, v]) => [k, Array.isArray(v) ? v.join(',') : String(v ?? '')]),
+          ),
+          body,
+        });
+        if ((req.url ?? '').includes('/elsewhere')) {
+          redirected = true;
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ access_token: TOKEN }));
+          return;
+        }
+        res.writeHead(302, { Location: `${origin}/elsewhere` });
+        res.end();
+      });
+    });
+
+    const report = await run();
+    expect(report.ok).toBe(false);
+    expect(redirected).toBe(false);
+    expect(seen).toHaveLength(1);
+    expect(stepOf(report, 'token').status).not.toBe('ok');
+  });
+
+  it('surfaces a dead server as unreachable, not as a credential problem', async () => {
+    const report = await runOneRosterConnectionTest({
+      // Port 1 is reserved and nothing listens there.
+      baseUrl: 'http://127.0.0.1:1/admin',
+      tokenUrl: 'http://127.0.0.1:1/admin/token/',
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+    expect(stepOf(report, 'token').message).toMatch(/Could not reach/i);
+    expect(stepOf(report, 'token').message).not.toMatch(/not the certificate/i);
+  });
+});

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -45,7 +45,7 @@ interface Seen {
 const everything = (r: Seen) =>
   [r.url, r.body, ...Object.entries(r.headers).map(([k, v]) => `${k}: ${v}`)].join('\n');
 
-type Handler = (req: Seen) => { status: number; body?: unknown };
+type Handler = (req: Seen) => { status: number; body?: unknown; headers?: Record<string, string> };
 
 let server: Server;
 let origin: string;
@@ -67,8 +67,8 @@ beforeAll(async () => {
         body,
       };
       seen.push(entry);
-      const { status, body: out } = handler(entry);
-      res.writeHead(status, { 'Content-Type': 'application/json' });
+      const { status, body: out, headers } = handler(entry);
+      res.writeHead(status, { 'Content-Type': 'application/json', ...(headers ?? {}) });
       res.end(out === undefined ? '' : JSON.stringify(out));
     });
   });
@@ -146,6 +146,41 @@ describe('the OneRoster exchange over real HTTP', () => {
     }
   });
 
+  it('form-encodes each credential before building the Basic header (RFC 6749 §2.3.1)', async () => {
+    // Raised by Codex. Basic auth splits on the FIRST colon, so a consumer ID
+    // containing one produces a credential the token endpoint cannot parse
+    // back — and this route deliberately accepts any credential shape, because
+    // vendors differ and there is nothing safe to validate against.
+    handler = allGood;
+    await runOneRosterConnectionTest({
+      baseUrl: `${origin}/admin`,
+      tokenUrl: `${origin}/admin/token/`,
+      clientId: 'id:with:colons',
+      clientSecret: 'se%cret with spaces',
+    });
+
+    const decoded = Buffer.from(
+      seen[0].auth!.replace(/^Basic /, ''),
+      'base64',
+    ).toString('utf8');
+
+    // Exactly one colon survives — the separator. The ones inside the id are
+    // encoded, so the server can split and decode back to the real values.
+    expect(decoded.split(':')).toHaveLength(2);
+    const [user, pass] = decoded.split(':');
+    expect(decodeURIComponent(user)).toBe('id:with:colons');
+    expect(decodeURIComponent(pass.replace(/\+/g, '%20'))).toBe('se%cret with spaces');
+  });
+
+  it('leaves an ordinary alphanumeric credential completely untouched', async () => {
+    // The encoding must be a no-op for the common case, or it would break every
+    // district it was meant to protect.
+    handler = allGood;
+    await run();
+    const decoded = Buffer.from(seen[0].auth!.replace(/^Basic /, ''), 'base64').toString('utf8');
+    expect(decoded).toBe(`${CLIENT_ID}:${CLIENT_SECRET}`);
+  });
+
   it('asks for client_credentials and only the roster-core scope', async () => {
     handler = allGood;
     await run();
@@ -203,6 +238,42 @@ describe('the OneRoster exchange over real HTTP', () => {
     expect(stepOf(report, 'orgs').message).not.toMatch(/not the certificate/i);
   });
 
+  it('a 200 that is NOT a collection is refused, not reported as "Working"', async () => {
+    // Raised by Codex, and confirmed against the real code before fixing: with
+    // `body?.orgs ?? []`, a 200 carrying {"error": "..."} — a proxy error page,
+    // a maintenance response, an HTML-to-JSON gateway — became an empty array,
+    // and the district was told "Connected. OneRoster is ready." about a
+    // response we could not use at all.
+    handler = (req) =>
+      req.url.includes('/token')
+        ? { status: 200, body: { access_token: TOKEN } }
+        : { status: 200, body: { error: 'upstream unavailable' } };
+
+    const report = await run();
+    expect(report.ok).toBe(false);
+    expect(report.summary).not.toMatch(/ready/i);
+    expect(stepOf(report, 'orgs').status).not.toBe('ok');
+  });
+
+  it('an EMPTY collection reports "nothing is shared", not "ready"', async () => {
+    // Raised by CodeRabbit, and it was right where I was wrong: I first wrote
+    // this asserting the opposite. A district's OneRoster always exposes at
+    // least the district org, so zero rows does not mean "no data yet" — it
+    // means nothing is shared with us, and telling them "Connected. OneRoster
+    // is ready." is precisely the confident-wrong-advice this feature exists to
+    // prevent. 'denied', not 'error': the connection itself genuinely works.
+    handler = (req) =>
+      req.url.includes('/token')
+        ? { status: 200, body: { access_token: TOKEN } }
+        : { status: 200, body: { orgs: [] } };
+
+    const report = await run();
+    expect(report.ok).toBe(false);
+    expect(report.summary).not.toMatch(/ready/i);
+    expect(stepOf(report, 'orgs').status).toBe('denied');
+    expect(stepOf(report, 'orgs').message).toMatch(/nothing is shared/i);
+  });
+
   it('a 200 token response with no access_token is not reported as unreachable', async () => {
     // A real OneRoster failure mode. Reporting it as a network problem sends
     // the district to look at a firewall that is working perfectly.
@@ -218,45 +289,34 @@ describe('the OneRoster exchange over real HTTP', () => {
     // The escape `redirect: 'error'` exists to close: a public host answering
     // 302 toward an internal address. Following it would carry the district's
     // consumer secret to a destination the guard never validated.
+    //
+    // Driven through the shared `handler` rather than by swapping the server's
+    // request listener. The first version of this test called
+    // `server.removeAllListeners('request')` and never restored it, so every
+    // test written after it would have silently received a 302 — a landmine for
+    // whoever appended the next case.
     let redirected = false;
     handler = (req) => {
       if (req.url.includes('/elsewhere')) {
         redirected = true;
         return { status: 200, body: { access_token: TOKEN } };
       }
-      return { status: 302, body: {} };
+      return { status: 302, headers: { Location: `${origin}/elsewhere` } };
     };
-    // 302 needs a Location header; add one via a bespoke handler.
-    server.removeAllListeners('request');
-    server.on('request', (req, res) => {
-      let body = '';
-      req.on('data', (c) => (body += c));
-      req.on('end', () => {
-        seen.push({
-          url: req.url ?? '',
-          method: req.method ?? '',
-          auth: req.headers.authorization,
-          headers: Object.fromEntries(
-            Object.entries(req.headers).map(([k, v]) => [k, Array.isArray(v) ? v.join(',') : String(v ?? '')]),
-          ),
-          body,
-        });
-        if ((req.url ?? '').includes('/elsewhere')) {
-          redirected = true;
-          res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ access_token: TOKEN }));
-          return;
-        }
-        res.writeHead(302, { Location: `${origin}/elsewhere` });
-        res.end();
-      });
-    });
 
     const report = await run();
     expect(report.ok).toBe(false);
     expect(redirected).toBe(false);
     expect(seen).toHaveLength(1);
     expect(stepOf(report, 'token').status).not.toBe('ok');
+  });
+
+  it('leaves the shared server usable for the tests that follow it', async () => {
+    // Guards the landmine above: if the redirect case ever swaps the listener
+    // again, this fails immediately instead of in whatever test comes next.
+    handler = allGood;
+    const report = await run();
+    expect(report.ok).toBe(true);
   });
 
   it('surfaces a dead server as unreachable, not as a credential problem', async () => {

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -172,6 +172,30 @@ describe('the OneRoster exchange over real HTTP', () => {
     expect(decodeURIComponent(pass.replace(/\+/g, '%20'))).toBe('se%cret with spaces');
   });
 
+  it('encodes the sub-delimiters encodeURIComponent leaves alone', async () => {
+    // The gap CodeRabbit found in the hand-rolled helper this replaced:
+    // encodeURIComponent leaves ! ' ( ) ~ unescaped, where form encoding
+    // percent-escapes them. Invisible to a compliant server — `!` and `%21`
+    // both decode to `!` — but pinning it means nobody has to re-derive the
+    // character set, which is how the hand-rolled version went wrong.
+    handler = allGood;
+    await runOneRosterConnectionTest({
+      baseUrl: `${origin}/admin`,
+      tokenUrl: `${origin}/admin/token/`,
+      clientId: "id!'()~",
+      clientSecret: "secret!'()~",
+    });
+
+    const decoded = Buffer.from(seen[0].auth!.replace(/^Basic /, ''), 'base64').toString('utf8');
+    const [user, pass] = decoded.split(':');
+
+    expect(user).toBe('id%21%27%28%29%7E');
+    expect(pass).toBe('secret%21%27%28%29%7E');
+    // And still round-trips to what the district actually typed.
+    expect(decodeURIComponent(user)).toBe("id!'()~");
+    expect(decodeURIComponent(pass)).toBe("secret!'()~");
+  });
+
   it('leaves an ordinary alphanumeric credential completely untouched', async () => {
     // The encoding must be a no-op for the common case, or it would break every
     // district it was meant to protect.

--- a/__tests__/unit/lib/sis/oneroster-setup.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.test.ts
@@ -1,0 +1,201 @@
+/**
+ * SPE-397 · OneRoster URL normalization, and that the SSRF guard is WIRED IN.
+ *
+ * The guard is deliberately NOT mocked here. `oneroster-setup.http.test.ts`
+ * stubs it to test transport against a local server; this file mocks DNS
+ * underneath the real guard and asserts the observable consequence — a bad
+ * address means no request is made and no credential is sent.
+ *
+ * That split exists because of what happened on SPE-396: the guard had 60 tests
+ * of its internals and zero proving anything CALLED it, so the entire control
+ * was deletable with a green suite. OneRoster has two district-supplied URLs
+ * rather than one, which doubles the number of places that can go unchecked.
+ */
+const mockLookup = jest.fn();
+jest.mock('dns/promises', () => ({ lookup: (...a: unknown[]) => mockLookup(...a) }));
+
+const mockFetchToken = jest.fn();
+const mockGetOrgs = jest.fn();
+jest.mock('@/lib/integrations/oneroster', () => {
+  const actual = jest.requireActual('@/lib/integrations/oneroster');
+  return {
+    ...actual,
+    OneRosterClient: class {
+      fetchToken = (...a: unknown[]) => mockFetchToken(...a);
+      getOrgs = (...a: unknown[]) => mockGetOrgs(...a);
+      getSchools = jest.fn().mockResolvedValue([]);
+    },
+  };
+});
+
+import {
+  normalizeOneRosterBaseUrl,
+  normalizeOneRosterTokenUrl,
+  runOneRosterConnectionTest,
+  toStoredOneRosterTestResult,
+} from '@/lib/sis/oneroster-setup';
+
+const CREDS = { clientId: 'consumer-id', clientSecret: 'consumer-secret' };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFetchToken.mockResolvedValue('token');
+  mockGetOrgs.mockResolvedValue([{ sourcedId: 'org-1' }]);
+});
+
+describe('normalizeOneRosterBaseUrl', () => {
+  it('keeps a plain district base URL', () => {
+    expect(normalizeOneRosterBaseUrl('https://jsusdapi.aeries.net/admin')).toBe(
+      'https://jsusdapi.aeries.net/admin',
+    );
+  });
+
+  it('assumes https when the district pasted a bare host', () => {
+    expect(normalizeOneRosterBaseUrl('jsusdapi.aeries.net/admin')).toBe(
+      'https://jsusdapi.aeries.net/admin',
+    );
+  });
+
+  it.each([
+    'https://jsusdapi.aeries.net/admin/ims/oneroster/v1p1',
+    'https://jsusdapi.aeries.net/admin/ims/oneroster/v1p1/',
+  ])('strips the version segment the district pasted (%s)', (input) => {
+    // They copy what their Aeries page shows, which is often the full data URL.
+    // Appending our own path to that yields .../v1p1/ims/oneroster/v1p1/orgs.
+    expect(normalizeOneRosterBaseUrl(input)).toBe('https://jsusdapi.aeries.net/admin');
+  });
+
+  it('drops a trailing slash so two spellings do not become two stored rows', () => {
+    expect(normalizeOneRosterBaseUrl('https://jsusdapi.aeries.net/admin/')).toBe(
+      'https://jsusdapi.aeries.net/admin',
+    );
+  });
+
+  it('refuses http:// rather than silently upgrading it', () => {
+    expect(() => normalizeOneRosterBaseUrl('http://jsusdapi.aeries.net/admin')).toThrow(/https:\/\//);
+  });
+
+  it('refuses an empty address with an instruction', () => {
+    expect(() => normalizeOneRosterBaseUrl('   ')).toThrow(/Enter your OneRoster address/i);
+  });
+
+  // These are refused ONLY by the SSRF guard. Delete that call and every one
+  // of them passes.
+  it.each([
+    ['https://127.0.0.1/admin', 'an IP literal'],
+    ['https://127.0.0.1../admin', 'an IP literal wearing two trailing dots'],
+    ['https://localhost/admin', 'localhost'],
+    ['https://sis.internal/admin', 'an internal-only name'],
+    ['https://oneroster/admin', 'a single-label intranet name'],
+  ])('refuses %s (%s)', (url) => {
+    expect(() => normalizeOneRosterBaseUrl(url)).toThrow();
+  });
+
+  it('speaks OneRoster, not Aeries, when it refuses', () => {
+    // One shared guard serves both connectors; a OneRoster district must not be
+    // told to check their "Aeries web address".
+    expect(() => normalizeOneRosterBaseUrl('https://127.0.0.1/admin')).toThrow(
+      /OneRoster web address/i,
+    );
+  });
+});
+
+describe('normalizeOneRosterTokenUrl', () => {
+  it('keeps the vendor-specific token path intact', () => {
+    // Unlike the base URL there is no version segment to strip, and the path
+    // genuinely varies: /token, /token/, /oauth/token.
+    expect(normalizeOneRosterTokenUrl('https://jsusdapi.aeries.net/admin/token/')).toBe(
+      'https://jsusdapi.aeries.net/admin/token',
+    );
+    expect(normalizeOneRosterTokenUrl('https://vendor.example.com/oauth/token')).toBe(
+      'https://vendor.example.com/oauth/token',
+    );
+  });
+
+  it('refuses http:// and internal addresses here too', () => {
+    expect(() => normalizeOneRosterTokenUrl('http://jsusdapi.aeries.net/token')).toThrow(/https:\/\//);
+    expect(() => normalizeOneRosterTokenUrl('https://169.254.169.254/token')).toThrow();
+  });
+});
+
+describe('runOneRosterConnectionTest guards both URLs before sending a credential', () => {
+  it('makes NO request when the TOKEN url resolves to a private address', async () => {
+    mockLookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+
+    const report = await runOneRosterConnectionTest({
+      baseUrl: 'https://jsusdapi.aeries.net/admin',
+      tokenUrl: 'https://token.example.com/token',
+      ...CREDS,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.steps[0].message).toMatch(/token address/i);
+    expect(mockFetchToken).not.toHaveBeenCalled();
+  });
+
+  it('makes NO request when only the DATA url resolves privately', async () => {
+    // The one a single-URL guard would miss. The token endpoint is a perfectly
+    // ordinary public host; the data host is the internal one — and the token
+    // request would already have carried the district's secret by the time we
+    // got to it.
+    mockLookup.mockImplementation((host: string) =>
+      host === 'token.example.com'
+        ? Promise.resolve([{ address: '104.16.0.1', family: 4 }])
+        : Promise.resolve([{ address: '10.0.0.5', family: 4 }]),
+    );
+
+    const report = await runOneRosterConnectionTest({
+      baseUrl: 'https://data.example.com/admin',
+      tokenUrl: 'https://token.example.com/token',
+      ...CREDS,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.steps[0].message).toMatch(/OneRoster address/i);
+    expect(mockFetchToken).not.toHaveBeenCalled();
+  });
+
+  it('proceeds when both resolve publicly', async () => {
+    // The other half: a guard that refused everything would pass both tests
+    // above while breaking every real district.
+    mockLookup.mockResolvedValue([{ address: '104.16.0.1', family: 4 }]);
+
+    const report = await runOneRosterConnectionTest({
+      baseUrl: 'https://data.example.com/admin',
+      tokenUrl: 'https://token.example.com/token',
+      ...CREDS,
+    });
+
+    expect(mockFetchToken).toHaveBeenCalled();
+    expect(report.ok).toBe(true);
+  });
+});
+
+describe('toStoredOneRosterTestResult', () => {
+  it('keeps step names and the summary, and drops the counts', () => {
+    const stored = toStoredOneRosterTestResult({
+      ok: false,
+      steps: [
+        { key: 'token', label: 'Sign-in', status: 'ok', message: 'Working.', count: 1 },
+        { key: 'orgs', label: 'Districts and schools', status: 'denied', message: 'no', count: 9 },
+        { key: 'schools', label: 'Schools', status: 'ok', message: 'Working.', count: 42 },
+      ],
+      summary: 'Connected, but 1 of 3 checks need attention.',
+    });
+
+    expect(stored.area).toBe('Districts and schools');
+    expect(stored.message).toMatch(/1 of 3/);
+    // The district's own staff can read this column. How many schools a
+    // district has is not something the connection log needs to remember.
+    expect(JSON.stringify(stored)).not.toContain('42');
+  });
+
+  it('records "all" when everything worked', () => {
+    const stored = toStoredOneRosterTestResult({
+      ok: true,
+      steps: [{ key: 'token', label: 'Sign-in', status: 'ok', message: 'Working.' }],
+      summary: 'Connected. OneRoster is ready.',
+    });
+    expect(stored.area).toBe('all');
+  });
+});

--- a/__tests__/unit/lib/sis/oneroster-setup.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.test.ts
@@ -23,7 +23,7 @@ jest.mock('@/lib/integrations/oneroster', () => {
     OneRosterClient: class {
       fetchToken = (...a: unknown[]) => mockFetchToken(...a);
       getOrgs = (...a: unknown[]) => mockGetOrgs(...a);
-      getSchools = jest.fn().mockResolvedValue([]);
+      getSchools = jest.fn().mockResolvedValue([{ sourcedId: 'school-1' }]);
     },
   };
 });

--- a/__tests__/unit/lib/sis/ssrf-guard.test.ts
+++ b/__tests__/unit/lib/sis/ssrf-guard.test.ts
@@ -13,9 +13,11 @@
  * at it.
  */
 import {
-  assertPublicAeriesHost,
-  assertPublicAeriesHostSyntax,
+  assertPublicSisHost,
+  assertPublicSisHostSyntax,
   isPrivateAddress,
+  AERIES_URL_LABELS as L,
+  ONEROSTER_URL_LABELS,
 } from '@/lib/sis/ssrf-guard';
 
 const mockLookup = jest.fn();
@@ -108,7 +110,7 @@ describe('isPrivateAddress', () => {
   });
 });
 
-describe('assertPublicAeriesHostSyntax', () => {
+describe('assertPublicSisHostSyntax', () => {
   it.each([
     ['127.0.0.1', 'loopback literal'],
     ['10.0.0.5', 'private literal'],
@@ -116,11 +118,11 @@ describe('assertPublicAeriesHostSyntax', () => {
     ['::1', 'IPv6 literal'],
     ['[::1]', 'bracketed IPv6 literal'],
   ])('refuses the IP literal %s (%s)', (host) => {
-    expect(() => assertPublicAeriesHostSyntax(host)).toThrow(/not an IP address/i);
+    expect(() => assertPublicSisHostSyntax(host, L)).toThrow(/not an IP address/i);
   });
 
   it.each(['localhost', 'sub.localhost', 'localhost.'])('refuses %s', (host) => {
-    expect(() => assertPublicAeriesHostSyntax(host)).toThrow(/this server/i);
+    expect(() => assertPublicSisHostSyntax(host, L)).toThrow(/this server/i);
   });
 
   it.each(['localhost.', 'sis.internal.', 'aeries.local.'])(
@@ -129,38 +131,58 @@ describe('assertPublicAeriesHostSyntax', () => {
       // Found by probing the guard rather than reading it: a trailing dot is
       // the fully-qualified form of the same name and resolves identically,
       // but `endsWith('.internal')` and `=== 'localhost'` both miss it.
-      expect(() => assertPublicAeriesHostSyntax(host)).toThrow();
+      expect(() => assertPublicSisHostSyntax(host, L)).toThrow();
     },
   );
 
   it.each(['sis.internal', 'aeries.local', 'server.corp', 'box.lan'])(
     'refuses the internal-only name %s',
     (host) => {
-      expect(() => assertPublicAeriesHostSyntax(host)).toThrow(/inside your network/i);
+      expect(() => assertPublicSisHostSyntax(host, L)).toThrow(/inside your network/i);
     },
   );
 
   it('refuses a single-label intranet shortcut', () => {
-    expect(() => assertPublicAeriesHostSyntax('aeries')).toThrow(/internal shortcut/i);
+    expect(() => assertPublicSisHostSyntax('aeries', L)).toThrow(/internal shortcut/i);
+  });
+
+  // The reason this guard takes labels at all. One audited control serves every
+  // SIS, but a OneRoster district must not be told to check their "Aeries web
+  // address" — the alternative to this parameter was a second copy of the file,
+  // which is the security control most likely to drift out of sync.
+  it('speaks the right product name to a OneRoster district', () => {
+    expect(() => assertPublicSisHostSyntax('127.0.0.1', ONEROSTER_URL_LABELS)).toThrow(
+      /OneRoster web address/i,
+    );
+    expect(() => assertPublicSisHostSyntax('sis.internal', ONEROSTER_URL_LABELS)).toThrow(
+      /so OneRoster needs a publicly reachable address/i,
+    );
+    // Not `.not.toThrow(/Aeries/i)` — that fails, and correctly so: the
+    // OneRoster example address is `yourdistrictapi.aeries.net`, because Aeries
+    // is who hosts OneRoster for these districts. What must not leak is the
+    // PRODUCT name in the instruction, so that is what is asserted.
+    expect(() => assertPublicSisHostSyntax('127.0.0.1', ONEROSTER_URL_LABELS)).not.toThrow(
+      /Aeries web address/i,
+    );
   });
 
   it('accepts a real district hostname', () => {
-    expect(() => assertPublicAeriesHostSyntax('jsusd.aeries.net')).not.toThrow();
-    expect(() => assertPublicAeriesHostSyntax('sis.somedistrict.k12.ca.us')).not.toThrow();
+    expect(() => assertPublicSisHostSyntax('jsusd.aeries.net', L)).not.toThrow();
+    expect(() => assertPublicSisHostSyntax('sis.somedistrict.k12.ca.us', L)).not.toThrow();
   });
 });
 
-describe('assertPublicAeriesHost', () => {
+describe('assertPublicSisHost', () => {
   it('accepts a name that resolves publicly', async () => {
     mockLookup.mockResolvedValue([{ address: '104.16.0.1', family: 4 }]);
-    await expect(assertPublicAeriesHost('demo.aeries.net')).resolves.toBeUndefined();
+    await expect(assertPublicSisHost('demo.aeries.net', L)).resolves.toBeUndefined();
   });
 
   it('refuses a public-looking name that resolves to a private address', async () => {
     // The attack the syntax check alone cannot stop: nothing prevents a
     // district from pointing sis.example.com at 10.0.0.5.
     mockLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
-    await expect(assertPublicAeriesHost('sis.example.com')).rejects.toThrow(/private network/i);
+    await expect(assertPublicSisHost('sis.example.com', L)).rejects.toThrow(/private network/i);
   });
 
   it('refuses when ANY resolved address is private, not just the first', async () => {
@@ -170,21 +192,21 @@ describe('assertPublicAeriesHost', () => {
       { address: '104.16.0.1', family: 4 },
       { address: '192.168.1.10', family: 4 },
     ]);
-    await expect(assertPublicAeriesHost('sis.example.com')).rejects.toThrow(/private network/i);
+    await expect(assertPublicSisHost('sis.example.com', L)).rejects.toThrow(/private network/i);
   });
 
   it('refuses a name that resolves to nothing', async () => {
     mockLookup.mockResolvedValue([]);
-    await expect(assertPublicAeriesHost('sis.example.com')).rejects.toThrow(/private network/i);
+    await expect(assertPublicSisHost('sis.example.com', L)).rejects.toThrow(/private network/i);
   });
 
   it('reports an unresolvable name as a typo, not a security refusal', async () => {
     mockLookup.mockRejectedValue(new Error('ENOTFOUND'));
-    await expect(assertPublicAeriesHost('typo.aeries.net')).rejects.toThrow(/couldn't find/i);
+    await expect(assertPublicSisHost('typo.aeries.net', L)).rejects.toThrow(/couldn't find/i);
   });
 
   it('applies the syntax check before spending a DNS lookup', async () => {
-    await expect(assertPublicAeriesHost('127.0.0.1')).rejects.toThrow(/not an IP address/i);
+    await expect(assertPublicSisHost('127.0.0.1', L)).rejects.toThrow(/not an IP address/i);
     expect(mockLookup).not.toHaveBeenCalled();
   });
 });

--- a/app/(dashboard)/dashboard/tech/page.tsx
+++ b/app/(dashboard)/dashboard/tech/page.tsx
@@ -22,10 +22,12 @@ import AeriesSetupGuide from '../../../components/tech/aeries-setup-guide';
 import AeriesConnectionCard, {
   type ConnectionSummary,
 } from '../../../components/tech/aeries-connection-card';
+import OneRosterSetupGuide from '../../../components/tech/oneroster-setup-guide';
+import OneRosterConnectionCard from '../../../components/tech/oneroster-connection-card';
 
 /** Mirrors the GRANT in 20260806_spe395_district_sis_connections.sql. */
 const CONNECTION_COLUMNS =
-  'id, sis_type, base_url, credential_hint, status, dpa_cleared_at, last_tested_at';
+  'id, sis_type, base_url, token_url, credential_hint, status, dpa_cleared_at, last_tested_at';
 
 interface TechProfile {
   full_name: string | null;
@@ -86,7 +88,32 @@ export default function TechPortalPage() {
   }
 
   const aeries = connections.find((c) => c.sis_type === 'aeries');
+  const oneroster = connections.find((c) => c.sis_type === 'oneroster');
   const districtName = profile?.school_district || 'your district';
+
+  /**
+   * The DPA gate, shared by both connectors. Nothing the district can do about
+   * it from here, so the copy says who moves it forward instead of offering a
+   * dead control.
+   */
+  const dpaGate = (product: string) => (
+    <Card>
+      <CardHeader>
+        <CardTitle>Waiting on your data privacy agreement</CardTitle>
+      </CardHeader>
+      <CardBody>
+        <p className="text-sm text-gray-600">
+          Before {districtName} can share student data with Speddy, your signed data privacy
+          agreement needs to be on file. Your Speddy contact is handling that — they&apos;ll let
+          you know as soon as this page opens up.
+        </p>
+        <p className="mt-4 text-sm text-gray-600">
+          Nothing is needed from you yet. If you want to get a head start, you can ask whoever
+          manages your {product} settings to be ready.
+        </p>
+      </CardBody>
+    </Card>
+  );
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -108,7 +135,7 @@ export default function TechPortalPage() {
         )}
 
         <div className="space-y-6">
-          {!aeries ? (
+          {!aeries && !oneroster && (
             <Card>
               <CardHeader>
                 <CardTitle>No connection yet</CardTitle>
@@ -125,31 +152,50 @@ export default function TechPortalPage() {
                 </p>
               </CardBody>
             </Card>
-          ) : !aeries.dpa_cleared_at ? (
-            // The DPA gate. Nothing they can do about it from here, so the copy
-            // says who moves it forward instead of offering a dead control.
-            <Card>
-              <CardHeader>
-                <CardTitle>Waiting on your data privacy agreement</CardTitle>
-              </CardHeader>
-              <CardBody>
-                <p className="text-sm text-gray-600">
-                  Before {districtName} can share student data with Speddy, your signed data
-                  privacy agreement needs to be on file. Your Speddy contact is handling that —
-                  they&apos;ll let you know as soon as this page opens up.
-                </p>
-                <p className="mt-4 text-sm text-gray-600">
-                  Nothing is needed from you yet. If you want to get a head start, you can ask
-                  whoever manages your Aeries security settings to be ready.
-                </p>
-              </CardBody>
-            </Card>
-          ) : (
-            <>
-              <AeriesConnectionCard connection={aeries} onChanged={load} />
-              <AeriesSetupGuide />
-            </>
           )}
+
+          {aeries &&
+            (!aeries.dpa_cleared_at ? (
+              dpaGate('Aeries security')
+            ) : (
+              <>
+                <AeriesConnectionCard connection={aeries} onChanged={load} />
+                <AeriesSetupGuide />
+              </>
+            ))}
+
+          {oneroster &&
+            (!oneroster.dpa_cleared_at ? (
+              dpaGate('Aeries security')
+            ) : (
+              <>
+                {/*
+                  The limitation, stated where the work happens rather than
+                  buried in a FAQ. A district can complete this whole setup
+                  correctly and still not see the thing Speddy is for, and
+                  finding that out afterwards is how trust gets spent.
+                */}
+                <div className="rounded-md border border-blue-200 bg-blue-50 p-4">
+                  <p className="text-sm font-medium text-blue-900">
+                    What OneRoster can and can&apos;t give us
+                  </p>
+                  <p className="mt-1 text-sm text-blue-800">
+                    OneRoster shares your students, staff, schools and class rosters. It does not
+                    carry special education information — there is no IEP flag, no program
+                    membership and no eligibility date anywhere in the standard. That isn&apos;t a
+                    setting we can ask you to turn on; it simply isn&apos;t part of OneRoster.
+                  </p>
+                  <p className="mt-2 text-sm text-blue-800">
+                    So your team will still identify their own caseloads in Speddy. This
+                    connection saves them from typing student and teacher names, and keeps those
+                    lists current. If you want Speddy to see special education records directly,
+                    that needs the Aeries connection instead — your Speddy contact can set it up.
+                  </p>
+                </div>
+                <OneRosterConnectionCard connection={oneroster} onChanged={load} />
+                <OneRosterSetupGuide />
+              </>
+            ))}
 
           <Card>
             <CardHeader>
@@ -163,14 +209,14 @@ export default function TechPortalPage() {
                 </li>
                 <li>
                   <span className="font-medium text-gray-900">
-                    Your certificate is encrypted and never shown again.
+                    Whatever you paste in is encrypted and never shown again.
                   </span>{' '}
                   Not to us in a support screen, and not back to you here — only its last four
                   characters.
                 </li>
                 <li>
                   <span className="font-medium text-gray-900">
-                    We check each area separately.
+                    We check each piece separately.
                   </span>{' '}
                   If something isn&apos;t granted, we tell you exactly which box to tick in
                   Aeries rather than just saying it failed.

--- a/app/(dashboard)/dashboard/tech/page.tsx
+++ b/app/(dashboard)/dashboard/tech/page.tsx
@@ -17,6 +17,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
+import { BROWSER_CONNECTION_COLUMNS } from '@/lib/sis/connection-columns';
 import { Card, CardHeader, CardTitle, CardBody } from '../../../components/ui/card';
 import AeriesSetupGuide from '../../../components/tech/aeries-setup-guide';
 import AeriesConnectionCard, {
@@ -25,9 +26,10 @@ import AeriesConnectionCard, {
 import OneRosterSetupGuide from '../../../components/tech/oneroster-setup-guide';
 import OneRosterConnectionCard from '../../../components/tech/oneroster-connection-card';
 
-/** Mirrors the GRANT in 20260806_spe395_district_sis_connections.sql. */
-const CONNECTION_COLUMNS =
-  'id, sis_type, base_url, token_url, credential_hint, status, dpa_cleared_at, last_tested_at';
+// Shared with scripts/sim-district/verify-sis-connections-rls.ts, so the
+// verification cannot silently check a different column list than the one this
+// page actually sends.
+const CONNECTION_COLUMNS = BROWSER_CONNECTION_COLUMNS;
 
 interface TechProfile {
   full_name: string | null;

--- a/app/(dashboard)/dashboard/tech/page.tsx
+++ b/app/(dashboard)/dashboard/tech/page.tsx
@@ -168,7 +168,7 @@ export default function TechPortalPage() {
 
           {oneroster &&
             (!oneroster.dpa_cleared_at ? (
-              dpaGate('Aeries security')
+              dpaGate('OneRoster')
             ) : (
               <>
                 {/*

--- a/app/api/tech/sis/oneroster/route.ts
+++ b/app/api/tech/sis/oneroster/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withRoute } from '@/lib/api/with-route';
+import { resolveDistrictSisCaller } from '@/lib/api/district-sis-caller';
+import { logger } from '@/lib/logger';
+import { listConnections, storeCredential } from '@/lib/sis/connections';
+import {
+  normalizeOneRosterBaseUrl,
+  normalizeOneRosterTokenUrl,
+} from '@/lib/sis/oneroster-setup';
+
+const log = logger.child({ module: 'tech-sis-oneroster' });
+
+/**
+ * POST /api/tech/sis/oneroster — a district submits its OneRoster credentials.
+ *
+ * The Aeries sibling of this route (`../aeries/route.ts`) carries the same three
+ * guarantees, and they hold here for the same reasons: the district comes from
+ * the caller's own grants and never the request body; both secrets are
+ * encrypted before reaching the database and are never echoed back; and the DPA
+ * gate is enforced beneath this in `storeCredential` and again by a CHECK
+ * constraint, so this route cannot bypass it even by mistake.
+ *
+ * WHAT IS DIFFERENT: two credentials and two URLs instead of one of each. The
+ * shape of the validation below is deliberately loose on the credentials — see
+ * the note on the schema.
+ */
+export const POST = withRoute(
+  {
+    body: z.object({
+      baseUrl: z.string().min(1, 'Enter your OneRoster address'),
+      tokenUrl: z.string().min(1, 'Enter your OneRoster token address'),
+      // No format regex on either credential, unlike the Aeries certificate's
+      // 32-character shape. OneRoster consumer IDs and secrets have no length
+      // or character set defined by the standard, and they differ per vendor —
+      // there is no shape to check that would not eventually lock out a
+      // legitimate district. A wrong value fails the connection test in one
+      // click with a specific message, which is the cheaper failure.
+      clientId: z.string().trim().min(1, 'Enter the Consumer ID'),
+      clientSecret: z.string().trim().min(1, 'Enter the Consumer Secret Key'),
+    }),
+    rateLimit: { requests: 10, windowSeconds: 60, name: 'tech-sis-oneroster-store' },
+  },
+  async ({ userId, body }) => {
+    const caller = await resolveDistrictSisCaller(userId);
+    if (!caller.ok) {
+      log.warn('Non-district-tech tried to store a OneRoster credential', {
+        userId,
+        denied: caller.denied,
+      });
+      return NextResponse.json(
+        { error: 'Forbidden: district tech admin access required' },
+        { status: 403 },
+      );
+    }
+
+    let baseUrl: string;
+    let tokenUrl: string;
+    try {
+      baseUrl = normalizeOneRosterBaseUrl(body.baseUrl);
+      tokenUrl = normalizeOneRosterTokenUrl(body.tokenUrl);
+    } catch (err) {
+      // Written for the district administrator and containing nothing
+      // sensitive — passing them through is the point.
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : 'That OneRoster address is not valid.' },
+        { status: 400 },
+      );
+    }
+
+    // Wrapped rather than left to the route wrapper: withRoute's catch echoes
+    // error.message to the client when NODE_ENV=development, and a Supabase
+    // error names tables and constraints.
+    let connections;
+    try {
+      connections = await listConnections(caller.districtId);
+    } catch (err) {
+      log.error('Failed to load SIS connections', err, { districtId: caller.districtId });
+      return NextResponse.json({ error: 'Could not load your connection.' }, { status: 500 });
+    }
+
+    const connection = connections.find((c) => c.sis_type === 'oneroster');
+    if (!connection) {
+      return NextResponse.json(
+        {
+          error:
+            'OneRoster setup has not been opened for your district yet. Your Speddy contact will enable it.',
+        },
+        { status: 409 },
+      );
+    }
+    if (!connection.dpa_cleared_at) {
+      return NextResponse.json(
+        {
+          error:
+            "Your district's data privacy agreement is not on file yet. Your Speddy contact will let you know when setup can begin.",
+        },
+        { status: 409 },
+      );
+    }
+
+    try {
+      const updated = await storeCredential({
+        connectionId: connection.id,
+        actorId: userId,
+        baseUrl,
+        tokenUrl,
+        clientId: body.clientId,
+        clientSecret: body.clientSecret,
+      });
+      log.info('OneRoster credentials stored', {
+        districtId: caller.districtId,
+        connectionId: connection.id,
+      });
+      return NextResponse.json({ connection: updated });
+    } catch (err) {
+      log.error('Failed to store OneRoster credentials', err, {
+        districtId: caller.districtId,
+      });
+      // Fixed message: the underlying error can name constraints and columns.
+      return NextResponse.json({ error: 'Could not save the credentials.' }, { status: 500 });
+    }
+  },
+);

--- a/app/api/tech/sis/oneroster/test/route.ts
+++ b/app/api/tech/sis/oneroster/test/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from 'next/server';
+import { withRoute } from '@/lib/api/with-route';
+import { resolveDistrictSisCaller } from '@/lib/api/district-sis-caller';
+import { logger } from '@/lib/logger';
+import {
+  getDecryptedCredential,
+  listConnections,
+  recordTestResult,
+} from '@/lib/sis/connections';
+import {
+  runOneRosterConnectionTest,
+  toStoredOneRosterTestResult,
+} from '@/lib/sis/oneroster-setup';
+
+const log = logger.child({ module: 'tech-sis-oneroster-test' });
+
+/**
+ * POST /api/tech/sis/oneroster/test — check the stored credentials, step by step.
+ *
+ * The OneRoster counterpart to the Aeries test route, and the same idea: rather
+ * than "it didn't work", the district gets the exact step that failed. Here the
+ * steps are sign-in, then orgs, then schools — and the distinction that earns
+ * its keep is sign-in versus everything after it, because a sign-in failure
+ * almost always means the certificate was pasted where the Consumer ID and
+ * Secret belong.
+ *
+ * Both decrypted secrets exist only inside this request. They are fetched, used
+ * for the exchange, and dropped; the response carries diagnostics only, and what
+ * is persisted is narrower still (`toStoredOneRosterTestResult` drops counts).
+ *
+ * Rate-limited harder than the credential write: each call reaches out to the
+ * district's own SIS several times.
+ */
+export const POST = withRoute(
+  { rateLimit: { requests: 6, windowSeconds: 60, name: 'tech-sis-oneroster-test' } },
+  async ({ userId }) => {
+    const caller = await resolveDistrictSisCaller(userId);
+    if (!caller.ok) {
+      log.warn('Non-district-tech tried to test a OneRoster connection', {
+        userId,
+        denied: caller.denied,
+      });
+      return NextResponse.json(
+        { error: 'Forbidden: district tech admin access required' },
+        { status: 403 },
+      );
+    }
+
+    const connections = await listConnections(caller.districtId);
+    const connection = connections.find((c) => c.sis_type === 'oneroster');
+    if (!connection) {
+      return NextResponse.json({ error: 'No OneRoster connection to test.' }, { status: 404 });
+    }
+
+    // Decryption throws when the ciphertext can't be opened — most plausibly
+    // after an encryption-key rotation. That reads to the district exactly like
+    // "no credentials stored", and the fix is the same, so say so rather than
+    // returning a 500 they can do nothing with.
+    let credential: Awaited<ReturnType<typeof getDecryptedCredential>> = null;
+    try {
+      credential = await getDecryptedCredential(connection.id);
+    } catch (err) {
+      log.error('Could not decrypt the stored OneRoster credentials', err, {
+        connectionId: connection.id,
+      });
+    }
+    if (!credential || credential.sisType !== 'oneroster') {
+      // Not an error state: a connection can legitimately exist with no
+      // credentials yet. Say what to do rather than reporting a failure.
+      return NextResponse.json(
+        { error: 'Enter your Consumer ID and Secret Key first, then run the test.' },
+        { status: 409 },
+      );
+    }
+    if (!connection.base_url || !connection.token_url) {
+      // Both are required, and which one is missing changes nothing the district
+      // would do differently — they re-enter the pair either way.
+      return NextResponse.json(
+        {
+          error:
+            'This connection is missing its OneRoster or token address. Re-enter them and save again.',
+        },
+        { status: 409 },
+      );
+    }
+
+    const report = await runOneRosterConnectionTest({
+      baseUrl: connection.base_url,
+      tokenUrl: connection.token_url,
+      clientId: credential.clientId,
+      clientSecret: credential.clientSecret,
+    });
+
+    try {
+      await recordTestResult({
+        connectionId: connection.id,
+        actorId: userId,
+        ok: report.ok,
+        result: toStoredOneRosterTestResult(report),
+      });
+    } catch (err) {
+      // The exchange already ran. Turning a bookkeeping failure into a 500 would
+      // hide a completed report AND invite the district to run it again, sending
+      // more requests at their SIS to learn what we already know.
+      log.error('Failed to record OneRoster test result', err, {
+        connectionId: connection.id,
+      });
+    }
+
+    log.info('OneRoster connection tested', {
+      districtId: caller.districtId,
+      connectionId: connection.id,
+      ok: report.ok,
+    });
+
+    return NextResponse.json({ report });
+  },
+);

--- a/app/api/tech/sis/oneroster/test/route.ts
+++ b/app/api/tech/sis/oneroster/test/route.ts
@@ -46,7 +46,16 @@ export const POST = withRoute(
       );
     }
 
-    const connections = await listConnections(caller.districtId);
+    // Wrapped for the same reason the write route wraps it: withRoute's catch
+    // echoes error.message to the client when NODE_ENV=development, and a
+    // Supabase error names tables and constraints.
+    let connections;
+    try {
+      connections = await listConnections(caller.districtId);
+    } catch (err) {
+      log.error('Failed to load SIS connections', err, { districtId: caller.districtId });
+      return NextResponse.json({ error: 'Could not load your connection.' }, { status: 500 });
+    }
     const connection = connections.find((c) => c.sis_type === 'oneroster');
     if (!connection) {
       return NextResponse.json({ error: 'No OneRoster connection to test.' }, { status: 404 });

--- a/app/components/tech/aeries-connection-card.tsx
+++ b/app/components/tech/aeries-connection-card.tsx
@@ -13,21 +13,11 @@ import type { AeriesAreaResult, AeriesTestReport } from '@/lib/sis/aeries-setup'
  * one — there is no "reveal", and there is nothing to reveal.
  */
 
-/**
- * The non-secret columns a browser session may read (SPE-395's GRANT). Shared
- * with the OneRoster card — `token_url` is null for Aeries and carries the
- * OAuth2 endpoint for OneRoster.
- */
-export interface ConnectionSummary {
-  id: string;
-  sis_type: string;
-  base_url: string | null;
-  token_url: string | null;
-  credential_hint: string | null;
-  status: string;
-  dpa_cleared_at: string | null;
-  last_tested_at: string | null;
-}
+// Defined beside BROWSER_CONNECTION_COLUMNS, the column list it mirrors, so a
+// column change and the field change it implies happen in one file. Re-exported
+// here because the page and the OneRoster card already import it from this one.
+export type { ConnectionSummary } from '@/lib/sis/connection-columns';
+import type { ConnectionSummary } from '@/lib/sis/connection-columns';
 
 // 'untested' is deliberately neutral. Those areas were never probed, and
 // colouring them red would send a district off to fix checkboxes that may well

--- a/app/components/tech/aeries-connection-card.tsx
+++ b/app/components/tech/aeries-connection-card.tsx
@@ -13,10 +13,16 @@ import type { AeriesAreaResult, AeriesTestReport } from '@/lib/sis/aeries-setup'
  * one — there is no "reveal", and there is nothing to reveal.
  */
 
+/**
+ * The non-secret columns a browser session may read (SPE-395's GRANT). Shared
+ * with the OneRoster card — `token_url` is null for Aeries and carries the
+ * OAuth2 endpoint for OneRoster.
+ */
 export interface ConnectionSummary {
   id: string;
   sis_type: string;
   base_url: string | null;
+  token_url: string | null;
   credential_hint: string | null;
   status: string;
   dpa_cleared_at: string | null;

--- a/app/components/tech/oneroster-connection-card.tsx
+++ b/app/components/tech/oneroster-connection-card.tsx
@@ -1,0 +1,281 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardHeader, CardTitle, CardBody } from '../ui/card';
+import type { OneRosterStepResult, OneRosterTestReport } from '@/lib/sis/oneroster-setup';
+import type { ConnectionSummary } from './aeries-connection-card';
+
+/**
+ * OneRoster credential entry and the step-by-step test result (SPE-397).
+ *
+ * Four fields rather than two, and the pairing is the part districts get wrong:
+ * the token address goes with the OneRoster address, and the Consumer ID goes
+ * with the Secret Key. The Secret is the only masked field — the Consumer ID is
+ * an identifier, not a secret, and masking it would just make it harder to check
+ * a paste against the Aeries screen.
+ *
+ * Like the Aeries card, the Secret is write-only: once stored, all this screen
+ * can say is the last four characters, because that is all the server will ever
+ * return (SPE-395's column grants).
+ */
+
+const STEP_STYLES: Record<OneRosterStepResult['status'], string> = {
+  ok: 'border-emerald-200 bg-emerald-50',
+  denied: 'border-amber-200 bg-amber-50',
+  error: 'border-red-200 bg-red-50',
+  untested: 'border-gray-200 bg-gray-50',
+};
+
+const STEP_MARK: Record<OneRosterStepResult['status'], string> = {
+  ok: 'text-emerald-600',
+  denied: 'text-amber-600',
+  error: 'text-red-600',
+  untested: 'text-gray-400',
+};
+
+const STEP_GLYPH: Record<OneRosterStepResult['status'], string> = {
+  ok: '✓',
+  denied: '!',
+  error: '!',
+  untested: '–',
+};
+
+function StepRow({ step }: { step: OneRosterStepResult }) {
+  return (
+    <li className={`rounded-md border p-3 ${STEP_STYLES[step.status]}`}>
+      <div className="flex items-start gap-2">
+        <span className={`mt-0.5 text-sm font-bold ${STEP_MARK[step.status]}`}>
+          {STEP_GLYPH[step.status]}
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-gray-900">{step.label}</p>
+          <p className="mt-0.5 text-sm text-gray-700">{step.message}</p>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export default function OneRosterConnectionCard({
+  connection,
+  onChanged,
+}: {
+  connection: ConnectionSummary;
+  onChanged: () => void | Promise<void>;
+}) {
+  const [baseUrl, setBaseUrl] = useState(connection.base_url ?? '');
+  const [tokenUrl, setTokenUrl] = useState(connection.token_url ?? '');
+  const [clientId, setClientId] = useState('');
+  const [clientSecret, setClientSecret] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [report, setReport] = useState<OneRosterTestReport | null>(null);
+
+  const hasCredential = Boolean(connection.credential_hint);
+  const canSave =
+    baseUrl.trim() && tokenUrl.trim() && clientId.trim() && clientSecret.trim();
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    setReport(null);
+    try {
+      const res = await fetch('/api/tech/sis/oneroster', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ baseUrl, tokenUrl, clientId, clientSecret }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || 'Could not save the credentials.');
+      // Clear both from component state the moment they are stored. They are
+      // already unrecoverable from the server; there is no reason to keep the
+      // plaintext sitting in the page.
+      setClientId('');
+      setClientSecret('');
+      await onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save the credentials.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const test = async () => {
+    setTesting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/tech/sis/oneroster/test', { method: 'POST' });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || 'Could not test the connection.');
+      setReport(json.report as OneRosterTestReport);
+      await onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not test the connection.');
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          {hasCredential ? 'Your OneRoster connection' : 'Enter your OneRoster details'}
+        </CardTitle>
+      </CardHeader>
+      <CardBody>
+        {error && (
+          <div
+            role="alert"
+            className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="oneroster-url" className="block text-sm font-medium text-gray-900">
+              Your OneRoster address
+            </label>
+            <input
+              id="oneroster-url"
+              type="text"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              placeholder="https://yourdistrictapi.aeries.net/admin"
+              autoComplete="off"
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+            <p className="mt-1 text-xs text-gray-500">
+              Note this is usually a different address from the one you sign in to Aeries with —
+              it often has <span className="font-mono">api</span> in it.
+            </p>
+          </div>
+
+          <div>
+            <label htmlFor="oneroster-token-url" className="block text-sm font-medium text-gray-900">
+              Your token address
+            </label>
+            <input
+              id="oneroster-token-url"
+              type="text"
+              value={tokenUrl}
+              onChange={(e) => setTokenUrl(e.target.value)}
+              placeholder="https://yourdistrictapi.aeries.net/admin/token/"
+              autoComplete="off"
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+            <p className="mt-1 text-xs text-gray-500">
+              Usually the same address as above with <span className="font-mono">/token/</span> on
+              the end.
+            </p>
+          </div>
+
+          <div>
+            <label htmlFor="oneroster-client-id" className="block text-sm font-medium text-gray-900">
+              Consumer ID
+            </label>
+            <input
+              id="oneroster-client-id"
+              // Not masked: this is an identifier, not a secret, and hiding it
+              // only makes it harder to check a paste against the Aeries screen.
+              type="text"
+              value={clientId}
+              onChange={(e) => setClientId(e.target.value)}
+              placeholder={hasCredential ? 'Enter both again to replace the saved pair' : ''}
+              autoComplete="off"
+              spellCheck={false}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="oneroster-client-secret"
+              className="block text-sm font-medium text-gray-900"
+            >
+              Consumer Secret Key
+            </label>
+            <input
+              id="oneroster-client-secret"
+              // `password` so it is masked, excluded from autofill, and not read
+              // aloud by screen readers in the clear.
+              type="password"
+              value={clientSecret}
+              onChange={(e) => setClientSecret(e.target.value)}
+              autoComplete="off"
+              spellCheck={false}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+            {hasCredential ? (
+              <p className="mt-1 text-xs text-gray-500">
+                A secret key ending{' '}
+                <span className="font-mono">{connection.credential_hint?.slice(-4)}</span> is
+                saved. It can&apos;t be shown again — leave these blank unless you&apos;re
+                replacing them.
+              </p>
+            ) : (
+              <p className="mt-1 text-xs text-gray-500">
+                Both come from{' '}
+                <span className="font-medium">Display Consumer ID &amp; Secret Keys</span> in
+                Aeries — <span className="font-medium">not</span> the certificate. The secret is
+                stored encrypted and never shown again.
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-center gap-3 border-t border-gray-200 pt-4">
+          <button
+            type="button"
+            onClick={save}
+            disabled={saving || !canSave}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : hasCredential ? 'Replace credentials' : 'Save and continue'}
+          </button>
+
+          {hasCredential && (
+            <button
+              type="button"
+              onClick={test}
+              disabled={testing}
+              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
+            >
+              {testing ? 'Checking…' : 'Test connection'}
+            </button>
+          )}
+
+          {connection.last_tested_at && !report && (
+            <span className="text-xs text-gray-500">
+              Last checked {new Date(connection.last_tested_at).toLocaleString()}
+            </span>
+          )}
+        </div>
+
+        {report && (
+          <div role="status" aria-live="polite" className="mt-6 border-t border-gray-200 pt-5">
+            <p
+              className={`text-sm font-medium ${report.ok ? 'text-emerald-700' : 'text-amber-700'}`}
+            >
+              {report.summary}
+            </p>
+            <ul className="mt-3 space-y-2">
+              {report.steps.map((s) => (
+                <StepRow key={s.key} step={s} />
+              ))}
+            </ul>
+            {!report.ok && (
+              <p className="mt-4 text-xs text-gray-600">
+                Fix the steps above, then run the test again. Nothing needs to be re-entered here
+                unless you&apos;re changing a credential.
+              </p>
+            )}
+          </div>
+        )}
+      </CardBody>
+    </Card>
+  );
+}

--- a/app/components/tech/oneroster-connection-card.tsx
+++ b/app/components/tech/oneroster-connection-card.tsx
@@ -77,6 +77,10 @@ export default function OneRosterConnectionCard({
     baseUrl.trim() && tokenUrl.trim() && clientId.trim() && clientSecret.trim();
 
   const save = async () => {
+    // setSaving(true) does not disable the button until the next render, so a
+    // double click inside one tick starts two writes. Each test run reaches the
+    // district's own SIS and writes an audit row.
+    if (saving) return;
     setSaving(true);
     setError(null);
     setReport(null);
@@ -102,6 +106,7 @@ export default function OneRosterConnectionCard({
   };
 
   const test = async () => {
+    if (testing) return;
     setTesting(true);
     setError(null);
     try {

--- a/app/components/tech/oneroster-setup-guide.tsx
+++ b/app/components/tech/oneroster-setup-guide.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Card, CardHeader, CardTitle, CardBody } from '../ui/card';
+
+/**
+ * The district-side instructions for issuing Speddy OneRoster credentials
+ * (SPE-397).
+ *
+ * Two warnings here are not decoration — they are the two things that stall a
+ * OneRoster setup for days, and both are called out by name in the ticket:
+ *
+ *  1. **Aeries Support must be involved first.** An Aeries-hosted district's
+ *     FIRST OneRoster connection needs certificate verification and an app-pool
+ *     recycle on Aeries' side. A district that doesn't know this will tick every
+ *     box correctly and still get nothing, with no error explaining why. Said up
+ *     front, before the steps, because it has a lead time.
+ *
+ *  2. **OneRoster uses the Consumer ID and Secret, NOT the certificate.** Same
+ *     admin page, adjacent fields, completely different credential. This is the
+ *     single most common wrong paste, and the connection test names it too — but
+ *     it is cheaper to prevent here than to diagnose there.
+ */
+
+export const ONEROSTER_STEPS = [
+  {
+    title: 'Turn OneRoster on',
+    detail: 'District-level School Options → OneRoster Settings → Enable.',
+  },
+  {
+    title: 'Add Speddy as a vendor',
+    detail: 'Security → API Security → Add New Record, with Product Name "Speddy".',
+  },
+  {
+    title: 'Tick the OneRoster box',
+    detail: 'On that same record, tick OneRoster.',
+  },
+  {
+    title: 'Copy the Consumer ID and Secret Key',
+    detail: 'Click "Display Consumer ID & Secret Keys" and copy both.',
+  },
+] as const;
+
+const COPYABLE = [
+  'Aeries OneRoster setup for Speddy',
+  '',
+  'BEFORE STARTING: if this is the district\'s first OneRoster connection and',
+  'Aeries hosts us, contact Aeries Support first. They need to verify the',
+  'certificate and recycle the app pool, and nothing works until they have.',
+  '',
+  ...ONEROSTER_STEPS.map((s, i) => `${i + 1}. ${s.title}\n   ${s.detail}`),
+  '',
+  'IMPORTANT: OneRoster uses the Consumer ID and Consumer Secret Key, NOT the',
+  'certificate. They are on the same page, right next to each other.',
+  '',
+  'Speddy only ever reads. We never write anything back to Aeries.',
+].join('\n');
+
+export default function OneRosterSetupGuide() {
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear any pending reset on unmount, and before scheduling a new one: two
+  // clicks inside the reset window would otherwise have the first timer wipe
+  // the second confirmation.
+  useEffect(() => () => {
+    if (resetTimer.current) clearTimeout(resetTimer.current);
+  }, []);
+
+  const copy = async () => {
+    if (resetTimer.current) clearTimeout(resetTimer.current);
+    try {
+      await navigator.clipboard.writeText(COPYABLE);
+      setCopyState('copied');
+    } catch {
+      // Clipboard access can be denied by permissions policy. Say so — the
+      // silent version leaves the button reading "Copy these steps" and the
+      // user believing it worked. The steps are all on screen either way.
+      setCopyState('failed');
+    }
+    resetTimer.current = setTimeout(() => setCopyState('idle'), 2500);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>How to create your OneRoster credentials</CardTitle>
+      </CardHeader>
+      <CardBody>
+        <div className="rounded-md border border-amber-200 bg-amber-50 p-4">
+          <p className="text-sm font-medium text-amber-900">
+            Start here if this is your first OneRoster connection
+          </p>
+          <p className="mt-1 text-sm text-amber-800">
+            If Aeries hosts your district, contact Aeries Support before you begin. Your first
+            OneRoster connection needs them to verify the certificate and recycle the app pool on
+            their side. Everything below will look correct and still return nothing until they
+            have done that — so it is worth starting that request now.
+          </p>
+        </div>
+
+        <p className="mt-5 text-sm text-gray-600">
+          You&apos;ll do this inside Aeries, not here. If someone else manages your Aeries security
+          settings, send them these steps.
+        </p>
+
+        <ol className="mt-5 space-y-4 text-sm text-gray-700">
+          {ONEROSTER_STEPS.map((step, i) => (
+            <li key={step.title} className="flex gap-3">
+              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-blue-100 text-xs font-semibold text-blue-700">
+                {i + 1}
+              </span>
+              <span>
+                <span className="font-medium text-gray-900">{step.title}.</span> {step.detail}
+              </span>
+            </li>
+          ))}
+        </ol>
+
+        <div className="mt-5 rounded-md border border-amber-200 bg-amber-50 p-4">
+          <p className="text-sm font-medium text-amber-900">
+            The one that catches nearly everyone
+          </p>
+          <p className="mt-1 text-sm text-amber-800">
+            OneRoster uses the <span className="font-medium">Consumer ID</span> and{' '}
+            <span className="font-medium">Consumer Secret Key</span> — not the certificate. All
+            three sit on the same page, right next to each other. If you paste the certificate,
+            the connection test will tell you so, but it saves a round trip to know now.
+          </p>
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-center gap-3 border-t border-gray-200 pt-4">
+          <button
+            type="button"
+            onClick={copy}
+            className="rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200"
+          >
+            {copyState === 'copied' ? 'Copied' : 'Copy these steps'}
+          </button>
+          <span role="status" aria-live="polite" className="text-xs text-gray-500">
+            {copyState === 'copied'
+              ? 'Steps copied.'
+              : copyState === 'failed'
+                ? 'Copy failed — select the steps above and copy them manually.'
+                : 'Sending this to whoever manages Aeries security? Copy the steps and paste them into an email.'}
+          </span>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -1,0 +1,258 @@
+/**
+ * OneRoster v1.1 — server-only REST client (SPE-397).
+ *
+ * Two-step auth, which is the whole reason this client exists separately from
+ * the Aeries one: POST the client credentials to the token endpoint, get a
+ * bearer token, then send that token on the data requests. Aeries' native API
+ * is a single header on every call.
+ *
+ * That split is not just plumbing — it is the diagnostic. "Your credentials are
+ * wrong" and "your credentials are fine but this data isn't shared" arrive at
+ * different steps, and a district can only act on the difference if we keep
+ * them apart. `OneRosterApiError.phase` carries it.
+ *
+ * SECRETS. Three things here must never leave the server or reach a log: the
+ * client secret, the bearer token, and any response body (OneRoster error
+ * bodies can echo the request). Every log call in this file is status + path +
+ * phase, and there is no branch that widens that.
+ *
+ * Auth layering note (SPE-397 asks for this explicitly): the token request is
+ * isolated in `fetchToken` so that OneRoster 1.2's scoped client-credentials
+ * flow can be added beside it later without touching the request path. 1.2 is
+ * NOT implemented here.
+ */
+
+import { logger } from '@/lib/logger';
+import {
+  ONEROSTER_API_PATH,
+  ONEROSTER_SCOPE,
+  type OneRosterConnectionConfig,
+} from './config';
+import type {
+  OneRosterTokenResponse,
+  RawOneRosterOrg,
+  RawOneRosterSchool,
+} from './types';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** Which half of the exchange failed. The district-facing advice differs entirely. */
+export type OneRosterPhase = 'token' | 'request';
+
+/** Raised on a non-2xx from either the token endpoint or a data endpoint. */
+export class OneRosterApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly path: string,
+    readonly phase: OneRosterPhase,
+  ) {
+    super(message);
+    this.name = 'OneRosterApiError';
+  }
+}
+
+export interface OneRosterRequestOptions {
+  /** 1-based pagination (`limit`/`offset` in OneRoster's vocabulary). */
+  limit?: number;
+  offset?: number;
+  /** Extra query params passed through verbatim. */
+  query?: Record<string, string | number>;
+  /** Per-request timeout in ms (default 30s). */
+  timeoutMs?: number;
+}
+
+export class OneRosterClient {
+  private readonly config: OneRosterConnectionConfig;
+  /** Cached for the lifetime of this client instance only — never persisted. */
+  private token: string | null = null;
+
+  constructor(config: OneRosterConnectionConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Exchange the consumer ID and secret for a bearer token.
+   *
+   * Credentials go in the Authorization header via HTTP Basic, not in the body.
+   * Both are permitted by RFC 6749, but a body parameter is far more likely to
+   * be captured by an intermediary's request logging, and this is a district's
+   * long-lived SIS credential rather than a short-lived token.
+   */
+  async fetchToken(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<string> {
+    if (this.token) return this.token;
+
+    const basic = Buffer.from(
+      `${this.config.clientId}:${this.config.clientSecret}`,
+    ).toString('base64');
+
+    const body = new URLSearchParams({
+      grant_type: 'client_credentials',
+      scope: ONEROSTER_SCOPE,
+    });
+
+    const res = await this.dial(
+      this.config.tokenUrl,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${basic}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+        },
+        body: body.toString(),
+      },
+      'token',
+      timeoutMs,
+      'token endpoint',
+    );
+
+    let parsed: OneRosterTokenResponse;
+    try {
+      parsed = (await res.json()) as OneRosterTokenResponse;
+    } catch {
+      throw new OneRosterApiError(
+        'The token endpoint did not return JSON.',
+        502,
+        'token endpoint',
+        'token',
+      );
+    }
+
+    if (!parsed?.access_token) {
+      // A 200 with no token is a real OneRoster failure mode, and reporting it
+      // as a network problem would send the district looking at their firewall.
+      throw new OneRosterApiError(
+        'The token endpoint answered but returned no access token.',
+        502,
+        'token endpoint',
+        'token',
+      );
+    }
+
+    this.token = parsed.access_token;
+    return this.token;
+  }
+
+  /** GET a OneRoster collection, fetching a token first if needed. */
+  async get<T>(path: string, options: OneRosterRequestOptions = {}): Promise<T> {
+    const token = await this.fetchToken(options.timeoutMs);
+    const url = this.buildUrl(path, options);
+
+    const res = await this.dial(
+      url,
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
+      },
+      'request',
+      options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      path,
+    );
+
+    try {
+      return (await res.json()) as T;
+    } catch {
+      throw new OneRosterApiError(
+        `${path} answered but did not return JSON.`,
+        502,
+        path,
+        'request',
+      );
+    }
+  }
+
+  // -- Typed endpoint helpers -------------------------------------------------
+
+  /** `GET /orgs` — districts and schools. The first call that needs real access. */
+  async getOrgs(options?: OneRosterRequestOptions): Promise<RawOneRosterOrg[]> {
+    const body = await this.get<{ orgs?: RawOneRosterOrg[] }>('orgs', options);
+    return body?.orgs ?? [];
+  }
+
+  /** `GET /schools` — orgs already filtered to schools. */
+  async getSchools(options?: OneRosterRequestOptions): Promise<RawOneRosterSchool[]> {
+    const body = await this.get<{ orgs?: RawOneRosterSchool[] }>('schools', options);
+    return body?.orgs ?? [];
+  }
+
+  // -- Internal ---------------------------------------------------------------
+
+  /**
+   * The one place a request actually leaves this process, so the transport
+   * policy is stated once and cannot drift between the token call and the data
+   * calls — which is exactly how a hardened request path grows a soft spot.
+   */
+  private async dial(
+    url: string,
+    init: RequestInit,
+    phase: OneRosterPhase,
+    timeoutMs: number,
+    path: string,
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const res = await fetch(url, {
+        ...init,
+        signal: controller.signal,
+        // Never cache: tokens are credentials and roster data is student PII.
+        cache: 'no-store',
+        // Refuse redirects outright, same reasoning as the Aeries client
+        // (SPE-396): the base and token URLs are district-supplied and checked
+        // against private-network ranges before we dial them, but that check
+        // covers the host WE resolve. Following a 302 hands the destination
+        // back to the remote server, which would let a public host bounce a
+        // request carrying the district's OneRoster secret into an internal
+        // address and defeat the guard entirely.
+        redirect: 'error',
+      });
+
+      if (!res.ok) {
+        // Status and path only. A OneRoster error body can echo the submitted
+        // credentials, so it is never logged and never surfaced.
+        logger.error('OneRoster API request failed', {
+          status: res.status,
+          path,
+          phase,
+        });
+        throw new OneRosterApiError(
+          `OneRoster responded ${res.status} for ${path}`,
+          res.status,
+          path,
+          phase,
+        );
+      }
+
+      return res;
+    } catch (err) {
+      if (err instanceof OneRosterApiError) throw err;
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new OneRosterApiError(
+          `OneRoster request timed out after ${timeoutMs}ms for ${path}`,
+          408,
+          path,
+          phase,
+        );
+      }
+      logger.error('OneRoster API request error', err, { path, phase });
+      throw err;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private buildUrl(path: string, options: OneRosterRequestOptions): string {
+    const cleanPath = path.replace(/^\/+/, '');
+    const url = new URL(`${this.config.baseUrl}${ONEROSTER_API_PATH}/${cleanPath}`);
+
+    if (options.limit != null) url.searchParams.set('limit', String(options.limit));
+    if (options.offset != null) url.searchParams.set('offset', String(options.offset));
+    for (const [key, value] of Object.entries(options.query ?? {})) {
+      url.searchParams.set(key, String(value));
+    }
+
+    return url.toString();
+  }
+}

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -37,15 +37,20 @@ import type {
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 /**
- * `application/x-www-form-urlencoded` per RFC 6749 Appendix B.
+ * `application/x-www-form-urlencoded`, per RFC 6749 §2.3.1 / Appendix B.
  *
- * `encodeURIComponent` alone is not quite it: form encoding writes a space as
- * `+` rather than `%20`. The difference only shows up in a credential that
- * contains a space, which is pathological — but the whole point of encoding
- * here is to be correct for the credentials we cannot predict.
+ * Delegated to `URLSearchParams` rather than hand-rolled. The first version was
+ * `encodeURIComponent(v).replace(/%20/g, '+')`, which gets `:`, `%` and space
+ * right — the three that actually change behaviour — but leaves `!`, `'`, `(`,
+ * `)` and `~` unescaped, where form encoding percent-escapes them.
+ *
+ * For a compliant server that difference is invisible: `!` and `%21` both
+ * decode to `!`. The reason to use the platform's implementation anyway is that
+ * it removes the question entirely — nobody has to re-derive which characters
+ * this needs to cover, which is exactly how the hand-rolled version was wrong.
  */
 function formEncode(value: string): string {
-  return encodeURIComponent(value).replace(/%20/g, '+');
+  return new URLSearchParams({ value }).toString().slice('value='.length);
 }
 
 /** Which half of the exchange failed. The district-facing advice differs entirely. */

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -36,6 +36,18 @@ import type {
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+/**
+ * `application/x-www-form-urlencoded` per RFC 6749 Appendix B.
+ *
+ * `encodeURIComponent` alone is not quite it: form encoding writes a space as
+ * `+` rather than `%20`. The difference only shows up in a credential that
+ * contains a space, which is pathological — but the whole point of encoding
+ * here is to be correct for the credentials we cannot predict.
+ */
+function formEncode(value: string): string {
+  return encodeURIComponent(value).replace(/%20/g, '+');
+}
+
 /** Which half of the exchange failed. The district-facing advice differs entirely. */
 export type OneRosterPhase = 'token' | 'request';
 
@@ -82,8 +94,15 @@ export class OneRosterClient {
   async fetchToken(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<string> {
     if (this.token) return this.token;
 
+    // Each component is form-urlencoded BEFORE being joined and base64'd, per
+    // RFC 6749 §2.3.1. For the ordinary alphanumeric credential this is a
+    // no-op, so it costs nothing in the common case — but Basic auth splits on
+    // the FIRST colon, so a consumer ID containing one produces a credential
+    // the token endpoint cannot parse back. The route deliberately accepts any
+    // credential shape (vendors differ and there is nothing safe to validate
+    // against), which is exactly why this cannot assume a safe character set.
     const basic = Buffer.from(
-      `${this.config.clientId}:${this.config.clientSecret}`,
+      `${formEncode(this.config.clientId)}:${formEncode(this.config.clientSecret)}`,
     ).toString('base64');
 
     const body = new URLSearchParams({
@@ -166,14 +185,42 @@ export class OneRosterClient {
 
   /** `GET /orgs` — districts and schools. The first call that needs real access. */
   async getOrgs(options?: OneRosterRequestOptions): Promise<RawOneRosterOrg[]> {
-    const body = await this.get<{ orgs?: RawOneRosterOrg[] }>('orgs', options);
-    return body?.orgs ?? [];
+    return this.collection<RawOneRosterOrg>('orgs', options);
   }
 
   /** `GET /schools` — orgs already filtered to schools. */
   async getSchools(options?: OneRosterRequestOptions): Promise<RawOneRosterSchool[]> {
-    const body = await this.get<{ orgs?: RawOneRosterSchool[] }>('schools', options);
-    return body?.orgs ?? [];
+    return this.collection<RawOneRosterSchool>('schools', options);
+  }
+
+  /**
+   * Read a OneRoster collection, refusing anything that isn't one.
+   *
+   * `body?.orgs ?? []` was the obvious shape and it was wrong in a way that
+   * matters more than a crash: a 200 carrying `{"error": "..."}` — a proxy
+   * error page, a maintenance response, an HTML-to-JSON gateway — produced an
+   * empty array, which the diagnostics reported as "Working." with a count of
+   * zero. The district was told "Connected. OneRoster is ready." about a
+   * response we could not use at all, which is the one failure this whole
+   * feature exists to prevent.
+   *
+   * An empty roster is legitimate and stays legitimate; a MISSING collection is
+   * not. Only the latter is refused.
+   */
+  private async collection<T>(
+    path: string,
+    options?: OneRosterRequestOptions,
+  ): Promise<T[]> {
+    const body = await this.get<{ orgs?: T[] }>(path, options);
+    if (!body || !Array.isArray(body.orgs)) {
+      throw new OneRosterApiError(
+        `${path} answered, but not with a OneRoster collection.`,
+        502,
+        path,
+        'request',
+      );
+    }
+    return body.orgs;
   }
 
   // -- Internal ---------------------------------------------------------------
@@ -245,7 +292,13 @@ export class OneRosterClient {
 
   private buildUrl(path: string, options: OneRosterRequestOptions): string {
     const cleanPath = path.replace(/^\/+/, '');
-    const url = new URL(`${this.config.baseUrl}${ONEROSTER_API_PATH}/${cleanPath}`);
+    // A stored base_url can carry a trailing slash — normalizeOneRosterBaseUrl
+    // strips one at write time, but the test path re-validates a stored row
+    // without re-normalizing it. `...//ims/oneroster/v1p1/orgs` 404s on most
+    // servers, and the district then reads "that address has no OneRoster data"
+    // about an address that is perfectly correct.
+    const base = this.config.baseUrl.replace(/\/+$/, '');
+    const url = new URL(`${base}${ONEROSTER_API_PATH}/${cleanPath}`);
 
     if (options.limit != null) url.searchParams.set('limit', String(options.limit));
     if (options.offset != null) url.searchParams.set('offset', String(options.offset));

--- a/lib/integrations/oneroster/config.ts
+++ b/lib/integrations/oneroster/config.ts
@@ -1,0 +1,40 @@
+/**
+ * OneRoster v1.1 — connection config (SPE-397).
+ *
+ * Unlike the Aeries native client, there is no env-var fallback and no demo
+ * instance: OneRoster is per-district by construction, and every field here
+ * comes from a district's own API Security page. The config is passed in from
+ * the stored connection row (SPE-395), never resolved from the environment.
+ *
+ * WHY TWO URLS. OneRoster splits the token endpoint from the data endpoints,
+ * and on Aeries-hosted districts they are on the same host but different paths
+ * (`/admin/token/` vs `/admin/ims/oneroster/v1p1/...`). Other SIS vendors put
+ * them on entirely different hosts. So we ask for both rather than deriving one
+ * from the other — deriving it is the kind of guess that works for the pilot
+ * district and fails for the second one.
+ */
+
+/** The version segment we speak. 1.2 is deliberately not implemented yet. */
+export const ONEROSTER_API_PATH = '/ims/oneroster/v1p1';
+
+/**
+ * The single OAuth2 scope we request.
+ *
+ * `roster-core.readonly` covers getAllOrgs and getAllSchools — exactly the two
+ * calls the connection test makes, and nothing else. It deliberately excludes
+ * `roster-demographics.readonly`: demographics is the one OneRoster scope that
+ * carries birthdate, sex and race, and this flow has no use for any of it. Ask
+ * for the smallest scope that answers the question, so a district reviewing
+ * what they granted sees a request that matches what we actually do.
+ */
+export const ONEROSTER_SCOPE = 'https://purl.imsglobal.org/spec/or/v1p1/scope/roster-core.readonly';
+
+export interface OneRosterConnectionConfig {
+  /** Base URL up to but NOT including `/ims/oneroster/v1p1`. */
+  baseUrl: string;
+  /** Full URL of the OAuth2 token endpoint. */
+  tokenUrl: string;
+  /** Aeries calls these the Consumer ID and Consumer Secret Key. */
+  clientId: string;
+  clientSecret: string;
+}

--- a/lib/integrations/oneroster/index.ts
+++ b/lib/integrations/oneroster/index.ts
@@ -1,0 +1,24 @@
+/**
+ * OneRoster v1.1 integration — public surface (SPE-397).
+ *
+ * Server-only. Import from here rather than reaching into sub-modules.
+ */
+
+export {
+  OneRosterClient,
+  OneRosterApiError,
+  type OneRosterPhase,
+  type OneRosterRequestOptions,
+} from './client';
+
+export {
+  ONEROSTER_API_PATH,
+  ONEROSTER_SCOPE,
+  type OneRosterConnectionConfig,
+} from './config';
+
+export type {
+  RawOneRosterOrg,
+  RawOneRosterSchool,
+  OneRosterTokenResponse,
+} from './types';

--- a/lib/integrations/oneroster/types.ts
+++ b/lib/integrations/oneroster/types.ts
@@ -1,0 +1,42 @@
+/**
+ * OneRoster v1.1 — type definitions (SPE-397).
+ *
+ * Only the two collections the connection test reads are typed. OneRoster
+ * returns a large permissive payload; we keep an index signature so unknown
+ * fields don't break parsing, and we type only what we consume.
+ *
+ * Spec: https://www.imsglobal.org/oneroster-v11-final-specification
+ *
+ * NOTE ON WHAT IS ABSENT. There is no special-education anything in OneRoster
+ * v1.1 — no IEP flag, no program membership, no eligibility date. That is a
+ * property of the standard, not of this file, and it is the reason SPE-397
+ * calls OneRoster an owner-accepted limitation rather than a second path to the
+ * same data.
+ */
+
+/** An org from `GET /orgs`. Districts and schools are both orgs; `type` says which. */
+export interface RawOneRosterOrg {
+  sourcedId: string;
+  name?: string;
+  type?: 'department' | 'school' | 'district' | 'local' | 'state' | 'national';
+  status?: 'active' | 'tobedeleted';
+  [key: string]: unknown;
+}
+
+/** A school from `GET /schools` — an org already filtered to `type: 'school'`. */
+export interface RawOneRosterSchool extends RawOneRosterOrg {
+  [key: string]: unknown;
+}
+
+/**
+ * The OAuth2 token response.
+ *
+ * `access_token` is a bearer credential: it must never be logged, persisted, or
+ * returned to the browser. It lives for the duration of one connection test.
+ */
+export interface OneRosterTokenResponse {
+  access_token: string;
+  token_type?: string;
+  expires_in?: number;
+  scope?: string;
+}

--- a/lib/integrations/oneroster/types.ts
+++ b/lib/integrations/oneroster/types.ts
@@ -35,7 +35,13 @@ export interface RawOneRosterSchool extends RawOneRosterOrg {
  * returned to the browser. It lives for the duration of one connection test.
  */
 export interface OneRosterTokenResponse {
-  access_token: string;
+  /**
+   * Optional because the client casts an UNVALIDATED JSON body to this type.
+   * Declaring it required would state a guarantee the parse does not make, and
+   * would let a future caller skip the runtime check that catches a 200 with no
+   * token in it.
+   */
+  access_token?: string;
   token_type?: string;
   expires_in?: number;
   scope?: string;

--- a/lib/sis/aeries-setup.ts
+++ b/lib/sis/aeries-setup.ts
@@ -22,7 +22,7 @@
  * Server-only: reaches an external SIS with a decrypted credential.
  */
 import { AeriesApiError, AeriesClient } from '@/lib/integrations/aeries';
-import { assertPublicAeriesHostSyntax, assertSafeAeriesUrl } from './ssrf-guard';
+import { AERIES_URL_LABELS, assertPublicSisHostSyntax, assertSafeSisUrl } from './ssrf-guard';
 import type { SisTestResult } from './connections';
 
 export const AERIES_API_PATH = '/aeries/api/v5';
@@ -68,9 +68,9 @@ export function normalizeAeriesBaseUrl(input: string): string {
   }
 
   // Refuse anything that could point our server at a private network. This is
-  // the syntactic half; assertPublicAeriesHost() resolves the name too, and is
+  // the syntactic half; assertPublicSisHost() resolves the name too, and is
   // what the store and test paths actually await.
-  assertPublicAeriesHostSyntax(url.hostname);
+  assertPublicSisHostSyntax(url.hostname, AERIES_URL_LABELS);
 
   // Strip whatever path they landed on and append the API path ourselves.
   // /admin, /student, a deep link — none of it is the API root, and guessing
@@ -170,7 +170,7 @@ export async function runAeriesConnectionTest(params: {
   // Re-checked here, not just at write time: the stored row could predate the
   // guard, and a name's addresses can change after it was saved.
   try {
-    await assertSafeAeriesUrl(params.baseUrl);
+    await assertSafeSisUrl(params.baseUrl, AERIES_URL_LABELS);
   } catch (err) {
     const message = err instanceof Error ? err.message : 'That address cannot be used.';
     return {

--- a/lib/sis/connection-columns.ts
+++ b/lib/sis/connection-columns.ts
@@ -1,0 +1,23 @@
+/**
+ * The `district_sis_connections` columns a BROWSER session may read.
+ *
+ * One constant, imported by both the tech portal page and the RLS verification
+ * script, because the failure mode otherwise is silent and specific: the page
+ * starts selecting a new column, the grant doesn't cover it, and PostgREST
+ * refuses the ENTIRE select with 42501 — the portal shows "could not load your
+ * integration status" for every district at once. A verification script that
+ * checks its own hand-copied subset stays green throughout.
+ *
+ * This must mirror the GRANT in
+ * `supabase/migrations/20260806_spe395_district_sis_connections.sql`. Adding a
+ * column here without adding it there breaks the page; the script is what
+ * catches that, and it can only catch it if both read from here.
+ *
+ * Deliberately NOT `*`: on this table `*` expands to the credential columns and
+ * is refused outright. That is the designed behaviour (SPE-395) — a loud error
+ * rather than silently shipping a district's SIS credential to a browser.
+ *
+ * No React, no server imports: a plain string so a Node script can import it.
+ */
+export const BROWSER_CONNECTION_COLUMNS =
+  'id, sis_type, base_url, token_url, credential_hint, status, dpa_cleared_at, last_tested_at';

--- a/lib/sis/connection-columns.ts
+++ b/lib/sis/connection-columns.ts
@@ -21,3 +21,23 @@
  */
 export const BROWSER_CONNECTION_COLUMNS =
   'id, sis_type, base_url, token_url, credential_hint, status, dpa_cleared_at, last_tested_at';
+
+/**
+ * The row shape those columns produce.
+ *
+ * Kept in this file rather than in a component so a column change and the field
+ * change it implies happen in one place — the two drifting apart is how the page
+ * ends up reading a field the grant never returned.
+ *
+ * `token_url` is null for Aeries and carries the OAuth2 endpoint for OneRoster.
+ */
+export interface ConnectionSummary {
+  id: string;
+  sis_type: string;
+  base_url: string | null;
+  token_url: string | null;
+  credential_hint: string | null;
+  status: string;
+  dpa_cleared_at: string | null;
+  last_tested_at: string | null;
+}

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -69,13 +69,28 @@ export function normalizeOneRosterBaseUrl(input: string): string {
  * endpoint differently don't produce two different stored rows.
  */
 export function normalizeOneRosterTokenUrl(input: string): string {
-  return normalizeSisUrl(input, (url) => `${url.origin}${url.pathname.replace(/\/+$/, '')}`);
+  return normalizeSisUrl(
+    input,
+    (url) => `${url.origin}${url.pathname.replace(/\/+$/, '')}`,
+    'OneRoster token address',
+  );
 }
 
-/** Shared parse/guard/https path for both URLs, so neither can skip a check. */
-function normalizeSisUrl(input: string, shape: (url: URL) => string): string {
+/**
+ * Shared parse/guard/https path for both URLs, so neither can skip a check.
+ *
+ * `what` names the FIELD, not the product. This flow has two URLs and the
+ * message goes straight to the district: telling someone whose token address is
+ * blank to "enter your OneRoster address" sends them to correct the field that
+ * is already right.
+ */
+function normalizeSisUrl(
+  input: string,
+  shape: (url: URL) => string,
+  what = 'OneRoster address',
+): string {
   const trimmed = input.trim();
-  if (!trimmed) throw new Error('Enter your OneRoster address.');
+  if (!trimmed) throw new Error(`Enter your ${what}.`);
 
   const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
 
@@ -89,9 +104,7 @@ function normalizeSisUrl(input: string, shape: (url: URL) => string): string {
   }
 
   if (url.protocol !== 'https:') {
-    throw new Error(
-      'The OneRoster address must start with https:// so credentials stay encrypted.',
-    );
+    throw new Error(`The ${what} must start with https:// so credentials stay encrypted.`);
   }
 
   assertPublicSisHostSyntax(url.hostname, ONEROSTER_URL_LABELS);
@@ -183,9 +196,22 @@ async function step(
   key: OneRosterStepResult['key'],
   label: string,
   run: () => Promise<number>,
+  /** What an empty result means, when empty is not a success. */
+  emptyMeans?: string,
 ): Promise<OneRosterStepResult> {
   try {
     const count = await run();
+    if (emptyMeans && count === 0) {
+      // Raised by CodeRabbit, and it is right: a 200 with `{"orgs": []}` was
+      // reporting "Connected. OneRoster is ready." A district's OneRoster
+      // always exposes at least the district org, so nothing coming back does
+      // not mean "no data yet" — it means nothing is shared with us, and the
+      // district would discover that only when no data ever arrived.
+      //
+      // 'denied' rather than 'error': the connection genuinely works. What is
+      // missing is a sharing setting, which is a different thing to go fix.
+      return { key, label, status: 'denied', message: emptyMeans, count };
+    }
     return { key, label, status: 'ok', message: 'Working.', count };
   } catch (err) {
     return { key, label, ...explain(err, label) };
@@ -246,16 +272,26 @@ export async function runOneRosterConnectionTest(params: {
 
   // One record is enough to prove the collection is readable. Walking it would
   // pull the district's whole roster to learn nothing more.
-  const orgs = await step('orgs', 'Districts and schools', async () => {
-    const rows = await client.getOrgs({ limit: 1 });
-    return rows.length;
-  });
+  const orgs = await step(
+    'orgs',
+    'Districts and schools',
+    async () => {
+      const rows = await client.getOrgs({ limit: 1 });
+      return rows.length;
+    },
+    'Connected, but nothing is shared with Speddy yet. In Aeries, check that OneRoster is enabled under District-level School Options → OneRoster Settings.',
+  );
   steps.push(orgs);
 
-  const schools = await step('schools', 'Schools', async () => {
-    const rows = await client.getSchools({ limit: 1 });
-    return rows.length;
-  });
+  const schools = await step(
+    'schools',
+    'Schools',
+    async () => {
+      const rows = await client.getSchools({ limit: 1 });
+      return rows.length;
+    },
+    'Connected, but no schools came back. Check that your schools are included in the OneRoster settings in Aeries.',
+  );
   steps.push(schools);
 
   const failed = steps.filter((s) => s.status !== 'ok');

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -1,0 +1,283 @@
+/**
+ * OneRoster connection setup: URL normalization and step-wise diagnostics
+ * (SPE-397).
+ *
+ * Same persona and same contract as the Aeries flow (`aeries-setup.ts`): a
+ * district generalist who has never opened the API Security page, and a report
+ * that names the fix rather than the HTTP status.
+ *
+ * WHAT IS DIFFERENT HERE, and why it gets its own module rather than a branch
+ * inside the Aeries one:
+ *
+ *  1. **Two credentials, not one.** OneRoster uses the Consumer ID and Consumer
+ *     Secret, which live on the same Aeries page as the certificate and are
+ *     routinely confused with it. That confusion is the single most common
+ *     setup failure, so the diagnostics call it out by name.
+ *
+ *  2. **Two steps, not one.** Getting a token and using it fail separately.
+ *     "Your credentials are wrong" (token) and "your credentials are fine but
+ *     nothing is shared with you" (request) send the district to two different
+ *     screens, and collapsing them is exactly the round-trip this removes.
+ *
+ *  3. **Two URLs, not one.** The token endpoint and the data endpoints are
+ *     distinct and vary by vendor, so both are asked for and both are guarded.
+ *
+ * Aggregate-only, identically to the Aeries flow: every step reports a count
+ * and a step name, never a record. `district_tech` has no right to student data
+ * (SPE-393), and OneRoster's payloads are full of it.
+ *
+ * Server-only: reaches an external SIS with a decrypted credential.
+ */
+import {
+  ONEROSTER_API_PATH,
+  OneRosterApiError,
+  OneRosterClient,
+} from '@/lib/integrations/oneroster';
+import {
+  ONEROSTER_URL_LABELS,
+  assertPublicSisHostSyntax,
+  assertSafeSisUrl,
+} from './ssrf-guard';
+import type { SisTestResult } from './connections';
+
+/**
+ * Normalize whatever the district pasted into a OneRoster base URL.
+ *
+ * They will paste what their Aeries admin page shows, which is frequently the
+ * full data URL including the version segment. Appending our own path to that
+ * produces `.../ims/oneroster/v1p1/ims/oneroster/v1p1/orgs`, so the version
+ * segment is stripped if present rather than rejected — a district should not
+ * have to know which half of the URL we wanted.
+ */
+export function normalizeOneRosterBaseUrl(input: string): string {
+  return normalizeSisUrl(input, (url) => {
+    // Strip a trailing OneRoster version path, with or without a trailing slash.
+    const path = url.pathname.replace(/\/+$/, '');
+    const stripped = path.endsWith(ONEROSTER_API_PATH)
+      ? path.slice(0, -ONEROSTER_API_PATH.length)
+      : path;
+    return `${url.origin}${stripped}`;
+  });
+}
+
+/**
+ * Normalize the token endpoint.
+ *
+ * Kept whole — unlike the base URL there is no version segment to strip, and
+ * the path genuinely varies between vendors (`/token`, `/token/`, `/oauth/token`).
+ * Only the trailing slash is normalized, so two districts who typed the same
+ * endpoint differently don't produce two different stored rows.
+ */
+export function normalizeOneRosterTokenUrl(input: string): string {
+  return normalizeSisUrl(input, (url) => `${url.origin}${url.pathname.replace(/\/+$/, '')}`);
+}
+
+/** Shared parse/guard/https path for both URLs, so neither can skip a check. */
+function normalizeSisUrl(input: string, shape: (url: URL) => string): string {
+  const trimmed = input.trim();
+  if (!trimmed) throw new Error('Enter your OneRoster address.');
+
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+
+  let url: URL;
+  try {
+    url = new URL(withScheme);
+  } catch {
+    throw new Error(
+      `"${trimmed}" doesn't look like a web address. It should look like ${ONEROSTER_URL_LABELS.example}`,
+    );
+  }
+
+  if (url.protocol !== 'https:') {
+    throw new Error(
+      'The OneRoster address must start with https:// so credentials stay encrypted.',
+    );
+  }
+
+  assertPublicSisHostSyntax(url.hostname, ONEROSTER_URL_LABELS);
+  return shape(url);
+}
+
+/** One step of the exchange, in the district's terms. */
+export interface OneRosterStepResult {
+  key: 'token' | 'orgs' | 'schools';
+  label: string;
+  status: 'ok' | 'denied' | 'error' | 'untested';
+  /** Plain English. Never contains a name, an ID, or either credential. */
+  message: string;
+  /** Aggregate only — how many records the step returned, when it succeeded. */
+  count?: number;
+}
+
+export interface OneRosterTestReport {
+  ok: boolean;
+  steps: OneRosterStepResult[];
+  summary: string;
+}
+
+/**
+ * Map a failure to something the district can act on.
+ *
+ * The 401-at-token case is the one worth the most: on Aeries-hosted districts
+ * it usually means the certificate was pasted instead of the Consumer ID and
+ * Secret. Same admin page, adjacent fields, completely different credential —
+ * and "401 Unauthorized" gives them no way to work that out.
+ */
+function explain(err: unknown, step: string): { status: 'denied' | 'error'; message: string } {
+  if (err instanceof OneRosterApiError) {
+    if (err.phase === 'token') {
+      if (err.status === 401 || err.status === 400) {
+        return {
+          status: 'error',
+          message:
+            'Those credentials were rejected. OneRoster uses the Consumer ID and Consumer Secret Key — not the certificate. Both are on Security → API Security → "Display Consumer ID & Secret Keys".',
+        };
+      }
+      if (err.status === 404) {
+        return {
+          status: 'error',
+          message:
+            'Nothing answered at that token address. It usually ends in /token/ — check it against your Aeries OneRoster settings.',
+        };
+      }
+      if (err.status === 408) {
+        return {
+          status: 'error',
+          message: 'The token address did not respond in time. Try again in a moment.',
+        };
+      }
+      return {
+        status: 'error',
+        message: `The token address returned an unexpected error (${err.status}).`,
+      };
+    }
+
+    // phase === 'request': the credentials already worked once.
+    if (err.status === 401 || err.status === 403) {
+      return {
+        status: 'denied',
+        message: `Your credentials work, but ${step} is not shared with Speddy. In Aeries, check that the OneRoster box is ticked on the Speddy API Security record.`,
+      };
+    }
+    if (err.status === 404) {
+      return {
+        status: 'error',
+        message:
+          'Your credentials work, but that address has no OneRoster data at it. Check the OneRoster URL — the token address and the data address are different.',
+      };
+    }
+    if (err.status === 408) {
+      return { status: 'error', message: 'OneRoster did not respond in time. Try again in a moment.' };
+    }
+    return { status: 'error', message: `OneRoster returned an unexpected error (${err.status}).` };
+  }
+
+  return {
+    status: 'error',
+    message:
+      'Could not reach OneRoster at that address. Check the address and that it is publicly reachable.',
+  };
+}
+
+async function step(
+  key: OneRosterStepResult['key'],
+  label: string,
+  run: () => Promise<number>,
+): Promise<OneRosterStepResult> {
+  try {
+    const count = await run();
+    return { key, label, status: 'ok', message: 'Working.', count };
+  } catch (err) {
+    return { key, label, ...explain(err, label) };
+  }
+}
+
+const NOT_REACHED = 'Not checked — the previous step has to work first.';
+
+/**
+ * Run the connection test: token grant, then orgs, then schools.
+ *
+ * Strictly sequential and short-circuiting. If the token grant fails, the two
+ * data steps report `untested` rather than three variations of the same
+ * failure — a district reading three red rows goes looking for three problems.
+ */
+export async function runOneRosterConnectionTest(params: {
+  baseUrl: string;
+  tokenUrl: string;
+  clientId: string;
+  clientSecret: string;
+}): Promise<OneRosterTestReport> {
+  // Both URLs are re-checked here, not just at write time: a stored row could
+  // predate the guard, and a name's addresses can change after it was saved.
+  // Checked BEFORE the client is constructed, so no credential is ever sent to
+  // an address that has not passed.
+  for (const [url, what] of [
+    [params.tokenUrl, 'token address'],
+    [params.baseUrl, 'OneRoster address'],
+  ] as const) {
+    try {
+      await assertSafeSisUrl(url, ONEROSTER_URL_LABELS);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'That address cannot be used.';
+      return {
+        ok: false,
+        steps: [{ key: 'token', label: 'Connection', status: 'error', message: `${what}: ${message}` }],
+        summary: 'Could not connect to OneRoster.',
+      };
+    }
+  }
+
+  const client = new OneRosterClient(params);
+  const steps: OneRosterStepResult[] = [];
+
+  const token = await step('token', 'Sign-in', async () => {
+    await client.fetchToken();
+    return 1;
+  });
+  steps.push(token);
+
+  if (token.status !== 'ok') {
+    steps.push(
+      { key: 'orgs', label: 'Districts and schools', status: 'untested', message: NOT_REACHED },
+      { key: 'schools', label: 'Schools', status: 'untested', message: NOT_REACHED },
+    );
+    return { ok: false, steps, summary: 'Could not connect to OneRoster.' };
+  }
+
+  // One record is enough to prove the collection is readable. Walking it would
+  // pull the district's whole roster to learn nothing more.
+  const orgs = await step('orgs', 'Districts and schools', async () => {
+    const rows = await client.getOrgs({ limit: 1 });
+    return rows.length;
+  });
+  steps.push(orgs);
+
+  const schools = await step('schools', 'Schools', async () => {
+    const rows = await client.getSchools({ limit: 1 });
+    return rows.length;
+  });
+  steps.push(schools);
+
+  const failed = steps.filter((s) => s.status !== 'ok');
+  const summary = failed.length === 0
+    ? 'Connected. OneRoster is ready.'
+    : failed.length === steps.length
+      ? 'Could not connect to OneRoster.'
+      : `Connected, but ${failed.length} of ${steps.length} checks need attention.`;
+
+  return { ok: failed.length === 0, steps, summary };
+}
+
+/**
+ * Reduce a report to what may be persisted in `last_test_result`.
+ *
+ * That column is readable by the district's own staff (SPE-395), so the counts
+ * are dropped and only step names and outcomes are kept.
+ */
+export function toStoredOneRosterTestResult(report: OneRosterTestReport): SisTestResult {
+  const failed = report.steps.filter((s) => s.status !== 'ok').map((s) => s.label);
+  return {
+    area: failed.length ? failed.join(', ') : 'all',
+    message: report.summary,
+  };
+}

--- a/lib/sis/ssrf-guard.ts
+++ b/lib/sis/ssrf-guard.ts
@@ -1,5 +1,8 @@
 /**
  * Keep district-supplied SIS addresses pointed at the public internet (SPE-396).
+
+ * Shared by every SIS connector (Aeries, OneRoster). Only the wording of a
+ * refusal differs per product — see `SisUrlLabels`.
  *
  * WHY THIS EXISTS. A district tech admin types the address their SIS lives at,
  * and our server then makes authenticated requests to it and reports, per
@@ -10,9 +13,9 @@
  * and "unreachable" for you.
  *
  * Two layers, because either alone is bypassable:
- *   - syntactic (`assertPublicAeriesHostSyntax`): reject IP literals and
+ *   - syntactic (`assertPublicSisHostSyntax`): reject IP literals and
  *     obviously-internal names before anything is stored;
- *   - resolved (`assertPublicAeriesHost`): resolve the name and reject if it
+ *   - resolved (`assertPublicSisHost`): resolve the name and reject if it
  *     lands on a private, loopback, link-local, or carrier-NAT address —
  *     because `sis.example.com` is free to be an A record for 10.0.0.5.
  *
@@ -26,8 +29,34 @@
  */
 import { lookup } from 'dns/promises';
 
+/**
+ * What to call the thing in a refusal message, and an address to show as an
+ * example.
+ *
+ * The guard is shared by every SIS we connect to, and the wording is the only
+ * part that differs. Telling a OneRoster district to "enter your Aeries web
+ * address" is its own small bug, and the alternative — a second copy of this
+ * file per SIS — is much worse: it is the security control that would drift.
+ */
+export interface SisUrlLabels {
+  /** What the district calls it: "Aeries", "OneRoster". */
+  product: string;
+  /** A concrete address of the right shape for that product. */
+  example: string;
+}
+
+export const AERIES_URL_LABELS: SisUrlLabels = {
+  product: 'Aeries',
+  example: 'https://yourdistrict.aeries.net',
+};
+
+export const ONEROSTER_URL_LABELS: SisUrlLabels = {
+  product: 'OneRoster',
+  example: 'https://yourdistrictapi.aeries.net/admin',
+};
+
 /** Reject any literal IP address, and names that cannot be public. */
-export function assertPublicAeriesHostSyntax(hostname: string): void {
+export function assertPublicSisHostSyntax(hostname: string, labels: SisUrlLabels): void {
   // Strip ALL trailing dots before ANY comparison. `localhost.` is the
   // fully-qualified form of `localhost`, resolves identically, and would
   // otherwise sail past every check below.
@@ -45,12 +74,14 @@ export function assertPublicAeriesHostSyntax(hostname: string): void {
   // before it needs picking apart.
   if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host) || host.includes(':')) {
     throw new Error(
-      'Enter your Aeries web address as a name (for example https://yourdistrict.aeries.net), not an IP address.',
+      `Enter your ${labels.product} web address as a name (for example ${labels.example}), not an IP address.`,
     );
   }
 
   if (host === 'localhost' || host.endsWith('.localhost')) {
-    throw new Error('That address points at this server rather than your Aeries instance.');
+    throw new Error(
+      `That address points at this server rather than your ${labels.product} instance.`,
+    );
   }
 
   // Names that only resolve inside a private network. Speddy runs in the cloud
@@ -58,14 +89,14 @@ export function assertPublicAeriesHostSyntax(hostname: string): void {
   // failure later even in the innocent case.
   if (/\.(local|internal|intranet|lan|home|corp|localdomain)$/.test(host)) {
     throw new Error(
-      'That address is only reachable inside your network. Speddy connects over the public internet, so Aeries needs a publicly reachable address.',
+      `That address is only reachable inside your network. Speddy connects over the public internet, so ${labels.product} needs a publicly reachable address.`,
     );
   }
 
   // A single label ("aeries", "sis") is an intranet short name.
   if (!host.includes('.')) {
     throw new Error(
-      'That address looks like an internal shortcut. Use the full public address, for example https://yourdistrict.aeries.net',
+      `That address looks like an internal shortcut. Use the full public address, for example ${labels.example}`,
     );
   }
 }
@@ -103,7 +134,7 @@ export function isPrivateAddress(address: string, family: number): boolean {
   // Enumerating the ways to write "loopback" in IPv6 is not a winnable game.
   //
   // So: the only globally routable IPv6 is 2000::/3. Everything outside it is
-  // special-purpose by IANA assignment and cannot be a district's Aeries host.
+  // special-purpose by IANA assignment and cannot be a district's SIS host.
   // One rule, and every encoding above is refused by construction rather than
   // by having been thought of.
   const v6 = address.toLowerCase().split('%')[0]; // drop any zone id (fe80::1%eth0)
@@ -128,21 +159,21 @@ export function isPrivateAddress(address: string, family: number): boolean {
  * one public and one private A record would otherwise pass and then be dialled
  * at whichever the resolver picked.
  */
-export async function assertPublicAeriesHost(hostname: string): Promise<void> {
-  assertPublicAeriesHostSyntax(hostname);
+export async function assertPublicSisHost(hostname: string, labels: SisUrlLabels): Promise<void> {
+  assertPublicSisHostSyntax(hostname, labels);
 
   let addresses: { address: string; family: number }[];
   try {
     addresses = await lookup(hostname, { all: true });
   } catch {
     throw new Error(
-      `We couldn't find ${hostname}. Check the address — it should look like https://yourdistrict.aeries.net`,
+      `We couldn't find ${hostname}. Check the address — it should look like ${labels.example}`,
     );
   }
 
   if (!addresses.length || addresses.some((a) => isPrivateAddress(a.address, a.family))) {
     throw new Error(
-      'That address resolves to a private network address, so Speddy cannot use it. Aeries needs to be reachable over the public internet.',
+      `That address resolves to a private network address, so Speddy cannot use it. ${labels.product} needs to be reachable over the public internet.`,
     );
   }
 }
@@ -163,19 +194,21 @@ export async function assertPublicAeriesHost(hostname: string): Promise<void> {
  * Callers get one function so the two halves cannot drift apart, and so a test
  * that stubs the guard stubs all of it rather than silently keeping half.
  */
-export async function assertSafeAeriesUrl(baseUrl: string): Promise<void> {
+export async function assertSafeSisUrl(baseUrl: string, labels: SisUrlLabels): Promise<void> {
   let parsed: URL;
   try {
     parsed = new URL(baseUrl);
   } catch {
     throw new Error(
-      'That does not look like a web address. It should look like https://yourdistrict.aeries.net',
+      `That does not look like a web address. It should look like ${labels.example}`,
     );
   }
 
   if (parsed.protocol !== 'https:') {
-    throw new Error('The Aeries address must start with https:// so credentials stay encrypted.');
+    throw new Error(
+      `The ${labels.product} address must start with https:// so credentials stay encrypted.`,
+    );
   }
 
-  await assertPublicAeriesHost(parsed.hostname);
+  await assertPublicSisHost(parsed.hostname, labels);
 }

--- a/scripts/sim-district/verify-sis-connections-rls.ts
+++ b/scripts/sim-district/verify-sis-connections-rls.ts
@@ -40,6 +40,7 @@ import {
   decryptSisCredential,
   encryptSisCredential,
 } from '../../lib/sis/credential-crypto';
+import { BROWSER_CONNECTION_COLUMNS } from '../../lib/sis/connection-columns';
 
 const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
 const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
@@ -52,7 +53,19 @@ const CREDENTIAL_COLUMNS = [
   'oneroster_client_id_encrypted',
   'oneroster_client_secret_encrypted',
 ];
-const SAFE_COLUMNS = 'id,district_id,sis_type,status,credential_hint,dpa_cleared_at';
+// The page's OWN column list, imported rather than hand-copied. The previous
+// literal here was a subset — it omitted base_url and token_url — so the portal
+// could start selecting a column the grant did not cover, break for every
+// district with a 42501 on the whole select, and leave this script green.
+// PostgREST wants no spaces in `select`.
+const SAFE_COLUMNS = BROWSER_CONNECTION_COLUMNS.replace(/\s+/g, '');
+
+// The page deliberately does NOT select district_id — it has no use for it — so
+// the tenancy assertion below has to ask for it explicitly. Splitting these two
+// reads is the point: SAFE_COLUMNS proves the PAGE's select works against the
+// live grant, and this proves the policy's district clause is load-bearing.
+// Collapsing them means one of those two properties stops being checked.
+const ISOLATION_COLUMNS = `${SAFE_COLUMNS},district_id`;
 
 let failures = 0;
 function check(ok: boolean, label: string, detail = ''): void {
@@ -174,10 +187,11 @@ async function main(): Promise<void> {
       // that makes the policy's district clause load-bearing: drop it and this
       // read returns 2 rows and fails, instead of quietly passing because the
       // only other personas are excluded on role.
+      const owned = await read(token, ISOLATION_COLUMNS);
       check(
-        safe.rows.length === 1 && safe.rows[0]?.district_id === DISTRICT.id,
+        owned.rows.length === 1 && owned.rows[0]?.district_id === DISTRICT.id,
         `${label}: sees ONLY their own district's connection`,
-        `${safe.rows.length} row(s), district=${safe.rows[0]?.district_id ?? 'none'}`);
+        `${owned.rows.length} row(s), district=${owned.rows[0]?.district_id ?? 'none'}`);
 
       for (const col of CREDENTIAL_COLUMNS) {
         const r = await read(token, col);


### PR DESCRIPTION
The OneRoster path from SPE-392, built alongside Aeries (#808) so JSUSD's tech contact can connect *something* rather than stall.

## The limitation is the headline, not a footnote

OneRoster carries **no special-education data at all** — no IEP flag, no program membership, no eligibility date. That is a property of the standard, not a setting anyone can switch on. A district can complete this entire setup correctly and still not see the thing Speddy is for.

So it is stated in the portal, above the credential form, where the work is actually happening — not in a FAQ someone finds afterwards. The copy says what OneRoster *does* give them (students, staff, schools, rosters — no more typing names), what it can't, and that Aeries is the connection that carries special-ed records. **Owner call on the wording**; it is deliberately plain rather than reassuring.

## What is genuinely different from the Aeries flow

Three things, and together they are why this is a sibling module rather than a branch inside the Aeries one:

**Two credentials.** OneRoster uses the Consumer ID and Consumer Secret Key. They live on the same Aeries page as the certificate, immediately adjacent to it, and pasting the certificate is the single most common setup failure. The guide warns about it up front and a 401 at sign-in names it explicitly rather than saying "unauthorized".

**Two steps.** Getting a token and using it fail separately, and the difference sends a district to two different screens:

| What happened | What we say |
|---|---|
| 401 at sign-in | "Those credentials were rejected. OneRoster uses the Consumer ID and Consumer Secret Key — not the certificate." |
| 401/403 *after* a good token | "Your credentials work, but *Districts and schools* is not shared with Speddy." |

Collapsing those into "connection failed" is exactly the round-trip this feature removes. If sign-in fails, the two data steps report `untested` rather than three variations of one problem — a district reading three red rows goes looking for three problems.

**Two URLs.** Token endpoint and data endpoint are distinct and vary by vendor, so both are asked for and **both** go through the SSRF guard before any credential is sent.

## Security

The guard is the one from SPE-396, **not a copy**. Its messages are now parameterised by product (`SisUrlLabels`) so a OneRoster district isn't told to check their "Aeries web address". A second copy of that file is precisely the security control that would drift out of sync.

- **Both URLs guarded, before the client is constructed** — so no credential is sent to an address that hasn't passed. Mutation-tested: dropping the token URL from the check fails the test that covers it.
- **Scope is `roster-core.readonly` only** — exactly the two calls the test makes. `roster-demographics.readonly` is deliberately excluded; it is the scope carrying birthdate, sex and race, and this flow has no use for any of it. A district reviewing what they granted should see a request that matches what we actually do.
- **Redirects refused** (`redirect: 'error'`), same reasoning as #808.
- **Credentials in an HTTP Basic header, not the POST body** — both are legal per RFC 6749, but a body parameter is far likelier to be captured by intermediary request logging, and this is a district's long-lived SIS credential.

## Verification

**Against a real HTTP server, not a mocked client**, because the properties worth the most here are about *which credential travels where* — something a mocked client cannot see at all.

Mutation testing earned its place twice, and the first one was my own bug:

- The secret-placement test **passed** while a mutant leaked the consumer secret in an `X-Secret:` header on every data request. It only inspected `Authorization`. It now asserts over the whole request — every header, the body, and the URL — and catches it.
- The two-URL guard test correctly failed when the token URL was dropped from the check.

**The browser read was exercised with a real signed-in session**, not confirmed by reading the migration. The portal now selects `token_url`; Theo reads the page's exact select, `token_url` comes back, and both OneRoster credential columns are still refused with `42501`.

That turned up a real gap in the *verification*: `verify-sis-connections-rls.ts` checked a hand-copied subset that omitted `base_url` and `token_url`, so the portal could start selecting an ungranted column, break for **every district at once** — a `42501` refuses the whole select, not just that column — and leave the script green. The column list is now one exported constant both the page and the script import. Proved by mutation: adding an ungranted column fails 6 checks with HTTP 403, where before it failed nothing.

Running that also caught a second-order mistake in my own fix — the page doesn't select `district_id`, so sharing one constant silently dropped the tenancy assertion (it passed with `district=none`). The script now issues both reads deliberately: one proving the page's select works against the live grant, one proving the policy's district clause is load-bearing.

**Gates:** 90 suites / 920 tests, typecheck clean, 0 lint errors, `next build` green. `sim:reset` + `sim:verify` green before and after; `sim:verify-sis-rls` and `sim:verify-sis-lifecycle` green with no residue.

No migration — `token_url` was already in SPE-395's column grant.

## Not covered, stated precisely

- **No live OneRoster instance has ever answered this code.** The ticket asks to check the Aeries demo instance's OneRoster availability early; that host is blocked by the build sandbox's egress policy, as it was for #808. So the token exchange, the error mapping and the transport are proven against a real HTTP server, and **Aeries' own OneRoster behaviour is still assumed** — specifically that it returns 401 for bad credentials rather than 400, and 403 rather than an empty 200 for an unshared collection. Only a real district can settle that, and JSUSD is the intended proof.
- **OneRoster 1.2 is not implemented.** The token request is isolated in `fetchToken` so 1.2's scoped client-credentials flow can slot in beside it later, as the ticket asks — but nothing here speaks 1.2.
- **CSV/SFTP OneRoster is out of scope**, per the ticket. We run no SFTP endpoint.
- **GitHub Actions has been unavailable all session**, so every gate above was run locally. SPE-405 covers the missing `concurrency` groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9wB9cKyt21z79WXbhyFtp

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9wB9cKyt21z79WXbhyFtp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OneRoster v1.1 integration with secure credential setup and connection testing.
  * Added setup guidance, copy-to-clipboard instructions, validation feedback, and step-by-step diagnostics.
  * Tech portal now supports managing both Aeries and OneRoster connections.
  * Added support for retrieving organizations and schools through OneRoster.

* **Security**
  * Added HTTPS, public-host, redirect, and credential safeguards for SIS connections.

* **Bug Fixes**
  * Improved connection error handling and generalized SIS URL validation across integrations.
  * Improved handling of authentication failures, unavailable endpoints, and empty roster data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->