### PR TITLE
SPE-334: multi-teacher foundation — `student_teachers` join table

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -825,6 +825,67 @@ live `children` table + `children_select` / `children_update` policies;
 `lib/import/child-match.ts`; `scripts/sim-district/manifest.ts`
 (`childKey` / `childId` / `TOTAL_CHILDREN`).
 
+### Teacher links — `student_teachers` (SPE-334)
+
+**A child has a *set* of teachers, and the set lives on the child.**
+`student_teachers` is `(child_id, teacher_id)` + optional `subject` / `period`,
+unique per pair. It anchors on `children.id`, not `students.id`: "who teaches
+this kid" is a fact about the kid, so a child served by an RSP and an SLP has
+two caseload rows but **one** teacher set.
+
+Elementary students have one teacher (or two co-teachers); secondary students
+have one per subject/period. The table is what makes the second case
+representable — and it is the shape the SIS syncs (**SPE-342** Aeries,
+**SPE-414** OneRoster) will write into, since a SIS knows children and class
+schedules, not Speddy caseloads.
+
+- **Co-teachers are equals.** There is deliberately **no primary/secondary
+  flag** — the set is unordered (product decision 2026-07-26). `subject` and
+  `period` are **display labels only**: Speddy does not schedule at secondary
+  (§9, SPE-149/193), and nothing may read them as scheduling semantics.
+- **One school per link.** `trg_student_teachers_school_consistency` refuses a
+  link whose teacher is at a different school than the child (precedent:
+  `staff_teacher_assignments`). It **abstains when either side has no school** —
+  20 legacy accountless `teachers` rows carry none, and one of them is named by
+  a live caseload row, so a hard NOT NULL rule would silently drop a real link.
+- **Reads go through one seam.** `get_teacher_student_ids()` (SECURITY DEFINER)
+  resolves teacher account → links → every caseload row of the linked children,
+  and the teacher branch of `students_select`, `children_select`,
+  `student_details` and `schedule_sessions_select` all call it. That is
+  load-bearing, not stylistic: reading the junction inline would put its
+  policies (which read `students`) inside `students`' own policy — the exact
+  cycle the 2025-11 recursion fixes undid (§2, SPE-332).
+- **Dual-write, in both directions, until SPE-341 retires the old columns.**
+  A write to `students.teacher_id` mirrors into the link set (and withdraws the
+  previous teacher, unless another caseload row of the same child still names
+  them). A link change points the legacy `teacher_id` / `teacher_name` pair at
+  the child's first listed link — but **only** on caseload rows whose current
+  teacher is not, or is no longer, one of the child's teachers, so it can never
+  fight the edit that triggered it. Deleting a `students` row withdraws
+  **nothing**: links carry no provenance, so guessing would destroy links added
+  by hand or by the SIS.
+- **Access mirrors the student.** `student_teachers_select` reproduces every
+  branch of `children_select` (provider, teacher, assigned specialist,
+  delivering SEA, site admin). Writes are coarser — a provider with a caseload
+  row for the child, or a site admin at its school — matching `children_update`'s
+  posture; case-manager-only narrowing is **SPE-201**.
+- **Behaviour-identical at the switch.** Verified against production
+  2026-08-07: 284 teacher-bearing caseload rows collapsed to 282 links (the
+  2-row gap is the one real shared child whose copies name the same teacher),
+  and **no** child had copies naming different teachers — so every read set was
+  unchanged. Where copies ever do disagree the link set is their union.
+
+**Source of truth:** `supabase/migrations/20260807_spe334_student_teachers.sql`;
+live `student_teachers` table + its four policies;
+`get_teacher_student_ids()`, `chat_is_student_participant()`,
+`get_student_chat_participants()`, `get_my_chat_students()`,
+`matching_provider_student_ids()`,
+`verify_student_teacher_school_consistency()`,
+`students_mirror_teacher_link()`, `student_teachers_mirror_legacy()`;
+`scripts/sim-district/manifest.ts` (`studentTeacherLinkId` /
+`TOTAL_STUDENT_TEACHER_LINKS`);
+`scripts/sim-district/verify-student-teachers-rls.ts`.
+
 ### The session tables
 
 `schedule_sessions` is the core table. It uses a **template → instance** pattern:
@@ -1184,11 +1245,14 @@ of school (Master Schedule stays), and Internal sets the `school_type` /
 > `/dashboard/special-activities`, and `/dashboard/plan` stay reachable by direct
 > URL on a secondary site (RLS still scopes data).
 >
-> **Known gap — SPE-194 (Medium):** the model is **one teacher per student**
-> (`students.teacher_id`, a single FK; the Teacher roster query is
-> `students … eq('teacher_id', …)`). Secondary students have **many** teachers
-> (one per subject/period), which the current model can't represent —
-> foundational for real secondary support; complements the SPE-181 rostering spike.
+> **Known gap — SPE-194 (Medium), half closed:** the *data model* can now hold
+> many teachers per student — `student_teachers` (SPE-334, §6) — and RLS,
+> chat membership and cross-provider matching already resolve teachers through
+> it. What has **not** moved yet is the application layer: the Teacher roster
+> query is still `students … eq('teacher_id', …)`, and every teacher picker is
+> still single-select. Switching the reads is **SPE-336**, the editing UI is
+> **SPE-337**, and retiring `students.teacher_id` / `teacher_name` is
+> **SPE-341**. Complements the SPE-181 rostering spike.
 
 **Source of truth:** `lib/school-helpers.ts` (`isSecondarySchool`,
 `classifyByType`, `parseGradeLevel`); `app/components/providers/school-context.tsx`
@@ -1211,7 +1275,7 @@ Re-check Linear for current state.
 | **SPE-188** | Low | Security | Idle logout is client-side only; no server-side session-lifetime backstop. |
 | **SPE-190** | Low | Security | Admin-created teachers get a temp password that's never force-rotated (no `must_change_password` on creation). |
 | **SPE-193** | Low | UX / robustness | Elementary/secondary feature gating is client-side only; hidden routes reachable by URL on secondary sites. |
-| **SPE-194** | Medium | Data model | One-teacher-per-student (`students.teacher_id` single FK) can't represent secondary's many-teachers-per-student; foundational for secondary rollout. |
+| **SPE-194** | Medium | Data model | Half closed: `student_teachers` (SPE-334) now holds N teachers per child and RLS/chat/matching resolve through it, but the app still reads and edits the single `students.teacher_id`. Reads switch in SPE-336, editing UI in SPE-337, column retirement in SPE-341. |
 
 **Related context tickets:** SPE-132 (middleware `getSession()` + per-nav
 profile query), SPE-134 (FERPA wording reworded to match reality), SPE-142

--- a/docs/SIM_DISTRICT.md
+++ b/docs/SIM_DISTRICT.md
@@ -399,7 +399,7 @@ Env requirements are scoped per command. Every command needs
 |---|---|---|
 | `sim:reset` | `SIM_DISTRICT_PASSWORD` | it sets the persona passwords |
 | `sim:verify`, `sim:teardown` | — | read-only / delete-only, so they never receive the credential secret |
-| the three `sim:verify-*` guards | `SIM_DISTRICT_PASSWORD` + `NEXT_PUBLIC_SUPABASE_ANON_KEY` | they sign IN as personas, which needs the same derived password and a client-side key |
+| the four `sim:verify-*` guards | `SIM_DISTRICT_PASSWORD` + `NEXT_PUBLIC_SUPABASE_ANON_KEY` | they sign IN as personas, which needs the same derived password and a client-side key |
 
 **Preflight, before any write.** Scripts hard-fail unless: **(a)** the host in
 `NEXT_PUBLIC_SUPABASE_URL` is a front for the project pinned in `manifest.ts` —

--- a/docs/SIM_DISTRICT.md
+++ b/docs/SIM_DISTRICT.md
@@ -286,6 +286,16 @@ Field conventions:
   also calls one child. It is an artifact of the initials generator rather than
   a designed pair, so it stays two children — negative space for SPE-348's
   create-or-attach step, which must cope with exactly that shape.
+- **One `student_teachers` link per (child, teacher) (SPE-334), 200 today.**
+  The child's teacher set, anchored on `children` — so the co-served pairs carry
+  one link between them, not one per caseload copy, exactly as production's
+  backfill collapsed its one real shared pair. Seeding is still **1:1 with the
+  legacy `students.teacher_id`** in this ticket; per-period sets at Cedar/Redwood
+  and the elementary co-teacher pair arrive with SPE-336 (§10). Links are seeded
+  explicitly with manifest-derived ids **before** the caseload rows, so the
+  dual-write trigger's `ON CONFLICT DO NOTHING` is a no-op instead of planting a
+  row with an id the manifest does not own (invariant 1). `TOTAL_STUDENT_TEACHER_LINKS`
+  derives from the same functions the seed uses.
 - Both scoping systems set on every row: legacy text (`school_site`,
   `school_district`) **and** structured FKs (`school_id`, `district_id`,
   `state_id`), plus `teacher_name` text **and** `teacher_id` FK — mirroring
@@ -375,10 +385,12 @@ npm scripts: the three lifecycle commands `sim:reset`, `sim:teardown`,
 `sim:verify`, plus the **signed-in-session guards** that mocked unit tests
 structurally cannot cover (they see no RLS policy, trigger or SECURITY DEFINER
 guard at all): `sim:verify-rls` (`profiles`), `sim:verify-children-rls`
-(SPE-347 `children` RLS + the child-link trigger) and `sim:verify-child-link`
-(SPE-348: the server re-validating a claimed create-or-attach). All `npx tsx`.
-The two `children` guards write sim rows — re-seed afterward to restore a
-pristine fixture.
+(SPE-347 `children` RLS + the child-link trigger), `sim:verify-child-link`
+(SPE-348: the server re-validating a claimed create-or-attach) and
+`sim:verify-student-teachers-rls` (SPE-334: the teacher read sets, the
+co-teacher case, the school-consistency refusal and the dual-write). All
+`npx tsx`. The two `children` guards and the `student_teachers` guard write sim
+rows — re-seed afterward to restore a pristine fixture.
 
 Env requirements are scoped per command. Every command needs
 `NEXT_PUBLIC_SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`. Beyond that:

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "sim:verify-rls": "tsx scripts/sim-district/verify-profiles-rls.ts",
     "sim:verify-children-rls": "tsx scripts/sim-district/verify-children-rls.ts",
     "sim:verify-child-link": "tsx scripts/sim-district/verify-child-link.ts",
+    "sim:verify-student-teachers-rls": "tsx scripts/sim-district/verify-student-teachers-rls.ts",
     "sim:verify-special-activities-rls": "tsx scripts/sim-district/verify-special-activities-rls.ts",
     "sim:verify-multi-school-rls": "tsx scripts/sim-district/verify-multi-school-rls.ts",
     "sim:verify-provider-schools-rls": "tsx scripts/sim-district/verify-provider-schools-rls.ts",

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -381,6 +381,38 @@ export function studentTeacher(rule: CaseloadRule, index: number): { teacherRowI
   return { teacherRowId: teacherRecordId(t.key), teacherName: `${t.firstName} ${t.lastName}` };
 }
 
