### PR TITLE
SPE-410: say why a password was refused, instead of "Failed to update password"

### DIFF
--- a/__tests__/unit/app/api/auth/change-password.test.ts
+++ b/__tests__/unit/app/api/auth/change-password.test.ts
@@ -105,10 +105,47 @@ describe('POST /api/auth/change-password', () => {
     expect(mockLogInfo).toHaveBeenCalled();
   });
 
-  it('explains a weak password too', async () => {
-    updateUserResult = { error: { code: 'weak_password', message: 'Password is too weak' } };
+  it('explains a badly-FORMED password', async () => {
+    updateUserResult = {
+      error: { code: 'weak_password', message: 'too weak', reasons: ['length'] },
+    };
     const res = await POST(req());
     expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/not strong enough/i);
+  });
+
+  it('tells a BREACHED password apart from a badly-formed one', async () => {
+    // The two need opposite advice, and Supabase distinguishes them in
+    // `reasons`. validatePassword() has already required length, case, a digit
+    // and a symbol before we get here — so "add numbers and symbols" is advice
+    // this person has already followed, and it hides the real problem: their
+    // password is public, and they will try small variations of it.
+    updateUserResult = {
+      error: { code: 'weak_password', message: 'too weak', reasons: ['pwned'] },
+    };
+
+    const res = await POST(req());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/known data breach/i);
+    expect(body.error).toMatch(/not a variation/i);
+    // The formatting advice must NOT appear — it is the wrong instruction here.
+    expect(body.error).not.toMatch(/numbers and symbols/i);
+  });
+
+  it('treats pwned as breached even when combined with other reasons', async () => {
+    updateUserResult = {
+      error: { code: 'weak_password', message: 'too weak', reasons: ['characters', 'pwned'] },
+    };
+    expect((await (await POST(req())).json()).error).toMatch(/known data breach/i);
+  });
+
+  it('falls back to the formatting advice when reasons are absent', async () => {
+    // Older auth-js, or a shape we did not anticipate. Better to give the
+    // generic strength advice than to accuse someone of a breach.
+    updateUserResult = { error: { code: 'weak_password', message: 'too weak' } };
+    const res = await POST(req());
     expect((await res.json()).error).toMatch(/not strong enough/i);
   });
 

