### PR TITLE
SPE-398: SIS exploration tooling — match-rate and secondary teacher-linkage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,6 @@ html-report/
 /test-lesson-output.json
 /speddy-chrome-extension.tar.gz
 /speddy-extension-v2.0.0.zip
+
+# SIS exploration reports (SPE-398) — contain district student IDs, never commit
+/sis-reports/

--- a/__tests__/unit/lib/sis/oneroster-pagination.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-pagination.test.ts
@@ -1,0 +1,79 @@
+/**
+ * SPE-398 · OneRoster pagination, and its refusal to truncate quietly.
+ *
+ * A single large `limit` is not a substitute for paging: servers cap it
+ * silently, so a district bigger than the guess comes back short with no
+ * indication. That matters more here than usual — a truncated roster makes the
+ * DISTRICT's data look incomplete in the match-rate report, when the loss was
+ * entirely ours.
+ */
+import { createServer, type Server } from 'http';
+import type { AddressInfo } from 'net';
+import { OneRosterClient } from '@/lib/integrations/oneroster';
+
+let server: Server;
+let origin: string;
+/** How many rows the fake server holds, and how many it will serve per page. */
+let total = 0;
+let serverCap = 1000;
+let requests: string[] = [];
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const url = new URL(req.url ?? '', 'http://x');
+    requests.push(url.pathname + url.search);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    if (url.pathname.includes('/token')) return res.end(JSON.stringify({ access_token: 't' }));
+
+    const limit = Math.min(Number(url.searchParams.get('limit') ?? 100), serverCap);
+    const offset = Number(url.searchParams.get('offset') ?? 0);
+    const users = Array.from({ length: Math.max(0, Math.min(limit, total - offset)) }, (_, i) => ({
+      sourcedId: `u-${offset + i}`,
+    }));
+    res.end(JSON.stringify({ users }));
+  });
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => { await new Promise<void>((r) => server.close(() => r())); });
+beforeEach(() => { requests = []; serverCap = 1000; });
+
+const client = () =>
+  new OneRosterClient({
+    baseUrl: `${origin}/admin`,
+    tokenUrl: `${origin}/admin/token`,
+    clientId: 'id',
+    clientSecret: 'secret',
+  });
+
+it('walks past the first page to collect the whole collection', async () => {
+  total = 2500;
+  const rows = await client().getAllPages<{ sourcedId: string }>('students', 'users');
+  expect(rows).toHaveLength(2500);
+  // Distinct rows, not the first page fetched three times — an `offset` the
+  // client failed to send would still produce 2500 with only 1000 real students.
+  expect(new Set(rows.map((r) => r.sourcedId)).size).toBe(2500);
+});
+
+it('stops as soon as a page comes back short', async () => {
+  total = 10;
+  const rows = await client().getAllPages<{ sourcedId: string }>('students', 'users');
+  expect(rows).toHaveLength(10);
+  expect(requests.filter((r) => r.includes('/students'))).toHaveLength(1);
+});
+
+it('returns an empty collection without looping', async () => {
+  total = 0;
+  await expect(client().getAllPages('students', 'users')).resolves.toEqual([]);
+  expect(requests.filter((r) => r.includes('/students'))).toHaveLength(1);
+});
+
+it('THROWS rather than returning a silently truncated collection', async () => {
+  // A server that ignores `offset` — every page comes back full, so the walk
+  // never terminates on its own. Returning what it had would look like a
+  // complete roster and quietly wreck the match rate.
+  total = Number.MAX_SAFE_INTEGER;
+  serverCap = 1000;
+  await expect(client().getAllPages('students', 'users')).rejects.toThrow(/truncated/i);
+}, 60_000);

--- a/__tests__/unit/scripts/sis-explore/analysis.test.ts
+++ b/__tests__/unit/scripts/sis-explore/analysis.test.ts
@@ -1,0 +1,419 @@
+/**
+ * SPE-398 · the SIS exploration analysis.
+ *
+ * This tool exists to answer questions we cannot answer today, and its whole
+ * value is that the answers are TRUE. A match-rate report that flatters us is
+ * worse than no report: it would be used to decide whether the OneRoster
+ * strategy works, and nobody would re-check it.
+ *
+ * So the cases below are weighted toward the ways a report can be wrong in the
+ * reassuring direction — counting a co-served child twice, calling "we could
+ * not check" a confirmation, reporting "no overlap" when there was simply no
+ * data to overlap.
+ */
+import {
+  analyzeIdSemantics,
+  analyzeMatchRate,
+  analyzeSpedFlags,
+  analyzeTeacherLinkage,
+  enrollmentsToTeacherLinks,
+  type SchoolRow,
+  type SisStudent,
+  type SpeddyStudent,
+} from '../../../../scripts/sis-explore/analysis';
+
+const student = (o: Partial<SpeddyStudent> & { childId: string }): SpeddyStudent => ({
+  studentId: `s-${o.childId}`,
+  districtStudentId: null,
+  schoolId: 'SCH-1',
+  gradeLevel: '3',
+  teacherId: null,
+  ...o,
+});
+
+const sisStudent = (districtStudentId: string | null, o: Partial<SisStudent> = {}): SisStudent => ({
+  sisId: `sis-${districtStudentId}`,
+  districtStudentId,
+  schoolId: 'SCH-1',
+  gradeLevel: '3',
+  ...o,
+});
+
+describe('analyzeIdSemantics — does our number mean their number?', () => {
+  it('reports same-namespace when the IDs overlap', () => {
+    const r = analyzeIdSemantics(
+      [student({ childId: 'a', districtStudentId: '100001' })],
+      [sisStudent('100001'), sisStudent('100002')],
+    );
+    expect(r.verdict).toBe('same-namespace');
+    expect(r.overlap).toBe(1);
+  });
+
+  it('a PARTIAL overlap is still the same namespace, not a failure', () => {
+    // We hold a caseload; they hold the district. Incomplete overlap is the
+    // expected shape. Only ZERO overlap means different numbering — conflating
+    // the two would condemn a working integration.
+    const r = analyzeIdSemantics(
+      [
+        student({ childId: 'a', districtStudentId: '100001' }),
+        student({ childId: 'b', districtStudentId: '999999' }),
+      ],
+      [sisStudent('100001')],
+    );
+    expect(r.verdict).toBe('same-namespace');
+    expect(r.overlap).toBe(1);
+  });
+
+  it('reports no-overlap when the two sets are disjoint', () => {
+    const r = analyzeIdSemantics(
+      [student({ childId: 'a', districtStudentId: 'ABC-1' })],
+      [sisStudent('100001')],
+    );
+    expect(r.verdict).toBe('no-overlap');
+    expect(r.verdictReason).toMatch(/different numbers/i);
+  });
+
+  // The distinction that matters most in this file.
+  it('reports INCONCLUSIVE, not no-overlap, when Speddy has no IDs at all', () => {
+    // Zero overlap because there was nothing to overlap. Reporting that as
+    // "these are different numbers" would send someone hunting a field problem
+    // that does not exist — the real finding is "nobody entered any IDs".
+    const r = analyzeIdSemantics([student({ childId: 'a' })], [sisStudent('100001')]);
+    expect(r.verdict).toBe('inconclusive');
+    expect(r.verdict).not.toBe('no-overlap');
+    expect(r.verdictReason).toMatch(/nothing to compare/i);
+  });
+
+  it('reports INCONCLUSIVE when the SIS returned no identifiers', () => {
+    const r = analyzeIdSemantics(
+      [student({ childId: 'a', districtStudentId: '100001' })],
+      [sisStudent(null), sisStudent(null)],
+    );
+    expect(r.verdict).toBe('inconclusive');
+    expect(r.verdictReason).toMatch(/no identifiers/i);
+  });
+
+  it('summarizes the format of each side, so a shape mismatch is visible', () => {
+    const r = analyzeIdSemantics(
+      [student({ childId: 'a', districtStudentId: '100001' })],
+      [sisStudent('SIS-000001')],
+    );
+    expect(r.speddyFormat).toEqual({ count: 1, allDigits: 1, lengths: { 6: 1 } });
+    expect(r.sisFormat).toEqual({ count: 1, allDigits: 0, lengths: { 10: 1 } });
+  });
+});
+
+describe('analyzeMatchRate', () => {
+  const sis = [sisStudent('100001'), sisStudent('100002'), sisStudent('100003')];
+
+  it('counts matched, no-ID, and ID-not-in-SIS separately', () => {
+    const r = analyzeMatchRate(
+      [
+        student({ childId: 'a', districtStudentId: '100001' }),
+        student({ childId: 'b', districtStudentId: '999999' }),
+        student({ childId: 'c' }),
+      ],
+      sis,
+    );
+    expect(r.matched).toBe(1);
+    expect(r.unmatchedNotInSis).toBe(1);
+    expect(r.withoutId).toBe(1);
+    // The two denominators answer different questions and must not be merged:
+    // 33% of the caseload is enrichable today; 50% of the ones anyone bothered
+    // to enter an ID for.
+    expect(r.matchRateOfAll).toBe(33.3);
+    expect(r.matchRateOfThoseWithId).toBe(50);
+  });
+
+  it('counts a co-served child ONCE, not once per caseload', () => {
+    // Two providers, one child (SPE-347). Counting caseload rows would inflate
+    // both the numerator and the total by however much co-serving happens —
+    // silently, and differently at every district.
+    const r = analyzeMatchRate(
+      [
+        student({ childId: 'shared', studentId: 's1', districtStudentId: '100001' }),
+        student({ childId: 'shared', studentId: 's2', districtStudentId: '100001' }),
+      ],
+      sis,
+    );
+    expect(r.speddyStudents).toBe(2);
+    expect(r.speddyChildren).toBe(1);
+    expect(r.matched).toBe(1);
+    expect(r.matchRateOfAll).toBe(100);
+  });
+
+  it('flags the same district ID landing on two different children', () => {
+    const r = analyzeMatchRate(
+      [
+        student({ childId: 'a', districtStudentId: '100001' }),
+        student({ childId: 'b', districtStudentId: '100001' }),
+      ],
+      sis,
+    );
+    expect(r.duplicates).toEqual([{ districtStudentId: '100001', childIds: ['a', 'b'] }]);
+  });
+
+  it('counts OUR backfill gap separately from the district missing data', () => {
+    // A district ID that reached the caseload row but never the child record
+    // (SPE-347's backfill). Production has rows in this state. Reporting them
+    // as "no ID entered" would send someone to chase providers for data those
+    // providers already gave us.
+    const r = analyzeMatchRate(
+      [
+        student({ childId: 'a', districtStudentId: null, legacyDistrictStudentId: '100001' }),
+        student({ childId: 'b', districtStudentId: null }),
+      ],
+      sis,
+    );
+    expect(r.backfillGap).toBe(1);
+    expect(r.withoutId).toBe(2); // both are unmatchable today...
+    // ...but only one of them is unmatchable because of something WE did.
+  });
+
+  it('does not divide by zero on an empty caseload', () => {
+    const r = analyzeMatchRate([], sis);
+    expect(r.matchRateOfAll).toBe(0);
+    expect(r.matchRateOfThoseWithId).toBe(0);
+  });
+});
+
+describe('analyzeTeacherLinkage — the multi-teacher question', () => {
+  const schools: SchoolRow[] = [
+    { id: 'ELEM', name: 'Willow Elementary', school_type: 'Elementary' },
+    { id: 'HIGH', name: 'Cedar High', school_type: 'High School' },
+  ];
+  const sis = [sisStudent('100001'), sisStudent('100002')];
+
+  it('restricts itself to matched students at secondary schools', () => {
+    const r = analyzeTeacherLinkage(
+      [
+        student({ childId: 'a', districtStudentId: '100001', schoolId: 'HIGH', gradeLevel: '9' }),
+        student({ childId: 'b', districtStudentId: '100002', schoolId: 'ELEM', gradeLevel: '2' }),
+      ],
+      sis,
+      [],
+      schools,
+      new Map(),
+    );
+    expect(r.secondaryMatched).toBe(1);
+  });
+
+  it('falls back to grade when the school has no type recorded', () => {
+    // A district whose schools table is sparse would otherwise get an empty
+    // report and read it as "no secondary students".
+    const r = analyzeTeacherLinkage(
+      [student({ childId: 'a', districtStudentId: '100001', schoolId: 'UNKNOWN', gradeLevel: '9' })],
+      sis,
+      [],
+      [],
+      new Map(),
+    );
+    expect(r.secondaryMatched).toBe(1);
+  });
+
+  it('builds the teachers-per-student distribution', () => {
+    const r = analyzeTeacherLinkage(
+      [
+        student({ childId: 'a', districtStudentId: '100001', schoolId: 'HIGH', gradeLevel: '9' }),
+        student({ childId: 'b', districtStudentId: '100002', schoolId: 'HIGH', gradeLevel: '10' }),
+      ],
+      sis,
+      [
+        { districtStudentId: '100001', teacherKey: 'T1' },
+        { districtStudentId: '100001', teacherKey: 'T2' },
+        { districtStudentId: '100001', teacherKey: 'T2' }, // duplicate edge
+        { districtStudentId: '100002', teacherKey: 'T9' },
+      ],
+      schools,
+      new Map(),
+    );
+    // Duplicate edges collapse — 100001 has TWO distinct teachers, not three.
+    expect(r.teachersPerStudent).toEqual({ 2: 1, 1: 1 });
+    expect(r.oneTeacherModelCoverage).toBe(50);
+    expect(r.multiTeacherIds).toEqual(['100001']);
+  });
+
+  it('confirms Speddy\'s teacher only when the SIS actually lists them', () => {
+    const r = analyzeTeacherLinkage(
+      [student({ childId: 'a', districtStudentId: '100001', schoolId: 'HIGH', teacherId: 'sp-1' })],
+      sis,
+      [{ districtStudentId: '100001', teacherKey: 'T1' }],
+      schools,
+      new Map([['sp-1', 'T1']]),
+    );
+    expect(r.speddyTeacherConfirmed).toBe(1);
+    expect(r.speddyTeacherNotInSisSet).toBe(0);
+  });
+
+  // The reassuring-direction trap.
+  it('counts an UNRESOLVABLE teacher as not-confirmed, never as confirmed', () => {
+    // Speddy has a teacher, the SIS lists a teacher, but we cannot map one to
+    // the other. That is "we could not check" — and reporting it as a match
+    // would inflate exactly the number someone will use to decide that today's
+    // single-teacher model is fine.
+    const r = analyzeTeacherLinkage(
+      [student({ childId: 'a', districtStudentId: '100001', schoolId: 'HIGH', teacherId: 'sp-1' })],
+      sis,
+      [{ districtStudentId: '100001', teacherKey: 'T1' }],
+      schools,
+      new Map(), // no mapping available
+    );
+    expect(r.speddyTeacherConfirmed).toBe(0);
+    // And kept OUT of the disagreement bucket: `teachers` carries no SIS key,
+    // so resolution is by email and fails often. Counting our own data gap as
+    // "the district disagrees" would misdirect the fix entirely.
+    expect(r.speddyTeacherUnresolvable).toBe(1);
+    expect(r.speddyTeacherNotInSisSet).toBe(0);
+  });
+
+  it('separates a genuine disagreement from an unresolvable teacher', () => {
+    const r = analyzeTeacherLinkage(
+      [student({ childId: 'a', districtStudentId: '100001', schoolId: 'HIGH', teacherId: 'sp-1' })],
+      sis,
+      [{ districtStudentId: '100001', teacherKey: 'T1' }],
+      schools,
+      new Map([['sp-1', 'T-SOMEONE-ELSE']]), // resolved, but not this student's
+    );
+    expect(r.speddyTeacherNotInSisSet).toBe(1);
+    expect(r.speddyTeacherUnresolvable).toBe(0);
+  });
+
+  it('separates "Speddy has no teacher" from "the SIS disagrees"', () => {
+    const r = analyzeTeacherLinkage(
+      [student({ childId: 'a', districtStudentId: '100001', schoolId: 'HIGH', teacherId: null })],
+      sis,
+      [{ districtStudentId: '100001', teacherKey: 'T1' }],
+      schools,
+      new Map(),
+    );
+    expect(r.speddyTeacherAbsent).toBe(1);
+    expect(r.speddyTeacherNotInSisSet).toBe(0);
+  });
+
+  it('excludes students the SIS gave no teachers for from the coverage figure', () => {
+    // Otherwise a district that shares no schedule data at all reports 0%
+    // coverage, which reads as "the one-teacher model is wrong" rather than
+    // "we have no evidence either way".
+    const r = analyzeTeacherLinkage(
+      [
+        student({ childId: 'a', districtStudentId: '100001', schoolId: 'HIGH' }),
+        student({ childId: 'b', districtStudentId: '100002', schoolId: 'HIGH' }),
+      ],
+      sis,
+      [{ districtStudentId: '100001', teacherKey: 'T1' }],
+      schools,
+      new Map(),
+    );
+    expect(r.noSisTeachers).toBe(1);
+    expect(r.oneTeacherModelCoverage).toBe(100); // 1 of the 1 we have data for
+  });
+});
+
+describe('analyzeSpedFlags', () => {
+  it('splits both directions of disagreement', () => {
+    const r = analyzeSpedFlags(
+      [
+        student({ childId: 'a', districtStudentId: '100001' }),
+        student({ childId: 'b', districtStudentId: '100002' }),
+      ],
+      ['100002', '100003'],
+    );
+    expect(r.inBoth).toBe(1);
+    expect(r.speddyOnly).toBe(1);
+    expect(r.sisOnly).toBe(1);
+    expect(r.sisOnlyIds).toEqual(['100003']);
+    expect(r.speddyOnlyIds).toEqual(['100001']);
+  });
+});
+
+describe('enrollmentsToTeacherLinks — the join OneRoster does not give us', () => {
+  const map = new Map([['stu-1', '100001'], ['stu-2', '100002']]);
+
+  it('joins student and teacher through the class they share', () => {
+    const links = enrollmentsToTeacherLinks(
+      [
+        { role: 'student', user: { sourcedId: 'stu-1' }, class: { sourcedId: 'c1' } },
+        { role: 'teacher', user: { sourcedId: 'tea-1' }, class: { sourcedId: 'c1' } },
+      ],
+      map,
+    );
+    expect(links).toEqual([{ districtStudentId: '100001', teacherKey: 'tea-1' }]);
+  });
+
+  it('does NOT link a student and teacher who share no class', () => {
+    const links = enrollmentsToTeacherLinks(
+      [
+        { role: 'student', user: { sourcedId: 'stu-1' }, class: { sourcedId: 'c1' } },
+        { role: 'teacher', user: { sourcedId: 'tea-1' }, class: { sourcedId: 'c2' } },
+      ],
+      map,
+    );
+    expect(links).toEqual([]);
+  });
+
+  it('collapses a student and teacher who share SEVERAL classes into one edge', () => {
+    // A district with period-by-period enrollments would otherwise report six
+    // teachers where there is one — straight into the distribution SPE-334/342
+    // are waiting on.
+    const links = enrollmentsToTeacherLinks(
+      [
+        { role: 'student', user: { sourcedId: 'stu-1' }, class: { sourcedId: 'c1' } },
+        { role: 'teacher', user: { sourcedId: 'tea-1' }, class: { sourcedId: 'c1' } },
+        { role: 'student', user: { sourcedId: 'stu-1' }, class: { sourcedId: 'c2' } },
+        { role: 'teacher', user: { sourcedId: 'tea-1' }, class: { sourcedId: 'c2' } },
+      ],
+      map,
+    );
+    expect(links).toHaveLength(1);
+  });
+
+  it('counts two DIFFERENT teachers of the same student as two edges', () => {
+    const links = enrollmentsToTeacherLinks(
+      [
+        { role: 'student', user: { sourcedId: 'stu-1' }, class: { sourcedId: 'c1' } },
+        { role: 'teacher', user: { sourcedId: 'tea-1' }, class: { sourcedId: 'c1' } },
+        { role: 'student', user: { sourcedId: 'stu-1' }, class: { sourcedId: 'c2' } },
+        { role: 'teacher', user: { sourcedId: 'tea-2' }, class: { sourcedId: 'c2' } },
+      ],
+      map,
+    );
+    expect(links).toHaveLength(2);
+    expect(new Set(links.map((l) => l.teacherKey))).toEqual(new Set(['tea-1', 'tea-2']));
+  });
+
+  it('ignores roles that are neither student nor teacher', () => {
+    // An administrator enrolled in a class counted as a teacher would inflate
+    // every student's teacher count at that school.
+    const links = enrollmentsToTeacherLinks(
+      [
+        { role: 'student', user: { sourcedId: 'stu-1' }, class: { sourcedId: 'c1' } },
+        { role: 'administrator', user: { sourcedId: 'adm-1' }, class: { sourcedId: 'c1' } },
+      ],
+      map,
+    );
+    expect(links).toEqual([]);
+  });
+
+  it('drops students it cannot map to a district ID rather than guessing', () => {
+    const links = enrollmentsToTeacherLinks(
+      [
+        { role: 'student', user: { sourcedId: 'unknown-student' }, class: { sourcedId: 'c1' } },
+        { role: 'teacher', user: { sourcedId: 'tea-1' }, class: { sourcedId: 'c1' } },
+      ],
+      map,
+    );
+    expect(links).toEqual([]);
+  });
+
+  it('skips malformed enrollments without throwing', () => {
+    const links = enrollmentsToTeacherLinks(
+      [
+        { role: 'student', user: { sourcedId: 'stu-1' } },
+        { role: 'teacher', class: { sourcedId: 'c1' } },
+        {},
+      ],
+      map,
+    );
+    expect(links).toEqual([]);
+  });
+});

