### PR TITLE
SPE-336: teacher-facing reads switch to the link set

### DIFF
--- a/.claude/skills/sim-run/SKILL.md
+++ b/.claude/skills/sim-run/SKILL.md
@@ -79,10 +79,14 @@ the usual walk leads (email-local → who):
 | `sea.willow` | Leah — SEA (excluded from Chat/CARE/Schedule/Meetings nav; delegated sessions) |
 | `teacher.willow.1` | Nora — login teacher, Willow (availability prompt) |
 | `teacher.willow.2` | David — login teacher with ZERO students (empty state) |
+| `teacher.willow.3` | Imani — Nora's CO-TEACHER on the same grade-3 class (SPE-336) |
 | `teacher.cedar` | Fatima — login teacher, Cedar (secondary) |
+| `teacher.cedar.2` | Sanjay — a second Cedar subject teacher, shares Fatima's students |
 
 Cedar/Redwood are secondary sites: scheduling surfaces hidden, no session
-instances seeded — useful negative space.
+instances seeded — useful negative space. Since SPE-336 their students carry a
+teacher per period (six links each, from a faculty of eight), so they are also
+where multi-teacher reads get exercised.
 
 ## The run, step by step
 

--- a/__tests__/unit/lib/supabase/queries/iep-meetings-plan.test.ts
+++ b/__tests__/unit/lib/supabase/queries/iep-meetings-plan.test.ts
@@ -3,17 +3,20 @@ import {
   type CaseloadStudent,
   type PlanningData,
 } from '@/lib/supabase/queries/iep-meetings';
+import type { LinkedTeacher } from '@/lib/supabase/queries/student-teachers';
 import type { BusyBlock } from '@/lib/iep-meetings/availability';