--- a/__tests__/unit/app/api/auth/change-password.test.ts
+++ b/__tests__/unit/app/api/auth/change-password.test.ts
@@ -1,0 +1,147 @@
+/**
+ * POST /api/auth/change-password — what we tell someone when we refuse.
+ *
+ * This is the FIRST screen every admin-created account sees. Retyping the
+ * temporary password you were just handed is a natural thing to do on a page
+ * headed "Change Your Password", and until this fix that produced a bare
+ * "Failed to update password" with a 500: nothing the person could act on, and
+ * a server-fault entry in monitoring for something that was never our fault.
+ *
+ * Reported from production while onboarding the JSUSD tech admin.
+ *
+ * What the tests below pin, in order of how much they matter:
+ *   - a reused password explains itself, and answers 4xx not 5xx;
+ *   - an unrecognised auth failure stays generic and stays a 500, so this map
+ *     cannot become a way for upstream auth text to reach a browser;
+ *   - the refusal is not logged as an error, or the monitoring noise returns.
+ */
+import { NextRequest } from 'next/server';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+
+let updateUserResult: { error: any } = { error: null };
+let profileResult: { data: any; error: any } = {
+  data: { must_change_password: true },
+  error: null,
+};
+
+const mockUpdateUser = jest.fn(async () => updateUserResult);
+const mockLogError = jest.fn();
+const mockLogInfo = jest.fn();
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: async () => ({ data: { user: { id: USER_ID } }, error: null }),
+      updateUser: mockUpdateUser,
+    },
+    from: () => ({
+      select: () => ({ eq: () => ({ single: async () => profileResult }) }),
+    }),
+  }),
+  createServiceClient: () => ({
+    from: () => ({ update: () => ({ eq: async () => ({ error: null }) }) }),
+  }),
+}));
+
+jest.mock('@/lib/monitoring/logger', () => ({
+  log: { info: (...a: any[]) => mockLogInfo(...a), warn: jest.fn(), error: (...a: any[]) => mockLogError(...a) },
+}));
+
+jest.mock('@/lib/api/rate-limit-user', () => ({
+  checkUserRateLimit: async () => ({ allowed: true, remaining: 10, resetSeconds: 3600 }),
+}));
+
+import { POST } from '@/app/api/auth/change-password/route';
+
+const VALID_PASSWORD = 'Str0ng!Passw0rd42';
+
+const req = (password = VALID_PASSWORD) =>
+  new NextRequest('http://localhost/api/auth/change-password', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ password }),
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  updateUserResult = { error: null };
+  profileResult = { data: { must_change_password: true }, error: null };
+});
+
+describe('POST /api/auth/change-password', () => {
+  it('succeeds on a good password', async () => {
+    const res = await POST(req());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+  });
+
+  it('explains a REUSED password instead of failing blankly', async () => {
+    // The exact case reported: the temporary password typed back in.
+    updateUserResult = {
+      error: {
+        code: 'same_password',
+        message: 'New password should be different from the old password',
+      },
+    };
+
+    const res = await POST(req());
+    const body = await res.json();
+
+    // A person can fix this themselves, so it is their error, not ours.
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/must be different from the temporary one/i);
+    // And the old useless message is gone.
+    expect(body.error).not.toBe('Failed to update password');
+  });
+
+  it('does not file a reused password as a server error', async () => {
+    // The second half of the bug: every one of these landed in monitoring as
+    // though Speddy had broken, burying failures that actually had.
+    updateUserResult = { error: { code: 'same_password', message: 'x' } };
+    await POST(req());
+
+    expect(mockLogError).not.toHaveBeenCalled();
+    expect(mockLogInfo).toHaveBeenCalled();
+  });
+
+  it('explains a weak password too', async () => {
+    updateUserResult = { error: { code: 'weak_password', message: 'Password is too weak' } };
+    const res = await POST(req());
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/not strong enough/i);
+  });
+
+  it('keeps an UNKNOWN auth failure generic, and a 500', async () => {
+    // The guard on the mapping. Anything we have not deliberately worded stays
+    // ours to investigate — and upstream auth text never reaches the browser.
+    updateUserResult = {
+      error: { code: 'unexpected_failure', message: 'internal db constraint xyz' },
+    };
+
+    const res = await POST(req());
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Failed to update password');
+    expect(body.error).not.toMatch(/constraint|xyz/i);
+    expect(mockLogError).toHaveBeenCalled();
+  });
+
+  it('stays generic when the error carries no code at all', async () => {
+    // Older clients, or a network-shaped failure. Falling back to today's
+    // behaviour means this change cannot regress anything.
+    updateUserResult = { error: { message: 'boom' } };
+    const res = await POST(req());
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to update password');
+  });
+
+  it('still refuses when a password change was not required', async () => {
+    profileResult = { data: { must_change_password: false }, error: null };
+    const res = await POST(req());
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/not required/i);
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/app/api/auth/change-password.test.ts
+++ b/__tests__/unit/app/api/auth/change-password.test.ts
@@ -138,7 +138,16 @@ describe('POST /api/auth/change-password', () => {
     updateUserResult = {
       error: { code: 'weak_password', message: 'too weak', reasons: ['characters', 'pwned'] },
     };
-    expect((await (await POST(req())).json()).error).toMatch(/known data breach/i);
+
+    const res = await POST(req());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/known data breach/i);
+    // Not BOTH messages: a breached password that also happens to be short
+    // still needs the breach advice, and appending "add numbers and symbols"
+    // would send them right back to making variations.
+    expect(body.error).not.toMatch(/numbers and symbols/i);
   });
 
   it('falls back to the formatting advice when reasons are absent', async () => {
@@ -146,6 +155,7 @@ describe('POST /api/auth/change-password', () => {
     // generic strength advice than to accuse someone of a breach.
     updateUserResult = { error: { code: 'weak_password', message: 'too weak' } };
     const res = await POST(req());
+    expect(res.status).toBe(400);
     expect((await res.json()).error).toMatch(/not strong enough/i);
   });
 

--- a/app/api/auth/change-password/route.ts
+++ b/app/api/auth/change-password/route.ts
@@ -8,6 +8,23 @@ import { withRoute } from '@/lib/api/with-route';
 const bodySchema = z.object({ password: z.string().min(1) }).passthrough();
 
 /**
+ * Supabase auth failures the person at the keyboard can actually fix, in our
+ * own words.
+ *
+ * Deliberately a small allow-list rather than passing Supabase's message
+ * through. Upstream copy is written for developers ("New password should be
+ * different from the old password"), can change between releases without us
+ * noticing, and echoing arbitrary auth-server text to a browser is a habit
+ * worth not forming. Anything absent from this map stays generic.
+ */
+const USER_FIXABLE_AUTH_ERRORS: Record<string, string> = {
+  same_password:
+    'Your new password must be different from the temporary one you were given. Please choose a different password.',
+  weak_password:
+    'That password is not strong enough. Try making it longer, or adding numbers and symbols.',
+};
+
+/**
  * API endpoint for users to change their password after admin reset.
  * This endpoint:
  * 1. Verifies the user is authenticated
@@ -46,7 +63,28 @@ export const POST = withRoute({ body: bodySchema }, async ({ userId, body }) => 
     const { error: updateError } = await supabase.auth.updateUser({ password });
 
     if (updateError) {
-      log.error('Failed to update password', updateError, { userId });
+      // Supabase answers with a typed code here, and this handler used to throw
+      // it away: every refusal became "Failed to update password" with a 500.
+      //
+      // Two costs, both real. Someone who retyped the temporary password they
+      // were just given — a very natural thing to do on a screen headed "Change
+      // Your Password" — was told nothing about what was wrong, on the FIRST
+      // screen every admin-created account sees. And a person choosing a
+      // password we decline is not a server fault, so each attempt was filed in
+      // error monitoring as though Speddy had broken.
+      const friendly = USER_FIXABLE_AUTH_ERRORS[updateError.code ?? ''];
+      if (friendly) {
+        log.info('Password change refused for a user-fixable reason', {
+          userId,
+          code: updateError.code,
+        });
+        return NextResponse.json({ error: friendly }, { status: 400 });
+      }
+
+      // Anything we do not recognise keeps the old behaviour: say nothing
+      // specific and treat it as ours to investigate. Never pass an upstream
+      // auth message through verbatim.
+      log.error('Failed to update password', updateError, { userId, code: updateError.code });
       return NextResponse.json({ error: 'Failed to update password' }, { status: 500 });
     }
 

--- a/app/api/auth/change-password/route.ts
+++ b/app/api/auth/change-password/route.ts
@@ -8,21 +8,42 @@ import { withRoute } from '@/lib/api/with-route';
 const bodySchema = z.object({ password: z.string().min(1) }).passthrough();
 
 /**
- * Supabase auth failures the person at the keyboard can actually fix, in our
- * own words.
+ * Turn a Supabase auth failure into something the person at the keyboard can
+ * act on — or `undefined`, meaning "not one we have wording for".
  *
- * Deliberately a small allow-list rather than passing Supabase's message
- * through. Upstream copy is written for developers ("New password should be
- * different from the old password"), can change between releases without us
- * noticing, and echoing arbitrary auth-server text to a browser is a habit
- * worth not forming. Anything absent from this map stays generic.
+ * Deliberately an allow-list rather than passing Supabase's message through.
+ * Upstream copy is written for developers ("New password should be different
+ * from the old password"), can change between releases without us noticing, and
+ * echoing arbitrary auth-server text to a browser is a habit worth not forming.
  */
-const USER_FIXABLE_AUTH_ERRORS: Record<string, string> = {
-  same_password:
-    'Your new password must be different from the temporary one you were given. Please choose a different password.',
-  weak_password:
-    'That password is not strong enough. Try making it longer, or adding numbers and symbols.',
-};
+function friendlyAuthError(error: { code?: string; reasons?: string[] }): string | undefined {
+  if (error.code === 'same_password') {
+    return 'Your new password must be different from the temporary one you were given. Please choose a different password.';
+  }
+
+  if (error.code === 'weak_password') {
+    // `weak_password` covers two situations that need OPPOSITE advice, and
+    // Supabase distinguishes them in `reasons` (`length` / `characters` /
+    // `pwned`).
+    //
+    // The distinction is not academic here: validatePassword() has ALREADY
+    // required 8+ characters, upper, lower, a number and a symbol before we
+    // reach this line. So a weak_password coming back from Supabase has passed
+    // every formatting rule we have, which makes `pwned` — the password appears
+    // in a known breach — by far the likeliest reason.
+    //
+    // Telling that person to "add numbers and symbols" is advice they have
+    // already followed, and worse, it hides the actual problem: they will try
+    // small variations of a password that is already public. Raised by Codex on
+    // the PR that introduced this mapping.
+    if (error.reasons?.includes('pwned')) {
+      return 'That password has appeared in a known data breach, so it is not safe to use. Please choose a different password — not a variation of this one.';
+    }
+    return 'That password is not strong enough. Try making it longer, or adding numbers and symbols.';
+  }
+
+  return undefined;
+}
 
 /**
  * API endpoint for users to change their password after admin reset.
@@ -72,7 +93,7 @@ export const POST = withRoute({ body: bodySchema }, async ({ userId, body }) => 
       // screen every admin-created account sees. And a person choosing a
       // password we decline is not a server fault, so each attempt was filed in
       // error monitoring as though Speddy had broken.
-      const friendly = USER_FIXABLE_AUTH_ERRORS[updateError.code ?? ''];
+      const friendly = friendlyAuthError(updateError);
       if (friendly) {
         log.info('Password change refused for a user-fixable reason', {
           userId,


### PR DESCRIPTION
Reported from production while onboarding the JSUSD district tech admin. On `/change-password`, typing the temporary password back in as the new one produced:

> **Failed to update password**

Nothing else. No indication of what was wrong or what to do instead.

## Cause

Supabase answers that case with a typed code — `same_password` — and the handler threw it away:

```ts
if (updateError) {
  log.error('Failed to update password', updateError, { userId });
  return NextResponse.json({ error: 'Failed to update password' }, { status: 500 });
}
```

**Two defects out of one line:**

1. **The reason was discarded**, so a problem the person could fix in five seconds looked like Speddy had broken.
2. **It answered HTTP 500.** Someone choosing a password we decline is not a server fault, so every attempt was filed in error monitoring as an outage — noise that buries failures that were real.

## Why this one is worth more than its size

This is the **first screen every admin-created account sees**. Retyping the password you were just handed is a natural reading of a page headed "Change Your Password" — a common path, not an edge case. It was about to be the pilot district's tech contact's first interaction with the product.

## Fix

A small allow-list of auth codes mapped to our own wording, answering 400, logged at `info` rather than `error`:

| Code | What the user now sees |
|---|---|
| `same_password` | "Your new password must be different from the temporary one you were given. Please choose a different password." |
| `weak_password` | "That password is not strong enough. Try making it longer, or adding numbers and symbols." |

Deliberately **not** a pass-through of Supabase's message. Upstream copy is written for developers ("New password should be different from the old password"), can change between releases without us noticing, and echoing arbitrary auth-server text into a browser is a habit worth not forming.

Anything unrecognised — **including an error carrying no code at all** — keeps today's generic message and its 500. So this cannot regress a case nobody thought about; it can only improve the two we named.

No change to which passwords are accepted. Only to what we say when we refuse.

## Verification

Seven tests, mutation-tested: deleting the mapping fails exactly the three that claim to cover it, and no others.

Pinned alongside the happy path:

- an **unknown** code stays generic and stays a 500, and the upstream text (`internal db constraint xyz`) is asserted absent from the response body
- an error with **no code** falls back to today's behaviour
- a refusal does **not** call `log.error` — otherwise the monitoring half of the bug quietly returns
- the pre-existing "password change not required" guard still refuses without calling `updateUser`

**Gates:** 95 suites / 980 tests, typecheck clean, 0 lint errors, `next build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9wB9cKyt21z79WXbhyFtp

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9wB9cKyt21z79WXbhyFtp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Password changes now provide clear, user-friendly messages when the new password is reused, too weak, or found in a known breach.
  * Recoverable password errors return a client error instead of appearing as an unexpected server failure.
  * Unknown password update failures continue to use a generic error response for safety.

* **Tests**
  * Added coverage for successful changes, invalid and breached passwords, unexpected failures, and requests made when a password change is not required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->