--- a/__tests__/unit/scripts/sis-explore/out-path.test.ts
+++ b/__tests__/unit/scripts/sis-explore/out-path.test.ts
@@ -1,0 +1,43 @@
+/**
+ * SPE-398 · where a student-level report is allowed to land.
+ *
+ * The privacy control for this tool IS the `.gitignore` rule, so a `--out` path
+ * that escapes it silently defeats the whole design — and the CLI would have
+ * gone on printing "that file is git-ignored" about a file inside a tracked
+ * directory. Raised by both review bots.
+ */
+import { resolve } from 'path';
+import { resolveOutPath } from '../../../../scripts/sis-explore/run';
+
+const repoRoot = resolve(__dirname, '../../../../');
+
+describe('resolveOutPath', () => {
+  it('defaults into the git-ignored directory', () => {
+    expect(resolveOutPath(undefined, 'SIM-D001', 'aeries')).toBe(
+      resolve(repoRoot, 'sis-reports/SIM-D001-aeries.md'),
+    );
+  });
+
+  it('allows an explicit path inside the ignored directory', () => {
+    expect(resolveOutPath('sis-reports/custom.md', 'D', 'aeries')).toBe(
+      resolve(repoRoot, 'sis-reports/custom.md'),
+    );
+  });
+
+  it('allows any path OUTSIDE the repository — that is the caller\'s business', () => {
+    expect(resolveOutPath('/tmp/spe398.md', 'D', 'aeries')).toBe('/tmp/spe398.md');
+  });
+
+  it.each([
+    ['report.md', 'the repo root'],
+    ['docs/report.md', 'a tracked docs directory'],
+    ['sis-reports-elsewhere/x.md', 'a lookalike directory that is NOT the ignored one'],
+    ['sis-reports/../leak.md', 'a traversal back out of the ignored directory'],
+  ])('REFUSES %s (%s)', (path) => {
+    expect(() => resolveOutPath(path, 'D', 'aeries')).toThrow(/Refusing to write/i);
+  });
+
+  it('names the reason, so the operator knows what to do instead', () => {
+    expect(() => resolveOutPath('report.md', 'D', 'aeries')).toThrow(/only path\s+git ignores/i);
+  });
+});