+
+function linkedTeacher(overrides: Partial<LinkedTeacher> = {}): LinkedTeacher {
+  return { id: 't1', name: 'T One', profileId: null, email: null, ...overrides };
+}
 
 function student(overrides: Partial<CaseloadStudent>): CaseloadStudent {
   return {
     id: 's1',
     initials: 'A.B.',
     grade_level: '3',
-    teacher_id: null,
+    teachers: [],
     teacherName: null,
-    teacherProfileId: null,
-    teacherEmail: null,
     dueDate: '2026-10-01',
     meetingType: 'annual',
     hasUpcomingMeeting: false,
@@ -80,7 +83,7 @@ describe('buildPlanRequests', () => {
       ['teacher@d.org', [googleBlock('teacher')]],
     ]);
     const [request] = buildPlanRequests(
-      [student({ teacherProfileId: 't-profile', teacherEmail: 'teacher@d.org' })],
+      [student({ teachers: [linkedTeacher({ profileId: 't-profile', email: 'teacher@d.org' })] })],
       planning,
       googleBusy
     );
@@ -98,7 +101,7 @@ describe('buildPlanRequests', () => {
       ['noacct@d.org', [googleBlock('teacher')]],
     ]);
     const [request] = buildPlanRequests(
-      [student({ teacherEmail: 'noacct@d.org' })],
+      [student({ teachers: [linkedTeacher({ email: 'noacct@d.org' })] })],
       planningData(),
       googleBusy
     );
@@ -111,8 +114,8 @@ describe('buildPlanRequests', () => {
     ]);
     const requests = buildPlanRequests(
       [
-        student({ id: 's1', teacherEmail: 'teacher@d.org' }),
-        student({ id: 's2', teacherEmail: 'teacher@d.org' }),
+        student({ id: 's1', teachers: [linkedTeacher({ email: 'teacher@d.org' })] }),
+        student({ id: 's2', teachers: [linkedTeacher({ id: 't2', email: 'teacher@d.org' })] }),
       ],
       planningData(),
       googleBusy
@@ -120,9 +123,58 @@ describe('buildPlanRequests', () => {
     expect(requests[0].attendees[1]).toBe(requests[1].attendees[1]);
   });
 
+  // SPE-336: co-teachers are equals and share the class, so a co-taught
+  // student's meeting has to fit BOTH of them — one constraint each, not the
+  // first one silently winning.
+  it('constrains on every invited teacher, not just the first', () => {
+    const googleBusy = new Map<string, BusyBlock[]>([
+      ['davis@d.org', [googleBlock('davis')]],
+      ['winbery@d.org', [googleBlock('winbery')]],
+    ]);
+    const [request] = buildPlanRequests(
+      [
+        student({
+          teachers: [
+            linkedTeacher({ id: 't-davis', email: 'davis@d.org' }),
+            linkedTeacher({ id: 't-winbery', email: 'winbery@d.org' }),
+          ],
+        }),
+      ],
+      planningData(),
+      googleBusy
+    );
+    expect(request.attendees).toHaveLength(3); // organizer + both teachers
+    expect(request.attendees.slice(1).map(a => a.key).sort()).toEqual([
+      'email:davis@d.org',
+      'email:winbery@d.org',
+    ]);
+  });
+
+  // A teacher with nothing to constrain must not push the OTHER co-teacher out
+  // of the attendee list.
+  it('keeps a constrained co-teacher when the other has no constraints', () => {
+    const googleBusy = new Map<string, BusyBlock[]>([
+      ['winbery@d.org', [googleBlock('winbery')]],
+    ]);
+    const [request] = buildPlanRequests(
+      [
+        student({
+          teachers: [
+            linkedTeacher({ id: 't-davis', email: 'quiet@d.org' }),
+            linkedTeacher({ id: 't-winbery', email: 'winbery@d.org' }),
+          ],
+        }),
+      ],
+      planningData(),
+      googleBusy
+    );
+    expect(request.attendees).toHaveLength(2);
+    expect(request.attendees[1].key).toBe('email:winbery@d.org');
+  });
+
   it('omits the teacher constraint when there is nothing to constrain', () => {
     const [request] = buildPlanRequests(
-      [student({ teacherEmail: 'quiet@d.org' })],
+      [student({ teachers: [linkedTeacher({ email: 'quiet@d.org' })] })],
       planningData(),
       null
     );

--- a/app/(dashboard)/dashboard/meetings/page.tsx
+++ b/app/(dashboard)/dashboard/meetings/page.tsx
@@ -163,10 +163,11 @@ export default function MeetingsPage() {
             (max, s) => (s.dueDate! > max ? s.dueDate! : max),
             todayStr()
           );
+          // SPE-336: free/busy for every invited teacher, not just one.
           const emails = Array.from(
             new Set(
               inHorizon
-                .map(s => s.teacherEmail)
+                .flatMap(s => s.teachers.map(t => t.email))
                 .filter((e): e is string => !!e)
             )
           );

--- a/app/api/admin/district/teachers/[teacherId]/route.ts
+++ b/app/api/admin/district/teachers/[teacherId]/route.ts
@@ -74,9 +74,13 @@ export const GET = withRoute<{ teacherId: string }>({}, async ({ userId, params 
       .eq('id', teacherId)
       .single();
 
-    // Check for dependencies (students assigned to this teacher)
+    // SPE-336: count LINKS, not rows carrying the legacy column. A teacher who
+    // is only ever a CO-teacher has no `students.teacher_id` pointing at them,
+    // so the old check reported zero assigned students and let the delete
+    // through — and the FK cascade then silently destroyed their
+    // `student_teachers` rows, which are the authoritative assignment.
     const { count: studentCount } = await adminClient
-      .from('students')
+      .from('student_teachers')
       .select('id', { count: 'exact', head: true })
       .eq('teacher_id', teacherId);
 
@@ -245,9 +249,10 @@ export const DELETE = withRoute<{ teacherId: string }>({}, async ({ userId, para
     // Use admin client for checks and delete
     const adminClient = createServiceClient();
 
-    // Check for dependencies
+    // SPE-336: count LINKS — see the GET handler above. Deleting a teacher
+    // cascades their student_teachers rows away, so the guard has to see them.
     const { count: studentCount } = await adminClient
-      .from('students')
+      .from('student_teachers')
       .select('id', { count: 'exact', head: true })
       .eq('teacher_id', teacherId);
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -875,16 +875,50 @@ schedules, not Speddy caseloads.
   and **no** child had copies naming different teachers — so every read set was
   unchanged. Where copies ever do disagree the link set is their union.
 
-**Source of truth:** `supabase/migrations/20260807_spe334_student_teachers.sql`;
+#### Who reads the link set (SPE-336)
+
+Every teacher-facing read resolves through the junction rather than the legacy
+column. Two shapes, both in `lib/supabase/queries/student-teachers.ts`:
+
+- **"my students"** (teacher portal roster + today view) → `getMyLinkedStudentIds`,
+  which calls the `get_teacher_student_ids` seam. Keyed on the **account**, so
+  it returns exactly what RLS allows and covers an account holding teacher rows
+  at more than one school — which `getCurrentTeacher()`'s `.single()` cannot.
+- **"this teacher's students"** (admin directory, teacher details) →
+  `getLinkedStudentIds`, keyed on a `teachers` row.
+
+Also switched: the site-admin directory's per-teacher count and the
+**district teacher-delete guard** (both now count links — a teacher who is only
+ever a *co*-teacher has no `students.teacher_id` pointing at them, so the old
+check would have reported zero and let the cascade destroy their links); the
+SEA RPC `get_sea_students`, whose unchanged two teacher columns now carry the
+joined set and the first link; `groupStudentsByIdentity`, rekeyed onto
+`child_id`; and IEP-meeting attendee assembly. `getStudentDetails` /
+`getStudentResourceSchedule` gained caller-side scoping on top of RLS —
+defense in depth, so a policy regression alone cannot widen a teacher's reach.
+
+**IEP attendees differ by level, deliberately.** Elementary invites *every*
+linked teacher and constrains the schedule on all of them: a single-teacher
+class behaves exactly as before, a co-taught class invites both, since they
+share the class. Secondary takes the **first** linked teacher only — the legal
+minimum is at least one gen-ed teacher of the student, not all of them
+(`docs/IEP_MEETING_SCHEDULING_SPEC.md` §8), and auto-constraining on six
+calendars would make a meeting unschedulable. Choosing which one is a human's
+job: **SPE-322**'s attendee picker consumes this same set as its options.
+
+**Source of truth:** `supabase/migrations/20260807_spe334_student_teachers.sql`,
+`20260807_spe336_get_sea_students_teacher_set.sql`;
 live `student_teachers` table + its four policies;
 `get_teacher_student_ids()`, `chat_is_student_participant()`,
 `get_student_chat_participants()`, `get_my_chat_students()`,
 `matching_provider_student_ids()`,
 `verify_student_teacher_school_consistency()`,
 `students_mirror_teacher_link()`, `student_teachers_mirror_legacy()`;
+`lib/supabase/queries/student-teachers.ts`;
 `scripts/sim-district/manifest.ts` (`studentTeacherLinkId` /
-`TOTAL_STUDENT_TEACHER_LINKS`);
-`scripts/sim-district/verify-student-teachers-rls.ts`.
+`studentTeacherLinks` / `SECONDARY_PERIODS` / `TOTAL_STUDENT_TEACHER_LINKS`);
+`scripts/sim-district/verify-student-teachers-rls.ts`,
+`scripts/sim-district/verify-teacher-set-reads.ts`.
 
 ### The session tables
 
@@ -1245,14 +1279,15 @@ of school (Master Schedule stays), and Internal sets the `school_type` /
 > `/dashboard/special-activities`, and `/dashboard/plan` stay reachable by direct
 > URL on a secondary site (RLS still scopes data).
 >
-> **Known gap — SPE-194 (Medium), half closed:** the *data model* can now hold
-> many teachers per student — `student_teachers` (SPE-334, §6) — and RLS,
-> chat membership and cross-provider matching already resolve teachers through
-> it. What has **not** moved yet is the application layer: the Teacher roster
-> query is still `students … eq('teacher_id', …)`, and every teacher picker is
-> still single-select. Switching the reads is **SPE-336**, the editing UI is
-> **SPE-337**, and retiring `students.teacher_id` / `teacher_name` is
-> **SPE-341**. Complements the SPE-181 rostering spike.
+> **Known gap — SPE-194 (Medium), nearly closed:** the data model holds many
+> teachers per student (`student_teachers`, SPE-334, §6) and **every read now
+> resolves through it** (SPE-336): the teacher portal roster and today view,
+> chat membership, admin directory counts, the SEA data layer, cross-provider
+> identity, and IEP-meeting attendee assembly. Every linked teacher sees their
+> student — all subject teachers at secondary, both co-teachers at elementary.
+> What remains is **writing** the links by hand: every teacher picker is still
+> single-select (**SPE-337**), and retiring `students.teacher_id` /
+> `teacher_name` is **SPE-341**. Complements the SPE-181 rostering spike.
 
 **Source of truth:** `lib/school-helpers.ts` (`isSecondarySchool`,
 `classifyByType`, `parseGradeLevel`); `app/components/providers/school-context.tsx`
@@ -1275,7 +1310,7 @@ Re-check Linear for current state.
 | **SPE-188** | Low | Security | Idle logout is client-side only; no server-side session-lifetime backstop. |
 | **SPE-190** | Low | Security | Admin-created teachers get a temp password that's never force-rotated (no `must_change_password` on creation). |
 | **SPE-193** | Low | UX / robustness | Elementary/secondary feature gating is client-side only; hidden routes reachable by URL on secondary sites. |
-| **SPE-194** | Medium | Data model | Half closed: `student_teachers` (SPE-334) now holds N teachers per child and RLS/chat/matching resolve through it, but the app still reads and edits the single `students.teacher_id`. Reads switch in SPE-336, editing UI in SPE-337, column retirement in SPE-341. |
+| **SPE-194** | Medium | Data model | Nearly closed: `student_teachers` (SPE-334) holds N teachers per child and every read resolves through it (SPE-336) — portal, chat, admin counts, SEA layer, cross-provider identity, IEP attendees. Remaining: the editing UI (SPE-337) and column retirement (SPE-341). |
 
 **Related context tickets:** SPE-132 (middleware `getSession()` + per-nav
 profile query), SPE-134 (FERPA wording reworded to match reality), SPE-142

--- a/docs/SIM_DISTRICT.md
+++ b/docs/SIM_DISTRICT.md
@@ -207,9 +207,11 @@ sites are the rare exception, so the sim doesn't model them).
 | 13 | Tomás Reyes-Sim | `speech` | Willow (primary) + Juniper + Cedar | `slp.itinerant` | **3-site itinerant near the 55-case SLP average (48)**: `provider_schools` M:N + `is_primary`, `user_site_schedules` workdays, school switcher, mixed elementary/secondary UX |
 | 14 | Jun Park-Sim | `ot` | Maple (primary) + Redwood | `ot.itinerant` | **Both UXes on one login** — elementary UX at Maple, trimmed secondary UX at Redwood (§9's exact scenario); OT service type |
 | 15 | Leah Kim-Sim | `sea` | Willow | `sea.willow` | `delivered_by='sea'` delegation (`assigned_to_sea_id`); lesson **view-only** RLS; no schedule editing |
-| 16 | Nora Ellison-Sim | `teacher` (gr 3) | Willow | `teacher.willow.1` | Teacher dashboard with a roster (`students.teacher_id`); linked `teachers.account_id`; submits CARE Lane A referral |
-| 17 | David Osei-Sim | `teacher` (gr 5) | Willow | `teacher.willow.2` | Teacher **empty state** — zero SPED students |
-| 18 | Fatima Haddad-Sim | `teacher` (gr 7) | Cedar | `teacher.cedar` | Secondary teacher view: "Case Manager" label, accommodations-first student page |
+| 16 | Nora Ellison-Sim | `teacher` (gr 3) | Willow | `teacher.willow.1` | Teacher dashboard with a roster (via `student_teachers`); linked `teachers.account_id`; submits CARE Lane A referral |
+| 17 | David Osei-Sim | `teacher` (gr 5) | Willow | `teacher.willow.2` | Teacher **empty state** — zero SPED students, and the only teacher who can prove a *non*-linked teacher sees nothing |
+| 18 | Imani Brooks-Sim | `teacher` (gr 3) | Willow | `teacher.willow.3` | **Nora's co-teacher** (SPE-336): the same grade-3 class, as equals. Both must see every student in it — the elementary half of multi-teacher |
+| 19 | Fatima Haddad-Sim | `teacher` (gr 7) | Cedar | `teacher.cedar` | Secondary teacher view: "Case Manager" label, accommodations-first student page |
+| 20 | Sanjay Rao-Sim | `teacher` (gr 7) | Cedar | `teacher.cedar.2` | **A second Cedar subject teacher** (SPE-336): shares students with Fatima across different periods, and must see them independently of her |
 
 ### Record-only teachers (no login)
 
@@ -217,17 +219,24 @@ sites are the rare exception, so the sim doesn't model them).
 "teacher exists as a record, not an account" state that admin rosters have to
 deal with, and a legitimate steady state rather than a half-finished signup:
 `teachers` is a directory, and only some of the people in it are also users.
-**Eighteen across all five
-schools** (5 at Willow, 4 at Maple, 4 at Juniper, 2 at Cedar, 3 at Redwood),
+**Twenty-seven across all five
+schools** (5 at Willow, 4 at Maple, 4 at Juniper, 6 at Cedar, 8 at Redwood),
 so every school's roster looks staffed and every seeded student has a
 homeroom teacher to hang off. Names (all `-Sim`) and grade assignments live
 in the manifest.
 
+The two secondary schools carry a deeper bench on purpose (SPE-336): eight
+teachers each, against `SECONDARY_PERIODS`' six. A middle/high student has a
+teacher per period, and if the faculty were only as deep as the timetable
+every student would carry an identical set — "which of my teachers" would
+never be a real question, and the fixture would prove nothing about the
+multi-teacher reads.
+
 **Deliberately absent from v1:** `counseling`, `psychologist`,
 `specialist`, `intervention` personas (they behave identically to the seeded
 provider roles at the RLS/delivery layer — `delivered_by='specialist'`); a
-high-school **teacher login** (record-only HS teachers hold the rosters;
-Fatima covers the secondary teacher UX); a second district; a state-scoped
+high-school **teacher login** (record-only HS teachers hold the
+rosters; Fatima and Sanjay cover the secondary teacher UX at middle school); a second district; a state-scoped
 admin. Each is a small manifest addition when a feature actually targets it.
 
 ---
@@ -290,8 +299,14 @@ Field conventions:
   The child's teacher set, anchored on `children` — so the co-served pairs carry
   one link between them, not one per caseload copy, exactly as production's
   backfill collapsed its one real shared pair. Seeding is still **1:1 with the
-  legacy `students.teacher_id`** in this ticket; per-period sets at Cedar/Redwood
-  and the elementary co-teacher pair arrive with SPE-336 (§10). Links are seeded
+  legacy `students.teacher_id`** at elementary — except Nora's grade-3 class,
+  which Imani co-teaches (two links per child). At **Cedar and Redwood every
+  student carries six links**, one per `SECONDARY_PERIODS` slot, drawn from the
+  school's eight teachers starting at their homeroom teacher and wrapping — so
+  the homeroom teacher is always in the set (which keeps the legacy column
+  naming a teacher the child really has) while different students still get
+  different sets. `subject`/`period` are display labels only; no seeded session
+  derives from them. Links are seeded
   explicitly with manifest-derived ids **before** the caseload rows, so the
   dual-write trigger's `ON CONFLICT DO NOTHING` is a no-op instead of planting a
   row with an id the manifest does not own (invariant 1). `TOTAL_STUDENT_TEACHER_LINKS`
@@ -388,9 +403,12 @@ guard at all): `sim:verify-rls` (`profiles`), `sim:verify-children-rls`
 (SPE-347 `children` RLS + the child-link trigger), `sim:verify-child-link`
 (SPE-348: the server re-validating a claimed create-or-attach) and
 `sim:verify-student-teachers-rls` (SPE-334: the teacher read sets, the
-co-teacher case, the school-consistency refusal and the dual-write). All
+co-teacher case, the school-consistency refusal and the dual-write) and
+`sim:verify-teacher-set-reads` (SPE-336: the two teacher-set reads the portal
+walk cannot see — `get_sea_students` and the IEP-meeting caseload). All
 `npx tsx`. The two `children` guards and the `student_teachers` guard write sim
-rows — re-seed afterward to restore a pristine fixture.
+rows — re-seed afterward to restore a pristine fixture;
+`sim:verify-teacher-set-reads` is read-only.
 
 Env requirements are scoped per command. Every command needs
 `NEXT_PUBLIC_SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`. Beyond that:
@@ -399,7 +417,7 @@ Env requirements are scoped per command. Every command needs
 |---|---|---|
 | `sim:reset` | `SIM_DISTRICT_PASSWORD` | it sets the persona passwords |
 | `sim:verify`, `sim:teardown` | — | read-only / delete-only, so they never receive the credential secret |
-| the four `sim:verify-*` guards | `SIM_DISTRICT_PASSWORD` + `NEXT_PUBLIC_SUPABASE_ANON_KEY` | they sign IN as personas, which needs the same derived password and a client-side key |
+| the five `sim:verify-*` guards | `SIM_DISTRICT_PASSWORD` + `NEXT_PUBLIC_SUPABASE_ANON_KEY` | they sign IN as personas, which needs the same derived password and a client-side key |
 
 **Preflight, before any write.** Scripts hard-fail unless: **(a)** the host in
 `NEXT_PUBLIC_SUPABASE_URL` is a front for the project pinned in `manifest.ts` —
@@ -528,7 +546,7 @@ Triggers to revisit this spec (tracked here so they don't rely on memory):
 | **AI features enabled** (SPE-174) | Sim-driven generation burns real API budget; keep generation steps deliberate and budgeted in verification runs. |
 | **Billing / payments return** | Sim users need an explicit exemption path before any billing integration ships. |
 | **Outbound email / notifications ship** | Re-confirm the sim domain can never receive or leak mail; decide per-channel whether sim users are suppressed or plus-addressed. |
-| **Secondary rostering ships (SPE-194)** | Today the sim mirrors the current one-teacher-per-student model even at Cedar/Redwood — a known simplification the owner has flagged (real secondary students have a teacher per period). When multi-teacher rostering lands, the sim gains per-period teacher assignments and the secondary session seeding switches on (§7). |
+| **Secondary rostering ships (SPE-194)** | ✅ **Fired 2026-08-07 (SPE-334/SPE-336).** The sim no longer mirrors one-teacher-per-student: Cedar and Redwood students carry a teacher per period, and Willow has a co-teacher pair (§7). Still open from this trigger: secondary **session** seeding, which stays off because Speddy does not schedule at secondary (SPE-149/193 posture). |
 | **Any new integration** | Standing question in its design: *"what does the sim district do here?"* |
 
 ---

--- a/lib/supabase/queries/admin-accounts.ts
+++ b/lib/supabase/queries/admin-accounts.ts
@@ -816,6 +816,8 @@ export async function deleteTeacher(teacherId: string) {
 
 export interface AdminStudentView {
   id: string;
+  /** SPE-336: the child this caseload row serves — the identity key. */
+  child_id: string | null;
   initials: string;
   grade_level: string;
   teacher_id: string | null;
@@ -849,8 +851,19 @@ export interface GroupedStudent {
 }
 
 /**
- * Groups students by their identity (initials + grade + teacher).
- * Multiple provider records for the same student are combined.
+ * Groups a school's caseload rows by the CHILD they serve, so one kid served
+ * by two providers is one row with two provider records.
+ *
+ * SPE-336: the key used to be `initials + grade + teacher_id`, which breaks
+ * both ways once a student can have more than one teacher — a second teacher
+ * would fragment one child into two rows. Dropping teacher from the tuple was
+ * the original plan, but that over-merges instead: two genuinely different
+ * children who happen to share initials and grade at one school would collapse
+ * into one. `child_id` (SPE-347) is the actual identity and avoids both, so
+ * that is the key. Rows with no child fall back to the old heuristic, which
+ * cannot happen today — every students row is linked, asserted by the
+ * migration and by sim:verify — but the fallback keeps a null from silently
+ * merging unrelated rows under one empty key.
  */
 export function groupStudentsByIdentity(students: AdminStudentView[]): GroupedStudent[] {
   const groupMap = new Map<string, GroupedStudent>();
@@ -859,7 +872,9 @@ export function groupStudentsByIdentity(students: AdminStudentView[]): GroupedSt
     // Null-safe grouping key - handle missing initials/grade gracefully
     const initials = (student.initials || '').toLowerCase();
     const gradeLevel = student.grade_level || '';
-    const groupKey = `${initials}_${gradeLevel}_${student.teacher_id || ''}`;
+    const groupKey = student.child_id
+      ? `child_${student.child_id}`
+      : `${initials}_${gradeLevel}_${student.id}`;
 
     if (!groupMap.has(groupKey)) {
       groupMap.set(groupKey, {
@@ -938,6 +953,7 @@ export async function getSchoolStudents(schoolId: string): Promise<AdminStudentV
         .from('students')
         .select(`
           id,
+          child_id,
           initials,
           grade_level,
           teacher_id,
@@ -966,6 +982,7 @@ export async function getSchoolStudents(schoolId: string): Promise<AdminStudentV
   // Transform to AdminStudentView format
   return (studentsResult.data || []).map(student => ({
     id: student.id,
+    child_id: student.child_id,
     initials: student.initials,
     grade_level: student.grade_level,
     teacher_id: student.teacher_id,

--- a/lib/supabase/queries/iep-meetings.ts
+++ b/lib/supabase/queries/iep-meetings.ts
@@ -15,6 +15,12 @@ import {
   removeHoldEvent,
   syncHoldEvents,
 } from '@/lib/calendar/hold-events-client';
+import { isSecondarySchool } from '@/lib/school-helpers';
+import {
+  formatTeacherSet,
+  getTeachersByChildId,
+  type LinkedTeacher,
+} from './student-teachers';
 import type { SiteMeetingRules } from '@/src/types';
 
 export interface MeetingListItem extends IepMeeting {
@@ -32,11 +38,25 @@ export interface CaseloadStudent {
   id: string;
   initials: string;
   grade_level: string;
-  teacher_id: string | null;
+  /**
+   * SPE-336: the teachers this student's meeting is assembled around.
+   *
+   * **Elementary — every linked teacher.** A single-teacher class behaves
+   * exactly as before; a co-taught class invites both co-teachers, because
+   * they share the class and are equals (product decision 2026-07-26).
+   *
+   * **Secondary — the first linked teacher only.** A secondary student has one
+   * teacher per period, and the legal minimum is *at least one* gen-ed teacher
+   * of the student, not all of them (IEP spec §8). Auto-inviting six teachers
+   * would be wrong, and auto-constraining a meeting on six calendars would
+   * make it unschedulable. Picking the one is a human's job — SPE-322's
+   * attendee picker, which consumes this same set as its options list. Until
+   * then this is exactly what secondary did before: one teacher, chosen for
+   * you.
+   */
+  teachers: LinkedTeacher[];
+  /** How the set reads on screen, e.g. "Davis / Winbery". */
   teacherName: string | null;
-  teacherProfileId: string | null;
-  /** For Google free/busy lookups via calendars shared with the organizer. */
-  teacherEmail: string | null;
   dueDate: string | null; // earlier of upcoming IEP / triennial
   meetingType: 'annual' | 'triennial';
   hasUpcomingMeeting: boolean;
@@ -102,17 +122,19 @@ export async function getPlanningData(schoolId: string): Promise<PlanningData> {
   } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');
 
-  const [rulesRes, studentsRes, sessionsRes, meetingsRes, adminsRes] =
+  const [rulesRes, studentsRes, sessionsRes, meetingsRes, adminsRes, schoolRes] =
     await Promise.all([
       supabase
         .from('site_meeting_rules')
         .select('*')
         .eq('school_id', schoolId)
         .maybeSingle(),
+      // SPE-336: the teacher embed on students.teacher_id is gone — the
+      // teacher set is resolved per child from student_teachers below.
       supabase
         .from('students')
         .select(
-          'id, initials, grade_level, teacher_id, teachers(id, account_id, first_name, last_name, email), student_details(upcoming_iep_date, upcoming_triennial_date)'
+          'id, child_id, initials, grade_level, student_details(upcoming_iep_date, upcoming_triennial_date)'
         )
         .eq('provider_id', user.id)
         .eq('school_id', schoolId),
@@ -130,6 +152,12 @@ export async function getPlanningData(schoolId: string): Promise<PlanningData> {
         .is('deleted_at', null)
         .not('scheduled_start', 'is', null),
       supabase.rpc('get_school_site_admins', { p_school_id: schoolId }),
+      // SPE-336: attendee assembly differs by level (see CaseloadStudent.teachers).
+      supabase
+        .from('schools')
+        .select('school_type, grade_span_low')
+        .eq('id', schoolId)
+        .maybeSingle(),
     ]);
 
   // Every source feeds planning constraints — a silently-failed fetch would
@@ -140,6 +168,7 @@ export async function getPlanningData(schoolId: string): Promise<PlanningData> {
     ['sessions', sessionsRes.error],
     ['meetings', meetingsRes.error],
     ['site admins', adminsRes.error],
+    ['school', schoolRes.error],
   ];
   for (const [what, err] of failures) {
     if (err) {
@@ -188,21 +217,23 @@ export async function getPlanningData(schoolId: string): Promise<PlanningData> {
     id: string;
     initials: string;
     grade_level: string;
-    teacher_id: string | null;
-    teachers: {
-      id: string;
-      account_id: string | null;
-      first_name: string | null;
-      last_name: string | null;
-      email: string | null;
-    } | null;
+    child_id: string | null;
     student_details: {
       upcoming_iep_date: string | null;
       upcoming_triennial_date: string | null;
     } | null;
   };
 
-  const caseload: CaseloadStudent[] = ((studentsRes.data ?? []) as unknown as StudentRow[]).map(s => {
+  const studentRows = (studentsRes.data ?? []) as unknown as StudentRow[];
+
+  // SPE-336: one round trip for the whole caseload's teacher sets.
+  const teachersByChild = await getTeachersByChildId(
+    supabase,
+    studentRows.map(s => s.child_id).filter((id): id is string => !!id),
+  );
+  const secondary = isSecondarySchool(schoolRes.data ?? null);
+
+  const caseload: CaseloadStudent[] = studentRows.map(s => {
     const details = Array.isArray(s.student_details)
       ? s.student_details[0]
       : s.student_details;
@@ -216,26 +247,26 @@ export async function getPlanningData(schoolId: string): Promise<PlanningData> {
       dueDate = triDue;
       meetingType = 'triennial';
     }
-    const teacher = Array.isArray(s.teachers) ? s.teachers[0] : s.teachers;
+    // Elementary invites the whole set; secondary takes the first only until
+    // SPE-322's picker lets a human choose (see CaseloadStudent.teachers).
+    const linked = s.child_id ? (teachersByChild.get(s.child_id) ?? []) : [];
+    const teachers = secondary ? linked.slice(0, 1) : linked;
     return {
       id: s.id,
       initials: s.initials,
       grade_level: s.grade_level,
-      teacher_id: s.teacher_id,
-      teacherName: teacher
-        ? [teacher.first_name, teacher.last_name].filter(Boolean).join(' ') || null
-        : null,
-      teacherProfileId: teacher?.account_id ?? null,
-      teacherEmail: teacher?.email ?? null,
+      teachers,
+      teacherName: formatTeacherSet(teachers),
       dueDate,
       meetingType,
       hasUpcomingMeeting: studentsWithMeetings.has(s.id),
     };
   });
 
-  // Teacher availability prefs → engine constraints, by teacher profile id
+  // Teacher availability prefs → engine constraints, by teacher profile id.
+  // SPE-336: every invited teacher on every student, not one per student.
   const teacherProfileIds = Array.from(
-    new Set(caseload.map(s => s.teacherProfileId).filter(Boolean))
+    new Set(caseload.flatMap(s => s.teachers.map(t => t.profileId)).filter(Boolean))
   ) as string[];
   const teacherConstraints = new Map<string, AttendeeConstraints>();
   if (teacherProfileIds.length > 0) {
@@ -308,16 +339,20 @@ export function buildPlanRequests(
   const teacherCache = new Map<string, AttendeeConstraints | null>();
   return students.map(student => {
     const attendees: AttendeeConstraints[] = [organizer];
-    const teacherKey =
-      student.teacherProfileId ??
-      (student.teacherEmail ? `email:${student.teacherEmail}` : null);
-    if (teacherKey) {
+    // SPE-336: constrain on EVERY invited teacher. At elementary that is the
+    // co-teacher pair, who must both be free; at secondary the set is already
+    // narrowed to one upstream, so this stays a single constraint there.
+    for (const teacherRecord of student.teachers) {
+      const teacherKey =
+        teacherRecord.profileId ??
+        (teacherRecord.email ? `email:${teacherRecord.email}` : null);
+      if (!teacherKey) continue;
       if (!teacherCache.has(teacherKey)) {
-        const prefs = student.teacherProfileId
-          ? planning.teacherConstraints.get(student.teacherProfileId)
+        const prefs = teacherRecord.profileId
+          ? planning.teacherConstraints.get(teacherRecord.profileId)
           : undefined;
-        const googleTeacherBusy = student.teacherEmail
-          ? (googleBusy?.get(student.teacherEmail) ?? [])
+        const googleTeacherBusy = teacherRecord.email
+          ? (googleBusy?.get(teacherRecord.email) ?? [])
           : [];
         teacherCache.set(
           teacherKey,
@@ -429,20 +464,26 @@ export async function reserveMeetings(
         rsvp_status: 'pending',
       });
     }
-    if (draft?.student.teacherProfileId) {
-      rows.push({
-        meeting_id: meeting.id,
-        profile_id: draft.student.teacherProfileId,
-        attendee_role: 'teacher',
-        rsvp_status: 'pending',
-      });
-    } else if (draft?.student.teacherName) {
-      rows.push({
-        meeting_id: meeting.id,
-        display_name: draft.student.teacherName,
-        attendee_role: 'teacher',
-        rsvp_status: 'pending',
-      });
+    // SPE-336: one attendee row per invited teacher. A single-teacher class is
+    // byte-identical to before; a co-taught class invites both, since they
+    // share the class. Teachers without a Speddy account are still recorded by
+    // display name so the meeting shows who is expected.
+    for (const teacherRecord of draft?.student.teachers ?? []) {
+      if (teacherRecord.profileId) {
+        rows.push({
+          meeting_id: meeting.id,
+          profile_id: teacherRecord.profileId,
+          attendee_role: 'teacher',
+          rsvp_status: 'pending',
+        });
+      } else if (teacherRecord.name) {
+        rows.push({
+          meeting_id: meeting.id,
+          display_name: teacherRecord.name,
+          attendee_role: 'teacher',
+          rsvp_status: 'pending',
+        });
+      }
     }
     return rows;
   });

--- a/lib/supabase/queries/school-directory.ts
+++ b/lib/supabase/queries/school-directory.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@/lib/supabase/client';
 import { safeQuery } from '@/lib/supabase/safe-query';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
+import { getLinkedStudentIds } from './student-teachers';
 import type { Database } from '../../../src/types/database';
 
 type Teacher = Database['public']['Tables']['teachers']['Row'];
@@ -270,7 +271,7 @@ export async function getTeachersWithStudentCount(schoolId?: string) {
           created_by_admin,
           created_at,
           updated_at,
-          students:students(count)
+          student_teachers:student_teachers(count)
         `)
         .eq('school_id', targetSchoolId)
         .order('last_name', { ascending: true })
@@ -278,11 +279,15 @@ export async function getTeachersWithStudentCount(schoolId?: string) {
 
       if (error) throw error;
 
-      // Transform the data to include student_count as a number
-      // Handle case where students array might be empty or undefined
-      return data.map(({ students, ...teacher }) => ({
+      // SPE-336: count LINKS, not caseload rows. The old embed rode the
+      // implicit FK on students.teacher_id, which sees one teacher per student
+      // and breaks outright when SPE-341 drops the column. Links also count a
+      // co-served child ONCE, where the caseload-row count double-counted a
+      // child served by two providers — the number a site admin actually means
+      // by "students".
+      return data.map(({ student_teachers, ...teacher }) => ({
         ...teacher,
-        student_count: (students && students.length > 0 && students[0].count !== undefined) ? students[0].count : 0
+        student_count: (student_teachers && student_teachers.length > 0 && student_teachers[0].count !== undefined) ? student_teachers[0].count : 0
       }));
     },
     {
@@ -307,6 +312,10 @@ export async function getTeachersWithStudentCount(schoolId?: string) {
 export async function getTeacherStudents(teacherId: string) {
   const supabase = createClient<Database>();
 
+  // SPE-336: through the link set, so a co-teacher's students show up here too.
+  const studentIds = await getLinkedStudentIds(supabase, teacherId);
+  if (studentIds.length === 0) return [];
+
   const fetchPerf = measurePerformanceWithAlerts('fetch_teacher_students', 'database');
   const fetchResult = await safeQuery(
     async () => {
@@ -323,7 +332,7 @@ export async function getTeacherStudents(teacherId: string) {
             role
           )
         `)
-        .eq('teacher_id', teacherId)
+        .in('id', studentIds)
         .order('grade_level', { ascending: true });
 
       if (error) throw error;

--- a/lib/supabase/queries/student-teachers.ts
+++ b/lib/supabase/queries/student-teachers.ts
@@ -1,0 +1,135 @@
+/**
+ * SPE-336 — resolving a teacher's students through `student_teachers`.
+ *
+ * The link is anchored on the CHILD (SPE-334), not on the caseload row, so
+ * "the students of teacher X" is two hops:
+ *
+ *     teacher -> student_teachers.child_id -> students.child_id
+ *
+ * Every teacher-facing read goes through one of these helpers rather than
+ * `.eq('teacher_id', …)`, which only ever saw the single legacy column.
+ *
+ * Why helpers and not a nested PostgREST embed: an embed
+ * (`children!inner(student_teachers!inner(…))`) would work, but it injects a
+ * `children` key into every returned row that each caller has to strip, and it
+ * keys off ONE teacher row. These return plain id lists, so call sites keep
+ * their exact result shape and just swap `.eq(...)` for `.in('id', ids)`.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '../../../src/types/database';
+
+type Client = SupabaseClient<Database>;
+
+/**
+ * The caseload rows a single `teachers` row is linked to.
+ *
+ * Used by admin/directory surfaces, which ask about a specific teacher record.
+ * Returns [] when the teacher has no links — callers should short-circuit
+ * rather than issue an `.in('id', [])` query.
+ *
+ * RLS applies normally: the caller sees only links and caseload rows they are
+ * already permitted to read.
+ */
+export async function getLinkedStudentIds(
+  supabase: Client,
+  teacherId: string,
+): Promise<string[]> {
+  const { data: links, error } = await supabase
+    .from('student_teachers')
+    .select('child_id')
+    .eq('teacher_id', teacherId);
+  if (error) throw error;
+
+  const childIds = Array.from(new Set((links ?? []).map(l => l.child_id)));
+  if (childIds.length === 0) return [];
+
+  const { data: rows, error: rowsError } = await supabase
+    .from('students')
+    .select('id')
+    .in('child_id', childIds);
+  if (rowsError) throw rowsError;
+
+  return Array.from(new Set((rows ?? []).map(r => r.id)));
+}
+
+/**
+ * The caseload rows the signed-in teacher ACCOUNT may see.
+ *
+ * Keyed on the account rather than a teacher row, via the same SECURITY
+ * DEFINER seam every RLS policy uses (`get_teacher_student_ids`), so this
+ * returns exactly the set RLS would allow — no more, no less — and covers an
+ * account holding teacher rows at more than one school (SPE-362), which
+ * `getCurrentTeacher()`'s `.single()` cannot.
+ */
+export async function getMyLinkedStudentIds(
+  supabase: Client,
+  userId: string,
+): Promise<string[]> {
+  const { data, error } = await supabase.rpc('get_teacher_student_ids', {
+    user_id: userId,
+  });
+  if (error) throw error;
+  return Array.from(new Set((data ?? []) as string[]));
+}
+
+export interface LinkedTeacher {
+  /** `teachers` row id. */
+  id: string;
+  /** Display name, or null when the directory row carries neither name. */
+  name: string | null;
+  /** `profiles` id when the teacher has a Speddy account, else null. */
+  profileId: string | null;
+  email: string | null;
+}
+
+/**
+ * Every child's teacher set, keyed by `children.id`.
+ *
+ * One round trip for a page's worth of students. The order within each child
+ * is the link order (oldest first, id as tiebreak) — the same order the
+ * legacy-column mirror calls "first listed", so a surface that shows one
+ * teacher shows the same one the legacy column names.
+ */
+export async function getTeachersByChildId(
+  supabase: Client,
+  childIds: string[],
+): Promise<Map<string, LinkedTeacher[]>> {
+  const byChild = new Map<string, LinkedTeacher[]>();
+  const unique = Array.from(new Set(childIds.filter(Boolean)));
+  if (unique.length === 0) return byChild;
+
+  const { data, error } = await supabase
+    .from('student_teachers')
+    .select('child_id, created_at, id, teachers(id, first_name, last_name, email, account_id)')
+    .in('child_id', unique)
+    .order('created_at', { ascending: true })
+    .order('id', { ascending: true });
+  if (error) throw error;
+
+  for (const link of data ?? []) {
+    const teacher = Array.isArray(link.teachers) ? link.teachers[0] : link.teachers;
+    if (!teacher) continue;
+    const list = byChild.get(link.child_id) ?? [];
+    list.push({
+      id: teacher.id,
+      name: [teacher.first_name, teacher.last_name].filter(Boolean).join(' ') || null,
+      profileId: teacher.account_id ?? null,
+      email: teacher.email ?? null,
+    });
+    byChild.set(link.child_id, list);
+  }
+
+  return byChild;
+}
+
+/**
+ * How a set of teachers reads on screen.
+ *
+ * Elementary class lists are written "Davis / Winbery", so that is the
+ * separator (SPE-337 uses the same rule for the students page). Returns null
+ * for an empty set so callers can fall back to whatever they showed before.
+ */
+export function formatTeacherSet(teachers: LinkedTeacher[]): string | null {
+  const names = teachers.map(t => t.name).filter((n): n is string => !!n);
+  return names.length > 0 ? names.join(' / ') : null;
+}

--- a/lib/supabase/queries/teacher-details.ts
+++ b/lib/supabase/queries/teacher-details.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@/lib/supabase/client';
 import { safeQuery } from '@/lib/supabase/safe-query';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
+import { getLinkedStudentIds } from './student-teachers';
 import type { Database } from '../../../src/types/database';
 import type { PostgrestError } from '@supabase/supabase-js';
 
@@ -46,8 +47,12 @@ export async function getTeacherDetails(teacherId: string): Promise<TeacherDetai
   
   const user = authResult.data.data.user;
 
+  // SPE-336: the caller's own caseload rows for this teacher, resolved through
+  // the link set rather than the single legacy column.
+  const linkedStudentIds = await getLinkedStudentIds(supabase, teacherId);
+
   const fetchPerf = measurePerformanceWithAlerts('fetch_teacher_details', 'database');
-  
+
   const [teacherResult, studentsResult] = await Promise.all([
     safeQuery(
       async () => {
@@ -70,7 +75,7 @@ export async function getTeacherDetails(teacherId: string): Promise<TeacherDetai
         const { data, error } = await supabase
           .from('students')
           .select('id, initials, grade_level, sessions_per_week, minutes_per_session')
-          .eq('teacher_id', teacherId)
+          .in('id', linkedStudentIds)
           .eq('provider_id', user.id)
           .order('grade_level', { ascending: true })
           .order('initials', { ascending: true });
@@ -200,13 +205,17 @@ export async function getStudentsByTeacher(teacherId: string): Promise<Student[]
   
   const user = authResult.data.data.user;
 
+  // SPE-336: through the link set (see getTeacherDetails above).
+  const linkedStudentIds = await getLinkedStudentIds(supabase, teacherId);
+  if (linkedStudentIds.length === 0) return [];
+
   const fetchPerf = measurePerformanceWithAlerts('fetch_students_by_teacher', 'database');
   const fetchResult = await safeQuery(
     async () => {
       const { data, error } = await supabase
         .from('students')
         .select('*')
-        .eq('teacher_id', teacherId)
+        .in('id', linkedStudentIds)
         .eq('provider_id', user.id)
         .order('grade_level', { ascending: true })
         .order('initials', { ascending: true });

--- a/lib/supabase/queries/teacher-portal.ts
+++ b/lib/supabase/queries/teacher-portal.ts
@@ -3,6 +3,7 @@ import { safeQuery } from '@/lib/supabase/safe-query';
 import { measurePerformanceWithAlerts } from '@/lib/monitoring/performance-alerts';
 import { requireNonNull } from '@/lib/types/utils';
 import { getCurrentSchoolYear } from '@/lib/school-year';
+import { getMyLinkedStudentIds } from './student-teachers';
 import type { Database } from '../../../src/types/database';
 
 type Student = Database['public']['Tables']['students']['Row'];
@@ -69,8 +70,13 @@ export async function getMyStudentsInResource() {
 
   const user = authResult.data.data.user;
 
-  // First get teacher ID
-  const teacher = await getCurrentTeacher();
+  // SPE-336: the roster is the teacher's LINK SET, not the single legacy
+  // column — at secondary that is every subject teacher's students, and at
+  // elementary both co-teachers see the shared class. Resolved through the
+  // same seam RLS uses, so this returns exactly what RLS would allow and
+  // covers an account holding teacher rows at more than one school.
+  const studentIds = await getMyLinkedStudentIds(supabase, user.id);
+  if (studentIds.length === 0) return [];
 
   const fetchPerf = measurePerformanceWithAlerts('fetch_my_students_in_resource', 'database');
   const fetchResult = await safeQuery(
@@ -91,7 +97,7 @@ export async function getMyStudentsInResource() {
             full_name
           )
         `)
-        .eq('teacher_id', teacher.id)
+        .in('id', studentIds)
         .order('grade_level', { ascending: true })
         .order('initials', { ascending: true });
       if (error) throw error;
@@ -99,8 +105,7 @@ export async function getMyStudentsInResource() {
     },
     {
       operation: 'fetch_my_students_in_resource',
-      userId: user.id,
-      teacherId: teacher.id
+      userId: user.id
     }
   );
   fetchPerf.end({ success: !fetchResult.error });
@@ -129,6 +134,16 @@ export async function getStudentDetails(studentId: string) {
 
   const user = authResult.data.data.user;
 
+  // SPE-336 defense in depth: this used to rely 100% on RLS to decide whether
+  // the caller may see this student. Scope the query to the caller's own link
+  // set as well, so a policy regression cannot quietly widen a teacher's
+  // reach — the exact failure mode SPE-332 hid for seven months. Belt and
+  // braces: RLS still runs, this just stops trusting it alone.
+  const myStudentIds = await getMyLinkedStudentIds(supabase, user.id);
+  if (!myStudentIds.includes(studentId)) {
+    throw new Error('Student not found or access denied');
+  }
+
   const fetchPerf = measurePerformanceWithAlerts('fetch_student_details', 'database');
   const fetchResult = await safeQuery(
     async () => {
@@ -150,6 +165,7 @@ export async function getStudentDetails(studentId: string) {
           )
         `)
         .eq('id', studentId)
+        .in('id', myStudentIds)
         .single();
       if (error) throw error;
       return data;
@@ -185,6 +201,12 @@ export async function getStudentResourceSchedule(studentId: string) {
   }
 
   const user = authResult.data.data.user;
+
+  // SPE-336 defense in depth — see getStudentDetails above.
+  const myStudentIds = await getMyLinkedStudentIds(supabase, user.id);
+  if (!myStudentIds.includes(studentId)) {
+    return [];
+  }
 
   const fetchPerf = measurePerformanceWithAlerts('fetch_student_schedule', 'database');
   const fetchResult = await safeQuery(
@@ -452,30 +474,12 @@ export async function getTodayStudentSessions() {
   }
 
   const user = authResult.data.data.user;
-  const teacher = await getCurrentTeacher();
 
-  // First, get the student IDs for this teacher
-  const studentsResult = await safeQuery(
-    async () => {
-      const { data, error } = await supabase
-        .from('students')
-        .select('id')
-        .eq('teacher_id', teacher.id);
-      if (error) throw error;
-      return data;
-    },
-    {
-      operation: 'fetch_teacher_student_ids',
-      userId: user.id,
-      teacherId: teacher.id
-    }
-  );
-
-  if (studentsResult.error || !studentsResult.data || studentsResult.data.length === 0) {
+  // SPE-336: same link set as the roster above.
+  const studentIds = await getMyLinkedStudentIds(supabase, user.id);
+  if (studentIds.length === 0) {
     return [];
   }
-
-  const studentIds = studentsResult.data.map(s => s.id);
 
   const fetchPerf = measurePerformanceWithAlerts('fetch_today_student_sessions', 'database');
   const fetchResult = await safeQuery(
@@ -506,8 +510,7 @@ export async function getTodayStudentSessions() {
     },
     {
       operation: 'fetch_today_student_sessions',
-      userId: user.id,
-      teacherId: teacher.id
+      userId: user.id
     }
   );
   fetchPerf.end({ success: !fetchResult.error });

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "sim:verify-children-rls": "tsx scripts/sim-district/verify-children-rls.ts",
     "sim:verify-child-link": "tsx scripts/sim-district/verify-child-link.ts",
     "sim:verify-student-teachers-rls": "tsx scripts/sim-district/verify-student-teachers-rls.ts",
+    "sim:verify-teacher-set-reads": "tsx scripts/sim-district/verify-teacher-set-reads.ts",
     "sim:verify-special-activities-rls": "tsx scripts/sim-district/verify-special-activities-rls.ts",
     "sim:verify-multi-school-rls": "tsx scripts/sim-district/verify-multi-school-rls.ts",
     "sim:verify-provider-schools-rls": "tsx scripts/sim-district/verify-provider-schools-rls.ts",

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -480,7 +480,17 @@ export function studentTeacherLinks(rule: CaseloadRule, index: number): StudentT
 
   if (school.isSecondary) {
     const pool = secondaryTeacherPool(rule.schoolId);
-    const start = Math.max(0, pool.indexOf(homeroom));
+    const start = pool.indexOf(homeroom);
+    // The homeroom teacher MUST be in the set: the seed writes them to the
+    // legacy `students.teacher_id`, and a column naming a teacher the child
+    // has no link to is exactly the drift the SPE-334 mirror exists to repair
+    // — it would silently rewrite the fixture on first write. Fail loudly
+    // rather than start at 0 and hope.
+    if (start < 0) {
+      throw new Error(
+        `manifest: homeroom teacher ${homeroom} is not in ${rule.schoolId}'s secondary pool`,
+      );
+    }
     return SECONDARY_PERIODS.map((slot, n) => ({
       teacherRowId: pool[(start + n) % pool.length],
       subject: slot.subject,

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -192,7 +192,17 @@ export const PERSONAS: SimPersona[] = [
   },
   { key: 'nora', fullName: 'Nora Ellison-Sim', role: 'teacher', emailLocal: 'teacher.willow.1', schoolIds: [WILLOW], gradeLevel: '3' },
   { key: 'david', fullName: 'David Osei-Sim', role: 'teacher', emailLocal: 'teacher.willow.2', schoolIds: [WILLOW], gradeLevel: '5' },
+  // SPE-336: Nora's CO-TEACHER. Both hold the same grade-3 class as equals, so
+  // both must see those students — the elementary half of the multi-teacher
+  // payoff. Deliberately a NEW persona rather than reusing David: his
+  // zero-students empty state is load-bearing fixture (§6) and giving him a
+  // caseload would delete the only teacher with nothing to show.
+  { key: 'imani', fullName: 'Imani Brooks-Sim', role: 'teacher', emailLocal: 'teacher.willow.3', schoolIds: [WILLOW], gradeLevel: '3' },
   { key: 'fatima', fullName: 'Fatima Haddad-Sim', role: 'teacher', emailLocal: 'teacher.cedar', schoolIds: [CEDAR], gradeLevel: '7' },
+  // SPE-336: a SECOND Cedar teacher with a login. Without one, "another
+  // subject teacher sees the same student independently" — the secondary half
+  // of the payoff — has nobody to sign in as.
+  { key: 'sanjay', fullName: 'Sanjay Rao-Sim', role: 'teacher', emailLocal: 'teacher.cedar.2', schoolIds: [CEDAR], gradeLevel: '7' },
 ];
 
 export function persona(key: string): SimPersona {
@@ -238,6 +248,21 @@ export const RECORD_TEACHERS: RecordTeacher[] = [
   { key: 'diane', firstName: 'Diane', lastName: 'Kowalski-Sim', schoolId: REDWOOD, gradeLevel: '9' },
   { key: 'robert', firstName: 'Robert', lastName: 'Ngata-Sim', schoolId: REDWOOD, gradeLevel: '10' },
   { key: 'lucia', firstName: 'Lucia', lastName: 'Moretti-Sim', schoolId: REDWOOD, gradeLevel: '11' },
+  // SPE-336 — secondary faculty. A middle/high student has a teacher per
+  // period, so each secondary school needs a faculty deeper than the number of
+  // periods; otherwise every student would carry an identical teacher set and
+  // "which of my teachers" would never be a real question. Eight per school
+  // against SECONDARY_PERIODS' six gives every student a distinct-but-
+  // overlapping set (see secondaryTeacherPool / studentTeacherLinks).
+  { key: 'nadia', firstName: 'Nadia', lastName: 'Farouk-Sim', schoolId: CEDAR, gradeLevel: '7' },
+  { key: 'tobias', firstName: 'Tobias', lastName: 'Lindgren-Sim', schoolId: CEDAR, gradeLevel: '8' },
+  { key: 'priscilla', firstName: 'Priscilla', lastName: 'Okonkwo-Sim', schoolId: CEDAR, gradeLevel: '6' },
+  { key: 'kenji', firstName: 'Kenji', lastName: 'Watanabe-Sim', schoolId: CEDAR, gradeLevel: '7' },
+  { key: 'martine', firstName: 'Martine', lastName: 'Dubois-Sim', schoolId: REDWOOD, gradeLevel: '9' },
+  { key: 'ahmed', firstName: 'Ahmed', lastName: 'Rahimi-Sim', schoolId: REDWOOD, gradeLevel: '12' },
+  { key: 'gwen', firstName: 'Gwen', lastName: 'Prichard-Sim', schoolId: REDWOOD, gradeLevel: '10' },
+  { key: 'esteban', firstName: 'Esteban', lastName: 'Ferrer-Sim', schoolId: REDWOOD, gradeLevel: '11' },
+  { key: 'ingrid', firstName: 'Ingrid', lastName: 'Solberg-Sim', schoolId: REDWOOD, gradeLevel: '12' },
 ];
 
 export function teacherRecordId(key: string): string {
@@ -400,16 +425,89 @@ export function studentTeacherLinkId(childUuid: string, teacherRowId: string): s
 }
 
 /**
- * Distinct (child, teacher) links the seed plants — students minus the links
- * the shared pairs collapse. Derived from the same functions the seed uses, so
- * it cannot drift from what actually lands.
+ * SPE-336 — the secondary class day. `subject` / `period` are DISPLAY LABELS
+ * ONLY (SPE-334): Speddy does not schedule at secondary, and no seeded session
+ * is derived from them.
+ */
+export const SECONDARY_PERIODS = [
+  { period: '1', subject: 'English' },
+  { period: '2', subject: 'Math' },
+  { period: '3', subject: 'Science' },
+  { period: '4', subject: 'World History' },
+  { period: '5', subject: 'PE' },
+  { period: '6', subject: 'Elective' },
+] as const;
+
+/**
+ * Every teacher at a secondary school, in a stable order: login teachers first
+ * (persona order), then record-only teachers (list order). Eight per school
+ * against six periods, so students get overlapping-but-different sets.
+ */
+export function secondaryTeacherPool(schoolId: string): string[] {
+  return [
+    ...PERSONAS.filter(p => p.role === 'teacher' && p.schoolIds.includes(schoolId))
+      .map(p => teacherRecordId(`login:${p.key}`)),
+    ...RECORD_TEACHERS.filter(t => t.schoolId === schoolId).map(t => teacherRecordId(t.key)),
+  ];
+}
+
+export interface StudentTeacherLink {
+  teacherRowId: string;
+  subject: string | null;
+  period: string | null;
+}
+
+/**
+ * SPE-336 — the full teacher set for one caseload row, replacing the single
+ * `studentTeacher()` assignment as what the fixture actually seeds.
+ *
+ * **Secondary (Cedar / Redwood):** one teacher per period. The homeroom
+ * teacher `studentTeacher()` picks takes period 1 and the rest of the pool
+ * follows, wrapping — so the homeroom teacher is always in the set (which is
+ * what keeps the legacy `students.teacher_id` column naming a teacher the
+ * child really has) while different students still get different sets.
+ *
+ * **Elementary:** the homeroom teacher, plus Imani as Nora's CO-TEACHER on the
+ * grade-3 class they share. Every other elementary student keeps exactly one
+ * teacher, so the single-teacher path stays the fixture's common case.
+ *
+ * Labels are null at elementary: there are no periods there, and inventing
+ * some would imply scheduling semantics the columns explicitly do not carry.
+ */
+export function studentTeacherLinks(rule: CaseloadRule, index: number): StudentTeacherLink[] {
+  const homeroom = studentTeacher(rule, index).teacherRowId;
+  const school = schoolById(rule.schoolId);
+
+  if (school.isSecondary) {
+    const pool = secondaryTeacherPool(rule.schoolId);
+    const start = Math.max(0, pool.indexOf(homeroom));
+    return SECONDARY_PERIODS.map((slot, n) => ({
+      teacherRowId: pool[(start + n) % pool.length],
+      subject: slot.subject,
+      period: slot.period,
+    }));
+  }
+
+  const links: StudentTeacherLink[] = [{ teacherRowId: homeroom, subject: null, period: null }];
+  if (homeroom === teacherRecordId('login:nora')) {
+    links.push({ teacherRowId: teacherRecordId('login:imani'), subject: null, period: null });
+  }
+  return links;
+}
+
+/**
+ * Distinct (child, teacher) links the seed plants. Fewer than the sum of every
+ * student's set, because the shared pairs (spec §6) resolve to one child and
+ * their sets collapse. Derived from the same function the seed uses, so it
+ * cannot drift from what actually lands.
  */
 export const TOTAL_STUDENT_TEACHER_LINKS = new Set(
   CASELOADS.flatMap(rule =>
-    Array.from(
-      { length: rule.count },
-      (_, i) => `${childKey(rule.providerKey, rule.schoolId, i)}|${studentTeacher(rule, i).teacherRowId}`,
-    ),
+    Array.from({ length: rule.count }, (_, i) =>
+      studentTeacherLinks(rule, i).map(
+        link => `${childKey(rule.providerKey, rule.schoolId, i)}|${link.teacherRowId}`,
+      ),
+    ).flat(),
   ),
 ).size;
 

--- a/scripts/sim-district/seed.ts
+++ b/scripts/sim-district/seed.ts
@@ -63,6 +63,7 @@ import {
   studentInitials,
   studentTeacher,
   studentTeacherLinkId,
+  studentTeacherLinks,
   teacherRecordId,
   userSiteScheduleId,
   detailsCount,
@@ -317,17 +318,21 @@ async function main() {
             : [],
         });
       }
-      const linkId = studentTeacherLinkId(childUuid, teacher.teacherRowId);
-      if (!linkRows.has(linkId)) {
-        linkRows.set(linkId, {
-          id: linkId,
-          child_id: childUuid,
-          teacher_id: teacher.teacherRowId,
-          // subject/period stay null: 1:1 elementary-shaped seeding in this
-          // ticket. SPE-336 is where Cedar/Redwood gain per-period sets.
-          subject: null,
-          period: null,
-        });
+      // SPE-336: the child's whole teacher set — one per period at Cedar and
+      // Redwood, the homeroom teacher plus a co-teacher on Nora's shared
+      // grade-3 class, one teacher everywhere else. Deduped by link id, so a
+      // co-served child carries one set, not one per caseload copy.
+      for (const link of studentTeacherLinks(rule, i)) {
+        const linkId = studentTeacherLinkId(childUuid, link.teacherRowId);
+        if (!linkRows.has(linkId)) {
+          linkRows.set(linkId, {
+            id: linkId,
+            child_id: childUuid,
+            teacher_id: link.teacherRowId,
+            subject: link.subject,
+            period: link.period,
+          });
+        }
       }
       studentRows.push({
         id,

--- a/scripts/sim-district/verify-student-teachers-rls.ts
+++ b/scripts/sim-district/verify-student-teachers-rls.ts
@@ -160,6 +160,10 @@ async function main(): Promise<void> {
   const { data: targetRow } = await admin
     .from('students').select('child_id, school_id').eq('id', targetStudentId).single();
   const targetChildId = targetRow!.child_id as string;
+  // Derived, not hardcoded: the fixture seeds co-teachers at elementary
+  // (SPE-336), so "how many links does this child have" is a property of the
+  // seed, not a constant this guard gets to assume.
+  const baselineLinks = (await linkTeacherIds(targetChildId)).length;
   {
     check((await linkTeacherIds(targetChildId)).includes(davidTeacherId) === false,
       'David starts with NO link to the probe child', targetChildId);
@@ -205,8 +209,9 @@ async function main(): Promise<void> {
 
     const { data: bothLinks } = await david.from('student_teachers')
       .select('teacher_id').eq('child_id', targetChildId);
-    check((bothLinks?.length ?? 0) === 2, 'both links are visible to a linked teacher',
-      `${bothLinks?.length ?? 0} links`);
+    check((bothLinks?.length ?? 0) === baselineLinks + 1,
+      'the added link is visible to a linked teacher',
+      `${bothLinks?.length ?? 0} links (baseline ${baselineLinks})`);
 
     // Chat membership flips at the DB layer with this ticket (SPE-336 verifies
     // the UI): both teacher accounts must now be participants.
@@ -241,8 +246,8 @@ async function main(): Promise<void> {
       const client = await signIn(key);
       const { count, error } = await client.from('student_teachers')
         .select('*', { count: 'exact', head: true }).eq('child_id', targetChildId);
-      check(!error && (count ?? 0) === 1, `${label} reads the child's links`,
-        error ? error.message : `count=${count}`);
+      check(!error && (count ?? 0) === baselineLinks, `${label} reads the child's links`,
+        error ? error.message : `count=${count} (expected ${baselineLinks})`);
     }
 
     const alicia = await signIn('alicia');
@@ -257,7 +262,7 @@ async function main(): Promise<void> {
 
     const { data: delRows, error: delErr } = await alicia.from('student_teachers')
       .delete().eq('child_id', targetChildId).select('id');
-    check((delRows?.length ?? 0) === 0 && (await linkTeacherIds(targetChildId)).length === 1,
+    check((delRows?.length ?? 0) === 0 && (await linkTeacherIds(targetChildId)).length === baselineLinks,
       'unlinked provider DELETE affects 0 rows',
       `code=${delErr?.code ?? 'none'} rows=${delRows?.length ?? 0}`);
   }

--- a/scripts/sim-district/verify-teacher-set-reads.ts
+++ b/scripts/sim-district/verify-teacher-set-reads.ts
@@ -1,0 +1,168 @@
+/**
+ * SPE-336 — the teacher-set read paths the teacher-portal UI walk cannot
+ * reach, exercised with REAL signed-in sessions.
+ *
+ * The portal walk (Fatima / Sanjay / Nora / Imani / David) proves the roster.
+ * These two do not surface a teacher on screen today, so they need a probe:
+ *
+ *   * `get_sea_students` — the SEA data layer. Its shape is unchanged, but
+ *     `teacher_name` must now read as the whole set ("Davis / Winbery") and
+ *     `teacher_id` as the first link.
+ *   * the IEP-meeting caseload — a co-taught student must carry BOTH teachers,
+ *     because both get invited and both constrain the schedule.
+ *
+ * Both are SECURITY DEFINER / RLS-gated, so a mocked client would prove
+ * nothing (CLAUDE.md): the sessions here are real.
+ *
+ * Requires a seeded sim district (`npm run sim:reset -- --yes`). Read-only —
+ * it creates nothing, so no re-seed is needed afterwards.
+ *
+ * Usage: npm run sim:verify-teacher-set-reads
+ */
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createAdmin, requireEnv } from './lib';
+import { WILLOW, derivePassword, personaEmail, teacherRecordId } from './manifest';
+
+const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+const secret = requireEnv('SIM_DISTRICT_PASSWORD');
+
+const admin = createAdmin();
+
+let failures = 0;
+function check(ok: boolean, label: string, detail = ''): void {
+  if (!ok) failures++;
+  console.log(`  [${ok ? 'ok  ' : 'FAIL'}] ${label.padEnd(58)} ${detail}`);
+}
+
+async function signIn(personaKey: string): Promise<SupabaseClient> {
+  const email = personaEmail(personaKey);
+  const client = createClient(url, anon, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: derivePassword(secret, email),
+  });
+  if (error) throw new Error(`sim login failed for ${email} — is the district seeded? (${error.message})`);
+  return client;
+}
+
+async function main(): Promise<void> {
+  const noraTeacherId = teacherRecordId('login:nora');
+  const imaniTeacherId = teacherRecordId('login:imani');
+
+  // The co-taught children: Nora and Imani share this class (manifest
+  // studentTeacherLinks). Resolved from data, never assumed.
+  const { data: coTaught, error: ctErr } = await admin
+    .from('student_teachers').select('child_id').eq('teacher_id', imaniTeacherId);
+  if (ctErr) throw new Error(`co-taught lookup failed: ${ctErr.message}`);
+  const coTaughtChildIds = new Set((coTaught ?? []).map(r => r.child_id as string));
+  if (coTaughtChildIds.size === 0) {
+    throw new Error('no co-taught children in the fixture — re-seed (npm run sim:reset -- --yes)');
+  }
+
+  console.log('the fixture really is co-taught:');
+  {
+    const { data: noraLinks } = await admin
+      .from('student_teachers').select('child_id').eq('teacher_id', noraTeacherId);
+    const noraChildIds = new Set((noraLinks ?? []).map(r => r.child_id as string));
+    check(
+      coTaughtChildIds.size > 0 && [...coTaughtChildIds].every(id => noraChildIds.has(id)),
+      'Imani co-teaches exactly Nora\'s children',
+      `${coTaughtChildIds.size} shared / ${noraChildIds.size} Nora`,
+    );
+  }
+
+  console.log('get_sea_students reports the whole teacher set:');
+  {
+    const leah = await signIn('leah');
+    const { data, error } = await leah.rpc('get_sea_students', { p_school_id: WILLOW });
+    check(!error && (data?.length ?? 0) > 0, 'SEA reads their delegated students',
+      error ? error.message : `${data?.length ?? 0} students`);
+
+    const rows = (data ?? []) as { id: string; teacher_name: string | null; teacher_id: string | null }[];
+    const { data: linkRows } = await admin
+      .from('students').select('id, child_id').in('id', rows.map(r => r.id));
+    const childOf = new Map((linkRows ?? []).map(r => [r.id as string, r.child_id as string]));
+
+    const coTaughtRow = rows.find(r => coTaughtChildIds.has(childOf.get(r.id) ?? ''));
+    if (!coTaughtRow) {
+      check(false, 'a co-taught student is among the SEA\'s delegated students',
+        'none — the SEA delegation and the co-taught class no longer overlap');
+    } else {
+      check(true, 'a co-taught student is among the SEA\'s delegated students', coTaughtRow.id);
+      // The whole point: a joined set, not one name.
+      check(
+        (coTaughtRow.teacher_name ?? '').includes(' / '),
+        'teacher_name joins both co-teachers',
+        `${coTaughtRow.teacher_name}`,
+      );
+      check(
+        coTaughtRow.teacher_id === noraTeacherId || coTaughtRow.teacher_id === imaniTeacherId,
+        'teacher_id is one of the linked teachers (the first link)',
+        `${coTaughtRow.teacher_id}`,
+      );
+    }
+
+    // A singly-taught student must read exactly as it did before this ticket.
+    const singleRow = rows.find(r => !coTaughtChildIds.has(childOf.get(r.id) ?? ''));
+    if (singleRow) {
+      check(
+        !(singleRow.teacher_name ?? '').includes(' / '),
+        'a single-teacher student still reads as one name',
+        `${singleRow.teacher_name}`,
+      );
+    }
+  }
+
+  console.log('the IEP caseload carries every invited teacher:');
+  {
+    // Rachel owns the co-taught caseload rows at Willow.
+    const rachel = await signIn('rachel');
+    const { data: rows, error } = await rachel
+      .from('students')
+      .select('id, child_id')
+      .eq('school_id', WILLOW);
+    check(!error && (rows ?? []).length > 0, 'provider reads their Willow caseload',
+      error ? error.message : `${rows?.length ?? 0} rows`);
+
+    const coTaughtRow = (rows ?? []).find(r => coTaughtChildIds.has(r.child_id as string));
+    check(!!coTaughtRow, 'a co-taught student is on that caseload', coTaughtRow?.id ?? 'none');
+
+    if (coTaughtRow) {
+      // Exactly the read getPlanningData performs, through Rachel's session.
+      const { data: links, error: linkErr } = await rachel
+        .from('student_teachers')
+        .select('child_id, created_at, id, teachers(id, first_name, last_name, email, account_id)')
+        .in('child_id', [coTaughtRow.child_id as string])
+        .order('created_at', { ascending: true })
+        .order('id', { ascending: true });
+      check(!linkErr && (links ?? []).length === 2,
+        'the planner sees BOTH co-teachers, not just the first',
+        linkErr ? linkErr.message : `${links?.length ?? 0} teachers`);
+
+      const withAccounts = (links ?? []).filter(l => {
+        const t = Array.isArray(l.teachers) ? l.teachers[0] : l.teachers;
+        return !!t?.account_id;
+      });
+      // Both co-teachers are login personas, so both become real attendee rows
+      // (profile_id) rather than display-name-only placeholders.
+      check(withAccounts.length === 2,
+        'both resolve to Speddy accounts, so both become invitable attendees',
+        `${withAccounts.length} with accounts`);
+    }
+  }
+
+  if (failures === 0) {
+    console.log('\nAll checks passed.');
+  } else {
+    console.log(`\n${failures} check(s) failed.`);
+  }
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/supabase/migrations/20260807_spe336_get_sea_students_teacher_set.sql
+++ b/supabase/migrations/20260807_spe336_get_sea_students_teacher_set.sql
@@ -1,0 +1,106 @@
+-- SPE-336: `get_sea_students` reports the child's TEACHER SET, not one column.
+--
+-- The RPC's return shape is deliberately unchanged — same columns, same types,
+-- same order — so `lib/supabase/queries/sea-students.ts` and every consumer of
+-- it keep compiling and rendering exactly as they do today. What changes is
+-- where the two teacher columns come from:
+--
+--   * `teacher_name` — every linked teacher, joined "Davis / Winbery", the way
+--     elementary class lists are written (the same separator SPE-337 uses on
+--     the students page). One teacher renders identically to before.
+--   * `teacher_id`   — the FIRST link (oldest, id as tiebreak), which is the
+--     same row the legacy-column mirror calls "first listed". A caller that
+--     opens a teacher by id therefore opens the same teacher it did before.
+--
+-- The SEA UI does not display a teacher today, so this is groundwork rather
+-- than a visible change; keeping the shape minimal is deliberate (SPE-336),
+-- not an oversight. When the SEA surface does want the full set, it should
+-- read `student_teachers` directly rather than growing this signature.
+--
+-- Both columns fall back to the row's own legacy values when the child has no
+-- links at all. That covers the one production caseload row carrying a
+-- hand-typed `teacher_name` with no `teacher_id` — SPE-334 deliberately leaves
+-- it alone, and losing the only teacher its provider ever recorded would be a
+-- visible regression for that row's SEA.
+--
+-- Everything else — the SECURITY DEFINER posture, the
+-- `assigned_to_sea_id = auth.uid() AND delivered_by = 'sea'` gate (SPE-384's
+-- narrowing), and the school filters — is verbatim.
+
+CREATE OR REPLACE FUNCTION public.get_sea_students(
+  p_school_id character varying DEFAULT NULL::character varying,
+  p_school_site text DEFAULT NULL::text,
+  p_school_district text DEFAULT NULL::text
+)
+RETURNS TABLE(
+  id uuid, initials text, grade_level text, teacher_name text, teacher_id uuid,
+  sessions_per_week integer, minutes_per_session integer, school_id character varying,
+  provider_id uuid, created_at timestamp with time zone, updated_at timestamp with time zone,
+  iep_goals text[], first_name text, last_name text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  RETURN QUERY
+  SELECT DISTINCT
+    s.id,
+    s.initials,
+    s.grade_level,
+    COALESCE(links.teacher_names, s.teacher_name) AS teacher_name,
+    COALESCE(links.first_teacher_id, s.teacher_id) AS teacher_id,
+    s.sessions_per_week,
+    s.minutes_per_session,
+    s.school_id,
+    s.provider_id,
+    s.created_at,
+    s.updated_at,
+    COALESCE(sd.iep_goals, '{}'::TEXT[]) as iep_goals,
+    sd.first_name,
+    sd.last_name
+  FROM students s
+  INNER JOIN schedule_sessions ss ON ss.student_id = s.id
+  LEFT JOIN student_details sd ON sd.student_id = s.id
+  LEFT JOIN LATERAL (
+    SELECT
+      NULLIF(
+        string_agg(
+          NULLIF(btrim(concat_ws(' ', t.first_name, t.last_name)), ''),
+          ' / ' ORDER BY st.created_at, st.id
+        ),
+        ''
+      ) AS teacher_names,
+      (array_agg(st.teacher_id ORDER BY st.created_at, st.id))[1] AS first_teacher_id
+    FROM public.student_teachers st
+    JOIN public.teachers t ON t.id = st.teacher_id
+    WHERE st.child_id = s.child_id
+  ) links ON TRUE
+  WHERE ss.assigned_to_sea_id = auth.uid()
+    AND ss.delivered_by = 'sea'
+    AND (
+      (p_school_id IS NULL AND p_school_site IS NULL AND p_school_district IS NULL)
+      OR
+      (p_school_id IS NOT NULL AND s.school_id IS NOT NULL AND s.school_id = p_school_id)
+      OR
+      (p_school_site IS NOT NULL AND p_school_district IS NOT NULL
+       AND s.school_site = p_school_site AND s.school_district = p_school_district)
+    )
+  ORDER BY s.initials;
+END;
+$function$;
+
+DO $spe336_sea_check$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'get_sea_students'
+      AND p.prosecdef
+      AND pg_get_functiondef(p.oid) LIKE '%student_teachers%'
+  ) THEN
+    RAISE EXCEPTION 'SPE-336: get_sea_students still reads only the legacy teacher column';
+  END IF;
+END;
+$spe336_sea_check$;


### PR DESCRIPTION
Phase 2 of the multi-teacher plan ([SPE-336](https://linear.app/speddy/issue/SPE-336)), on top of SPE-334's table. **This is the visible payoff: every linked teacher now sees their student** — at secondary each subject teacher, at elementary both co-teachers. Writing the links by hand is still SPE-337.

## One helper, two shapes

`lib/supabase/queries/student-teachers.ts`. The link is anchored on the child, so "the students of teacher X" is two hops (`teacher → student_teachers.child_id → students.child_id`), and every call site now swaps `.eq('teacher_id', …)` for `.in('id', ids)` — result shapes are untouched.

- **"my students"** (portal roster + today view) — account-keyed, through the `get_teacher_student_ids` seam, so it returns exactly what RLS allows *and* covers an account holding teacher rows at more than one school, which `getCurrentTeacher()`'s `.single()` cannot.
- **"this teacher's students"** (admin directory, teacher details) — teacher-row-keyed.

I used id lists rather than a nested PostgREST embed (`children!inner(student_teachers!inner(…))`) on purpose: the embed works but injects a `children` key into every row each caller has to strip, and it keys off one teacher row.

## What switched

| Surface | Change |
|---|---|
| Teacher portal roster + today view | Read the link set |
| `getStudentDetails` / `getStudentResourceSchedule` | **Caller-side scoping added on top of RLS** — these relied 100% on policy before |
| Admin directory count | Counts **links**, not caseload rows |
| District teacher-delete guard | Counts **links** (see below) |
| `get_sea_students` | Same return shape; `teacher_name` is the joined set, `teacher_id` the first link |
| `groupStudentsByIdentity` | Rekeyed onto `child_id` |
| IEP attendee assembly | Every linked teacher at elementary; first only at secondary |
| Chat membership | Already flipped at the DB layer in SPE-334 — **verified** here, not changed |

## Three judgement calls

**1. The delete guard was a real latent bug — the one Codex caught on #812.** A teacher who is only ever a *co*-teacher has no `students.teacher_id` pointing at them, so the old check reported "0 students assigned", allowed the delete, and the FK cascade then silently destroyed their `student_teachers` rows — the authoritative assignment. Not yet reachable (every link today has a matching legacy column) but it becomes live the moment SPE-337 ships the picker. Both handlers now count links.

**2. `groupStudentsByIdentity` is keyed on `child_id`, not "initials + grade" as the ticket proposed.** The ticket asked to drop teacher from the tuple, and it's right that a second teacher would fragment one child into two rows — but dropping it over-merges instead: two genuinely different children who share initials and grade at one school would collapse into one. `child_id` is the actual identity (and only exists because SPE-347 landed after this ticket was written), so it avoids both failures. Rows without a child fall back to a per-row key rather than colliding under one empty string; that path is unreachable today (`sim:verify` asserts zero unlinked students) but a null must not merge strangers.

**3. IEP attendees differ by level, deliberately.** Elementary invites **every** linked teacher and constrains the schedule on all of them — a single-teacher class behaves exactly as before, a co-taught class invites both, since they share the class. Secondary takes the **first** only: the legal minimum is at least one gen-ed teacher of the student, not all of them (`IEP_MEETING_SCHEDULING_SPEC.md` §8), and auto-constraining a meeting on six calendars would make it unschedulable. Choosing which one is a human's job — [SPE-322](https://linear.app/speddy/issue/SPE-322)'s picker consumes this same set as its options. The branch happens once, where the caseload is assembled, so everything downstream reads one uniform `teachers[]`.

## Sim district — what §10 said would happen when this landed

Cedar and Redwood students now carry **a teacher per period** (six links each, drawn from a faculty of eight starting at their homeroom teacher and wrapping — so the homeroom teacher is always in the set, keeping the legacy column honest, while students still get different sets). Willow gains a **co-teacher pair**.

Two new login personas, because the walks need someone to sign in as: **Imani** (`teacher.willow.3`, Nora's co-teacher on the same grade-3 class) and **Sanjay** (`teacher.cedar.2`, a second Cedar subject teacher). Deliberately *not* reusing David — his zero-students empty state is load-bearing fixture, and it's the only way to prove a non-linked teacher still sees nothing.

Links went 200 → 533; teachers 21 → 32. Both counts derive from the manifest, so they can't drift.

## Verification — real signed-in sessions, real UI

**15-check Playwright walk** (`sim:reset` → green `sim:verify` first), every count cross-checked against a service-client query:

- **Fatima** (Cedar, gr-7) — roster loads, shows exactly her 30 linked students, nothing off-site.
- **Sanjay** (Cedar, second subject teacher) — sees his own roster **independently**, and the students he shares with Fatima appear on both.
- **Nora + Imani** (Willow co-teachers) — each sees the whole shared grade-3 class (5/5).
- **David** (no links) — empty state, zero rows, and a **direct URL** to another teacher's student renders nothing.
- **Priya** (site admin) — directory lists the co-teacher with a non-zero count; the old FK count would have shown 0.

**Plus** new `npm run sim:verify-teacher-set-reads` (10 checks) for the two paths the UI walk can't see: `get_sea_students` returns `"Imani Brooks-Sim / Nora Ellison-Sim"` for a co-taught child while a single-teacher child still reads as one name, and the IEP planner sees **both** co-teachers with accounts.

**Regression guards:** `sim:verify-student-teachers-rls` 33/33 (its hardcoded link counts now derive from the fixture, since co-teachers are seeded), `sim:verify-children-rls` 26/26. `sim:teardown` → `sim:verify --expect-empty` all zeros, proving the sweeps catch the new links, then re-seeded green.

`npm test` 985 passing (two new co-teacher constraint tests) · `typecheck` clean · `lint` clean (2 pre-existing warnings, untouched files).

**Not auto-deployable** (user-facing behavior + an RPC change). Holding for your merge call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMVhGgFe7rmM3sQXhT5pQ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMVhGgFe7rmM3sQXhT5pQ5)_