+/**
+ * SPE-334 — a row in `student_teachers`, the child's teacher set.
+ *
+ * The link is anchored on the CHILD, not on the caseload row, so a co-served
+ * child carries ONE link per teacher no matter how many providers serve them.
+ * That is why the id is keyed on (childId, teacherRowId) rather than on the
+ * students row: the two mirrored Willow pairs collapse to a single link each,
+ * exactly as the production backfill collapses the one real shared pair.
+ *
+ * Seeding stays 1:1 with `studentTeacher()` in this ticket — one link per child,
+ * the same teacher the legacy `students.teacher_id` column names. Per-period
+ * teacher sets at Cedar/Redwood and the elementary co-teacher pair arrive with
+ * SPE-336 (docs/SIM_DISTRICT.md §10, "Secondary rostering ships").
+ */
+export function studentTeacherLinkId(childUuid: string, teacherRowId: string): string {
+  return simUuid(`student_teacher:${childUuid}:${teacherRowId}`);
+}
+
+/**
+ * Distinct (child, teacher) links the seed plants — students minus the links
+ * the shared pairs collapse. Derived from the same functions the seed uses, so
+ * it cannot drift from what actually lands.
+ */
+export const TOTAL_STUDENT_TEACHER_LINKS = new Set(
+  CASELOADS.flatMap(rule =>
+    Array.from(
+      { length: rule.count },
+      (_, i) => `${childKey(rule.providerKey, rule.schoolId, i)}|${studentTeacher(rule, i).teacherRowId}`,
+    ),
+  ),
+).size;
+
 // Edge-case rows (spec §6), all on Rachel's Willow caseload:
 export const EDGE = {
   /** Index of the student with zero scheduled sessions (unscheduled alert). */
@@ -675,7 +707,13 @@ export const SEEDED_TABLES = [
   // `children` is a PARENT of students (students.child_id), so it seeds before
   // them and tears down after them — the one entry here whose order is the
   // reverse of the rest (SPE-347).
-  'user_site_schedules', 'teachers', 'children', 'students', 'student_details',
+  // `student_teachers` (SPE-334) is the child's teacher set. It seeds between
+  // children and students — before students so the legacy-column dual-write
+  // trigger finds the link already there (its ON CONFLICT DO NOTHING then makes
+  // the insert a no-op rather than planting a row with an unmanifested id), and
+  // it tears down between them so the reverse mirror has no caseload rows left
+  // to repoint.
+  'user_site_schedules', 'teachers', 'children', 'student_teachers', 'students', 'student_details',
   'bell_schedules', 'school_hours', 'special_activities',
   'session_groups', 'schedule_sessions',
   'attendance', 'care_referrals', 'care_cases', 'care_meeting_notes',

--- a/scripts/sim-district/seed.ts
+++ b/scripts/sim-district/seed.ts
@@ -62,6 +62,7 @@ import {
   studentId,
   studentInitials,
   studentTeacher,
+  studentTeacherLinkId,
   teacherRecordId,
   userSiteScheduleId,
   detailsCount,
@@ -272,6 +273,7 @@ async function main() {
   // way: it only fires when child_id arrives NULL.
   console.log('Step 6/9: children + students + student_details...');
   const childRows = new Map<string, Record<string, unknown>>();
+  const linkRows = new Map<string, Record<string, unknown>>();
   const studentRows: Record<string, unknown>[] = [];
   const detailRows: Record<string, unknown>[] = [];
   for (const rule of CASELOADS) {
@@ -315,6 +317,18 @@ async function main() {
             : [],
         });
       }
+      const linkId = studentTeacherLinkId(childUuid, teacher.teacherRowId);
+      if (!linkRows.has(linkId)) {
+        linkRows.set(linkId, {
+          id: linkId,
+          child_id: childUuid,
+          teacher_id: teacher.teacherRowId,
+          // subject/period stay null: 1:1 elementary-shaped seeding in this
+          // ticket. SPE-336 is where Cedar/Redwood gain per-period sets.
+          subject: null,
+          period: null,
+        });
+      }
       studentRows.push({
         id,
         child_id: childUuid,
@@ -355,6 +369,12 @@ async function main() {
     }
   }
   counts['children'] = await bulkInsert(admin, 'children', [...childRows.values()]);
+  // SPE-334: the child's teacher set, planted BEFORE the caseload rows. The
+  // dual-write trigger on students would otherwise create these links itself,
+  // with ids this manifest does not own (invariant 1); inserting them first
+  // turns that trigger's ON CONFLICT DO NOTHING into a no-op. Deduped by
+  // (child, teacher), so a co-served child carries one link, not one per copy.
+  counts['student_teachers'] = await bulkInsert(admin, 'student_teachers', [...linkRows.values()]);
   counts['students'] = await bulkInsert(admin, 'students', studentRows);
   counts['student_details'] = await bulkInsert(admin, 'student_details', detailRows);
 

--- a/scripts/sim-district/teardown.ts
+++ b/scripts/sim-district/teardown.ts
@@ -113,9 +113,15 @@ export async function teardown(admin: Admin): Promise<Record<string, number>> {
     admin, 'care_referrals', 'school_id', SIM_SCHOOL_IDS,
   );
 
-  // 5. Students and their detail rows, then the children they pointed at.
+  // 5. Students and their detail rows, then the teacher links, then the children
+  //    they all pointed at. The links go AFTER students on purpose (SPE-334):
+  //    deleting a link fires the legacy-column mirror, and with the caseload
+  //    rows already gone that mirror has nothing to repoint. Deleting children
+  //    would cascade the links away anyway; doing it explicitly keeps the
+  //    teardown symmetric with the seed and countable.
   deleted['student_details'] = await deleteWhereIn(admin, 'student_details', 'student_id', simStudentIds);
   deleted['students'] = await deleteWhereIn(admin, 'students', 'id', simStudentIds);
+  deleted['student_teachers'] = await deleteWhereIn(admin, 'student_teachers', 'child_id', simChildIds);
   deleted['children'] = await deleteWhereIn(admin, 'children', 'id', simChildIds);
 
   // 6. Teachers, permissions, school assignments.

--- a/scripts/sim-district/verify-student-teachers-rls.ts
+++ b/scripts/sim-district/verify-student-teachers-rls.ts
@@ -150,6 +150,12 @@ async function main(): Promise<void> {
 
   console.log('a teacher with no links (fresh fixture, nothing to lose):');
   const david = await signIn('david');
+  // check() records and continues, so an unseeded fixture would otherwise fail
+  // several probes later inside .single() — a readback error that says nothing
+  // about the actual cause. Everything below needs a probe student.
+  if (noraViaLinks.size === 0) {
+    throw new Error('no linked students for Nora — re-seed the fixture (npm run sim:reset -- --yes)');
+  }
   const targetStudentId = [...noraViaLinks][0]!;
   const { data: targetRow } = await admin
     .from('students').select('child_id, school_id').eq('id', targetStudentId).single();

--- a/scripts/sim-district/verify-student-teachers-rls.ts
+++ b/scripts/sim-district/verify-student-teachers-rls.ts
@@ -1,0 +1,348 @@
+/**
+ * SPE-334 — `student_teachers` RLS, the rewritten teacher read paths, and the
+ * dual-write, run with REAL signed-in sessions.
+ *
+ * Same reason this is a script and not a jest test as its siblings
+ * verify-children-rls.ts / verify-profiles-rls.ts: our unit tests mock the
+ * Supabase client, so they cannot see RLS at all — they pass identically
+ * whether a policy permits a write or denies every one. This ticket rewrites
+ * the teacher branch of `students_select`, `children_select` and
+ * `student_details`, which is exactly the kind of change that blind spot hides.
+ *
+ * The contract asserted here:
+ *   - a linked teacher reads EXACTLY the caseload rows the legacy
+ *     `students.teacher_id` column gave them — the "zero visible behavior
+ *     change" claim, measured rather than reasoned about;
+ *   - a teacher with no links reads none, and cannot manufacture one;
+ *   - BOTH co-teachers of a child see that child once a second link exists,
+ *     and the first teacher does not lose it (the whole point of the table);
+ *   - everyone who can read the STUDENT can read its teacher links; an unlinked
+ *     provider cannot, and cannot write one;
+ *   - a link across schools is refused, with the reason asserted;
+ *   - the dual-write holds in both directions through a real session.
+ *
+ * Three traps this deliberately avoids (CLAUDE.md):
+ *   - assert the write PERSISTED, not the HTTP status — PostgREST reports an
+ *     RLS-filtered UPDATE as a 2xx with an empty body;
+ *   - assert WHY a refusal happened (SQLSTATE / rows affected), so a value
+ *     rejected incidentally cannot keep a negative check green;
+ *   - negative checks run against a FRESH target the actor has no link to, so
+ *     an already-permitted state cannot pass them for the wrong reason.
+ *
+ * Requires a seeded sim district (`npm run sim:reset -- --yes`). It creates and
+ * removes its own links and probe rows, so re-seed afterwards to restore a
+ * pristine fixture.
+ *
+ * Usage: npm run sim:verify-student-teachers-rls
+ */
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createAdmin, requireEnv } from './lib';
+import { CEDAR, WILLOW, derivePassword, personaEmail, teacherRecordId } from './manifest';
+
+const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+const secret = requireEnv('SIM_DISTRICT_PASSWORD');
+
+const admin = createAdmin();
+
+let failures = 0;
+function check(ok: boolean, label: string, detail = ''): void {
+  if (!ok) failures++;
+  console.log(`  [${ok ? 'ok  ' : 'FAIL'}] ${label.padEnd(58)} ${detail}`);
+}
+
+async function signIn(personaKey: string): Promise<SupabaseClient> {
+  const email = personaEmail(personaKey);
+  const client = createClient(url, anon, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: derivePassword(secret, email),
+  });
+  if (error) throw new Error(`sim login failed for ${email} — is the district seeded? (${error.message})`);
+  return client;
+}
+
+async function profileId(personaKey: string): Promise<string> {
+  const { data, error } = await admin
+    .from('profiles').select('id').eq('email', personaEmail(personaKey)).single();
+  if (error) throw new Error(`profile lookup failed for ${personaKey}: ${error.message}`);
+  return data.id as string;
+}
+
+/** The caseload rows a teacher row reaches through the junction, service-side. */
+async function linkedStudentIds(teacherRowId: string): Promise<Set<string>> {
+  const { data: links, error } = await admin
+    .from('student_teachers').select('child_id').eq('teacher_id', teacherRowId);
+  if (error) throw new Error(`link lookup failed: ${error.message}`);
+  const childIds = [...new Set((links ?? []).map(l => l.child_id as string))];
+  if (childIds.length === 0) return new Set();
+  const { data: rows, error: sErr } = await admin
+    .from('students').select('id').in('child_id', childIds);
+  if (sErr) throw new Error(`caseload lookup failed: ${sErr.message}`);
+  return new Set((rows ?? []).map(r => r.id as string));
+}
+
+/** The caseload rows the LEGACY column gave that teacher — the pre-SPE-334 set. */
+async function legacyStudentIds(teacherRowId: string): Promise<Set<string>> {
+  const { data, error } = await admin
+    .from('students').select('id').eq('teacher_id', teacherRowId);
+  if (error) throw new Error(`legacy caseload lookup failed: ${error.message}`);
+  return new Set((data ?? []).map(r => r.id as string));
+}
+
+async function legacyPair(studentId: string): Promise<{ teacher_id: string | null; teacher_name: string | null }> {
+  const { data, error } = await admin
+    .from('students').select('teacher_id, teacher_name').eq('id', studentId).single();
+  if (error) throw new Error(`legacy pair readback failed: ${error.message}`);
+  return data as { teacher_id: string | null; teacher_name: string | null };
+}
+
+async function linkTeacherIds(childId: string): Promise<string[]> {
+  const { data, error } = await admin
+    .from('student_teachers').select('teacher_id').eq('child_id', childId).order('created_at');
+  if (error) throw new Error(`link readback failed: ${error.message}`);
+  return (data ?? []).map(r => r.teacher_id as string);
+}
+
+const sameSet = (a: Set<string>, b: Set<string>) =>
+  a.size === b.size && [...a].every(v => b.has(v));
+
+async function main(): Promise<void> {
+  const noraTeacherId = teacherRecordId('login:nora');
+  const davidTeacherId = teacherRecordId('login:david');
+  const fatimaTeacherId = teacherRecordId('login:fatima');
+
+  const rachelId = await profileId('rachel');
+
+  // Nora's students, computed two ways: through the junction (what the policy
+  // now uses) and through the legacy column (what it used yesterday).
+  const noraViaLinks = await linkedStudentIds(noraTeacherId);
+  const noraViaLegacy = await legacyStudentIds(noraTeacherId);
+
+  console.log('read-set invariance (the zero-behaviour-change claim):');
+  {
+    check(noraViaLinks.size > 0, 'the fixture actually links Nora to students', `${noraViaLinks.size}`);
+    check(sameSet(noraViaLinks, noraViaLegacy),
+      'junction read set == legacy-column read set',
+      `links=${noraViaLinks.size} legacy=${noraViaLegacy.size}`);
+
+    const nora = await signIn('nora');
+    const { data: seen, error } = await nora.from('students').select('id');
+    const seenIds = new Set((seen ?? []).map(r => r.id as string));
+    check(!error && sameSet(seenIds, noraViaLinks),
+      'linked teacher SELECTs exactly that set through RLS',
+      error ? error.message : `saw ${seenIds.size}`);
+
+    // The rewrite touches three policies; a teacher blind to details or the
+    // child record would be a silent half-migration.
+    const { count: details } = await nora.from('student_details')
+      .select('*', { count: 'exact', head: true });
+    check((details ?? 0) > 0, 'linked teacher still reads student_details', `count=${details}`);
+    const { count: kids } = await nora.from('children').select('*', { count: 'exact', head: true });
+    check((kids ?? 0) > 0 && (kids ?? 0) <= noraViaLinks.size,
+      'linked teacher still reads the child records', `children=${kids}`);
+    const { count: sessions } = await nora.from('schedule_sessions')
+      .select('*', { count: 'exact', head: true });
+    check((sessions ?? 0) > 0, 'linked teacher still reads their students\' sessions', `count=${sessions}`);
+  }
+
+  console.log('a teacher with no links (fresh fixture, nothing to lose):');
+  const david = await signIn('david');
+  const targetStudentId = [...noraViaLinks][0]!;
+  const { data: targetRow } = await admin
+    .from('students').select('child_id, school_id').eq('id', targetStudentId).single();
+  const targetChildId = targetRow!.child_id as string;
+  {
+    check((await linkTeacherIds(targetChildId)).includes(davidTeacherId) === false,
+      'David starts with NO link to the probe child', targetChildId);
+
+    const { data: seen, error } = await david.from('students').select('id');
+    check(!error && (seen?.length ?? 0) === 0, 'unlinked teacher SELECTs 0 students',
+      error ? error.message : `saw ${seen?.length ?? 0}`);
+
+    const { count, error: cErr } = await david.from('students')
+      .select('id', { count: 'exact', head: true }).eq('id', targetStudentId);
+    check(!cErr && count === 0, 'and 0 rows for a specific student of Nora\'s', `count=${count}`);
+
+    const { count: links } = await david.from('student_teachers')
+      .select('*', { count: 'exact', head: true }).eq('child_id', targetChildId);
+    check(links === 0, 'cannot read that child\'s teacher links', `count=${links}`);
+
+    // The denial that matters: a teacher must not be able to enrol themselves.
+    // 42501 is RLS refusing the INSERT — not a NOT NULL, not a bad FK.
+    const { error: insErr } = await david.from('student_teachers')
+      .insert({ child_id: targetChildId, teacher_id: davidTeacherId });
+    check(insErr?.code === '42501', 'cannot link THEMSELVES to a child (RLS 42501)',
+      `code=${insErr?.code ?? 'none'} ${insErr?.message ?? ''}`);
+    check((await linkTeacherIds(targetChildId)).includes(davidTeacherId) === false,
+      'and no link was created', 'service-client readback');
+  }
+
+  console.log('co-teachers are equals — both see the shared student:');
+  {
+    // Rachel owns the caseload row, so she is the one allowed to add the link.
+    const rachel = await signIn('rachel');
+    const { data: added, error } = await rachel.from('student_teachers')
+      .insert({ child_id: targetChildId, teacher_id: davidTeacherId }).select('id').single();
+    check(!error && !!added?.id, 'the owning provider CAN add a co-teacher',
+      error ? `${error.code} ${error.message}` : 'inserted');
+
+    const { data: davidSees } = await david.from('students')
+      .select('id').eq('id', targetStudentId);
+    check((davidSees?.length ?? 0) === 1, 'the new co-teacher now sees the student', targetStudentId);
+
+    const nora = await signIn('nora');
+    const { data: noraStill } = await nora.from('students').select('id').eq('id', targetStudentId);
+    check((noraStill?.length ?? 0) === 1, 'and the first teacher did NOT lose it', targetStudentId);
+
+    const { data: bothLinks } = await david.from('student_teachers')
+      .select('teacher_id').eq('child_id', targetChildId);
+    check((bothLinks?.length ?? 0) === 2, 'both links are visible to a linked teacher',
+      `${bothLinks?.length ?? 0} links`);
+
+    // Chat membership flips at the DB layer with this ticket (SPE-336 verifies
+    // the UI): both teacher accounts must now be participants.
+    const { data: participants, error: pErr } = await rachel
+      .rpc('get_student_chat_participants', { p_student_id: targetStudentId });
+    const ids = new Set((participants ?? []) as string[]);
+    check(!pErr && ids.has(await profileId('nora')) && ids.has(await profileId('david')),
+      'both teachers are chat participants for the student',
+      pErr ? pErr.message : `${ids.size} participants`);
+
+    // The legacy column must NOT have been repointed: it already names a valid
+    // link (Nora), so the mirror leaves it alone.
+    const pair = await legacyPair(targetStudentId);
+    check(pair.teacher_id === noraTeacherId,
+      'adding a co-teacher does not repoint the legacy column', `teacher_id=${pair.teacher_id}`);
+
+    // Clean up: back to the seeded 1:1 shape.
+    await admin.from('student_teachers')
+      .delete().eq('child_id', targetChildId).eq('teacher_id', davidTeacherId);
+    const { data: davidAfter } = await david.from('students').select('id').eq('id', targetStudentId);
+    check((davidAfter?.length ?? 0) === 0, 'removing the link removes the visibility again',
+      `saw ${davidAfter?.length ?? 0}`);
+  }
+
+  console.log('student_teachers read access mirrors who can read the student:');
+  {
+    for (const [key, label] of [
+      ['rachel', 'owning provider'],
+      ['nora', 'teacher of the student'],
+      ['priya', 'site admin for the school'],
+    ] as const) {
+      const client = await signIn(key);
+      const { count, error } = await client.from('student_teachers')
+        .select('*', { count: 'exact', head: true }).eq('child_id', targetChildId);
+      check(!error && (count ?? 0) === 1, `${label} reads the child's links`,
+        error ? error.message : `count=${count}`);
+    }
+
+    const alicia = await signIn('alicia');
+    const { count, error } = await alicia.from('student_teachers')
+      .select('*', { count: 'exact', head: true }).eq('child_id', targetChildId);
+    check(!error && count === 0, 'unlinked provider (other school) reads 0', `count=${count}`);
+
+    const { error: insErr } = await alicia.from('student_teachers')
+      .insert({ child_id: targetChildId, teacher_id: davidTeacherId });
+    check(insErr?.code === '42501', 'unlinked provider INSERT refused (RLS 42501)',
+      `code=${insErr?.code ?? 'none'}`);
+
+    const { data: delRows, error: delErr } = await alicia.from('student_teachers')
+      .delete().eq('child_id', targetChildId).select('id');
+    check((delRows?.length ?? 0) === 0 && (await linkTeacherIds(targetChildId)).length === 1,
+      'unlinked provider DELETE affects 0 rows',
+      `code=${delErr?.code ?? 'none'} rows=${delRows?.length ?? 0}`);
+  }
+
+  console.log('a link may not cross schools:');
+  {
+    const rachel = await signIn('rachel');
+    // Fatima teaches at Cedar; the probe child is at Willow. 23514 is the
+    // consistency trigger, not a FK or a NOT NULL.
+    const { error } = await rachel.from('student_teachers')
+      .insert({ child_id: targetChildId, teacher_id: fatimaTeacherId });
+    check(error?.code === '23514' && /not at this child/i.test(error?.message ?? ''),
+      'cross-school link refused by the consistency trigger',
+      `code=${error?.code ?? 'none'} ${error?.message ?? ''}`);
+  }
+
+  console.log('dual-write, through a real session:');
+  {
+    const rachel = await signIn('rachel');
+    const willowTeacherA = teacherRecordId('grace');
+    const willowTeacherB = teacherRecordId('yuki');
+
+    const { data: created, error } = await rachel.from('students').insert({
+      provider_id: rachelId, initials: 'QT', grade_level: '3',
+      school_id: WILLOW, district_id: 'SIM-D001', state_id: 'CA',
+      teacher_id: willowTeacherA, teacher_name: 'Grace Lindqvist-Sim',
+      sessions_per_week: 1, minutes_per_session: 30,
+    }).select('id, child_id').single();
+    check(!error && !!created?.child_id, 'INSERT with a teacher still works',
+      error ? `${error.code} ${error.message}` : `child=${created?.child_id}`);
+
+    if (created) {
+      const childId = created.child_id as string;
+      check((await linkTeacherIds(childId)).join() === willowTeacherA,
+        'legacy column INSERT mirrored into a link', (await linkTeacherIds(childId)).join());
+
+      await rachel.from('students').update({ teacher_id: willowTeacherB }).eq('id', created.id);
+      check((await linkTeacherIds(childId)).join() === willowTeacherB,
+        'changing the column swaps the link (old one withdrawn)',
+        (await linkTeacherIds(childId)).join());
+
+      // Reverse direction: the column follows the link set only when it has
+      // gone stale, so adding a second link must NOT repoint it.
+      await rachel.from('student_teachers').insert({ child_id: childId, teacher_id: willowTeacherA });
+      let pair = await legacyPair(created.id);
+      check(pair.teacher_id === willowTeacherB,
+        'adding a link leaves a still-valid column alone', `teacher_id=${pair.teacher_id}`);
+
+      // Delete the link the column names -> it must fall back to the survivor.
+      await rachel.from('student_teachers')
+        .delete().eq('child_id', childId).eq('teacher_id', willowTeacherB);
+      pair = await legacyPair(created.id);
+      check(pair.teacher_id === willowTeacherA && pair.teacher_name === 'Grace Lindqvist-Sim',
+        'deleting the named link repoints the column to the survivor',
+        `${pair.teacher_id} / ${pair.teacher_name}`);
+
+      // Remove the last link -> the column clears rather than naming a teacher
+      // the child no longer has.
+      await rachel.from('student_teachers').delete().eq('child_id', childId);
+      pair = await legacyPair(created.id);
+      check(pair.teacher_id === null && pair.teacher_name === null,
+        'removing the last link clears the column',
+        `${pair.teacher_id} / ${pair.teacher_name}`);
+
+      await admin.from('students').delete().eq('id', created.id);
+      await admin.from('children').delete().eq('id', childId);
+    }
+  }
+
+  console.log('secondary teacher (Cedar) is unaffected by Willow activity:');
+  {
+    const fatima = await signIn('fatima');
+    const fatimaExpected = await linkedStudentIds(fatimaTeacherId);
+    const { data: seen, error } = await fatima.from('students').select('id, school_id');
+    const seenIds = new Set((seen ?? []).map(r => r.id as string));
+    check(!error && sameSet(seenIds, fatimaExpected),
+      'Cedar teacher reads exactly her linked students',
+      error ? error.message : `saw ${seenIds.size} / expected ${fatimaExpected.size}`);
+    check((seen ?? []).every(r => r.school_id === CEDAR),
+      'and nothing outside her school', `${(seen ?? []).length} rows`);
+  }
+
+  if (failures === 0) {
+    console.log('\nAll checks passed. Re-seed (npm run sim:reset -- --yes) to restore the fixture.');
+  } else {
+    console.log(`\n${failures} check(s) failed.`);
+  }
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/sim-district/verify.ts
+++ b/scripts/sim-district/verify.ts
@@ -22,6 +22,7 @@ import {
   SESSION_GROUPS,
   SWEPT_TABLES,
   TOTAL_CHILDREN,
+  TOTAL_STUDENT_TEACHER_LINKS,
   TOTAL_STUDENTS,
   careCaseId,
 } from './manifest';
@@ -101,6 +102,7 @@ async function collectCounts(admin: Admin) {
     user_site_schedules: simUserIds.length > 0 ? await countWhereIn(admin, 'user_site_schedules', 'user_id', simUserIds) : 0,
     teachers: await countWhereIn(admin, 'teachers', 'school_id', SIM_SCHOOL_IDS),
     children: simChildIds.length,
+    student_teachers: simChildIds.length > 0 ? await countWhereIn(admin, 'student_teachers', 'child_id', simChildIds) : 0,
     'students with no child': unlinkedStudents,
     students: simStudentIds.length,
     student_details: simStudentIds.length > 0 ? await countWhereIn(admin, 'student_details', 'student_id', simStudentIds) : 0,
@@ -235,6 +237,10 @@ async function main() {
     // whole point — the gap is exactly the fixture's shared pairs (spec §6),
     // and TOTAL_CHILDREN derives from the same childKey() the seed uses.
     expect('children', n => n === TOTAL_CHILDREN, String(TOTAL_CHILDREN));
+    // SPE-334: one link per (child, teacher). Fewer links than students for the
+    // same reason there are fewer children — the shared pairs name one teacher
+    // between them, so their two caseload rows collapse to one link.
+    expect('student_teachers', n => n === TOTAL_STUDENT_TEACHER_LINKS, String(TOTAL_STUDENT_TEACHER_LINKS));
     expect('students with no child', n => n === 0, '0');
     expect('student_details', n => n > 0, '> 0');
     expect('bell_schedules', n => n > 0, '> 0');

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -3785,6 +3785,51 @@ export type Database = {
           },
         ]
       }
+      student_teachers: {
+        Row: {
+          child_id: string
+          created_at: string
+          id: string
+          period: string | null
+          subject: string | null
+          teacher_id: string
+          updated_at: string
+        }
+        Insert: {
+          child_id: string
+          created_at?: string
+          id?: string
+          period?: string | null
+          subject?: string | null
+          teacher_id: string
+          updated_at?: string
+        }
+        Update: {
+          child_id?: string
+          created_at?: string
+          id?: string
+          period?: string | null
+          subject?: string | null
+          teacher_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "student_teachers_child_id_fkey"
+            columns: ["child_id"]
+            isOneToOne: false
+            referencedRelation: "children"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "student_teachers_teacher_id_fkey"
+            columns: ["teacher_id"]
+            isOneToOne: false
+            referencedRelation: "teachers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       students: {
         Row: {
           child_id: string | null

--- a/supabase/migrations/20260807_spe334_matching_fallback_fidelity.sql
+++ b/supabase/migrations/20260807_spe334_matching_fallback_fidelity.sql
@@ -1,0 +1,127 @@
+-- SPE-334 follow-up: restore the cross-provider matcher's free-text fallback to
+-- its pre-SPE-334 reach.
+--
+-- Caught by the deep self-review on PR #812, before merge. The foundation
+-- migration is left as-applied rather than rewritten, so this reads as the fix
+-- it is (same treatment as 20260729_spe347_children_hardening.sql).
+--
+-- ---------------------------------------------------------------------------
+-- What was wrong
+-- ---------------------------------------------------------------------------
+-- The pre-SPE-334 fallback in `matching_provider_student_ids` was ROW-keyed:
+--
+--     (both rows name a teacher AND it is the same teacher)
+--     OR (EITHER row names none  AND the free-text teacher_name matches)
+--
+-- SPE-334 re-expressed it against the CHILD's link set, but translated the
+-- second branch as "NEITHER child has a link", where the original says
+-- "EITHER row lacks one". That is strictly narrower: a row with a hand-typed
+-- teacher name and no teacher_id, compared against a row that HAS one, used to
+-- reach the name fallback and no longer did — so a pair the matcher used to
+-- call the same child it would now call two.
+--
+-- Not observable on today's production data (the one free-text-only caseload
+-- row has no same-school/initials/grade counterpart, and its child carries no
+-- links), which is exactly why it needed catching by reading rather than by
+-- watching a count. The claim this ticket makes is behaviour-IDENTICAL, so
+-- "narrower in a corner nobody currently occupies" is still wrong.
+--
+-- ---------------------------------------------------------------------------
+-- The fix
+-- ---------------------------------------------------------------------------
+-- One operator: the two NOT EXISTS guards join with OR, not AND. The first
+-- branch already implies both children have links (an overlap cannot exist
+-- otherwise), so the pair now reads exactly like the original:
+--
+--     (the two children share a teacher)
+--     OR (EITHER child has no teacher set AND the free-text names match)
+--
+-- Everything else in the function — including the `provider_id = auth.uid()`
+-- gate that keeps a caller from resolving matches for someone else's student —
+-- is byte-identical to the SPE-334 version.
+
+CREATE OR REPLACE FUNCTION public.matching_provider_student_ids(p_student_id uuid)
+RETURNS SETOF uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'auth', 'pg_temp'
+AS $$
+BEGIN
+  -- Security: only the student's owner may resolve matches.
+  IF NOT EXISTS (
+    SELECT 1 FROM students WHERE id = p_student_id AND provider_id = auth.uid()
+  ) THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT s.id
+  FROM students s
+  JOIN students source ON source.id = p_student_id
+  LEFT JOIN student_details src_d ON src_d.student_id = source.id
+  LEFT JOIN student_details cand_d ON cand_d.student_id = s.id
+  WHERE s.id <> p_student_id
+    AND s.provider_id <> source.provider_id
+    AND s.school_id IS NOT NULL
+    AND s.school_id = source.school_id
+    AND (
+      -- Name-authoritative path: both sides named -> names (+ grade) must agree.
+      (
+        norm_student_name(src_d.first_name, src_d.last_name) IS NOT NULL
+        AND norm_student_name(cand_d.first_name, cand_d.last_name) IS NOT NULL
+        AND norm_student_name(src_d.first_name, src_d.last_name)
+            = norm_student_name(cand_d.first_name, cand_d.last_name)
+        AND s.grade_level = source.grade_level
+      )
+      OR
+      -- Fallback path: a name is missing on at least one side -> initials + grade + teacher.
+      (
+        (
+          norm_student_name(src_d.first_name, src_d.last_name) IS NULL
+          OR norm_student_name(cand_d.first_name, cand_d.last_name) IS NULL
+        )
+        AND LOWER(s.initials) = LOWER(source.initials)
+        AND s.grade_level = source.grade_level
+        AND (
+          -- SPE-334: the two children share at least one teacher.
+          EXISTS (
+            SELECT 1
+            FROM student_teachers a
+            JOIN student_teachers b ON b.teacher_id = a.teacher_id
+            WHERE a.child_id = s.child_id
+              AND b.child_id = source.child_id
+          )
+          OR (
+            -- EITHER child has no teacher set -> fall back to the free-text name,
+            -- the same reach the row-keyed `teacher_id IS NULL` test had.
+            (
+              NOT EXISTS (SELECT 1 FROM student_teachers a WHERE a.child_id = s.child_id)
+              OR NOT EXISTS (SELECT 1 FROM student_teachers b WHERE b.child_id = source.child_id)
+            )
+            AND LOWER(COALESCE(s.teacher_name, '')) = LOWER(COALESCE(source.teacher_name, ''))
+            AND COALESCE(s.teacher_name, '') <> ''
+          )
+        )
+      )
+    );
+END;
+$$;
+
+-- The function keeps the grants it already had; CREATE OR REPLACE preserves
+-- them and the signature is unchanged, so the 20260529 / 20260531 revoke lists
+-- stay accurate as written.
+
+DO $spe334_fallback_check$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'matching_provider_student_ids'
+      AND p.prosecdef
+      AND pg_get_functiondef(p.oid) LIKE '%EITHER child has no teacher set%'
+  ) THEN
+    RAISE EXCEPTION 'SPE-334: matching_provider_student_ids fallback fix did not apply';
+  END IF;
+END;
+$spe334_fallback_check$;

--- a/supabase/migrations/20260807_spe334_matching_fallback_row_keyed.sql
+++ b/supabase/migrations/20260807_spe334_matching_fallback_row_keyed.sql
@@ -1,0 +1,130 @@
+-- SPE-334 follow-up #2: gate the matcher's free-text fallback on the ROW's own
+-- teacher_id, the way it always was.
+--
+-- Supersedes 20260807_spe334_matching_fallback_fidelity.sql, from the same
+-- pre-merge review round on PR #812. Both earlier steps are left as-applied so
+-- the sequence reads as the correction it is (SPE-347's hardening precedent).
+--
+-- ---------------------------------------------------------------------------
+-- The three versions, and why this is the last one
+-- ---------------------------------------------------------------------------
+-- ORIGINAL (pre-SPE-334), row-keyed:
+--     (s.teacher_id IS NULL OR source.teacher_id IS NULL) AND names match
+--
+-- SPE-334 as first applied: translated that to "NEITHER child has a link",
+--     which was narrower on two counts. Caught by self-review.
+--
+-- _fidelity (previous step): relaxed AND -> OR, giving
+--     "EITHER child has no link". That fixed the operator but kept the test at
+--     CHILD level, and CodeRabbit's review named the remaining gap precisely:
+--     `teacher_name` is a ROW-level column, so a link contributed by a SIBLING
+--     caseload row of the same child would close the fallback for a row whose
+--     own teacher is still nothing but typed-in text. Shape: an OT adds a
+--     caseload row for a child an RSP already serves and types a teacher name
+--     without picking a directory record. Zero instances in production today
+--     (no child has a mix of teacher-bearing and teacher-less copies), but
+--     creatable through the ordinary add-student form — and this ticket's whole
+--     claim is behaviour-IDENTICAL, which "identical except in a shape a user
+--     can still produce" does not satisfy.
+--
+-- THIS STEP restores the original predicate verbatim. Note the operator: the
+-- review's suggested patch proposed
+--     s.teacher_id IS NULL AND source.teacher_id IS NULL
+-- which would have been narrower than the original in the other direction —
+-- closing the fallback whenever only ONE side lacks a teacher, which is exactly
+-- the case the original OR exists to serve. The diagnosis was right; the patch
+-- was not, so only the diagnosis is taken here.
+--
+-- ---------------------------------------------------------------------------
+-- What SPE-334 does change here, deliberately
+-- ---------------------------------------------------------------------------
+-- The FIRST branch — "the two rows name the same teacher" — becomes link-set
+-- overlap, which is what the ticket asked for and is a genuine (intended)
+-- widening: two children who share any teacher now match, where before only an
+-- exact same-single-teacher pair did. That cannot fire on today's data (no
+-- child carries more than one link) and is the correct semantics once secondary
+-- rostering fills the table.
+--
+-- The SECOND branch is pure compatibility for rows that never got a teacher
+-- record at all, and is now untouched by this ticket.
+
+CREATE OR REPLACE FUNCTION public.matching_provider_student_ids(p_student_id uuid)
+RETURNS SETOF uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'auth', 'pg_temp'
+AS $$
+BEGIN
+  -- Security: only the student's owner may resolve matches.
+  IF NOT EXISTS (
+    SELECT 1 FROM students WHERE id = p_student_id AND provider_id = auth.uid()
+  ) THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT s.id
+  FROM students s
+  JOIN students source ON source.id = p_student_id
+  LEFT JOIN student_details src_d ON src_d.student_id = source.id
+  LEFT JOIN student_details cand_d ON cand_d.student_id = s.id
+  WHERE s.id <> p_student_id
+    AND s.provider_id <> source.provider_id
+    AND s.school_id IS NOT NULL
+    AND s.school_id = source.school_id
+    AND (
+      -- Name-authoritative path: both sides named -> names (+ grade) must agree.
+      (
+        norm_student_name(src_d.first_name, src_d.last_name) IS NOT NULL
+        AND norm_student_name(cand_d.first_name, cand_d.last_name) IS NOT NULL
+        AND norm_student_name(src_d.first_name, src_d.last_name)
+            = norm_student_name(cand_d.first_name, cand_d.last_name)
+        AND s.grade_level = source.grade_level
+      )
+      OR
+      -- Fallback path: a name is missing on at least one side -> initials + grade + teacher.
+      (
+        (
+          norm_student_name(src_d.first_name, src_d.last_name) IS NULL
+          OR norm_student_name(cand_d.first_name, cand_d.last_name) IS NULL
+        )
+        AND LOWER(s.initials) = LOWER(source.initials)
+        AND s.grade_level = source.grade_level
+        AND (
+          -- SPE-334: the two children share at least one teacher. Replaces the
+          -- old "both rows name the same teacher" test.
+          EXISTS (
+            SELECT 1
+            FROM student_teachers a
+            JOIN student_teachers b ON b.teacher_id = a.teacher_id
+            WHERE a.child_id = s.child_id
+              AND b.child_id = source.child_id
+          )
+          OR (
+            -- Either ROW names no teacher record -> compare the free-text name.
+            -- Verbatim from the pre-SPE-334 definition; a row-level column gets
+            -- a row-level test.
+            (s.teacher_id IS NULL OR source.teacher_id IS NULL)
+            AND LOWER(COALESCE(s.teacher_name, '')) = LOWER(COALESCE(source.teacher_name, ''))
+            AND COALESCE(s.teacher_name, '') <> ''
+          )
+        )
+      )
+    );
+END;
+$$;
+
+DO $spe334_row_keyed_check$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'matching_provider_student_ids'
+      AND p.prosecdef
+      AND pg_get_functiondef(p.oid) LIKE '%Either ROW names no teacher record%'
+  ) THEN
+    RAISE EXCEPTION 'SPE-334: matching_provider_student_ids row-keyed fallback did not apply';
+  END IF;
+END;
+$spe334_row_keyed_check$;

--- a/supabase/migrations/20260807_spe334_student_teachers.sql
+++ b/supabase/migrations/20260807_spe334_student_teachers.sql
@@ -1,0 +1,806 @@
+-- SPE-334: multi-teacher foundation — the `student_teachers` join table.
+--
+-- Phase 1 of the multi-teacher-per-student plan. Goal: the data model can hold
+-- N teachers per student, with ZERO VISIBLE BEHAVIOR CHANGE. Every surface
+-- keeps showing exactly what it shows today; the follow-up tickets (SPE-336
+-- reads, SPE-337 editing UI) are what make the extra teachers visible.
+--
+-- ---------------------------------------------------------------------------
+-- Why the link anchors on the CHILD, not the caseload row
+-- ---------------------------------------------------------------------------
+-- Amended 2026-07-29 (approved), after SPE-347 landed `children`. A child served
+-- by an RSP and an SLP has two `students` rows; "who teaches this kid" is a fact
+-- about the KID, not about either service row. Anchoring on `children.id` means
+-- one link per real teacher instead of one per caseload copy, and it is the
+-- shape SPE-342 / SPE-414 will write into from the SIS (which knows children and
+-- class schedules, not Speddy caseloads).
+--
+-- Behaviour-identical on today's data, verified against prod 2026-08-07:
+--   * 284 students carry a teacher_id, over 282 distinct (child, teacher) pairs
+--     — the 2-row difference is the one real shared child whose two caseload
+--     copies name the SAME teacher, which now yields ONE link.
+--   * ZERO children have caseload copies naming DIFFERENT teachers, so every
+--     `get_teacher_student_ids` read set below is byte-identical to today's.
+--     Where copies ever do disagree (sim-only today) the link set is their
+--     union — the correct semantics under a child-anchored model.
+--
+-- ---------------------------------------------------------------------------
+-- Recursion posture (SPE-332 doctrine + the students⋈teachers history)
+-- ---------------------------------------------------------------------------
+-- `students_select` / `children_select` / `student_details` all grow a teacher
+-- branch that has to read `student_teachers`. Reading it inline would put
+-- `student_teachers`' own policies — which read `students` — inside `students`'
+-- policy, i.e. exactly the cycle that `20251112_fix_students_rls_infinite_
+-- recursion.sql` and `20251122_220000` were written to undo.
+--
+-- So every policy goes through ONE seam: `get_teacher_student_ids()`, already
+-- SECURITY DEFINER, already the designated seam for `schedule_sessions_select`.
+-- Inside it RLS does not apply, so the cycle is cut at the same place it has
+-- always been cut. No new policy helper is introduced and no new function is
+-- exposed to `authenticated`.
+--
+-- ---------------------------------------------------------------------------
+-- Order of operations (matters)
+-- ---------------------------------------------------------------------------
+--   1. table + indexes + school-consistency trigger  (so the backfill is
+--      validated by the same rule that will govern every later write)
+--   2. RLS + policies
+--   3. backfill
+--   4. policy / function rewrites onto the junction
+--   5. dual-write triggers — created LAST, on purpose: the backfill must not be
+--      able to rewrite a single existing `students` row. Nothing in this
+--      migration UPDATEs `students` or `student_details`.
+--   6. grants + post-wiring assertions
+
+-- ===========================================================================
+-- 1. The table
+-- ===========================================================================
+--
+-- No primary/secondary flag: co-teachers share duties as equals (product
+-- decision 2026-07-26), so the teacher set is unordered. `subject` / `period`
+-- are DISPLAY LABELS ONLY — secondary has no session scheduling in Speddy
+-- (SPE-149/193 posture), and nothing may read them as scheduling semantics.
+
+CREATE TABLE IF NOT EXISTS public.student_teachers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  child_id uuid NOT NULL REFERENCES public.children(id) ON DELETE CASCADE,
+  teacher_id uuid NOT NULL REFERENCES public.teachers(id) ON DELETE CASCADE,
+  subject text,
+  period text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT student_teachers_child_teacher_unique UNIQUE (child_id, teacher_id)
+);
+
+COMMENT ON TABLE public.student_teachers IS
+  'SPE-334: the teachers of a child. Anchored on children.id, not students.id — a child served by two providers has two caseload rows but ONE teacher set. Unordered: co-teachers are equals, no primary/secondary. Written by the dual-write triggers today, by hand in SPE-337, and from the SIS in SPE-342/SPE-414.';
+COMMENT ON COLUMN public.student_teachers.subject IS
+  'SPE-334: display label only (e.g. "Algebra I"). Carries no scheduling meaning.';
+COMMENT ON COLUMN public.student_teachers.period IS
+  'SPE-334: display label only (e.g. "3"). Carries no scheduling meaning — Speddy does not schedule at secondary.';
+
+CREATE INDEX IF NOT EXISTS idx_student_teachers_child_id
+  ON public.student_teachers (child_id);
+CREATE INDEX IF NOT EXISTS idx_student_teachers_teacher_id
+  ON public.student_teachers (teacher_id);
+
+CREATE TRIGGER trg_student_teachers_updated_at
+  BEFORE UPDATE ON public.student_teachers
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+-- ---------------------------------------------------------------------------
+-- School consistency (precedent: 20260408_staff_teacher_assignments.sql)
+-- ---------------------------------------------------------------------------
+--
+-- A child may only be linked to a teacher at the child's own school.
+--
+-- ONE deliberate tolerance: a teacher row with NO school passes. 20 such rows
+-- exist in production — all created by pre-2025-10 import paths, all with a
+-- last name only and NO account_id, so none of them can sign in and none can
+-- gain a read through the teacher branch of any policy. One of them
+-- ("Davis/Winbery", itself a hand-typed co-teacher pair) is named by a live
+-- caseload row, so enforcing NOT NULL here would make the backfill silently
+-- drop a real teacher link. There is nothing to compare against, so the check
+-- abstains rather than inventing a verdict. Every current write path sets
+-- school_id, so this tolerance covers legacy rows only.
+CREATE OR REPLACE FUNCTION public.verify_student_teacher_school_consistency()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_child_school text;
+  v_teacher_school text;
+BEGIN
+  SELECT c.school_id::text INTO v_child_school
+  FROM public.children c WHERE c.id = NEW.child_id;
+
+  SELECT t.school_id::text INTO v_teacher_school
+  FROM public.teachers t WHERE t.id = NEW.teacher_id;
+
+  IF v_child_school IS NOT NULL
+     AND v_teacher_school IS NOT NULL
+     AND v_child_school <> v_teacher_school THEN
+    RAISE EXCEPTION 'Teacher % is not at this child''s school (child school %, teacher school %)',
+      NEW.teacher_id, v_child_school, v_teacher_school
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.verify_student_teacher_school_consistency() IS
+  'SPE-334: BEFORE INSERT OR UPDATE on student_teachers. Refuses a link across schools. Abstains when either side has no school — 20 legacy accountless teacher rows have none.';
+
+CREATE TRIGGER trg_student_teachers_school_consistency
+  BEFORE INSERT OR UPDATE ON public.student_teachers
+  FOR EACH ROW EXECUTE FUNCTION public.verify_student_teacher_school_consistency();
+
+-- ===========================================================================
+-- 2. RLS
+-- ===========================================================================
+--
+-- SELECT mirrors `children_select` exactly — anybody who can see the child can
+-- see who teaches them — with the teacher branch routed through the definer
+-- seam (see the recursion note at the top).
+--
+-- Writes are deliberately coarse, matching SPE-347's `children_update` posture:
+-- any provider with a caseload row for the child, plus site admins at the
+-- child's school. Field-level narrowing (case-manager-only) is SPE-201, not
+-- this ticket. The dual-write triggers below are SECURITY DEFINER and do not
+-- depend on these policies.
+--
+-- No policy here reads `children`; the site-admin branch keys off
+-- `students.school_id`, the same column `children_select` uses, which keeps the
+-- evaluated table set to `students` + `admin_permissions`.
+
+ALTER TABLE public.student_teachers ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY student_teachers_select ON public.student_teachers
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.students s
+      WHERE s.child_id = student_teachers.child_id
+        AND (
+          -- Provider owns a caseload row for this child
+          s.provider_id = (SELECT auth.uid())
+          OR
+          -- Teacher of this child (definer seam — never read the junction here)
+          s.id IN (SELECT public.get_teacher_student_ids((SELECT auth.uid())))
+          OR
+          -- Specialist assigned to one of the child's sessions
+          EXISTS (
+            SELECT 1 FROM public.schedule_sessions ss
+            WHERE ss.student_id = s.id
+              AND ss.assigned_to_specialist_id = (SELECT auth.uid())
+          )
+          OR
+          -- SEA delivering one of the child's sessions (SPE-384 narrowing)
+          EXISTS (
+            SELECT 1 FROM public.schedule_sessions ss
+            WHERE ss.student_id = s.id
+              AND ss.assigned_to_sea_id = (SELECT auth.uid())
+              AND ss.delivered_by = 'sea'
+          )
+          OR
+          -- Site admin at the child's school
+          EXISTS (
+            SELECT 1 FROM public.admin_permissions ap
+            WHERE ap.admin_id = (SELECT auth.uid())
+              AND ap.role = 'site_admin'
+              AND ap.school_id::text = s.school_id::text
+          )
+        )
+    )
+  );
+
+CREATE POLICY student_teachers_insert ON public.student_teachers
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.students s
+      WHERE s.child_id = student_teachers.child_id
+        AND (
+          s.provider_id = (SELECT auth.uid())
+          OR EXISTS (
+            SELECT 1 FROM public.admin_permissions ap
+            WHERE ap.admin_id = (SELECT auth.uid())
+              AND ap.role = 'site_admin'
+              AND ap.school_id::text = s.school_id::text
+          )
+        )
+    )
+  );
+
+CREATE POLICY student_teachers_update ON public.student_teachers
+  FOR UPDATE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.students s
+      WHERE s.child_id = student_teachers.child_id
+        AND (
+          s.provider_id = (SELECT auth.uid())
+          OR EXISTS (
+            SELECT 1 FROM public.admin_permissions ap
+            WHERE ap.admin_id = (SELECT auth.uid())
+              AND ap.role = 'site_admin'
+              AND ap.school_id::text = s.school_id::text
+          )
+        )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.students s
+      WHERE s.child_id = student_teachers.child_id
+        AND (
+          s.provider_id = (SELECT auth.uid())
+          OR EXISTS (
+            SELECT 1 FROM public.admin_permissions ap
+            WHERE ap.admin_id = (SELECT auth.uid())
+              AND ap.role = 'site_admin'
+              AND ap.school_id::text = s.school_id::text
+          )
+        )
+    )
+  );
+
+CREATE POLICY student_teachers_delete ON public.student_teachers
+  FOR DELETE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.students s
+      WHERE s.child_id = student_teachers.child_id
+        AND (
+          s.provider_id = (SELECT auth.uid())
+          OR EXISTS (
+            SELECT 1 FROM public.admin_permissions ap
+            WHERE ap.admin_id = (SELECT auth.uid())
+              AND ap.role = 'site_admin'
+              AND ap.school_id::text = s.school_id::text
+          )
+        )
+    )
+  );
+
+-- ===========================================================================
+-- 3. Backfill
+-- ===========================================================================
+--
+-- Walk `students.teacher_id` THROUGH `students.child_id`. ON CONFLICT DO
+-- NOTHING collapses the shared child whose two caseload copies name the same
+-- teacher into the one link it always was.
+--
+-- Runs BEFORE the dual-write triggers exist, so it cannot write back into
+-- `students`. Nothing in this migration modifies an existing row of any
+-- pre-existing table.
+
+INSERT INTO public.student_teachers (child_id, teacher_id)
+SELECT DISTINCT s.child_id, s.teacher_id
+FROM public.students s
+WHERE s.teacher_id IS NOT NULL
+  AND s.child_id IS NOT NULL
+ON CONFLICT (child_id, teacher_id) DO NOTHING;
+
+DO $spe334_backfill$
+DECLARE
+  v_expected bigint;
+  v_actual bigint;
+  v_orphaned bigint;
+BEGIN
+  SELECT count(*) INTO v_expected
+  FROM (SELECT DISTINCT child_id, teacher_id FROM public.students
+        WHERE teacher_id IS NOT NULL AND child_id IS NOT NULL) p;
+
+  SELECT count(*) INTO v_actual FROM public.student_teachers;
+
+  IF v_actual <> v_expected THEN
+    RAISE EXCEPTION 'SPE-334 backfill: expected % links, found %', v_expected, v_actual;
+  END IF;
+
+  -- Every caseload row that names a teacher must be reachable through the
+  -- junction. This is the invariant the read rewrites below depend on.
+  SELECT count(*) INTO v_orphaned
+  FROM public.students s
+  WHERE s.teacher_id IS NOT NULL
+    AND s.child_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.student_teachers st
+      WHERE st.child_id = s.child_id AND st.teacher_id = s.teacher_id
+    );
+
+  IF v_orphaned > 0 THEN
+    RAISE EXCEPTION 'SPE-334 backfill: % caseload rows have no matching link', v_orphaned;
+  END IF;
+
+  RAISE LOG 'SPE-334 backfill: % links created from % teacher-bearing caseload rows',
+    v_actual, (SELECT count(*) FROM public.students WHERE teacher_id IS NOT NULL);
+END;
+$spe334_backfill$;
+
+-- ===========================================================================
+-- 4. Rewrite the read paths onto the junction (behaviour-identical)
+-- ===========================================================================
+
+-- ---------------------------------------------------------------------------
+-- 4a. The seam. Everything else routes through this.
+-- ---------------------------------------------------------------------------
+-- Was: students ⋈ teachers ON students.teacher_id.
+-- Now: teachers -> student_teachers -> every caseload row of the linked child.
+-- Same rows today (no child has divergent copies); the union is the point.
+CREATE OR REPLACE FUNCTION public.get_teacher_student_ids(user_id uuid)
+RETURNS SETOF uuid
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT DISTINCT s.id
+  FROM public.students s
+  INNER JOIN public.student_teachers st ON st.child_id = s.child_id
+  INNER JOIN public.teachers t ON t.id = st.teacher_id
+  WHERE t.account_id = user_id;
+$$;
+
+COMMENT ON FUNCTION public.get_teacher_student_ids(uuid) IS
+  'SPE-334: the caseload rows a teacher account may see, resolved through student_teachers (child-anchored). SECURITY DEFINER is load-bearing: it is the seam that keeps students/schedule_sessions/student_details policies from recursing into student_teachers.';
+
+-- ---------------------------------------------------------------------------
+-- 4b. students_select — teacher branch only; every other branch verbatim
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "students_select" ON public.students;
+
+CREATE POLICY "students_select" ON public.students
+  FOR SELECT TO authenticated
+  USING (
+    -- Provider owns the student
+    provider_id = (SELECT auth.uid())
+    OR
+    -- Teachers can view their students (SPE-334: via the link set)
+    id IN (SELECT public.get_teacher_student_ids((SELECT auth.uid())))
+    OR
+    -- Specialists can view students from assigned sessions
+    EXISTS (SELECT 1 FROM public.schedule_sessions WHERE schedule_sessions.student_id = students.id AND schedule_sessions.assigned_to_specialist_id = (SELECT auth.uid()))
+    OR
+    -- SEAs can view students from sessions they deliver
+    EXISTS (SELECT 1 FROM public.schedule_sessions WHERE schedule_sessions.student_id = students.id AND schedule_sessions.assigned_to_sea_id = (SELECT auth.uid()) AND schedule_sessions.delivered_by = 'sea')
+    OR
+    -- Site admins can view students at their school
+    EXISTS (SELECT 1 FROM public.admin_permissions WHERE admin_permissions.admin_id = (SELECT auth.uid()) AND admin_permissions.role = 'site_admin' AND admin_permissions.school_id::text = students.school_id::text)
+  );
+
+-- ---------------------------------------------------------------------------
+-- 4c. children_select — teacher branch only; every other branch verbatim
+-- ---------------------------------------------------------------------------
+-- Left stale, a teacher linked through the junction could read the caseload row
+-- but not the child record behind it.
+DROP POLICY IF EXISTS children_select ON public.children;
+
+CREATE POLICY children_select ON public.children
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.students s
+      WHERE s.child_id = children.id
+        AND (
+          s.provider_id = (SELECT auth.uid())
+          OR s.id IN (SELECT public.get_teacher_student_ids((SELECT auth.uid())))
+          OR EXISTS (
+            SELECT 1 FROM public.schedule_sessions ss
+            WHERE ss.student_id = s.id AND ss.assigned_to_specialist_id = (SELECT auth.uid())
+          )
+          OR EXISTS (
+            SELECT 1 FROM public.schedule_sessions ss
+            WHERE ss.student_id = s.id AND ss.assigned_to_sea_id = (SELECT auth.uid())
+              AND ss.delivered_by = 'sea'
+          )
+          OR EXISTS (
+            SELECT 1 FROM public.admin_permissions ap
+            WHERE ap.admin_id = (SELECT auth.uid()) AND ap.role = 'site_admin'
+              AND ap.school_id::text = s.school_id::text
+          )
+        )
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 4d. student_details SELECT — teacher branch only; provider + SEA verbatim
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "Users can view accessible student details" ON public.student_details;
+
+CREATE POLICY "Users can view accessible student details" ON public.student_details
+    FOR SELECT USING (
+        student_id IN (  -- Providers can view their own students' details
+            SELECT id FROM public.students WHERE provider_id = (SELECT auth.uid())
+        )
+        OR student_id IN (  -- SEAs can view details for assigned students
+            SELECT student_id FROM public.schedule_sessions
+            WHERE assigned_to_sea_id = (SELECT auth.uid())
+        )
+        OR student_id IN (  -- Teachers can view IEP goals for their students (SPE-334: via the link set)
+            SELECT public.get_teacher_student_ids((SELECT auth.uid()))
+        )
+    );
+
+-- ---------------------------------------------------------------------------
+-- 4e. Chat membership (docs/CHAT_MODULE_DESIGN.md:167-171 anticipated this)
+-- ---------------------------------------------------------------------------
+-- All three are already SECURITY DEFINER, so they read the junction directly
+-- rather than through the seam. Every non-teacher branch is verbatim.
+CREATE OR REPLACE FUNCTION public.chat_is_student_participant(p_student_id uuid, p_uid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.students s WHERE s.id = p_student_id AND s.provider_id = p_uid
+    UNION ALL
+    SELECT 1 FROM public.students s
+      JOIN public.student_teachers st ON st.child_id = s.child_id
+      JOIN public.teachers t ON t.id = st.teacher_id
+      WHERE s.id = p_student_id AND t.account_id = p_uid
+    UNION ALL
+    SELECT 1 FROM public.schedule_sessions ss
+      WHERE ss.student_id = p_student_id AND ss.is_template = TRUE AND ss.deleted_at IS NULL
+        AND ss.provider_id = p_uid
+    UNION ALL
+    SELECT 1 FROM public.students s JOIN public.admin_permissions ap ON ap.school_id = s.school_id
+      WHERE s.id = p_student_id AND ap.admin_id = p_uid AND ap.role = 'site_admin'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_student_chat_participants(p_student_id uuid)
+RETURNS SETOF uuid
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT DISTINCT uid FROM (
+    SELECT s.provider_id AS uid FROM public.students s WHERE s.id = p_student_id AND s.provider_id IS NOT NULL
+    UNION
+    SELECT t.account_id FROM public.students s
+      JOIN public.student_teachers st ON st.child_id = s.child_id
+      JOIN public.teachers t ON t.id = st.teacher_id
+      WHERE s.id = p_student_id AND t.account_id IS NOT NULL
+    UNION
+    SELECT ss.provider_id FROM public.schedule_sessions ss
+      WHERE ss.student_id = p_student_id AND ss.is_template = TRUE AND ss.deleted_at IS NULL AND ss.provider_id IS NOT NULL
+    UNION
+    SELECT ap.admin_id FROM public.students s JOIN public.admin_permissions ap ON ap.school_id = s.school_id
+      WHERE s.id = p_student_id AND ap.role = 'site_admin'
+  ) u
+  WHERE public.is_chat_eligible(u.uid)
+    AND public.chat_is_student_participant(p_student_id, auth.uid());
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_my_chat_students(p_school_id character varying DEFAULT NULL::character varying)
+RETURNS TABLE(id uuid, initials text, grade_level text, school_id character varying)
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  WITH participant_ids AS (
+    SELECT s.id FROM public.students s WHERE s.provider_id = auth.uid()
+    UNION
+    SELECT s.id FROM public.students s
+      JOIN public.student_teachers st ON st.child_id = s.child_id
+      JOIN public.teachers t ON t.id = st.teacher_id
+      WHERE t.account_id = auth.uid()
+    UNION
+    SELECT ss.student_id FROM public.schedule_sessions ss
+      WHERE ss.student_id IS NOT NULL AND ss.is_template = TRUE AND ss.deleted_at IS NULL
+        AND ss.provider_id = auth.uid()
+    UNION
+    SELECT s.id FROM public.students s JOIN public.admin_permissions ap ON ap.school_id = s.school_id
+      WHERE ap.admin_id = auth.uid() AND ap.role = 'site_admin'
+  )
+  SELECT s.id, s.initials, s.grade_level, s.school_id
+  FROM public.students s
+  JOIN participant_ids pi ON pi.id = s.id
+  WHERE public.is_chat_eligible(auth.uid())
+    AND (p_school_id IS NULL OR s.school_id = p_school_id)
+  ORDER BY s.initials;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 4f. Cross-provider matching — "same teacher" becomes link-set overlap
+-- ---------------------------------------------------------------------------
+-- Only the fallback path's teacher test changes (20260721_prefer_full_name_
+-- cross_provider_matching.sql). The name-authoritative path and the free-text
+-- `teacher_name` fallback — which is what carries rows that have no link at all
+-- — are verbatim.
+--
+-- Identical on today's data: with one teacher per child, "the two children
+-- share a link" and "the two rows carry the same teacher_id" are the same test.
+CREATE OR REPLACE FUNCTION public.matching_provider_student_ids(p_student_id uuid)
+RETURNS SETOF uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'auth', 'pg_temp'
+AS $$
+BEGIN
+  -- Security: only the student's owner may resolve matches.
+  IF NOT EXISTS (
+    SELECT 1 FROM students WHERE id = p_student_id AND provider_id = auth.uid()
+  ) THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT s.id
+  FROM students s
+  JOIN students source ON source.id = p_student_id
+  LEFT JOIN student_details src_d ON src_d.student_id = source.id
+  LEFT JOIN student_details cand_d ON cand_d.student_id = s.id
+  WHERE s.id <> p_student_id
+    AND s.provider_id <> source.provider_id
+    AND s.school_id IS NOT NULL
+    AND s.school_id = source.school_id
+    AND (
+      -- Name-authoritative path: both sides named -> names (+ grade) must agree.
+      (
+        norm_student_name(src_d.first_name, src_d.last_name) IS NOT NULL
+        AND norm_student_name(cand_d.first_name, cand_d.last_name) IS NOT NULL
+        AND norm_student_name(src_d.first_name, src_d.last_name)
+            = norm_student_name(cand_d.first_name, cand_d.last_name)
+        AND s.grade_level = source.grade_level
+      )
+      OR
+      -- Fallback path: a name is missing on at least one side -> initials + grade + teacher.
+      (
+        (
+          norm_student_name(src_d.first_name, src_d.last_name) IS NULL
+          OR norm_student_name(cand_d.first_name, cand_d.last_name) IS NULL
+        )
+        AND LOWER(s.initials) = LOWER(source.initials)
+        AND s.grade_level = source.grade_level
+        AND (
+          -- SPE-334: the two children share at least one teacher.
+          EXISTS (
+            SELECT 1
+            FROM student_teachers a
+            JOIN student_teachers b ON b.teacher_id = a.teacher_id
+            WHERE a.child_id = s.child_id
+              AND b.child_id = source.child_id
+          )
+          OR (
+            -- Neither side has a link -> fall back to the free-text name.
+            NOT EXISTS (SELECT 1 FROM student_teachers a WHERE a.child_id = s.child_id)
+            AND NOT EXISTS (SELECT 1 FROM student_teachers b WHERE b.child_id = source.child_id)
+            AND LOWER(COALESCE(s.teacher_name, '')) = LOWER(COALESCE(source.teacher_name, ''))
+            AND COALESCE(s.teacher_name, '') <> ''
+          )
+        )
+      )
+    );
+END;
+$$;
+
+-- ===========================================================================
+-- 5. Dual-write (compatibility plumbing only — no product meaning)
+-- ===========================================================================
+--
+-- Retiring `students.teacher_id` / `students.teacher_name` is SPE-341, a
+-- separate contract ticket. Until then the two representations must not drift,
+-- in either direction.
+--
+-- Created AFTER the backfill so this migration provably rewrites nothing.
+
+-- ---------------------------------------------------------------------------
+-- 5a. students.teacher_id  ->  the link set
+-- ---------------------------------------------------------------------------
+-- INSERT / UPDATE mirror the column onto the child's link set. On UPDATE the
+-- OLD teacher's link is withdrawn too, but ONLY when no remaining caseload row
+-- of that child still names them — otherwise one provider's edit would revoke a
+-- teacher another provider still asserts.
+--
+-- DELETE deliberately does NOT withdraw links. A link has no provenance column,
+-- so "was this link contributed by the row being deleted, or added by hand /
+-- by the SIS?" is unanswerable — and once SPE-337 and SPE-342 write links
+-- directly, guessing wrong would silently destroy them. Losing one caseload row
+-- also does not stop a child from having teachers.
+CREATE OR REPLACE FUNCTION public.students_mirror_teacher_link()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE'
+     AND OLD.teacher_id IS NOT NULL
+     AND OLD.child_id IS NOT NULL
+     AND (OLD.teacher_id IS DISTINCT FROM NEW.teacher_id
+          OR OLD.child_id IS DISTINCT FROM NEW.child_id) THEN
+    DELETE FROM public.student_teachers st
+    WHERE st.child_id = OLD.child_id
+      AND st.teacher_id = OLD.teacher_id
+      AND NOT EXISTS (
+        SELECT 1 FROM public.students s2
+        WHERE s2.child_id = OLD.child_id
+          AND s2.teacher_id = OLD.teacher_id
+          AND s2.id <> NEW.id
+      );
+  END IF;
+
+  IF NEW.teacher_id IS NOT NULL AND NEW.child_id IS NOT NULL THEN
+    INSERT INTO public.student_teachers (child_id, teacher_id)
+    VALUES (NEW.child_id, NEW.teacher_id)
+    ON CONFLICT (child_id, teacher_id) DO NOTHING;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.students_mirror_teacher_link() IS
+  'SPE-334 dual-write: mirrors the legacy students.teacher_id column into student_teachers. Adds on insert/update; withdraws the previous teacher only when no other caseload row of the same child still names them. Never withdraws on DELETE (links carry no provenance).';
+
+CREATE TRIGGER trg_students_mirror_teacher_link
+  AFTER INSERT OR UPDATE OF teacher_id, child_id ON public.students
+  FOR EACH ROW
+  WHEN (NEW.child_id IS NOT NULL)
+  EXECUTE FUNCTION public.students_mirror_teacher_link();
+
+-- ---------------------------------------------------------------------------
+-- 5b. the link set  ->  students.teacher_id / teacher_name
+-- ---------------------------------------------------------------------------
+-- The legacy pair mirrors the FIRST listed link (oldest, id as tiebreak) — but
+-- only on caseload rows whose current teacher_id is not, or is no longer, one
+-- of the child's teachers. A row already naming a valid link is left exactly as
+-- it is, so this can never fight the edit that triggered it, and no-op writes
+-- are excluded so the two triggers cannot ping-pong.
+--
+-- One row is never touched: a caseload row carrying a hand-typed teacher_name
+-- with no teacher_id at all (1 such row in production). That free text is the
+-- only teacher the provider ever recorded, and no link exists to replace it
+-- with; SPE-341 is where it gets resolved, not here.
+CREATE OR REPLACE FUNCTION public.student_teachers_mirror_legacy()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_child_ids uuid[];
+  v_child_id uuid;
+  v_teacher_id uuid;
+  v_teacher_name text;
+BEGIN
+  -- NEW is unset on DELETE and OLD is unset on INSERT, so neither may be read
+  -- unconditionally. A link that moves between children (service/SIS only) has
+  -- to remirror both sides.
+  IF TG_OP = 'INSERT' THEN
+    v_child_ids := ARRAY[NEW.child_id];
+  ELSIF TG_OP = 'DELETE' THEN
+    v_child_ids := ARRAY[OLD.child_id];
+  ELSIF NEW.child_id IS DISTINCT FROM OLD.child_id THEN
+    v_child_ids := ARRAY[OLD.child_id, NEW.child_id];
+  ELSE
+    v_child_ids := ARRAY[NEW.child_id];
+  END IF;
+
+  FOREACH v_child_id IN ARRAY v_child_ids LOOP
+    v_teacher_id := NULL;
+    v_teacher_name := NULL;
+
+    SELECT st.teacher_id INTO v_teacher_id
+    FROM public.student_teachers st
+    WHERE st.child_id = v_child_id
+    ORDER BY st.created_at, st.id
+    LIMIT 1;
+
+    IF v_teacher_id IS NOT NULL THEN
+      SELECT NULLIF(btrim(concat_ws(' ', t.first_name, t.last_name)), '')
+      INTO v_teacher_name
+      FROM public.teachers t
+      WHERE t.id = v_teacher_id;
+    END IF;
+
+    UPDATE public.students s
+       SET teacher_id = v_teacher_id,
+           teacher_name = v_teacher_name
+     WHERE s.child_id = v_child_id
+       AND NOT EXISTS (
+         SELECT 1 FROM public.student_teachers st
+         WHERE st.child_id = v_child_id AND st.teacher_id = s.teacher_id
+       )
+       AND NOT (s.teacher_id IS NULL AND COALESCE(btrim(s.teacher_name), '') <> '')
+       AND (s.teacher_id IS DISTINCT FROM v_teacher_id
+            OR s.teacher_name IS DISTINCT FROM v_teacher_name);
+  END LOOP;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.student_teachers_mirror_legacy() IS
+  'SPE-334 dual-write: points the legacy students.teacher_id/teacher_name pair at the child''s first listed link, on caseload rows whose current teacher is not one of the child''s teachers. Compatibility plumbing only — no product meaning. Retirement is SPE-341.';
+
+CREATE TRIGGER trg_student_teachers_mirror_legacy
+  AFTER INSERT OR UPDATE OR DELETE ON public.student_teachers
+  FOR EACH ROW EXECUTE FUNCTION public.student_teachers_mirror_legacy();
+
+-- ===========================================================================
+-- 6. Grants
+-- ===========================================================================
+--
+-- The three functions added here are trigger functions: nothing should reach
+-- them over /rest/v1/rpc. Postgres checks EXECUTE at CREATE TRIGGER time, not
+-- when the trigger fires, so the triggers above keep working (SPE-10 Tier 1+2
+-- treatment, same as SPE-347's).
+REVOKE ALL ON FUNCTION public.verify_student_teacher_school_consistency() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.students_mirror_teacher_link() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.student_teachers_mirror_legacy() FROM PUBLIC, anon, authenticated;
+
+-- The rewritten functions keep the grants they already had; CREATE OR REPLACE
+-- preserves them and no signature changed, so the 20260529 / 20260531 revoke
+-- lists stay accurate as written.
+--
+-- Table grants: Supabase's default privileges hand every new public table to
+-- anon as well. Nothing here is reachable without a session (all four policies
+-- are TO authenticated), but the grant is removed anyway — same posture as
+-- 20260531_scope_public_select_policies_to_authenticated.sql.
+REVOKE ALL ON public.student_teachers FROM anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.student_teachers TO authenticated;
+GRANT ALL ON public.student_teachers TO service_role;
+
+-- ===========================================================================
+-- 7. Post-wiring assertions
+-- ===========================================================================
+-- A partially applied migration must not be able to look successful.
+
+DO $spe334_check$
+BEGIN
+  IF NOT (SELECT relrowsecurity FROM pg_class WHERE oid = 'public.student_teachers'::regclass) THEN
+    RAISE EXCEPTION 'SPE-334: RLS not enabled on student_teachers';
+  END IF;
+
+  IF (SELECT count(*) FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid
+      WHERE c.relname = 'student_teachers') <> 4 THEN
+    RAISE EXCEPTION 'SPE-334: expected 4 policies on student_teachers';
+  END IF;
+
+  IF (SELECT count(*) FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid
+      WHERE NOT t.tgisinternal AND c.relname = 'student_teachers') <> 3 THEN
+    RAISE EXCEPTION 'SPE-334: expected 3 triggers on student_teachers (updated_at, school consistency, legacy mirror)';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid
+                 WHERE NOT t.tgisinternal AND c.relname = 'students'
+                   AND t.tgname = 'trg_students_mirror_teacher_link') THEN
+    RAISE EXCEPTION 'SPE-334: students -> link dual-write trigger missing';
+  END IF;
+
+  -- The seam must still be SECURITY DEFINER, or every rewritten policy recurses.
+  IF NOT (SELECT p.prosecdef FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+          WHERE n.nspname = 'public' AND p.proname = 'get_teacher_student_ids') THEN
+    RAISE EXCEPTION 'SPE-334: get_teacher_student_ids is not SECURITY DEFINER';
+  END IF;
+
+  -- No rewritten policy may name the legacy column any more.
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename IN ('students', 'children', 'student_details')
+      AND qual ILIKE '%teacher_id%'
+  ) THEN
+    RAISE EXCEPTION 'SPE-334: a rewritten policy still references students.teacher_id';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname IN ('verify_student_teacher_school_consistency',
+                        'students_mirror_teacher_link',
+                        'student_teachers_mirror_legacy')
+      AND (has_function_privilege('anon', p.oid, 'EXECUTE')
+           OR has_function_privilege('authenticated', p.oid, 'EXECUTE'))
+  ) THEN
+    RAISE EXCEPTION 'SPE-334: a trigger function is still EXECUTE-able by anon/authenticated';
+  END IF;
+END;
+$spe334_check$;