--- a/__tests__/unit/scripts/sis-explore/report.test.ts
+++ b/__tests__/unit/scripts/sis-explore/report.test.ts
@@ -1,0 +1,145 @@
+/**
+ * SPE-398 · the PII split, asserted rather than intended.
+ *
+ * The ticket's rule is that student-level district IDs go to a git-ignored file
+ * and never into Linear or chat beyond aggregates. The realistic way that rule
+ * breaks is nobody being careless — it is someone copying a terminal transcript
+ * into a ticket because the terminal is what they were looking at.
+ *
+ * So the CLI prints `renderSummary` and only `renderSummary`, and this file
+ * pins the property that makes that safe: no identifier disclosed in the full
+ * report may appear in the summary. It is written generically over
+ * `detailIds()` so a NEW detail list added later is covered automatically
+ * rather than needing someone to remember this test exists.
+ */
+import {
+  detailIds,
+  renderFull,
+  renderSummary,
+  type Findings,
+} from '../../../../scripts/sis-explore/report';
+
+/** Distinctive IDs — a substring match must not succeed by accident. */
+const UNMATCHED = ['777001', '777002'];
+const MULTI_TEACHER = ['777003'];
+const SIS_ONLY = ['777004'];
+const SPEDDY_ONLY = ['777005'];
+
+const findings = (over: Partial<Findings> = {}): Findings => ({
+  districtId: 'SIM-D001',
+  sisType: 'aeries',
+  source: 'stored connection',
+  idSemantics: {
+    speddyIdsEntered: 10,
+    sisRecords: 100,
+    sisIdsPresent: 100,
+    overlap: 8,
+    speddyFormat: { count: 10, allDigits: 10, lengths: { 6: 10 } },
+    sisFormat: { count: 100, allDigits: 100, lengths: { 6: 100 } },
+    verdict: 'same-namespace',
+    verdictReason: '8 of 10 district IDs entered in Speddy were found in the SIS.',
+  },
+  matchRate: {
+    speddyStudents: 12,
+    speddyChildren: 10,
+    withId: 10,
+    withoutId: 0,
+    matched: 8,
+    unmatchedNotInSis: 2,
+    matchRateOfAll: 80,
+    matchRateOfThoseWithId: 80,
+    duplicates: [],
+    backfillGap: 0,
+    unmatchedIds: UNMATCHED,
+  },
+  teacherLinkage: {
+    secondaryMatched: 4,
+    teachersPerStudent: { 1: 3, 5: 1 },
+    speddyTeacherConfirmed: 2,
+    speddyTeacherNotInSisSet: 1,
+    speddyTeacherUnresolvable: 1,
+    speddyTeacherAbsent: 0,
+    noSisTeachers: 0,
+    oneTeacherModelCoverage: 75,
+    multiTeacherIds: MULTI_TEACHER,
+  },
+  spedFlags: {
+    sisSpedStudents: 30,
+    speddyCaseloadChildren: 10,
+    inBoth: 8,
+    sisOnly: 22,
+    speddyOnly: 2,
+    sisOnlyIds: SIS_ONLY,
+    speddyOnlyIds: SPEDDY_ONLY,
+  },
+  ...over,
+});
+
+describe('the summary is safe to paste; the full report is not', () => {
+  it('leaks NO student identifier into the summary', () => {
+    const f = findings();
+    const summary = renderSummary(f);
+    const ids = detailIds(f);
+
+    expect(ids.length).toBeGreaterThan(0); // the assertion below must have teeth
+    for (const id of ids) {
+      expect(summary).not.toContain(id);
+    }
+  });
+
+  it('does disclose them in the full report — that is what it is for', () => {
+    const full = renderFull(findings());
+    for (const id of [...UNMATCHED, ...MULTI_TEACHER, ...SIS_ONLY, ...SPEDDY_ONLY]) {
+      expect(full).toContain(id);
+    }
+  });
+
+  it('warns, inside the file, against pasting it anywhere', () => {
+    expect(renderFull(findings())).toMatch(/git-ignored[\s\S]*do not paste/i);
+  });
+
+  it('still reports the counts in the summary, just not the identities', () => {
+    // The aggregates are the point of the summary — a redaction that removed
+    // them too would make the safe artifact useless and push people to the
+    // unsafe one.
+    const summary = renderSummary(findings());
+    expect(summary).toContain('Match rate: 80%');
+    expect(summary).toMatch(/not found in the SIS: 2/);
+  });
+});
+
+describe('the summary refuses to be read out of context', () => {
+  it('warns that the match rate is untrustworthy when the ID check did not settle', () => {
+    // Reporting "match rate: 0%" without this banner would look like a data
+    // problem at the district, when the real answer is that we are comparing
+    // two different numbers.
+    const summary = renderSummary(
+      findings({
+        idSemantics: { ...findings().idSemantics, verdict: 'no-overlap' },
+      }),
+    );
+    expect(summary).toMatch(/not\s+trustworthy yet/i);
+    expect(summary).toMatch(/Settle report 1 first/i);
+  });
+
+  it('does not warn when the ID check came back clean', () => {
+    expect(renderSummary(findings())).not.toMatch(/not\s+trustworthy yet/i);
+  });
+
+  it('names the backfill gap as ours, not the district\'s', () => {
+    const f = findings();
+    const summary = renderSummary({
+      ...f,
+      matchRate: { ...f.matchRate, backfillGap: 11 },
+    });
+    expect(summary).toMatch(/11 student\(s\)/);
+    expect(summary).toMatch(/our backfill gap, not missing data at the district/i);
+  });
+
+  it('says plainly that OneRoster cannot answer the special-ed question', () => {
+    // The owner-accepted limitation. A blank section would read as "we did not
+    // check" rather than "the standard has no such field".
+    const summary = renderSummary(findings({ sisType: 'oneroster', spedFlags: undefined }));
+    expect(summary).toMatch(/no special-education flag/i);
+  });
+});

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -38,6 +38,11 @@ import type {
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+/** Page size for `getAllPages`. Conservative — these are district SISs. */
+export const ONEROSTER_DEFAULT_PAGE_SIZE = 1000;
+/** Hard cap on pages walked, so a server that ignores `offset` cannot loop. */
+const MAX_PAGES = 1000;
+
 /**
  * `application/x-www-form-urlencoded`, per RFC 6749 §2.3.1 / Appendix B.
  *
@@ -213,6 +218,46 @@ export class OneRosterClient {
   /** `GET /enrollments` — the student↔class↔teacher edges (SPE-398 report 3). */
   async getEnrollments(options?: OneRosterRequestOptions): Promise<RawOneRosterEnrollment[]> {
     return this.namedCollection<RawOneRosterEnrollment>('enrollments', 'enrollments', options);
+  }
+
+  /**
+   * Walk a collection to completion, in bounded pages.
+   *
+   * OneRoster paginates with `limit`/`offset`, and a single large `limit` is
+   * not a substitute: servers cap it silently, so a district bigger than the
+   * guess comes back truncated with no indication. That failure is especially
+   * nasty for the SPE-398 reports — a short roster makes the DISTRICT's data
+   * look incomplete, when the truncation was ours.
+   *
+   * Exhausting MAX_PAGES without a short page throws rather than returning what
+   * it has, for the same reason: silently truncated results here become a wrong
+   * match rate that nobody re-checks.
+   */
+  async getAllPages<T>(
+    path: string,
+    key: string,
+    options: Omit<OneRosterRequestOptions, 'limit' | 'offset'> & { pageSize?: number } = {},
+  ): Promise<T[]> {
+    const { pageSize = ONEROSTER_DEFAULT_PAGE_SIZE, ...rest } = options;
+    const all: T[] = [];
+
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const batch = await this.namedCollection<T>(path, key, {
+        ...rest,
+        limit: pageSize,
+        offset: page * pageSize,
+      });
+      all.push(...batch);
+      if (batch.length < pageSize) return all;
+    }
+
+    throw new OneRosterApiError(
+      `OneRoster pagination exceeded ${MAX_PAGES} pages for ${path}; aborting rather than ` +
+        'returning a silently truncated collection',
+      508,
+      path,
+      'request',
+    );
   }
 
   /**

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -30,8 +30,10 @@ import {
 } from './config';
 import type {
   OneRosterTokenResponse,
+  RawOneRosterEnrollment,
   RawOneRosterOrg,
   RawOneRosterSchool,
+  RawOneRosterUser,
 } from './types';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -198,6 +200,21 @@ export class OneRosterClient {
     return this.collection<RawOneRosterSchool>('schools', options);
   }
 
+  /** `GET /students` — the roster. Used by the SPE-398 exploration tooling. */
+  async getStudents(options?: OneRosterRequestOptions): Promise<RawOneRosterUser[]> {
+    return this.namedCollection<RawOneRosterUser>('students', 'users', options);
+  }
+
+  /** `GET /teachers` — needed to resolve a Speddy teacher to a SIS teacher. */
+  async getTeachers(options?: OneRosterRequestOptions): Promise<RawOneRosterUser[]> {
+    return this.namedCollection<RawOneRosterUser>('teachers', 'users', options);
+  }
+
+  /** `GET /enrollments` — the student↔class↔teacher edges (SPE-398 report 3). */
+  async getEnrollments(options?: OneRosterRequestOptions): Promise<RawOneRosterEnrollment[]> {
+    return this.namedCollection<RawOneRosterEnrollment>('enrollments', 'enrollments', options);
+  }
+
   /**
    * Read a OneRoster collection, refusing anything that isn't one.
    *
@@ -216,8 +233,23 @@ export class OneRosterClient {
     path: string,
     options?: OneRosterRequestOptions,
   ): Promise<T[]> {
-    const body = await this.get<{ orgs?: T[] }>(path, options);
-    if (!body || !Array.isArray(body.orgs)) {
+    return this.namedCollection<T>(path, 'orgs', options);
+  }
+
+  /**
+   * The same refusal, for collections OneRoster names something other than
+   * `orgs` — `users` for students and teachers, `enrollments` for enrollments.
+   * Kept as one function so the "a 200 is not automatically a collection" rule
+   * cannot hold for some endpoints and quietly lapse for others.
+   */
+  private async namedCollection<T>(
+    path: string,
+    key: string,
+    options?: OneRosterRequestOptions,
+  ): Promise<T[]> {
+    const body = await this.get<Record<string, unknown>>(path, options);
+    const rows = body?.[key];
+    if (!Array.isArray(rows)) {
       throw new OneRosterApiError(
         `${path} answered, but not with a OneRoster collection.`,
         502,
@@ -225,7 +257,7 @@ export class OneRosterClient {
         'request',
       );
     }
-    return body.orgs;
+    return rows as T[];
   }
 
   // -- Internal ---------------------------------------------------------------

--- a/lib/integrations/oneroster/index.ts
+++ b/lib/integrations/oneroster/index.ts
@@ -7,6 +7,7 @@
 export {
   OneRosterClient,
   OneRosterApiError,
+  ONEROSTER_DEFAULT_PAGE_SIZE,
   type OneRosterPhase,
   type OneRosterRequestOptions,
 } from './client';

--- a/lib/integrations/oneroster/index.ts
+++ b/lib/integrations/oneroster/index.ts
@@ -20,5 +20,7 @@ export {
 export type {
   RawOneRosterOrg,
   RawOneRosterSchool,
+  RawOneRosterUser,
+  RawOneRosterEnrollment,
   OneRosterTokenResponse,
 } from './types';

--- a/lib/integrations/oneroster/types.ts
+++ b/lib/integrations/oneroster/types.ts
@@ -29,6 +29,34 @@ export interface RawOneRosterSchool extends RawOneRosterOrg {
 }
 
 /**
+ * A user from `GET /students` or `GET /teachers` (SPE-398).
+ *
+ * `identifier` is the field OneRoster nominates for "the district's own number",
+ * and `sourcedId` is the SIS's internal key. Which of the two a district's
+ * providers actually copied into Speddy is not knowable in advance — that is
+ * the question SPE-398's ID-semantics probe answers, so BOTH are typed.
+ */
+export interface RawOneRosterUser {
+  sourcedId: string;
+  identifier?: string | null;
+  status?: 'active' | 'tobedeleted';
+  email?: string | null;
+  grades?: string[];
+  orgs?: { sourcedId: string }[];
+  [key: string]: unknown;
+}
+
+/** An enrollment from `GET /enrollments` — the student↔class↔role edge. */
+export interface RawOneRosterEnrollment {
+  sourcedId: string;
+  role?: 'student' | 'teacher' | 'administrator';
+  user?: { sourcedId: string };
+  class?: { sourcedId: string };
+  school?: { sourcedId: string };
+  [key: string]: unknown;
+}
+
+/**
  * The OAuth2 token response.
  *
  * `access_token` is a bearer credential: it must never be logged, persisted, or

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "sim:verify-multi-school-rls": "tsx scripts/sim-district/verify-multi-school-rls.ts",
     "sim:verify-provider-schools-rls": "tsx scripts/sim-district/verify-provider-schools-rls.ts",
     "sim:verify-sis-rls": "tsx scripts/sim-district/verify-sis-connections-rls.ts",
-    "sim:verify-sis-lifecycle": "tsx scripts/sim-district/verify-sis-lifecycle.ts"
+    "sim:verify-sis-lifecycle": "tsx scripts/sim-district/verify-sis-lifecycle.ts",
+    "sis:explore": "tsx scripts/sis-explore/run.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -322,6 +322,29 @@ export function childId(providerKey: string, schoolId: string, index: number): s
   return simUuid(childKey(providerKey, schoolId, index));
 }
 
+/**
+ * The district's own student number, as a provider would have typed it in
+ * (SPE-339). Keyed off `childKey`, so a co-served child carries ONE number
+ * across both caseloads — which is the whole point of the column.
+ *
+ * DELIBERATELY NOT UNIVERSAL. Roughly one child in six has none, because that
+ * is the real shape: production sits near half-filled, and a fixture where
+ * every row matches would let SPE-398's match-rate report claim 100% without
+ * ever exercising the "no ID entered" branch it exists to count. Returns null
+ * for those, and the seed writes the column as NULL.
+ */
+export function districtStudentNumber(
+  providerKey: string,
+  schoolId: string,
+  index: number,
+): string | null {
+  const key = childKey(providerKey, schoolId, index);
+  const seed = createHash('sha1').update(`dsid:${key}`).digest();
+  if (seed[0] % 6 === 0) return null;
+  // Six digits, the shape Aeries and most CA SISs hand out.
+  return String(100000 + ((seed.readUInt32BE(1) % 900000)));
+}
+
 /** Distinct children across every caseload — students minus the shared pairs. */
 export const TOTAL_CHILDREN = new Set(
   CASELOADS.flatMap(rule =>

--- a/scripts/sim-district/seed.ts
+++ b/scripts/sim-district/seed.ts
@@ -42,6 +42,7 @@ import {
   careNoteId,
   careReferralId,
   childId,
+  districtStudentNumber,
   derivePassword,
   groupAssignmentFor,
   personaEmail,
@@ -295,6 +296,10 @@ async function main() {
       if (!seeded || (hasDetails && !seeded.first_name)) {
         childRows.set(childUuid, {
           id: childUuid,
+          // The district's own student number (SPE-339) — the key SPE-398's
+          // match-rate report joins on. Null for roughly one child in six, so
+          // the "no ID entered" branch is exercised rather than assumed away.
+          district_student_id: districtStudentNumber(rule.providerKey, rule.schoolId, i),
           first_name: hasDetails ? name.firstName : null,
           last_name: hasDetails ? name.lastName : null,
           date_of_birth: hasDetails ? `${seedDate.getUTCFullYear() - 6 - gradeNum}-0${(i % 9) + 1}-1${i % 9}` : null,

--- a/scripts/sis-explore/README.md
+++ b/scripts/sis-explore/README.md
@@ -10,6 +10,12 @@ npm run sis:explore -- --district=SIM-D001
 npm run sis:explore -- --district=SIM-D001 --out=/tmp/report.md
 ```
 
+`--out` may point anywhere **outside** the repository, or under `sis-reports/`
+inside it. Any other in-repo path is refused, up front, before the run touches
+the district's SIS — `/sis-reports/` is the only path git ignores, and a report
+written beside tracked files is one `git add -A` away from committing student
+IDs. The file is written `0600`.
+
 It needs a stored SIS connection with a credential — set one up through the tech
 portal first (SPE-396 for Aeries, SPE-397 for OneRoster).
 
@@ -45,8 +51,8 @@ portal first (SPE-396 for Aeries, SPE-397 for OneRoster).
 ## Where the output goes, and why it is split
 
 - **The terminal** gets aggregates only. Safe to paste into Linear or a chat.
-- **`sis-reports/`** (git-ignored) gets the same findings plus student-level
-  district IDs.
+- **`sis-reports/`** (git-ignored, mode `0600`) gets the same findings plus
+  student-level district IDs.
 
 The realistic way the PII rule breaks is not carelessness — it is someone
 copying a terminal transcript into a ticket. So the terminal simply never holds

--- a/scripts/sis-explore/README.md
+++ b/scripts/sis-explore/README.md
@@ -1,0 +1,71 @@
+# SIS exploration tooling (SPE-398)
+
+Internal only. No product UI. Read-only against both the SIS and Speddy.
+
+This is the "not blind" half of the concierge decision (SPE-392): the moment a
+district's credentials land, we need answers rather than a backlog item.
+
+```bash
+npm run sis:explore -- --district=SIM-D001
+npm run sis:explore -- --district=SIM-D001 --out=/tmp/report.md
+```
+
+It needs a stored SIS connection with a credential — set one up through the tech
+portal first (SPE-396 for Aeries, SPE-397 for OneRoster).
+
+## What it answers, in dependency order
+
+1. **Do our student numbers mean their student numbers?** Every district ID a
+   provider typed into Speddy is compared against each candidate identifier the
+   SIS exposes — Aeries offers `StudentID`, `StudentNumber` and `StateStudentID`;
+   OneRoster offers `identifier` and `sourcedId`. The one that actually overlaps
+   is the one the rest of the run uses.
+
+   Three verdicts, and the difference matters: `same-namespace` means believe the
+   numbers below; `no-overlap` means we are comparing two different numbers and
+   everything downstream is void; `inconclusive` means there was not enough data
+   on one side to say — which is *not* the same as "no overlap" and must never be
+   reported as if it were.
+
+2. **How much of the caseload can the SIS enrich?** Counted per *child*, not per
+   caseload row, so a co-served student counts once. Splits three ways: matched,
+   no ID entered, and ID entered but absent from the SIS. It also separates out
+   our own backfill gap — IDs sitting on a `students` row that never reached the
+   child record — because that is our bug, not the district's missing data.
+
+3. **How many teachers does a secondary student really have?** The empirical
+   input SPE-334/342 have been waiting on. Reports the teachers-per-student
+   distribution and what share of students today's single-teacher model actually
+   describes. "We could not resolve this Speddy teacher to a SIS teacher" is
+   counted separately from "the SIS disagrees" — they have different fixes.
+
+4. **Does the district's special-education flag agree with our caseload?**
+   Aeries only. OneRoster carries no such flag anywhere in the standard.
+
+## Where the output goes, and why it is split
+
+- **The terminal** gets aggregates only. Safe to paste into Linear or a chat.
+- **`sis-reports/`** (git-ignored) gets the same findings plus student-level
+  district IDs.
+
+The realistic way the PII rule breaks is not carelessness — it is someone
+copying a terminal transcript into a ticket. So the terminal simply never holds
+the identifiers, and a test (`__tests__/unit/scripts/sis-explore/report.test.ts`)
+asserts that no ID disclosed in the full report can appear in the summary.
+
+**Never** commit a report, paste one into Linear, or attach one to a ticket.
+Persisting anything the SIS tells us into Speddy tables is a separate
+stop-and-discuss decision; v1 writes nothing.
+
+## Known gaps
+
+- **Teacher linkage over Aeries is not collected.** Aeries expresses
+  student↔teacher through class-schedule endpoints our client does not speak yet
+  — that work is SPE-342. The run says so rather than reporting an empty
+  distribution as if it were a finding about the district.
+- **OneRoster cannot answer report 4.** Property of the standard, not a
+  permission a district can grant.
+- **No live SIS has answered this code.** `demo.aeries.net` is blocked by the
+  build sandbox's egress policy, so the transport was exercised against a local
+  mock built from the sim district's real rows. The analysis is unit-tested; the
+  first real district is the proof.

--- a/scripts/sis-explore/analysis.ts
+++ b/scripts/sis-explore/analysis.ts
@@ -1,0 +1,465 @@
+/**
+ * SPE-398 · the analysis half of the SIS exploration tooling.
+ *
+ * Deliberately PURE. Nothing here touches a network or a database: it takes
+ * already-fetched rows and returns findings. That split is the point — the
+ * questions this tool answers are the ones we cannot answer today, so the logic
+ * that answers them has to be testable without a district's credentials, and
+ * has to keep being testable after JSUSD connects.
+ *
+ * Every report separates AGGREGATES from DETAIL. Aggregates are safe to paste
+ * into Linear or a chat; detail carries student-level district IDs and is
+ * written only to a git-ignored file. `report.ts` enforces that split; this
+ * module just keeps the two apart so it can.
+ *
+ * Why these four, in this order (SPE-392's "I don't want the concierge option
+ * if it makes us blind"): each one is a precondition for the next. If our
+ * student number does not mean the same thing as theirs, the match rate is
+ * meaningless; if nothing matches, teacher linkage has nothing to link.
+ */
+import { isSecondarySchool, parseGradeLevel } from '../../lib/school-helpers';
+
+// ---------------------------------------------------------------------------
+// Inputs — normalized so Aeries and OneRoster produce the same shapes.
+// ---------------------------------------------------------------------------
+
+/** A caseload row as Speddy holds it. */
+export interface SpeddyStudent {
+  studentId: string;
+  childId: string;
+  /** What a provider typed in (SPE-339), from the CHILD record — canonical. */
+  districtStudentId: string | null;
+  /**
+   * The same column on `students`, which predates the child record (SPE-347).
+   *
+   * Carried so the match-rate report can tell "nobody entered an ID" apart from
+   * "an ID was entered but the backfill never moved it to the child record".
+   * Production has rows in that second state, and they would otherwise be
+   * counted as missing data at the district rather than a gap on our side.
+   */
+  legacyDistrictStudentId?: string | null;
+  schoolId: string | null;
+  gradeLevel: string;
+  teacherId: string | null;
+}
+
+/** A student as the SIS holds it. */
+export interface SisStudent {
+  /** The SIS's own primary key — Aeries StudentID, OneRoster sourcedId. */
+  sisId: string;
+  /** The field we HOPE is the district's student number. Report 1 tests that. */
+  districtStudentId: string | null;
+  schoolId: string | null;
+  gradeLevel: string | null;
+}
+
+/** One student↔teacher edge from the SIS's schedule/enrollment data. */
+export interface SisTeacherLink {
+  districtStudentId: string;
+  /** Stable SIS-side teacher key — TeacherNumber, or a OneRoster sourcedId. */
+  teacherKey: string;
+}
+
+/** Enough of a school to ask whether it runs the secondary experience. */
+export interface SchoolRow {
+  id: string;
+  name: string;
+  school_type?: string | null;
+  grade_span_low?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// 1. ID semantics — the cheapest question, and everything depends on it.
+// ---------------------------------------------------------------------------
+
+export interface FormatSummary {
+  /** How many values were examined. */
+  count: number;
+  allDigits: number;
+  lengths: Record<number, number>;
+}
+
+export interface IdSemanticsReport {
+  speddyIdsEntered: number;
+  sisRecords: number;
+  sisIdsPresent: number;
+  /** Speddy IDs that appear in the SIS's identifier set. */
+  overlap: number;
+  speddyFormat: FormatSummary;
+  sisFormat: FormatSummary;
+  /**
+   * The actual answer.
+   *
+   * `same-namespace` — enough overlap that the two fields plainly mean the same
+   *   thing, and the match-rate number below can be believed.
+   * `no-overlap` — they do NOT mean the same thing. Everything downstream is
+   *   void, and the next move is finding which SIS field our providers were
+   *   actually copying from. This is the outcome worth catching early, because
+   *   it invalidates the whole OneRoster strategy rather than degrading it.
+   * `inconclusive` — too little data on one side to say. Not the same as
+   *   `no-overlap`, and must never be reported as if it were.
+   */
+  verdict: 'same-namespace' | 'no-overlap' | 'inconclusive';
+  verdictReason: string;
+}
+
+function summarizeFormat(values: string[]): FormatSummary {
+  const lengths: Record<number, number> = {};
+  let allDigits = 0;
+  for (const v of values) {
+    lengths[v.length] = (lengths[v.length] ?? 0) + 1;
+    if (/^\d+$/.test(v)) allDigits++;
+  }
+  return { count: values.length, allDigits, lengths };
+}
+
+export function analyzeIdSemantics(
+  speddy: SpeddyStudent[],
+  sis: SisStudent[],
+): IdSemanticsReport {
+  const speddyIds = speddy.map((s) => s.districtStudentId).filter((v): v is string => !!v);
+  const sisIds = sis.map((s) => s.districtStudentId).filter((v): v is string => !!v);
+  const sisSet = new Set(sisIds);
+  const overlap = new Set(speddyIds.filter((id) => sisSet.has(id))).size;
+  const distinctSpeddy = new Set(speddyIds).size;
+
+  let verdict: IdSemanticsReport['verdict'];
+  let verdictReason: string;
+  if (distinctSpeddy === 0) {
+    verdict = 'inconclusive';
+    verdictReason = 'No Speddy student has a district student ID entered, so there is nothing to compare.';
+  } else if (sisSet.size === 0) {
+    verdict = 'inconclusive';
+    verdictReason = 'The SIS returned no identifiers in the field we read, so the comparison could not be made.';
+  } else if (overlap === 0) {
+    verdict = 'no-overlap';
+    verdictReason =
+      `None of the ${distinctSpeddy} district IDs entered in Speddy appear in the SIS's identifier field. ` +
+      'These are almost certainly different numbers — find which SIS field providers were copying before trusting any match rate.';
+  } else {
+    // A partial overlap is still the same namespace: we hold a caseload, they
+    // hold the whole district, and our data is hand-entered. What would signal
+    // a DIFFERENT namespace is zero overlap, not incomplete overlap.
+    verdict = 'same-namespace';
+    verdictReason =
+      `${overlap} of ${distinctSpeddy} district IDs entered in Speddy were found in the SIS. ` +
+      'The two fields refer to the same numbering, so the match rate below is meaningful.';
+  }
+
+  return {
+    speddyIdsEntered: distinctSpeddy,
+    sisRecords: sis.length,
+    sisIdsPresent: sisSet.size,
+    overlap,
+    speddyFormat: summarizeFormat([...new Set(speddyIds)]),
+    sisFormat: summarizeFormat([...sisSet]),
+    verdict,
+    verdictReason,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 2. Match rate — does the "we identify the caseload, the SIS enriches it"
+//    strategy actually work at this district?
+// ---------------------------------------------------------------------------
+
+export interface MatchRateReport {
+  speddyStudents: number;
+  speddyChildren: number;
+  withId: number;
+  withoutId: number;
+  matched: number;
+  /** An ID was entered, but the SIS has no student with it. */
+  unmatchedNotInSis: number;
+  /** Percentage of the WHOLE caseload we could enrich. */
+  matchRateOfAll: number;
+  /** Percentage of those that even had an ID to match on. */
+  matchRateOfThoseWithId: number;
+  /** Same district ID on more than one child — a data-entry collision. */
+  duplicates: { districtStudentId: string; childIds: string[] }[];
+  /**
+   * OUR bug, not the district's: an ID sits on the `students` row but never
+   * reached the child record, so the join above cannot see it.
+   */
+  backfillGap: number;
+  /** DETAIL — student-level, never leaves the git-ignored report. */
+  unmatchedIds: string[];
+}
+
+export function analyzeMatchRate(
+  speddy: SpeddyStudent[],
+  sis: SisStudent[],
+): MatchRateReport {
+  const sisSet = new Set(
+    sis.map((s) => s.districtStudentId).filter((v): v is string => !!v),
+  );
+
+  // Children, not caseload rows: a co-served child appears on two providers'
+  // caseloads and must count once, or the match rate is quietly inflated by
+  // however much co-serving this district does.
+  const byChild = new Map<string, SpeddyStudent>();
+  for (const s of speddy) if (!byChild.has(s.childId)) byChild.set(s.childId, s);
+  const children = [...byChild.values()];
+
+  const withId = children.filter((c) => !!c.districtStudentId);
+  const matched = withId.filter((c) => sisSet.has(c.districtStudentId!));
+  const unmatched = withId.filter((c) => !sisSet.has(c.districtStudentId!));
+
+  const collisions = new Map<string, string[]>();
+  for (const c of children) {
+    if (!c.districtStudentId) continue;
+    const list = collisions.get(c.districtStudentId) ?? [];
+    list.push(c.childId);
+    collisions.set(c.districtStudentId, list);
+  }
+
+  const backfillGap = children.filter(
+    (c) => !c.districtStudentId && !!c.legacyDistrictStudentId,
+  ).length;
+
+  const pct = (n: number, d: number) => (d === 0 ? 0 : Math.round((n / d) * 1000) / 10);
+
+  return {
+    speddyStudents: speddy.length,
+    speddyChildren: children.length,
+    withId: withId.length,
+    withoutId: children.length - withId.length,
+    matched: matched.length,
+    unmatchedNotInSis: unmatched.length,
+    matchRateOfAll: pct(matched.length, children.length),
+    matchRateOfThoseWithId: pct(matched.length, withId.length),
+    duplicates: [...collisions.entries()]
+      .filter(([, ids]) => ids.length > 1)
+      .map(([districtStudentId, childIds]) => ({ districtStudentId, childIds })),
+    backfillGap,
+    unmatchedIds: unmatched.map((c) => c.districtStudentId!),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 3. Secondary teacher linkage — the owner's named question, and the empirical
+//    input SPE-334/SPE-342 have been missing.
+// ---------------------------------------------------------------------------
+
+export interface TeacherLinkageReport {
+  /** Matched children at a school that runs the secondary experience. */
+  secondaryMatched: number;
+  /** How many SIS teachers each of those students has: count keyed by teachers. */
+  teachersPerStudent: Record<number, number>;
+  /** Students whose SIS teacher set contains the one teacher Speddy records. */
+  speddyTeacherConfirmed: number;
+  /** Speddy records a teacher, resolved to a SIS teacher, who is NOT listed. */
+  speddyTeacherNotInSisSet: number;
+  /**
+   * Speddy records a teacher we could not resolve to any SIS teacher at all.
+   *
+   * A SEPARATE bucket from the one above, because they are different findings
+   * with different fixes: "the SIS disagrees about this student's teacher" is
+   * about rostering, while "we cannot tell who this Speddy teacher is in the
+   * SIS" is about our own teacher records lacking an email that matches. The
+   * `teachers` table carries no SIS key, so resolution is by email and will
+   * fail often — collapsing the two would report our own data gap as a
+   * disagreement with the district.
+   */
+  speddyTeacherUnresolvable: number;
+  /** Speddy records no teacher at all. */
+  speddyTeacherAbsent: number;
+  /** Students the SIS gave no teacher edges for. */
+  noSisTeachers: number;
+  /**
+   * The number that answers the question. What share of secondary students does
+   * today's single-teacher model actually describe?
+   */
+  oneTeacherModelCoverage: number;
+  /** DETAIL — district IDs of students with more than one SIS teacher. */
+  multiTeacherIds: string[];
+}
+
+export function analyzeTeacherLinkage(
+  speddy: SpeddyStudent[],
+  sis: SisStudent[],
+  links: SisTeacherLink[],
+  schools: SchoolRow[],
+  /** Maps a Speddy teacher_id to the SIS-side key, when we can resolve it. */
+  speddyTeacherToSisKey: Map<string, string>,
+): TeacherLinkageReport {
+  const secondaryIds = new Set(
+    schools.filter((s) => isSecondarySchool(s)).map((s) => s.id),
+  );
+  const sisSet = new Set(
+    sis.map((s) => s.districtStudentId).filter((v): v is string => !!v),
+  );
+
+  const byChild = new Map<string, SpeddyStudent>();
+  for (const s of speddy) if (!byChild.has(s.childId)) byChild.set(s.childId, s);
+
+  // A school flagged secondary wins; otherwise fall back to the student's own
+  // grade, so a district whose school_type is blank still gets an answer rather
+  // than a silently empty report.
+  const isSecondary = (s: SpeddyStudent) => {
+    if (s.schoolId && secondaryIds.has(s.schoolId)) return true;
+    const g = parseGradeLevel(s.gradeLevel);
+    return g !== null && g >= 6;
+  };
+
+  const subjects = [...byChild.values()].filter(
+    (s) => s.districtStudentId && sisSet.has(s.districtStudentId) && isSecondary(s),
+  );
+
+  const linksByStudent = new Map<string, Set<string>>();
+  for (const l of links) {
+    const set = linksByStudent.get(l.districtStudentId) ?? new Set<string>();
+    set.add(l.teacherKey);
+    linksByStudent.set(l.districtStudentId, set);
+  }
+
+  const teachersPerStudent: Record<number, number> = {};
+  let confirmed = 0;
+  let notInSet = 0;
+  let unresolvable = 0;
+  let absent = 0;
+  let noSis = 0;
+  const multiTeacherIds: string[] = [];
+
+  for (const s of subjects) {
+    const sisTeachers = linksByStudent.get(s.districtStudentId!) ?? new Set<string>();
+    const n = sisTeachers.size;
+    teachersPerStudent[n] = (teachersPerStudent[n] ?? 0) + 1;
+    if (n === 0) noSis++;
+    if (n > 1) multiTeacherIds.push(s.districtStudentId!);
+
+    if (!s.teacherId) {
+      absent++;
+    } else {
+      const sisKey = speddyTeacherToSisKey.get(s.teacherId);
+      // Never counted as confirmed. "We could not check" and "it matched" are
+      // the two answers a reassuring report would merge.
+      if (!sisKey) unresolvable++;
+      else if (sisTeachers.has(sisKey)) confirmed++;
+      else notInSet++;
+    }
+  }
+
+  const withAnySis = subjects.length - noSis;
+  const exactlyOne = teachersPerStudent[1] ?? 0;
+
+  return {
+    secondaryMatched: subjects.length,
+    teachersPerStudent,
+    speddyTeacherConfirmed: confirmed,
+    speddyTeacherNotInSisSet: notInSet,
+    speddyTeacherUnresolvable: unresolvable,
+    speddyTeacherAbsent: absent,
+    noSisTeachers: noSis,
+    oneTeacherModelCoverage:
+      withAnySis === 0 ? 0 : Math.round((exactlyOne / withAnySis) * 1000) / 10,
+    multiTeacherIds,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 4. SpEd-flag comparison — Aeries only; OneRoster carries no such flag.
+// ---------------------------------------------------------------------------
+
+export interface SpedFlagReport {
+  sisSpedStudents: number;
+  speddyCaseloadChildren: number;
+  inBoth: number;
+  /** Flagged special education in Aeries, absent from every Speddy caseload. */
+  sisOnly: number;
+  /** On a Speddy caseload, not flagged in Aeries. */
+  speddyOnly: number;
+  /** DETAIL — district IDs, never leaves the git-ignored report. */
+  sisOnlyIds: string[];
+  speddyOnlyIds: string[];
+}
+
+export function analyzeSpedFlags(
+  speddy: SpeddyStudent[],
+  sisSpedDistrictIds: string[],
+): SpedFlagReport {
+  const sisSet = new Set(sisSpedDistrictIds);
+  const speddySet = new Set(
+    speddy.map((s) => s.districtStudentId).filter((v): v is string => !!v),
+  );
+
+  const inBoth = [...speddySet].filter((id) => sisSet.has(id));
+  const sisOnly = [...sisSet].filter((id) => !speddySet.has(id));
+  const speddyOnly = [...speddySet].filter((id) => !sisSet.has(id));
+
+  return {
+    sisSpedStudents: sisSet.size,
+    speddyCaseloadChildren: speddySet.size,
+    inBoth: inBoth.length,
+    sisOnly: sisOnly.length,
+    speddyOnly: speddyOnly.length,
+    sisOnlyIds: sisOnly,
+    speddyOnlyIds: speddyOnly,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// OneRoster enrollments → student↔teacher edges.
+// ---------------------------------------------------------------------------
+
+export interface EnrollmentRow {
+  role?: string;
+  user?: { sourcedId: string };
+  class?: { sourcedId: string };
+}
+
+/**
+ * Turn OneRoster enrollments into the student↔teacher edges report 3 needs.
+ *
+ * OneRoster does not state "this teacher teaches this student" anywhere. It
+ * states that a user is enrolled in a class, with a role. The edge has to be
+ * derived by joining the two roles THROUGH the class, which is the step that
+ * can be silently wrong — and wrong here means a fabricated teachers-per-student
+ * distribution, which is the exact number SPE-334/342 are waiting on.
+ *
+ * @param studentSourcedIdToDistrictId maps a OneRoster student to the district
+ *   number the rest of the analysis keys on. Students missing from it are
+ *   dropped rather than guessed at.
+ */
+export function enrollmentsToTeacherLinks(
+  enrollments: EnrollmentRow[],
+  studentSourcedIdToDistrictId: Map<string, string>,
+): SisTeacherLink[] {
+  const studentsByClass = new Map<string, Set<string>>();
+  const teachersByClass = new Map<string, Set<string>>();
+
+  for (const e of enrollments) {
+    const classId = e.class?.sourcedId;
+    const userId = e.user?.sourcedId;
+    if (!classId || !userId) continue;
+    const bucket = e.role === 'teacher' ? teachersByClass : e.role === 'student' ? studentsByClass : null;
+    // Any other role (administrator, or a value this district invented) is
+    // skipped rather than defaulted into one of the two — an administrator
+    // counted as a teacher would inflate every student's teacher count.
+    if (!bucket) continue;
+    const set = bucket.get(classId) ?? new Set<string>();
+    set.add(userId);
+    bucket.set(classId, set);
+  }
+
+  const seen = new Set<string>();
+  const links: SisTeacherLink[] = [];
+  for (const [classId, students] of studentsByClass) {
+    const teachers = teachersByClass.get(classId);
+    if (!teachers) continue;
+    for (const studentSourcedId of students) {
+      const districtStudentId = studentSourcedIdToDistrictId.get(studentSourcedId);
+      if (!districtStudentId) continue;
+      for (const teacherKey of teachers) {
+        // A student and teacher who share several classes are ONE edge, not
+        // several — otherwise a district with period-by-period enrollments
+        // reports six teachers where there is one.
+        const key = `${districtStudentId}::${teacherKey}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        links.push({ districtStudentId, teacherKey });
+      }
+    }
+  }
+  return links;
+}

--- a/scripts/sis-explore/analysis.ts
+++ b/scripts/sis-explore/analysis.ts
@@ -18,6 +18,18 @@
  * meaningless; if nothing matches, teacher linkage has nothing to link.
  */
 import { isSecondarySchool, parseGradeLevel } from '../../lib/school-helpers';
+import { normalizeDistrictStudentId } from '../../lib/utils/student-matcher';
+
+/**
+ * Compare IDs the way the rest of the app already does (`.trim().toUpperCase()`).
+ *
+ * Raised by Codex. Raw exact-match would call `abc123` and `ABC123` different
+ * students, where the import path (`lib/import/classify.ts`) treats them as the
+ * same — so a formatting-only difference could report `no-overlap` and void the
+ * whole run. Comparison is normalized; the values SHOWN in the detail report
+ * stay exactly as they were entered, so somebody can look them up.
+ */
+const norm = (id: string | null | undefined): string => normalizeDistrictStudentId(id);
 
 // ---------------------------------------------------------------------------
 // Inputs — normalized so Aeries and OneRoster produce the same shapes.
@@ -119,9 +131,9 @@ export function analyzeIdSemantics(
 ): IdSemanticsReport {
   const speddyIds = speddy.map((s) => s.districtStudentId).filter((v): v is string => !!v);
   const sisIds = sis.map((s) => s.districtStudentId).filter((v): v is string => !!v);
-  const sisSet = new Set(sisIds);
-  const overlap = new Set(speddyIds.filter((id) => sisSet.has(id))).size;
-  const distinctSpeddy = new Set(speddyIds).size;
+  const sisSet = new Set(sisIds.map(norm));
+  const overlap = new Set(speddyIds.map(norm).filter((id) => sisSet.has(id))).size;
+  const distinctSpeddy = new Set(speddyIds.map(norm)).size;
 
   let verdict: IdSemanticsReport['verdict'];
   let verdictReason: string;
@@ -191,7 +203,7 @@ export function analyzeMatchRate(
   sis: SisStudent[],
 ): MatchRateReport {
   const sisSet = new Set(
-    sis.map((s) => s.districtStudentId).filter((v): v is string => !!v),
+    sis.map((s) => norm(s.districtStudentId)).filter((v) => v !== ''),
   );
 
   // Children, not caseload rows: a co-served child appears on two providers'
@@ -202,15 +214,16 @@ export function analyzeMatchRate(
   const children = [...byChild.values()];
 
   const withId = children.filter((c) => !!c.districtStudentId);
-  const matched = withId.filter((c) => sisSet.has(c.districtStudentId!));
-  const unmatched = withId.filter((c) => !sisSet.has(c.districtStudentId!));
+  const matched = withId.filter((c) => sisSet.has(norm(c.districtStudentId)));
+  const unmatched = withId.filter((c) => !sisSet.has(norm(c.districtStudentId)));
 
   const collisions = new Map<string, string[]>();
   for (const c of children) {
     if (!c.districtStudentId) continue;
-    const list = collisions.get(c.districtStudentId) ?? [];
+    const key = norm(c.districtStudentId);
+    const list = collisions.get(key) ?? [];
     list.push(c.childId);
-    collisions.set(c.districtStudentId, list);
+    collisions.set(key, list);
   }
 
   const backfillGap = children.filter(
@@ -287,7 +300,7 @@ export function analyzeTeacherLinkage(
     schools.filter((s) => isSecondarySchool(s)).map((s) => s.id),
   );
   const sisSet = new Set(
-    sis.map((s) => s.districtStudentId).filter((v): v is string => !!v),
+    sis.map((s) => norm(s.districtStudentId)).filter((v) => v !== ''),
   );
 
   const byChild = new Map<string, SpeddyStudent>();
@@ -303,14 +316,15 @@ export function analyzeTeacherLinkage(
   };
 
   const subjects = [...byChild.values()].filter(
-    (s) => s.districtStudentId && sisSet.has(s.districtStudentId) && isSecondary(s),
+    (s) => s.districtStudentId && sisSet.has(norm(s.districtStudentId)) && isSecondary(s),
   );
 
   const linksByStudent = new Map<string, Set<string>>();
   for (const l of links) {
-    const set = linksByStudent.get(l.districtStudentId) ?? new Set<string>();
+    const key = norm(l.districtStudentId);
+    const set = linksByStudent.get(key) ?? new Set<string>();
     set.add(l.teacherKey);
-    linksByStudent.set(l.districtStudentId, set);
+    linksByStudent.set(key, set);
   }
 
   const teachersPerStudent: Record<number, number> = {};
@@ -322,7 +336,7 @@ export function analyzeTeacherLinkage(
   const multiTeacherIds: string[] = [];
 
   for (const s of subjects) {
-    const sisTeachers = linksByStudent.get(s.districtStudentId!) ?? new Set<string>();
+    const sisTeachers = linksByStudent.get(norm(s.districtStudentId)) ?? new Set<string>();
     const n = sisTeachers.size;
     teachersPerStudent[n] = (teachersPerStudent[n] ?? 0) + 1;
     if (n === 0) noSis++;
@@ -378,9 +392,9 @@ export function analyzeSpedFlags(
   speddy: SpeddyStudent[],
   sisSpedDistrictIds: string[],
 ): SpedFlagReport {
-  const sisSet = new Set(sisSpedDistrictIds);
+  const sisSet = new Set(sisSpedDistrictIds.map(norm).filter((v) => v !== ''));
   const speddySet = new Set(
-    speddy.map((s) => s.districtStudentId).filter((v): v is string => !!v),
+    speddy.map((s) => norm(s.districtStudentId)).filter((v) => v !== ''),
   );
 
   const inBoth = [...speddySet].filter((id) => sisSet.has(id));

--- a/scripts/sis-explore/report.ts
+++ b/scripts/sis-explore/report.ts
@@ -148,6 +148,10 @@ export function renderFull(f: Findings): string {
     '',
     section('District IDs entered in Speddy but not found in the SIS', m.unmatchedIds),
     section('Secondary students with more than one SIS teacher', t.multiTeacherIds),
+    section(
+      'District IDs entered on more than one child',
+      m.duplicates.map((d) => `${d.districtStudentId} → children ${d.childIds.join(', ')}`),
+    ),
     ...(sp
       ? [
           section('Flagged special education in Aeries, absent from Speddy', sp.sisOnlyIds),
@@ -161,6 +165,7 @@ export function renderFull(f: Findings): string {
 export function detailIds(f: Findings): string[] {
   return [
     ...f.matchRate.unmatchedIds,
+    ...f.matchRate.duplicates.map((d) => d.districtStudentId),
     ...f.teacherLinkage.multiTeacherIds,
     ...(f.spedFlags?.sisOnlyIds ?? []),
     ...(f.spedFlags?.speddyOnlyIds ?? []),

--- a/scripts/sis-explore/report.ts
+++ b/scripts/sis-explore/report.ts
@@ -1,0 +1,168 @@
+/**
+ * SPE-398 · rendering the findings, and keeping student IDs out of the terminal.
+ *
+ * THE PII RULE, made structural rather than remembered. SPE-398 says reports
+ * carry student-level district IDs, so they go to a git-ignored file and never
+ * into Linear or chat beyond aggregates. The obvious way to break that is not
+ * malice — it is copying a terminal transcript into a ticket.
+ *
+ * So there are two renderers and they are not the same text:
+ *
+ *   renderSummary() — aggregates only. Safe to paste anywhere. This is what
+ *     the CLI prints.
+ *   renderFull()    — the same findings plus the student-level lists. Written
+ *     to disk under a git-ignored path and never printed.
+ *
+ * A test asserts that no district ID appearing in the detail can appear in the
+ * summary. That makes the rule checkable instead of merely stated.
+ */
+import type {
+  IdSemanticsReport,
+  MatchRateReport,
+  SpedFlagReport,
+  TeacherLinkageReport,
+} from './analysis';
+
+export interface Findings {
+  districtId: string;
+  sisType: 'aeries' | 'oneroster';
+  source: string;
+  idSemantics: IdSemanticsReport;
+  matchRate: MatchRateReport;
+  teacherLinkage: TeacherLinkageReport;
+  /** Aeries only — OneRoster carries no special-education flag at all. */
+  spedFlags?: SpedFlagReport;
+}
+
+const pct = (n: number) => `${n}%`;
+
+function distribution(d: Record<number, number>): string {
+  const keys = Object.keys(d).map(Number).sort((a, b) => a - b);
+  if (keys.length === 0) return '_no data_';
+  return keys.map((k) => `${k} teacher${k === 1 ? '' : 's'}: ${d[k]}`).join(' · ');
+}
+
+/** Aggregates only. Safe to paste into Linear or a chat. */
+export function renderSummary(f: Findings): string {
+  const { idSemantics: id, matchRate: m, teacherLinkage: t, spedFlags: sp } = f;
+  const lines: string[] = [];
+
+  lines.push(`# SIS exploration — ${f.districtId} (${f.sisType})`);
+  lines.push(`Source: ${f.source}`);
+  lines.push('');
+
+  lines.push('## 1. Do our student numbers mean their student numbers?');
+  lines.push('');
+  lines.push(`**${id.verdict}** — ${id.verdictReason}`);
+  lines.push('');
+  lines.push(`- District IDs entered in Speddy: ${id.speddyIdsEntered}`);
+  lines.push(`- SIS records read: ${id.sisRecords} (${id.sisIdsPresent} carried an identifier)`);
+  lines.push(`- Found in both: ${id.overlap}`);
+  lines.push(
+    `- Format — Speddy: ${id.speddyFormat.allDigits}/${id.speddyFormat.count} all-digits, ` +
+      `lengths ${JSON.stringify(id.speddyFormat.lengths)}`,
+  );
+  lines.push(
+    `- Format — SIS: ${id.sisFormat.allDigits}/${id.sisFormat.count} all-digits, ` +
+      `lengths ${JSON.stringify(id.sisFormat.lengths)}`,
+  );
+  lines.push('');
+
+  lines.push('## 2. How much of the caseload can the SIS enrich?');
+  lines.push('');
+  if (id.verdict !== 'same-namespace') {
+    lines.push(
+      `> ⚠️ The ID check came back **${id.verdict}**, so the figures below are not ` +
+        'trustworthy yet. Settle report 1 first.',
+    );
+    lines.push('');
+  }
+  lines.push(`- Caseload rows: ${m.speddyStudents} → distinct children: ${m.speddyChildren}`);
+  lines.push(`- Have a district ID entered: ${m.withId} · missing one: ${m.withoutId}`);
+  lines.push(`- Matched to a SIS record: **${m.matched}**`);
+  lines.push(`- ID entered but not found in the SIS: ${m.unmatchedNotInSis}`);
+  lines.push(`- **Match rate: ${pct(m.matchRateOfAll)} of the caseload**, ` +
+    `${pct(m.matchRateOfThoseWithId)} of those with an ID entered`);
+  if (m.duplicates.length) {
+    lines.push(`- ⚠️ ${m.duplicates.length} district ID(s) appear on more than one child`);
+  }
+  if (m.backfillGap) {
+    lines.push(
+      `- ⚠️ ${m.backfillGap} student(s) have a district ID on the caseload row that never reached ` +
+        'the child record. That is our backfill gap, not missing data at the district — ' +
+        'those students are unmatchable until it is closed.',
+    );
+  }
+  lines.push('');
+
+  lines.push('## 3. Secondary teacher linkage (SPE-334/342)');
+  lines.push('');
+  lines.push(`- Matched students at secondary schools: ${t.secondaryMatched}`);
+  lines.push(`- Teachers per student: ${distribution(t.teachersPerStudent)}`);
+  lines.push(`- **Today's single-teacher model describes ${pct(t.oneTeacherModelCoverage)}** ` +
+    'of the students the SIS gave schedule data for');
+  lines.push(`- Speddy's teacher confirmed by the SIS: ${t.speddyTeacherConfirmed}`);
+  lines.push(`- Speddy's teacher resolved but NOT listed for that student: ${t.speddyTeacherNotInSisSet}`);
+  lines.push(`- Speddy's teacher could not be resolved to a SIS teacher: ${t.speddyTeacherUnresolvable}`);
+  lines.push(`- No teacher recorded in Speddy: ${t.speddyTeacherAbsent}`);
+  lines.push(`- No schedule data from the SIS: ${t.noSisTeachers}`);
+  lines.push('');
+
+  if (sp) {
+    lines.push('## 4. Special-education flag comparison (Aeries)');
+    lines.push('');
+    lines.push(`- Flagged in Aeries: ${sp.sisSpedStudents} · on a Speddy caseload: ${sp.speddyCaseloadChildren}`);
+    lines.push(`- In both: ${sp.inBoth}`);
+    lines.push(`- Flagged in Aeries, not on any Speddy caseload: ${sp.sisOnly}`);
+    lines.push(`- On a Speddy caseload, not flagged in Aeries: ${sp.speddyOnly}`);
+    lines.push('');
+  } else {
+    lines.push('## 4. Special-education flag comparison');
+    lines.push('');
+    lines.push('_Not available over OneRoster — the standard carries no special-education flag._');
+    lines.push('');
+  }
+
+  lines.push('---');
+  lines.push('Student-level detail is in the full report on disk, and is not reproduced here.');
+  return lines.join('\n');
+}
+
+/** The summary plus student-level lists. Git-ignored path only — never printed. */
+export function renderFull(f: Findings): string {
+  const { matchRate: m, teacherLinkage: t, spedFlags: sp } = f;
+  const section = (title: string, ids: string[]) =>
+    ids.length
+      ? [`### ${title} (${ids.length})`, '', ...ids.map((i) => `- ${i}`), ''].join('\n')
+      : `### ${title}\n\n_none_\n`;
+
+  return [
+    renderSummary(f),
+    '',
+    '---',
+    '',
+    '# Student-level detail',
+    '',
+    '> Contains district student IDs. This file is git-ignored. Do not paste it',
+    '> into Linear, a chat, or a ticket — the summary above is the shareable part.',
+    '',
+    section('District IDs entered in Speddy but not found in the SIS', m.unmatchedIds),
+    section('Secondary students with more than one SIS teacher', t.multiTeacherIds),
+    ...(sp
+      ? [
+          section('Flagged special education in Aeries, absent from Speddy', sp.sisOnlyIds),
+          section('On a Speddy caseload, not flagged in Aeries', sp.speddyOnlyIds),
+        ]
+      : []),
+  ].join('\n');
+}
+
+/** Every student-level identifier the full report discloses. Used by the PII test. */
+export function detailIds(f: Findings): string[] {
+  return [
+    ...f.matchRate.unmatchedIds,
+    ...f.teacherLinkage.multiTeacherIds,
+    ...(f.spedFlags?.sisOnlyIds ?? []),
+    ...(f.spedFlags?.speddyOnlyIds ?? []),
+  ];
+}

--- a/scripts/sis-explore/run.ts
+++ b/scripts/sis-explore/run.ts
@@ -1,0 +1,171 @@
+/**
+ * SPE-398 · `npm run sis:explore -- --district=<id>`
+ *
+ * The "not blind" tooling from SPE-392. Point it at a district with a stored
+ * SIS connection and it answers, in order:
+ *
+ *   1. Does our student number mean their student number?
+ *   2. How much of the caseload can the SIS actually enrich?
+ *   3. How many teachers does a secondary student really have?
+ *   4. Does the district's special-education flag agree with our caseload?
+ *
+ * Internal only. No product UI, read-only against both the SIS and Speddy.
+ *
+ * OUTPUT, and why it is split. The terminal gets aggregates; the full report,
+ * which carries student-level district IDs, goes to a git-ignored file. The
+ * realistic way the PII rule breaks is someone pasting a terminal transcript
+ * into a ticket, so the terminal simply never holds the identifiers.
+ *
+ * Usage:
+ *   npm run sis:explore -- --district=SIM-D001
+ *   npm run sis:explore -- --district=SIM-D001 --out=/tmp/report.md
+ */
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { AeriesClient } from '@/lib/integrations/aeries';
+import { OneRosterClient } from '@/lib/integrations/oneroster';
+import {
+  analyzeIdSemantics,
+  analyzeMatchRate,
+  analyzeSpedFlags,
+  analyzeTeacherLinkage,
+  type IdSemanticsReport,
+} from './analysis';
+import { detailIds, renderFull, renderSummary, type Findings } from './report';
+import {
+  fetchAeries,
+  fetchOneRoster,
+  loadConnection,
+  loadSchools,
+  loadSpeddyStudents,
+  loadSpeddyTeacherEmails,
+  type IdCandidate,
+  type SisSnapshot,
+} from './sources';
+
+/** Git-ignored (see .gitignore) — reports carry district student IDs. */
+const DEFAULT_OUT_DIR = 'sis-reports';
+
+function arg(name: string): string | undefined {
+  const hit = process.argv.find((a) => a.startsWith(`--${name}=`));
+  return hit?.slice(name.length + 3);
+}
+
+/**
+ * Pick the identifier field that actually lines up with what providers typed.
+ *
+ * Ranked by real overlap, not by which field we expected to win: the whole
+ * reason report 1 exists is that the expectation is unreliable, and a district
+ * whose providers copied StateStudentID would otherwise get a 0% match rate
+ * that reads like their data is broken.
+ */
+function chooseCandidate(
+  candidates: IdCandidate[],
+  speddy: Parameters<typeof analyzeIdSemantics>[0],
+): { chosen: IdCandidate; report: IdSemanticsReport; all: { field: string; report: IdSemanticsReport }[] } {
+  const all = candidates.map((c) => ({ field: c.field, report: analyzeIdSemantics(speddy, c.students) }));
+  let best = 0;
+  for (let i = 1; i < all.length; i++) {
+    if (all[i].report.overlap > all[best].report.overlap) best = i;
+  }
+  return { chosen: candidates[best], report: all[best].report, all };
+}
+
+async function main(): Promise<void> {
+  const districtId = arg('district');
+  if (!districtId) {
+    console.error('Usage: npm run sis:explore -- --district=<districtId> [--out=<path.md>]');
+    process.exit(2);
+  }
+
+  console.log(`\nSIS exploration · district ${districtId}`);
+  console.log('Read-only. Nothing is written to Speddy tables or to the SIS.\n');
+
+  const { connection, credential } = await loadConnection(districtId);
+  console.log(`Connection: ${connection.sis_type} · ${connection.base_url ?? '(no base url)'}\n`);
+
+  let snapshot: SisSnapshot;
+  if (credential.sisType === 'aeries') {
+    if (!connection.base_url) throw new Error('The stored Aeries connection has no base URL.');
+    snapshot = await fetchAeries(
+      new AeriesClient({ baseUrl: connection.base_url, certificate: credential.certificate }),
+    );
+  } else {
+    if (!connection.base_url || !connection.token_url) {
+      throw new Error('The stored OneRoster connection is missing its base or token URL.');
+    }
+    snapshot = await fetchOneRoster(
+      new OneRosterClient({
+        baseUrl: connection.base_url,
+        tokenUrl: connection.token_url,
+        clientId: credential.clientId,
+        clientSecret: credential.clientSecret,
+      }),
+    );
+  }
+
+  const [speddy, schools, speddyTeacherEmails] = await Promise.all([
+    loadSpeddyStudents(districtId),
+    loadSchools(districtId),
+    loadSpeddyTeacherEmails(districtId),
+  ]);
+
+  const { chosen, report: idSemantics, all } = chooseCandidate(snapshot.candidates, speddy);
+
+  // Speddy teacher → SIS teacher, by email. Built here rather than in the
+  // analysis so the analysis stays pure and the "we could not resolve this
+  // teacher" bucket is fed by a real join instead of an assumption.
+  const sisTeacherByEmail = new Map<string, string>();
+  for (const [key, email] of snapshot.teacherEmails) sisTeacherByEmail.set(email, key);
+  const speddyTeacherToSisKey = new Map<string, string>();
+  for (const [teacherId, email] of speddyTeacherEmails) {
+    const sisKey = sisTeacherByEmail.get(email);
+    if (sisKey) speddyTeacherToSisKey.set(teacherId, sisKey);
+  }
+
+  const findings: Findings = {
+    districtId,
+    sisType: credential.sisType,
+    source: `stored connection · identifier field: ${chosen.field}`,
+    idSemantics,
+    matchRate: analyzeMatchRate(speddy, chosen.students),
+    teacherLinkage: analyzeTeacherLinkage(
+      speddy,
+      chosen.students,
+      snapshot.teacherLinks,
+      schools,
+      speddyTeacherToSisKey,
+    ),
+    spedFlags:
+      credential.sisType === 'aeries' && snapshot.spedDistrictIds
+        ? analyzeSpedFlags(speddy, snapshot.spedDistrictIds)
+        : undefined,
+  };
+
+  // Aggregates only — safe to paste.
+  console.log(renderSummary(findings));
+
+  console.log('\n## Identifier fields tried\n');
+  for (const c of all) {
+    console.log(`- ${c.field}: ${c.report.overlap} of ${c.report.speddyIdsEntered} matched` +
+      (c.field === chosen.field ? '  ← used' : ''));
+  }
+
+  if (snapshot.notes.length) {
+    console.log('\n## Gaps in this run\n');
+    for (const n of snapshot.notes) console.log(`- ${n}`);
+  }
+
+  const out = resolve(arg('out') ?? `${DEFAULT_OUT_DIR}/${districtId}-${connection.sis_type}.md`);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, renderFull(findings), 'utf8');
+
+  const n = detailIds(findings).length;
+  console.log(`\nFull report (${n} student-level ID(s)) written to:\n  ${out}`);
+  console.log('That file is git-ignored. Do not paste it into Linear or a chat.');
+}
+
+main().catch((err) => {
+  console.error(`\nFAILED: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/scripts/sis-explore/run.ts
+++ b/scripts/sis-explore/run.ts
@@ -21,7 +21,7 @@
  *   npm run sis:explore -- --district=SIM-D001 --out=/tmp/report.md
  */
 import { mkdirSync, writeFileSync } from 'fs';
-import { dirname, resolve } from 'path';
+import { dirname, resolve, sep } from 'path';
 import { AeriesClient } from '@/lib/integrations/aeries';
 import { OneRosterClient } from '@/lib/integrations/oneroster';
 import {
@@ -64,11 +64,47 @@ function chooseCandidate(
   speddy: Parameters<typeof analyzeIdSemantics>[0],
 ): { chosen: IdCandidate; report: IdSemanticsReport; all: { field: string; report: IdSemanticsReport }[] } {
   const all = candidates.map((c) => ({ field: c.field, report: analyzeIdSemantics(speddy, c.students) }));
+  if (all.length === 0) {
+    throw new Error('The SIS snapshot offered no identifier fields to compare.');
+  }
   let best = 0;
   for (let i = 1; i < all.length; i++) {
     if (all[i].report.overlap > all[best].report.overlap) best = i;
   }
   return { chosen: candidates[best], report: all[best].report, all };
+}
+
+/**
+ * Decide where the full report may be written.
+ *
+ * The privacy control for this tool IS the ignore rule, and `--out=report.md`
+ * would have written student IDs into a tracked directory while the CLI
+ * cheerfully printed "that file is git-ignored". So a path inside the repo is
+ * accepted only under the ignored directory; anywhere outside the repo is the
+ * caller's own business and is allowed.
+ */
+export function resolveOutPath(
+  requested: string | undefined,
+  districtId: string,
+  sisType: string,
+): string {
+  const repoRoot = resolve(__dirname, '..', '..');
+  if (!requested) {
+    return resolve(repoRoot, DEFAULT_OUT_DIR, `${districtId}-${sisType}.md`);
+  }
+
+  const target = resolve(requested);
+  const inRepo = target === repoRoot || target.startsWith(repoRoot + sep);
+  if (!inRepo) return target;
+
+  const allowed = resolve(repoRoot, DEFAULT_OUT_DIR);
+  if (target === allowed || target.startsWith(allowed + sep)) return target;
+
+  throw new Error(
+    `Refusing to write a student-level report to ${target}.\n` +
+      `Inside the repository, reports may only go under ${DEFAULT_OUT_DIR}/ — the only path ` +
+      'git ignores. Pass an --out path outside the repository, or drop --out entirely.',
+  );
 }
 
 async function main(): Promise<void> {
@@ -80,6 +116,11 @@ async function main(): Promise<void> {
 
   console.log(`\nSIS exploration · district ${districtId}`);
   console.log('Read-only. Nothing is written to Speddy tables or to the SIS.\n');
+
+  // Validated BEFORE any fetching. A run makes real requests against a
+  // district's production SIS; discovering the output path is refusable only
+  // after all of them is a waste of their server and the operator's time.
+  const outPath = resolveOutPath(arg('out'), districtId, 'pending');
 
   const { connection, credential } = await loadConnection(districtId);
   console.log(`Connection: ${connection.sis_type} · ${connection.base_url ?? '(no base url)'}\n`);
@@ -111,6 +152,9 @@ async function main(): Promise<void> {
   ]);
 
   const { chosen, report: idSemantics, all } = chooseCandidate(snapshot.candidates, speddy);
+  // Derived AFTER the field is chosen — teacher links and special-education
+  // flags have to live in the same namespace the analysis joins on.
+  const derived = snapshot.forField(chosen.field);
 
   // Speddy teacher → SIS teacher, by email. Built here rather than in the
   // analysis so the analysis stays pure and the "we could not resolve this
@@ -132,13 +176,13 @@ async function main(): Promise<void> {
     teacherLinkage: analyzeTeacherLinkage(
       speddy,
       chosen.students,
-      snapshot.teacherLinks,
+      derived.teacherLinks,
       schools,
       speddyTeacherToSisKey,
     ),
     spedFlags:
-      credential.sisType === 'aeries' && snapshot.spedDistrictIds
-        ? analyzeSpedFlags(speddy, snapshot.spedDistrictIds)
+      credential.sisType === 'aeries' && derived.spedDistrictIds
+        ? analyzeSpedFlags(speddy, derived.spedDistrictIds)
         : undefined,
   };
 
@@ -156,16 +200,23 @@ async function main(): Promise<void> {
     for (const n of snapshot.notes) console.log(`- ${n}`);
   }
 
-  const out = resolve(arg('out') ?? `${DEFAULT_OUT_DIR}/${districtId}-${connection.sis_type}.md`);
+  // Re-resolved now the SIS type is known, so the default filename names it.
+  // Already proven acceptable above; this cannot newly throw for a custom path.
+  const out = arg('out') ? outPath : resolveOutPath(undefined, districtId, connection.sis_type);
   mkdirSync(dirname(out), { recursive: true });
-  writeFileSync(out, renderFull(findings), 'utf8');
+  // 0600: the report is student-level PII on a shared machine.
+  writeFileSync(out, renderFull(findings), { encoding: 'utf8', mode: 0o600 });
 
   const n = detailIds(findings).length;
   console.log(`\nFull report (${n} student-level ID(s)) written to:\n  ${out}`);
-  console.log('That file is git-ignored. Do not paste it into Linear or a chat.');
+  console.log('Contains district student IDs. Do not paste it into Linear or a chat.');
 }
 
-main().catch((err) => {
-  console.error(`\nFAILED: ${err instanceof Error ? err.message : String(err)}`);
-  process.exit(1);
-});
+// Only when invoked as a CLI. Without this guard, importing anything from this
+// file — a test of `resolveOutPath`, say — runs the whole exploration.
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(`\nFAILED: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/scripts/sis-explore/sources.ts
+++ b/scripts/sis-explore/sources.ts
@@ -1,0 +1,234 @@
+/**
+ * SPE-398 · fetching, kept apart from analysing.
+ *
+ * READ-ONLY, in both directions, and that is a v1 requirement rather than a
+ * habit: nothing here writes to a Speddy domain table, and nothing here writes
+ * to the SIS. Persisting anything a district's SIS tells us is a separate
+ * stop-and-discuss decision, so this module deliberately has no writer to
+ * misuse — it exports fetches and nothing else.
+ *
+ * Everything is normalized into the shapes `analysis.ts` consumes, so a report
+ * reads the same whether the district is on Aeries or OneRoster.
+ */
+import { AeriesClient } from '@/lib/integrations/aeries';
+import { OneRosterClient } from '@/lib/integrations/oneroster';
+import { getDecryptedCredential, listConnections } from '@/lib/sis/connections';
+import { createServiceClient } from '@/lib/supabase/server';
+import {
+  enrollmentsToTeacherLinks,
+  type SchoolRow,
+  type SisStudent,
+  type SisTeacherLink,
+  type SpeddyStudent,
+} from './analysis';
+
+/**
+ * One way of reading "the district's student number" out of the SIS.
+ *
+ * Plural because we do not know which field a district's providers copied.
+ * Aeries alone offers StudentID, StudentNumber and StateStudentID; guessing
+ * wrong produces a 0% match rate that looks like a data problem at the
+ * district. Report 1 tries each and says which one actually lines up.
+ */
+export interface IdCandidate {
+  field: string;
+  students: SisStudent[];
+}
+
+export interface SisSnapshot {
+  candidates: IdCandidate[];
+  teacherLinks: SisTeacherLink[];
+  /** SIS teacher key → lowercased email, for resolving Speddy's teachers. */
+  teacherEmails: Map<string, string>;
+  /** District IDs flagged special education. Aeries only. */
+  spedDistrictIds?: string[];
+  /** What could not be fetched, and why. Printed with the report. */
+  notes: string[];
+}
+
+// ---------------------------------------------------------------------------
+// The Speddy side.
+// ---------------------------------------------------------------------------
+
+export async function loadSpeddyStudents(districtId: string): Promise<SpeddyStudent[]> {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from('students')
+    .select('id, child_id, school_id, grade_level, teacher_id, district_student_id, children!inner(district_student_id)')
+    .eq('district_id', districtId);
+  if (error) throw new Error(`Could not read Speddy students: ${error.message}`);
+
+  return (data ?? []).map((r: Record<string, unknown>) => {
+    const child = r.children as { district_student_id: string | null } | null;
+    return {
+      studentId: String(r.id),
+      childId: String(r.child_id),
+      // The child record is canonical (SPE-347); the column on `students` is
+      // the pre-backfill copy. Both are read so the report can count the rows
+      // where the backfill never landed as OUR gap rather than the district's.
+      districtStudentId: child?.district_student_id ?? null,
+      legacyDistrictStudentId: r.district_student_id ? String(r.district_student_id) : null,
+      schoolId: r.school_id ? String(r.school_id) : null,
+      gradeLevel: String(r.grade_level ?? ''),
+      teacherId: r.teacher_id ? String(r.teacher_id) : null,
+    };
+  });
+}
+
+export async function loadSchools(districtId: string): Promise<SchoolRow[]> {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from('schools')
+    .select('id, name, school_type, grade_span_low')
+    .eq('district_id', districtId);
+  if (error) throw new Error(`Could not read schools: ${error.message}`);
+  return (data ?? []) as SchoolRow[];
+}
+
+/**
+ * Speddy teacher id → lowercased email.
+ *
+ * Email is the only join we have: `teachers` carries no SIS key. Where a
+ * teacher has no email, or the district's SIS holds a different one, the
+ * linkage report counts them "unresolvable" rather than guessing — which is
+ * itself a finding worth reading.
+ */
+export async function loadSpeddyTeacherEmails(districtId: string): Promise<Map<string, string>> {
+  const supabase = createServiceClient();
+  const { data: schools } = await supabase.from('schools').select('id').eq('district_id', districtId);
+  const schoolIds = (schools ?? []).map((s: { id: string }) => s.id);
+  if (schoolIds.length === 0) return new Map();
+
+  const { data, error } = await supabase
+    .from('teachers')
+    .select('id, email')
+    .in('school_id', schoolIds);
+  if (error) throw new Error(`Could not read teachers: ${error.message}`);
+
+  const map = new Map<string, string>();
+  for (const t of (data ?? []) as { id: string; email: string | null }[]) {
+    if (t.email) map.set(t.id, t.email.trim().toLowerCase());
+  }
+  return map;
+}
+
+/** Resolve the stored, decrypted connection for a district. */
+export async function loadConnection(districtId: string) {
+  const connections = await listConnections(districtId);
+  const connection = connections.find((c) => c.status !== 'disabled' && c.credential_hint);
+  if (!connection) {
+    throw new Error(
+      `No SIS connection with a stored credential for district ${districtId}. ` +
+        'Set one up in the tech portal first.',
+    );
+  }
+  const credential = await getDecryptedCredential(connection.id);
+  if (!credential) throw new Error('The stored connection has no readable credential.');
+  return { connection, credential };
+}
+
+// ---------------------------------------------------------------------------
+// The SIS side.
+// ---------------------------------------------------------------------------
+
+const str = (v: unknown): string | null =>
+  v === null || v === undefined || v === '' ? null : String(v);
+
+export async function fetchAeries(client: AeriesClient): Promise<SisSnapshot> {
+  const notes: string[] = [];
+  const schools = await client.getSchools({ fields: ['SchoolCode'] });
+  const codes = schools.map((s) => s.SchoolCode).filter((c) => Number.isFinite(c));
+
+  const rows: Record<string, unknown>[] = [];
+  for (const code of codes) {
+    const page = await client.getAllPages<Record<string, unknown>>(`schools/${code}/students`, {
+      fields: ['StudentID', 'StudentNumber', 'StateStudentID', 'SchoolCode', 'Grade'],
+    });
+    rows.push(...page);
+  }
+
+  // Every candidate, built from ONE fetch — asking three times would triple the
+  // load on a district's production SIS to answer one question.
+  const candidateFields = ['StudentID', 'StudentNumber', 'StateStudentID'] as const;
+  const candidates: IdCandidate[] = candidateFields.map((field) => ({
+    field,
+    students: rows.map((r) => ({
+      sisId: String(r.StudentID ?? ''),
+      districtStudentId: str(r[field]),
+      schoolId: str(r.SchoolCode),
+      gradeLevel: str(r.Grade),
+    })),
+  }));
+
+  const teacherEmails = new Map<string, string>();
+  for (const code of codes) {
+    const teachers = await client.getSchoolTeachers(code, {
+      fields: ['TeacherNumber', 'EmailAddress'],
+    });
+    for (const t of teachers) {
+      const email = str(t.EmailAddress);
+      if (email) teacherEmails.set(String(t.TeacherNumber), email.toLowerCase());
+    }
+  }
+
+  // Special education: program 144, plus 144x for students under evaluation.
+  const spedIds = new Set<string>();
+  for (const code of codes) {
+    for (const programCode of ['144', '144x']) {
+      const programs = await client.getStudentPrograms(code, 0, programCode, {
+        fields: ['StudentID'],
+      });
+      for (const p of programs as Record<string, unknown>[]) {
+        const id = str(p.StudentID);
+        if (id) spedIds.add(id);
+      }
+    }
+  }
+
+  // Stated, not silently omitted. Aeries expresses student↔teacher through
+  // class schedules, which our client does not speak yet — that endpoint work
+  // is SPE-342, and inventing a response shape here that no real instance has
+  // confirmed would produce a distribution that looks authoritative and is not.
+  notes.push(
+    'Teacher linkage was NOT collected over Aeries: the class-schedule endpoints are not implemented ' +
+      'in lib/integrations/aeries yet (SPE-342). Report 3 will show zero secondary students with SIS ' +
+      'teachers — that is a gap in this tool, not a finding about the district.',
+  );
+
+  return { candidates, teacherLinks: [], teacherEmails, spedDistrictIds: [...spedIds], notes };
+}
+
+export async function fetchOneRoster(client: OneRosterClient): Promise<SisSnapshot> {
+  const notes: string[] = [];
+  const students = await client.getStudents({ limit: 5000 });
+
+  const candidates: IdCandidate[] = (['identifier', 'sourcedId'] as const).map((field) => ({
+    field,
+    students: students.map((s) => ({
+      sisId: s.sourcedId,
+      districtStudentId: str(s[field]),
+      schoolId: s.orgs?.[0]?.sourcedId ?? null,
+      gradeLevel: s.grades?.[0] ?? null,
+    })),
+  }));
+
+  const teacherEmails = new Map<string, string>();
+  for (const t of await client.getTeachers({ limit: 5000 })) {
+    if (t.email) teacherEmails.set(t.sourcedId, t.email.trim().toLowerCase());
+  }
+
+  const enrollments = await client.getEnrollments({ limit: 20000 });
+  // Keyed on `identifier` — the district's own number — because that is what
+  // the rest of the analysis joins on. If report 1 says `sourcedId` is the
+  // field that actually matches, the run is re-done with that choice.
+  const byIdentifier = new Map<string, string>();
+  for (const s of students) if (s.identifier) byIdentifier.set(s.sourcedId, String(s.identifier));
+  const teacherLinks = enrollmentsToTeacherLinks(enrollments, byIdentifier);
+
+  notes.push(
+    'OneRoster carries no special-education flag, so report 4 is unavailable on this path. ' +
+      'That is a property of the standard (SPE-392), not a permission the district can grant.',
+  );
+
+  return { candidates, teacherLinks, teacherEmails, notes };
+}

--- a/scripts/sis-explore/sources.ts
+++ b/scripts/sis-explore/sources.ts
@@ -11,7 +11,11 @@
  * reads the same whether the district is on Aeries or OneRoster.
  */
 import { AeriesClient } from '@/lib/integrations/aeries';
-import { OneRosterClient } from '@/lib/integrations/oneroster';
+import {
+  OneRosterClient,
+  type RawOneRosterEnrollment,
+  type RawOneRosterUser,
+} from '@/lib/integrations/oneroster';
 import { getDecryptedCredential, listConnections } from '@/lib/sis/connections';
 import { createServiceClient } from '@/lib/supabase/server';
 import {
@@ -35,13 +39,28 @@ export interface IdCandidate {
   students: SisStudent[];
 }
 
+export interface DerivedForField {
+  teacherLinks: SisTeacherLink[];
+  /** District IDs flagged special education, in the chosen namespace. */
+  spedDistrictIds?: string[];
+}
+
 export interface SisSnapshot {
   candidates: IdCandidate[];
-  teacherLinks: SisTeacherLink[];
+  /**
+   * Derived data, keyed to the identifier field the caller actually picks.
+   *
+   * A FUNCTION rather than a field, because the choice happens after the fetch.
+   * The first version returned teacher links keyed on OneRoster's `identifier`
+   * and Aeries' special-education flags keyed on `StudentID`, both hard-coded —
+   * so the moment report 1 picked any other field, those two reports silently
+   * compared different namespaces and produced total disagreement. Both bots
+   * flagged it; it would have made the answer to the owner's named question
+   * confidently wrong.
+   */
+  forField(field: string): DerivedForField;
   /** SIS teacher key → lowercased email, for resolving Speddy's teachers. */
   teacherEmails: Map<string, string>;
-  /** District IDs flagged special education. Aeries only. */
-  spedDistrictIds?: string[];
   /** What could not be fetched, and why. Printed with the report. */
   notes: string[];
 }
@@ -95,7 +114,14 @@ export async function loadSchools(districtId: string): Promise<SchoolRow[]> {
  */
 export async function loadSpeddyTeacherEmails(districtId: string): Promise<Map<string, string>> {
   const supabase = createServiceClient();
-  const { data: schools } = await supabase.from('schools').select('id').eq('district_id', districtId);
+  // The error is checked, not discarded: a failed lookup returning an empty map
+  // would classify EVERY teacher as unresolvable and read as a finding about
+  // the district's data rather than a Speddy read failure.
+  const { data: schools, error: schoolsError } = await supabase
+    .from('schools')
+    .select('id')
+    .eq('district_id', districtId);
+  if (schoolsError) throw new Error(`Could not read schools: ${schoolsError.message}`);
   const schoolIds = (schools ?? []).map((s: { id: string }) => s.id);
   if (schoolIds.length === 0) return new Map();
 
@@ -195,12 +221,34 @@ export async function fetchAeries(client: AeriesClient): Promise<SisSnapshot> {
       'teachers — that is a gap in this tool, not a finding about the district.',
   );
 
-  return { candidates, teacherLinks: [], teacherEmails, spedDistrictIds: [...spedIds], notes };
+  // StudentID → this row's value for each candidate field, so the flags can be
+  // translated into whichever namespace report 1 selects.
+  const byStudentId = new Map<string, Record<string, string | null>>();
+  for (const r of rows) {
+    const key = str(r.StudentID);
+    if (key) {
+      byStudentId.set(key, Object.fromEntries(candidateFields.map((f) => [f, str(r[f])])));
+    }
+  }
+
+  return {
+    candidates,
+    forField: (field) => ({
+      teacherLinks: [],
+      spedDistrictIds: [...spedIds]
+        .map((sid) => byStudentId.get(sid)?.[field] ?? null)
+        .filter((v): v is string => !!v),
+    }),
+    teacherEmails,
+    notes,
+  };
 }
 
 export async function fetchOneRoster(client: OneRosterClient): Promise<SisSnapshot> {
   const notes: string[] = [];
-  const students = await client.getStudents({ limit: 5000 });
+  // Paged to completion. A fixed `limit` silently truncates a large district,
+  // and a short roster makes THEIR data look incomplete when the loss was ours.
+  const students = await client.getAllPages<RawOneRosterUser>('students', 'users');
 
   const candidates: IdCandidate[] = (['identifier', 'sourcedId'] as const).map((field) => ({
     field,
@@ -213,22 +261,31 @@ export async function fetchOneRoster(client: OneRosterClient): Promise<SisSnapsh
   }));
 
   const teacherEmails = new Map<string, string>();
-  for (const t of await client.getTeachers({ limit: 5000 })) {
+  for (const t of await client.getAllPages<RawOneRosterUser>('teachers', 'users')) {
     if (t.email) teacherEmails.set(t.sourcedId, t.email.trim().toLowerCase());
   }
 
-  const enrollments = await client.getEnrollments({ limit: 20000 });
-  // Keyed on `identifier` — the district's own number — because that is what
-  // the rest of the analysis joins on. If report 1 says `sourcedId` is the
-  // field that actually matches, the run is re-done with that choice.
-  const byIdentifier = new Map<string, string>();
-  for (const s of students) if (s.identifier) byIdentifier.set(s.sourcedId, String(s.identifier));
-  const teacherLinks = enrollmentsToTeacherLinks(enrollments, byIdentifier);
+  const enrollments = await client.getAllPages<RawOneRosterEnrollment>('enrollments', 'enrollments');
 
   notes.push(
     'OneRoster carries no special-education flag, so report 4 is unavailable on this path. ' +
       'That is a property of the standard (SPE-392), not a permission the district can grant.',
   );
 
-  return { candidates, teacherLinks, teacherEmails, notes };
+  return {
+    candidates,
+    // Built per chosen field, not hard-coded to `identifier`. Keying the links
+    // on a different field than the analysis joins on reports every matched
+    // secondary student as having no teachers, and 0% coverage.
+    forField: (field) => {
+      const bySourcedId = new Map<string, string>();
+      for (const st of students) {
+        const value = field === 'sourcedId' ? st.sourcedId : st[field];
+        if (value) bySourcedId.set(st.sourcedId, String(value));
+      }
+      return { teacherLinks: enrollmentsToTeacherLinks(enrollments, bySourcedId) };
+    },
+    teacherEmails,
+    notes,
+  };
 }


### PR DESCRIPTION
The last sub-issue of SPE-392, and the half of the concierge decision that keeps it honest: *"I don't want the concierge option if it makes us blind to determining what we can and can't do with data access."*

`npm run sis:explore -- --district=<id>`. Internal only, no product UI, read-only against both the SIS and Speddy.

## What it answers, in dependency order

Each question is a precondition for the next — if our student number doesn't mean theirs, the match rate is meaningless; if nothing matches, teacher linkage has nothing to link.

**1. Do our student numbers mean their student numbers?**

Every candidate identifier the SIS exposes is tried — Aeries offers `StudentID`, `StudentNumber` *and* `StateStudentID`; OneRoster offers `identifier` and `sourcedId` — and whichever actually overlaps is what the rest of the run uses. Guessing wrong produces a 0% match rate that reads like the district's data is broken.

Three verdicts, and the third is the one that earns its keep:

| Verdict | Means |
|---|---|
| `same-namespace` | Believe the numbers below. A *partial* overlap still counts — we hold a caseload, they hold a district. |
| `no-overlap` | We are comparing two different numbers. Everything downstream is void; find which SIS field providers were copying. |
| `inconclusive` | Not enough data on one side to say. **Not the same as `no-overlap`** — zero overlap because nobody entered any IDs is a different finding from zero overlap because the fields differ, and reporting the first as the second sends someone hunting a problem that doesn't exist. |

**2. How much of the caseload can the SIS enrich?**

Counted per **child**, not per caseload row, so a co-served student counts once — otherwise the rate is inflated by however much co-serving a district does, silently and differently at every district. Splits three ways: matched, no ID entered, ID entered but absent from the SIS.

It also separates out **our** backfill gap — IDs sitting on a `students` row that never reached the child record (SPE-347). Production has 11 of those. Reporting them as "no ID entered" would send someone to chase providers for data those providers already gave us.

**3. How many teachers does a secondary student really have?**

The empirical input SPE-334/342 have been waiting on. Reports the teachers-per-student distribution and what share of students today's single-teacher model actually describes.

"We could not resolve this Speddy teacher to a SIS teacher" is counted **apart from** "the SIS disagrees about this student's teacher". The `teachers` table carries no SIS key, so resolution is by email and fails often — merging the two would report our own data gap as a disagreement with the district, which is a different fix entirely.

**4. Does their special-education flag agree with our caseload?** Aeries only; OneRoster has no such field anywhere in the standard.

## The PII rule, made structural rather than remembered

The ticket says student-level IDs go to a git-ignored file and never into Linear or chat beyond aggregates. The realistic way that breaks isn't carelessness — it's someone copying a terminal transcript into a ticket.

So the terminal **never holds the identifiers**. There are two renderers, and a test asserts — generically over every detail list, so a new one added later is covered without anyone remembering this test exists — that nothing disclosed in the full report can appear in the summary.

Verified rather than asserted:
- **Mutation:** a plausible "helpful" line adding unmatched IDs to the summary fails the test.
- **`.gitignore`:** checked with `git check-ignore`, not just written.
- **End-to-end:** the real run printed **0** district IDs to the terminal while writing 28 to the git-ignored file.

## Verification

The analysis is pure and separately tested, and that's the point — these answers get used to decide whether the OneRoster strategy works, and a report that flatters us is worse than no report. So the cases are weighted toward the *reassuring* direction, and mutation-tested there:

| Mutation | Caught by |
|---|---|
| Count caseload rows instead of children | co-served-child test |
| Treat an unresolvable teacher as confirmed | unresolvable-teacher test |
| Drop dedup on duplicate class enrollments | shared-classes test |
| Leak unmatched IDs into the summary | PII test |

**End-to-end against a real stored connection**, encrypted credential, service-role reads, real analysis, real report — with the SIS itself a local mock built from the sim district's own rows, deliberately imperfect (holds most of our students, misses ten, adds 300 it has that we don't). A mock mirroring Speddy exactly would report 100% and prove nothing. It correctly picked `identifier` over `sourcedId` (144 matches vs 0) and reported 72% of the caseload / 93.5% of those with an ID.

One harness bug worth noting because it looked exactly like a product failure: the first run reported "token endpoint timed out". That was `execFileSync` blocking the event loop of the process *serving* the mock — suspect your own harness first.

**Sim fixture change:** seeded children now carry a district student number, roughly five in six. The fixture had **none at all**, so the match-rate report couldn't be exercised end-to-end, and 0% fill misrepresented production's ~48%. The one-in-six gap is deliberate, so the "no ID entered" branch is exercised rather than assumed away.

**Gates:** 92 suites / 961 tests, typecheck clean, 0 lint errors, `next build` green. `sim:reset` + `sim:verify` + `sim:verify-sis-rls` green, no residue.

## Not covered, stated rather than implied

- **Teacher linkage over Aeries is not collected.** Aeries expresses student↔teacher through class-schedule endpoints our client doesn't speak yet — that's SPE-342. The run prints this as a gap in the tool rather than reporting an empty distribution as if it were a finding about the district. Inventing a response shape no real instance has confirmed would produce numbers that look authoritative and aren't.
- **No live SIS has answered this code.** `demo.aeries.net` is blocked by the sandbox's egress policy, as it was for #808 and #809. The first real district is the proof.
- **Nothing is persisted.** v1 writes nothing to Speddy tables from the SIS; that decision is a separate stop-and-discuss, so `sources.ts` deliberately exports no writer to misuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9wB9cKyt21z79WXbhyFtp

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9wB9cKyt21z79WXbhyFtp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only SIS exploration tool for analyzing student matching, teacher links, identifiers, and special-education data.
  - Supports Aeries and OneRoster data sources, with aggregate summaries and optional detailed reports.
  - Added OneRoster student, teacher, and enrollment retrieval support.
  - Added deterministic district student identifiers to simulated data.

- **Documentation**
  - Added usage, privacy, output, and known-coverage guidance for SIS exploration.

- **Tests**
  - Added comprehensive analysis and report-rendering test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->