### PR DESCRIPTION
Phase 1 of the multi-teacher plan ([SPE-334](https://linear.app/speddy/issue/SPE-334)). The data model can now hold N teachers per student, with **zero visible behavior change** — every surface still shows exactly what it showed yesterday. SPE-336 switches the reads; SPE-337 adds the editing UI.

## Why the link anchors on the child

Per the ticket's 2026-07-29 amendment, now that SPE-347 landed `children`: a child served by an RSP and an SLP has two caseload rows, but *"who teaches this kid"* is a fact about the kid, not about either service row. So `student_teachers` is `(child_id, teacher_id)`, not `(student_id, teacher_id)`. That is also the shape the SIS syncs will write into — a SIS knows children and class schedules, not Speddy caseloads ([SPE-342](https://linear.app/speddy/issue/SPE-342) Aeries, [SPE-414](https://linear.app/speddy/issue/SPE-414) OneRoster).

Product decisions carried through, not relitigated: **no primary/secondary flag** (co-teachers are equals), and `subject`/`period` are **display labels only** — Speddy does not schedule at secondary.

## Behaviour-identical, measured rather than argued

Verified against production before applying:

| | count |
|---|---|
| caseload rows carrying a `teacher_id` | 284 |
| distinct (child, teacher) pairs → links created | **282** |
| children whose caseload copies name **different** teachers | **0** |

The 2-row gap is the one real shared child whose two copies name the same teacher — one link, as intended. Because no child has divergent copies, every `get_teacher_student_ids` read set is unchanged. Where copies ever *do* disagree (sim-only today), the link set is their union — the correct semantics under a child anchor.

**The migration provably rewrote nothing.** Dual-write triggers are created *after* the backfill, and the `students` teacher_id/teacher_name fingerprint is byte-identical before and after (`e51e5ec9…`). PITR restore point noted before applying: `2026-08-07 02:43:53 UTC`. The applied SQL is checksum-identical to the committed file.

## Recursion posture

Four policies grow a teacher branch that must read the junction. Reading it inline would put `student_teachers`' own policies (which read `students`) *inside* `students`' policy — the exact cycle the 2025-11 recursion fixes undid, and the failure mode SPE-332 cost seven months.

So everything routes through **one seam**: `get_teacher_student_ids()`, already SECURITY DEFINER and already the designated seam for `schedule_sessions_select`. No new policy helper, no new function exposed to `authenticated`.

Rewritten on the junction: `students_select`, `children_select`, `student_details` SELECT (every non-teacher branch verbatim, including SPE-384's `delivered_by = 'sea'` narrowing), the three chat membership functions, and `matching_provider_student_ids`' "same teacher" fallback → link-set overlap.

## Dual-write, both directions

Until [SPE-341](https://linear.app/speddy/issue/SPE-341) retires the legacy columns:

- **column → links:** an insert/update mirrors in; an update also withdraws the previous teacher, *unless* another caseload row of the same child still names them.
- **links → column:** points the legacy pair at the child's first listed link, but **only** on rows whose current teacher is not (or is no longer) one of the child's teachers — so it can never fight the edit that triggered it, and no-op writes are excluded so the two triggers cannot ping-pong.
- **a `students` DELETE withdraws nothing.** Links carry no provenance, so "was this link from the deleted row, or added by hand / by the SIS?" is unanswerable — and once SPE-337 and SPE-342 write links directly, guessing wrong would destroy them silently.

## Two judgement calls worth your eye

1. **The school-consistency trigger abstains when either side has no school.** 20 production `teachers` rows have no `school_id` — all pre-2025-10 import artifacts, last-name-only, none with an account (so none can sign in or gain a read). One of them is `"Davis/Winbery"`, named by a live caseload row. A hard rule would have made the backfill silently drop a real teacher link, so the check abstains rather than inventing a verdict. Cross-school links between two *known* schools are refused loudly.
2. **One production row is never touched by the reverse mirror:** a caseload row carrying a hand-typed `teacher_name` with no `teacher_id`. That free text is the only teacher its provider ever recorded and there is no link to replace it with; SPE-341 is where it gets resolved.

## Verification

Standing rule discharged with **real signed-in sessions**, not by reading policies:

- `npm run sim:reset` → `npm run sim:verify` **green** (33 checks incl. schema coverage; `student_teachers` classified + seeded).
- **New `npm run sim:verify-student-teachers-rls` — 33 checks, all passing:**
  - linked teacher's read set == the legacy-column read set, then == what RLS actually returns (5/5), plus details, children and sessions still readable;
  - unlinked teacher (David, fresh fixture, zero links) reads 0 students, 0 links, and **cannot link himself** — refusal asserted as `42501`, with a service-client readback proving no row appeared;
  - **co-teachers:** the owning provider adds a second teacher → the new co-teacher sees the student, the first teacher does not lose it, both are chat participants, and removing the link removes the visibility again;
  - cross-school link refused with `23514` and the trigger's message asserted (not just "it failed");
  - unlinked provider at another school: 0 rows on SELECT, `42501` on INSERT, 0 rows affected on DELETE;
  - the full dual-write cycle through a provider's own session (insert → swap → add → delete named → delete last).
- `npm run sim:verify-children-rls` (SPE-347's guard, direct regression cover for the rewritten `children_select`) **green, 26 checks**.
- `npm test` 983 passing · `typecheck` clean · `lint` clean (2 pre-existing warnings, untouched files).

## Out of scope / follow-ups

Reads and UI stay on the legacy column (SPE-336 / SPE-337). Filed while here: `is_teacher_of_student` / `is_teacher_for_student` are dead and unreachable (already revoked from `authenticated`, referenced by no policy or function) — one of them references a column dropped in 2025-11 — logged as a cleanup ticket rather than expanded into this diff.

**Not auto-deployable** (schema + RLS). Holding for your merge call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMVhGgFe7rmM3sQXhT5pQ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMVhGgFe7rmM3sQXhT5pQ5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for linking multiple teachers to a child.
  * Teacher access now extends across student records, chat, and matching features.
  * Added safeguards against teacher links across different schools.
  * Existing teacher assignments remain compatible and synchronized with new links.
* **Bug Fixes**
  * Improved teacher caseload visibility and co-teacher access.
  * Prevented unauthorized cross-school reads and updates.
* **Documentation**
  * Updated architecture and simulation documentation covering teacher links, compatibility, and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->