### PR TITLE
SPE-337: editing UI and displays for a student's teacher set

### DIFF
--- a/app/(dashboard)/dashboard/admin/students/page.tsx
+++ b/app/(dashboard)/dashboard/admin/students/page.tsx
@@ -19,9 +19,9 @@ import { createClient } from '@/lib/supabase/client';
 import { isSecondarySchool } from '@/lib/school-helpers';
 import {
   getTeacherSetsForStudents,
-  summarizeTeacherSet,
   type LinkedTeacher,
 } from '@/lib/supabase/queries/student-teachers';
+import { TeacherSetCell } from '@/app/components/teachers/teacher-set-cell';
 
 interface CareMatch {
   id: string;
@@ -85,19 +85,36 @@ export default function AdminStudentsPage() {
     }
     getTeacherSetsForStudents(supabase, students.map(s => s.id))
       .then(sets => { if (!cancelled) setTeacherSets(sets); })
-      .catch(err => console.error('Error fetching teacher sets:', err));
+      .catch(err => {
+        // Silence here is misleading: the Teacher column falls back to the
+        // legacy name and search stops matching co-teachers, with nothing to
+        // tell the admin the list is incomplete.
+        console.error('Error fetching teacher sets:', err);
+        if (!cancelled) {
+          showToast('Could not load linked teachers — teacher search may be incomplete.', 'error');
+        }
+      });
     return () => { cancelled = true; };
-  }, [students, supabase]);
+  }, [students, supabase, showToast]);
 
   useEffect(() => {
     let cancelled = false;
     if (!schoolId) return;
-    supabase
-      .from('schools')
-      .select('school_type, grade_span_low')
-      .eq('id', schoolId)
-      .maybeSingle()
-      .then(({ data }) => { if (!cancelled) setIsSecondary(isSecondarySchool(data ?? null)); });
+    // Falling back to the elementary shape (every name listed) is safe, so a
+    // failure here only needs to be logged rather than surfaced — but it does
+    // need to be caught.
+    (async () => {
+      const { data, error } = await supabase
+        .from('schools')
+        .select('school_type, grade_span_low')
+        .eq('id', schoolId)
+        .maybeSingle();
+      if (error) {
+        console.error('Error loading school level:', error);
+        return;
+      }
+      if (!cancelled) setIsSecondary(isSecondarySchool(data ?? null));
+    })().catch(err => console.error('Error loading school level:', err));
     return () => { cancelled = true; };
   }, [schoolId, supabase]);
 
@@ -334,14 +351,14 @@ export default function AdminStudentsPage() {
                     </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div
-                      className="text-sm text-gray-900"
-                      title={teachersForGroup(student).map(t => t.name).filter(Boolean).join(', ') || undefined}
-                    >
-                      {summarizeTeacherSet(teachersForGroup(student), isSecondary)
-                        || student.teacher_name || (
-                        <span className="text-gray-400 italic">Not set</span>
-                      )}
+                    <div className="text-sm">
+                      {/* Same cell as the provider roster, minus the teacher
+                          modal — this page has none, so no click handler. */}
+                      <TeacherSetCell
+                        teachers={teachersForGroup(student)}
+                        fallbackName={student.teacher_name}
+                        isSecondary={isSecondary}
+                      />
                     </div>
                   </td>
                   <td className="px-6 py-4">

--- a/app/(dashboard)/dashboard/admin/students/page.tsx
+++ b/app/(dashboard)/dashboard/admin/students/page.tsx
@@ -15,6 +15,13 @@ import { formatRoleLabel } from '@/lib/utils/role-utils';
 import { StudentScheduleModal } from '@/app/components/admin/student-schedule-modal';
 import { ConfirmationModal } from '@/app/components/ui/confirmation-modal';
 import { useToast } from '@/app/contexts/toast-context';
+import { createClient } from '@/lib/supabase/client';
+import { isSecondarySchool } from '@/lib/school-helpers';
+import {
+  getTeacherSetsForStudents,
+  summarizeTeacherSet,
+  type LinkedTeacher,
+} from '@/lib/supabase/queries/student-teachers';
 
 interface CareMatch {
   id: string;
@@ -32,6 +39,12 @@ export default function AdminStudentsPage() {
   const [scheduleModalStudent, setScheduleModalStudent] = useState<GroupedStudent | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<GroupedStudent | null>(null);
   const [careMatches, setCareMatches] = useState<CareMatch[]>([]);
+  // SPE-337: every student's teacher SET, keyed by caseload-row id. Search and
+  // the roster column both read it, so a search for a co-teacher's name finds
+  // the student even though the denormalized column names someone else.
+  const [teacherSets, setTeacherSets] = useState<Map<string, LinkedTeacher[]>>(new Map());
+  const [isSecondary, setIsSecondary] = useState(false);
+  const supabase = useMemo(() => createClient(), []);
   const { showToast } = useToast();
 
   const fetchStudents = async () => {
@@ -63,6 +76,40 @@ export default function AdminStudentsPage() {
     fetchStudents();
   }, []);
 
+  // Teacher sets + school level, once the students are in.
+  useEffect(() => {
+    let cancelled = false;
+    if (students.length === 0) {
+      setTeacherSets(new Map());
+      return;
+    }
+    getTeacherSetsForStudents(supabase, students.map(s => s.id))
+      .then(sets => { if (!cancelled) setTeacherSets(sets); })
+      .catch(err => console.error('Error fetching teacher sets:', err));
+    return () => { cancelled = true; };
+  }, [students, supabase]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!schoolId) return;
+    supabase
+      .from('schools')
+      .select('school_type, grade_span_low')
+      .eq('id', schoolId)
+      .maybeSingle()
+      .then(({ data }) => { if (!cancelled) setIsSecondary(isSecondarySchool(data ?? null)); });
+    return () => { cancelled = true; };
+  }, [schoolId, supabase]);
+
+  // A group is one child, so any of its caseload rows resolves the same set.
+  const teachersForGroup = (student: GroupedStudent): LinkedTeacher[] => {
+    for (const record of student.providerRecords) {
+      const set = teacherSets.get(record.id);
+      if (set && set.length > 0) return set;
+    }
+    return [];
+  };
+
   // Group students by identity (initials + grade + teacher)
   const groupedStudents = useMemo(() => {
     return groupStudentsByIdentity(students);
@@ -76,7 +123,11 @@ export default function AdminStudentsPage() {
     return groupedStudents.filter(student => {
       const initials = student.initials?.toLowerCase() || '';
       const grade = student.grade_level?.toLowerCase() || '';
-      const teacher = student.teacher_name?.toLowerCase() || '';
+      // SPE-337: match ANY linked teacher, not just the denormalized name.
+      const linked = teachersForGroup(student)
+        .map(t => t.name?.toLowerCase() || '')
+        .join(' ');
+      const teacher = `${student.teacher_name?.toLowerCase() || ''} ${linked}`.trim();
       // Also search across all specialist names
       const specialists = student.providerRecords
         .map(r => r.specialist_name?.toLowerCase() || '')
@@ -87,7 +138,8 @@ export default function AdminStudentsPage() {
              teacher.includes(searchLower) ||
              specialists.includes(searchLower);
     });
-  }, [groupedStudents, searchTerm]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupedStudents, searchTerm, teacherSets]);
 
   const handleDeleteGrouped = (student: GroupedStudent) => {
     setConfirmDelete(student);
@@ -282,8 +334,12 @@ export default function AdminStudentsPage() {
                     </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm text-gray-900">
-                      {student.teacher_name || (
+                    <div
+                      className="text-sm text-gray-900"
+                      title={teachersForGroup(student).map(t => t.name).filter(Boolean).join(', ') || undefined}
+                    >
+                      {summarizeTeacherSet(teachersForGroup(student), isSecondary)
+                        || student.teacher_name || (
                         <span className="text-gray-400 italic">Not set</span>
                       )}
                     </div>

--- a/app/(dashboard)/dashboard/students/page.tsx
+++ b/app/(dashboard)/dashboard/students/page.tsx
@@ -18,7 +18,6 @@ import { TeacherSetCell } from '../../../components/teachers/teacher-set-cell';
 import {
   getTeacherSetsForStudents,
   saveTeacherLinksForStudent,
-  summarizeTeacherSet,
   type EditableTeacherLink,
   type LinkedTeacher,
 } from '@/lib/supabase/queries/student-teachers';
@@ -289,15 +288,18 @@ export default function StudentsPage() {
       });
 
       // The first teacher arrived via the legacy column (and the SPE-334
-      // trigger mirrored it into a link); any co-teachers are written here,
-      // once the student — and therefore its child record — exists.
+      // trigger mirrored it into a bare link); everything the mirror cannot
+      // carry — co-teachers, and the subject/period labels on ANY link — is
+      // written here, once the student and its child record exist. Running
+      // this for a single teacher too is what keeps a secondary student's
+      // labels from being silently dropped whenever they have exactly one.
       //
       // This is a second round trip, so it can fail on its own. The student is
       // already created at this point: reporting the whole add as failed would
       // send the user to retry an entry that now trips the uniqueness
       // constraint. Treat the add as succeeded and name what is missing.
       let coTeachersFailed = false;
-      if (created && teacherLinks.length > 1) {
+      if (created && teacherLinks.length > 0) {
         try {
           await saveTeacherLinksForStudent(supabase, created.id, teacherLinks);
         } catch (linkError) {
@@ -319,8 +321,8 @@ export default function StudentsPage() {
       setTeacherFieldKey((k) => k + 1);
       if (coTeachersFailed) {
         setAddFormError(
-          `${addedInitials} was added, but the co-teachers could not be saved. ` +
-          `Open the student and add them again.`,
+          `${addedInitials} was added, but the teacher details could not be saved. ` +
+          `Open the student to set them again.`,
         );
       } else {
         setAddFormConfirmation(`${addedInitials} added`);

--- a/app/(dashboard)/dashboard/students/page.tsx
+++ b/app/(dashboard)/dashboard/students/page.tsx
@@ -13,7 +13,15 @@ import { useSchool } from '../../../components/providers/school-context';
 import { createClient } from '@/lib/supabase/client';
 import { StudentDetailsModal } from '../../../components/students/student-details-modal';
 import { TeacherDetailsModal } from '../../../components/teachers/teacher-details-modal';
-import { TeacherAutocomplete } from '../../../components/teachers/teacher-autocomplete';
+import { StudentTeachersField } from '../../../components/teachers/student-teachers-field';
+import { TeacherSetCell } from '../../../components/teachers/teacher-set-cell';
+import {
+  getTeacherSetsForStudents,
+  saveTeacherLinksForStudent,
+  summarizeTeacherSet,
+  type EditableTeacherLink,
+  type LinkedTeacher,
+} from '@/lib/supabase/queries/student-teachers';
 import { useRouter } from 'next/navigation';
 import { StudentImportModal } from '../../../components/students/student-import-modal';
 import { StudentImportReview } from '../../../components/students/review/student-import-review';
@@ -78,18 +86,21 @@ export default function StudentsPage() {
   // Synchronous guard against a double-submit (Enter pressed twice) before state
   // re-renders; the form is built for rapid keyboard entry.
   const savingStudentRef = useRef(false);
-  // Bumped after each add to remount TeacherAutocomplete — it keeps its own
-  // internal selected-teacher state, so without a fresh mount it would keep
-  // showing the previous teacher while formData.teacher_id has reset to null.
+  // Bumped after each add to remount the teacher field — the autocomplete
+  // inside keeps its own internal selected-teacher state, so without a fresh
+  // mount it would keep showing the teacher from the previous student.
   const [teacherFieldKey, setTeacherFieldKey] = useState(0);
   const [students, setStudents] = useState<Student[]>([]);
   const [loading, setLoading] = useState(true);
   const [userRole, setUserRole] = useState<string | null>(null);
+  // SPE-337: a teacher SET. The legacy single pair is still sent to
+  // createStudent (the dual-write keeps it and the link set consistent), and
+  // it derives from the first entry — which is simply the only entry at
+  // elementary, the common case.
+  const [teacherLinks, setTeacherLinks] = useState<EditableTeacherLink[]>([]);
   const [formData, setFormData] = useState({
     initials: '',
     grade_level: '',
-    teacher_id: null as string | null,
-    teacherName: null as string | null,
     sessions_per_week: '',
     minutes_per_session: '30'
   });
@@ -101,7 +112,11 @@ export default function StudentsPage() {
   });
 
   const [selectedStudent, setSelectedStudent] = useState<Student | null>(null);
-  const [selectedTeacherName, setSelectedTeacherName] = useState<string | null>(null);
+  // SPE-337: the teacher modal is keyed by teacher ID. It used to open on the
+  // free-text `students.teacher_name`, which meant a typo opened the wrong
+  // record — and with a set of teachers there is no single name to key on.
+  const [selectedTeacherId, setSelectedTeacherId] = useState<string | null>(null);
+  const [teacherSets, setTeacherSets] = useState<Map<string, LinkedTeacher[]>>(new Map());
   const [unscheduledCount, setUnscheduledCount] = useState<number>(0);
   const [sortByGrade, setSortByGrade] = useState(false);
   const [showFileUploadModal, setShowFileUploadModal] = useState(false);
@@ -224,6 +239,21 @@ export default function StudentsPage() {
     checkUnscheduledSessions();
   }, [currentSchool, fetchStudents, checkUnscheduledSessions]);
 
+  // SPE-337: each student's teacher SET, for the roster column. Loaded after
+  // the students rather than folded into getStudents(), so the query's
+  // contract — shared with several other callers — stays as it is.
+  useEffect(() => {
+    let cancelled = false;
+    if (students.length === 0) {
+      setTeacherSets(new Map());
+      return;
+    }
+    getTeacherSetsForStudents(supabase, students.map(s => s.id))
+      .then(sets => { if (!cancelled) setTeacherSets(sets); })
+      .catch(err => console.error('Error fetching teacher sets:', err));
+    return () => { cancelled = true; };
+  }, [students, supabase]);
+
   // Focus Initials when the form opens so entry starts at the keyboard.
   useEffect(() => {
     if (showAddForm) initialsInputRef.current?.focus();
@@ -244,11 +274,11 @@ export default function StudentsPage() {
     savingStudentRef.current = true;
     setSavingStudent(true);
     try {
-      await createStudent({
+      const created = await createStudent({
         initials: formData.initials,
         grade_level: formData.grade_level,
-        teacher_id: formData.teacher_id,
-        teacher_name: formData.teacherName || undefined,
+        teacher_id: teacherLinks[0]?.teacherId ?? null,
+        teacher_name: teacherLinks[0]?.name || undefined,
         sessions_per_week: parseInt(formData.sessions_per_week),
         minutes_per_session: parseInt(formData.minutes_per_session),
         school_site: currentSchool?.school_site || '',
@@ -258,17 +288,23 @@ export default function StudentsPage() {
         state_id: currentSchool?.state_id,
       });
 
+      // The first teacher arrived via the legacy column (and the SPE-334
+      // trigger mirrored it into a link); any co-teachers are written here,
+      // once the student — and therefore its child record — exists.
+      if (created && teacherLinks.length > 1) {
+        await saveTeacherLinksForStudent(supabase, created.id, teacherLinks);
+      }
+
       // SPE-237: stay open for the next entry. Reset the per-student fields but
       // keep the grade preselected (caseloads cluster by grade), confirm inline,
       // and refocus Initials so the next student can be typed without the mouse.
       setFormData({
         initials: '',
         grade_level: formData.grade_level,
-        teacher_id: null,
-        teacherName: null,
         sessions_per_week: '',
         minutes_per_session: '30'
       });
+      setTeacherLinks([]);
       setTeacherFieldKey((k) => k + 1);
       setAddFormConfirmation(`${addedInitials} added`);
       fetchStudents();
@@ -292,11 +328,10 @@ export default function StudentsPage() {
     setShowAddForm(false);
     setAddFormError(null);
     setAddFormConfirmation(null);
+    setTeacherLinks([]);
     setFormData({
       initials: '',
       grade_level: '',
-      teacher_id: null,
-      teacherName: null,
       sessions_per_week: '',
       minutes_per_session: '30'
     });
@@ -573,14 +608,13 @@ export default function StudentsPage() {
 
                   <div className="md:col-span-2">
                     <label className="block text-sm font-medium text-gray-700 mb-1">
-                      Teacher*
+                      {isSecondary ? 'Teachers*' : 'Teacher*'}
                     </label>
-                    <TeacherAutocomplete
+                    <StudentTeachersField
                       key={teacherFieldKey}
-                      value={formData.teacher_id}
-                      teacherName={formData.teacherName || undefined}
-                      onChange={(teacherId, teacherName) => setFormData({ ...formData, teacher_id: teacherId, teacherName })}
-                      placeholder="Search for a teacher..."
+                      value={teacherLinks}
+                      onChange={setTeacherLinks}
+                      isSecondary={isSecondary}
                       required
                       schoolId={currentSchool?.school_id || undefined}
                     />
@@ -666,11 +700,11 @@ export default function StudentsPage() {
         )}
 
         {/* Teacher Details Modal */}
-        {selectedTeacherName && (
+        {selectedTeacherId && (
           <TeacherDetailsModal
-            isOpen={!!selectedTeacherName}
-            onClose={() => setSelectedTeacherName(null)}
-            teacherName={selectedTeacherName}
+            isOpen={!!selectedTeacherId}
+            onClose={() => setSelectedTeacherId(null)}
+            teacherId={selectedTeacherId}
             onSave={async (teacher) => {
               // Refresh students list to show updated teacher name if changed
               await fetchStudents();
@@ -744,16 +778,12 @@ export default function StudentsPage() {
                       <GradeTag grade={student.grade_level} />
                     </TableCell>
                     <TableCell>
-                      {student.teacher_name ? (
-                        <button
-                          onClick={() => setSelectedTeacherName(student.teacher_name)}
-                          className="text-blue-600 hover:text-blue-800 hover:underline transition-colors"
-                        >
-                          {student.teacher_name}
-                        </button>
-                      ) : (
-                        <span className="text-gray-400 italic">Not assigned</span>
-                      )}
+                      <TeacherSetCell
+                        teachers={teacherSets.get(student.id) ?? []}
+                        fallbackName={student.teacher_name}
+                        isSecondary={isSecondary}
+                        onOpenTeacher={setSelectedTeacherId}
+                      />
                     </TableCell>
                     <TableCell>
                       {!isViewOnly && editingId === student.id ? (

--- a/app/(dashboard)/dashboard/students/page.tsx
+++ b/app/(dashboard)/dashboard/students/page.tsx
@@ -291,8 +291,19 @@ export default function StudentsPage() {
       // The first teacher arrived via the legacy column (and the SPE-334
       // trigger mirrored it into a link); any co-teachers are written here,
       // once the student — and therefore its child record — exists.
+      //
+      // This is a second round trip, so it can fail on its own. The student is
+      // already created at this point: reporting the whole add as failed would
+      // send the user to retry an entry that now trips the uniqueness
+      // constraint. Treat the add as succeeded and name what is missing.
+      let coTeachersFailed = false;
       if (created && teacherLinks.length > 1) {
-        await saveTeacherLinksForStudent(supabase, created.id, teacherLinks);
+        try {
+          await saveTeacherLinksForStudent(supabase, created.id, teacherLinks);
+        } catch (linkError) {
+          console.error('Error saving co-teacher links:', linkError);
+          coTeachersFailed = true;
+        }
       }
 
       // SPE-237: stay open for the next entry. Reset the per-student fields but
@@ -306,7 +317,14 @@ export default function StudentsPage() {
       });
       setTeacherLinks([]);
       setTeacherFieldKey((k) => k + 1);
-      setAddFormConfirmation(`${addedInitials} added`);
+      if (coTeachersFailed) {
+        setAddFormError(
+          `${addedInitials} was added, but the co-teachers could not be saved. ` +
+          `Open the student and add them again.`,
+        );
+      } else {
+        setAddFormConfirmation(`${addedInitials} added`);
+      }
       fetchStudents();
       checkUnscheduledSessions();
       initialsInputRef.current?.focus();

--- a/app/components/students/add-student-form.tsx
+++ b/app/components/students/add-student-form.tsx
@@ -51,11 +51,16 @@
           throw new Error('Failed to create student');
         }
 
+        // Everything the SPE-334 mirror cannot carry from the legacy column:
+        // co-teachers, and the subject/period labels on ANY link — so this runs
+        // for a single teacher too, or a secondary student with exactly one
+        // teacher would silently lose their labels.
+        //
         // Second round trip, and the student already exists. If it fails, the
         // add itself still succeeded — reporting it as a failure would send the
         // user to retry initials that now collide. Say what is missing instead.
         let coTeachersFailed = false;
-        if (teacherLinks.length > 1) {
+        if (teacherLinks.length > 0) {
           try {
             await saveTeacherLinksForStudent(createClient(), student.id, teacherLinks);
           } catch (linkError) {
@@ -68,7 +73,7 @@
         alert(
           `Student "${student.initials}" has been added successfully!` +
           (coTeachersFailed
-            ? `\n\nThe co-teachers could not be saved — open the student and add them again.`
+            ? `\n\nThe teacher details could not be saved — open the student to set them again.`
             : '') +
           `\n\nSessions created in Unscheduled Sessions! You can now drag them to the schedule grid or click "Schedule Sessions" to auto-place them.`
         );

--- a/app/components/students/add-student-form.tsx
+++ b/app/components/students/add-student-form.tsx
@@ -51,12 +51,27 @@
           throw new Error('Failed to create student');
         }
 
+        // Second round trip, and the student already exists. If it fails, the
+        // add itself still succeeded — reporting it as a failure would send the
+        // user to retry initials that now collide. Say what is missing instead.
+        let coTeachersFailed = false;
         if (teacherLinks.length > 1) {
-          await saveTeacherLinksForStudent(createClient(), student.id, teacherLinks);
+          try {
+            await saveTeacherLinksForStudent(createClient(), student.id, teacherLinks);
+          } catch (linkError) {
+            console.error('Error saving co-teacher links:', linkError);
+            coTeachersFailed = true;
+          }
         }
 
         // Show success message - sessions are auto-created
-        alert(`Student "${student.initials}" has been added successfully!\n\nSessions created in Unscheduled Sessions! You can now drag them to the schedule grid or click "Schedule Sessions" to auto-place them.`);
+        alert(
+          `Student "${student.initials}" has been added successfully!` +
+          (coTeachersFailed
+            ? `\n\nThe co-teachers could not be saved — open the student and add them again.`
+            : '') +
+          `\n\nSessions created in Unscheduled Sessions! You can now drag them to the schedule grid or click "Schedule Sessions" to auto-place them.`
+        );
 
         onSuccess();
         onClose();

--- a/app/components/students/add-student-form.tsx
+++ b/app/components/students/add-student-form.tsx
@@ -4,7 +4,9 @@
   import { createStudent } from '../../../lib/supabase/queries/students';
   import { Button } from '../ui/button';
   import { Label, Input, Select, FormGroup, FormSection, HelperText, ErrorMessage } from '../ui/form';
-  import { TeacherAutocomplete } from '../teachers/teacher-autocomplete';
+  import { StudentTeachersField } from '../teachers/student-teachers-field';
+  import { saveTeacherLinksForStudent, type EditableTeacherLink } from '@/lib/supabase/queries/student-teachers';
+  import { createClient } from '@/lib/supabase/client';
 
   interface AddStudentFormProps {
     onClose: () => void;
@@ -12,11 +14,13 @@
   }
 
   export function AddStudentForm({ onClose, onSuccess }: AddStudentFormProps) {
+    // SPE-337: a teacher SET. The first entry rides the legacy columns (the
+    // SPE-334 dual-write mirrors it into a link); any co-teachers are written
+    // once the student — and its child record — exists.
+    const [teacherLinks, setTeacherLinks] = useState<EditableTeacherLink[]>([]);
     const [formData, setFormData] = useState({
       initials: '',
       grade_level: '',
-      teacher_id: null as string | null,
-      teacherName: null as string | null,
       sessions_per_week: 1,
       minutes_per_session: 30,
     });
@@ -35,8 +39,8 @@
         const student = await createStudent({
           initials: formData.initials.toUpperCase(),
           grade_level: formData.grade_level.trim(),
-          teacher_id: formData.teacher_id,
-          teacher_name: formData.teacherName || undefined,
+          teacher_id: teacherLinks[0]?.teacherId ?? null,
+          teacher_name: teacherLinks[0]?.name || undefined,
           sessions_per_week: formData.sessions_per_week,
           minutes_per_session: formData.minutes_per_session,
         });
@@ -45,6 +49,10 @@
 
         if (!student) {
           throw new Error('Failed to create student');
+        }
+
+        if (teacherLinks.length > 1) {
+          await saveTeacherLinksForStudent(createClient(), student.id, teacherLinks);
         }
 
         // Show success message - sessions are auto-created
@@ -108,11 +116,9 @@
         <Label htmlFor="teacher" required>
           Teacher
         </Label>
-        <TeacherAutocomplete
-          value={formData.teacher_id}
-          teacherName={formData.teacherName || undefined}
-          onChange={(teacherId, teacherName) => setFormData({ ...formData, teacher_id: teacherId, teacherName })}
-          placeholder="Search for a teacher..."
+        <StudentTeachersField
+          value={teacherLinks}
+          onChange={setTeacherLinks}
           required
         />
       </FormGroup>

--- a/app/components/students/student-details-modal.tsx
+++ b/app/components/students/student-details-modal.tsx
@@ -95,6 +95,12 @@ export function StudentDetailsModal({
   // *requested* set means "remove every teacher". Saving during that window
   // would delete the student's real links, so Save waits for the load.
   const [linksLoaded, setLinksLoaded] = useState(false);
+  const [linksLoadFailed, setLinksLoadFailed] = useState(false);
+  // What the set looked like on open. A student's teachers are anchored on the
+  // CHILD, so a co-provider can add one while this modal sits open; writing an
+  // untouched snapshot back would delete their addition. Compare before
+  // writing, and a user who never touched the teacher field never disturbs it.
+  const [loadedLinks, setLoadedLinks] = useState<EditableTeacherLink[]>([]);
 
   const [studentInfo, setStudentInfo] = useState({
     initials: student.initials,
@@ -119,7 +125,9 @@ export function StudentDetailsModal({
       // under this student's name for the length of a fetch is worse than
       // showing none, and saving it would apply them to the wrong child.
       setTeacherLinks([]);
+      setLoadedLinks([]);
       setLinksLoaded(false);
+      setLinksLoadFailed(false);
 
       // Load existing student details and matching provider roles
       const loadData = async () => {
@@ -134,6 +142,7 @@ export function StudentDetailsModal({
           // A slower earlier request must not overwrite a newer student's data.
           if (stale) return;
           setTeacherLinks(links);
+          setLoadedLinks(links);
           setLinksLoaded(true);
 
           if (existingDetails) {
@@ -157,6 +166,9 @@ export function StudentDetailsModal({
         } catch (error) {
           if (stale) return;
           console.error('Error loading student data:', error);
+          // Save stays disabled without this — the user would face a dead
+          // button and no reason for it.
+          setLinksLoadFailed(true);
         }
       };
 
@@ -174,6 +186,17 @@ export function StudentDetailsModal({
       setActiveTab('iep');
     }
   }, [isSecondary, activeTab]);
+
+  // Set equality, not array equality: order carries no meaning (co-teachers
+  // are equals), so only membership and the labels count as an edit.
+  const teacherLinksChanged = (() => {
+    if (teacherLinks.length !== loadedLinks.length) return true;
+    const before = new Map(loadedLinks.map(l => [l.teacherId, l]));
+    return teacherLinks.some(l => {
+      const prev = before.get(l.teacherId);
+      return !prev || prev.subject !== l.subject || prev.period !== l.period;
+    });
+  })();
 
   const handleSave = async () => {
     // The set is the source of truth for what gets written; an unloaded [] is
@@ -195,7 +218,24 @@ export function StudentDetailsModal({
       // re-adding a co-teacher reorders the array without changing the set,
       // and the mirror would then read the new first entry as a replacement
       // and revoke the other teacher's access.
-      await saveTeacherLinksForStudent(supabase, student.id, teacherLinks);
+      //
+      // Only written when actually edited: the set belongs to the child, so a
+      // co-provider may have changed it since this modal opened, and someone
+      // saving an IEP date should not silently undo that.
+      //
+      // The details above are already committed by the time this runs, so a
+      // throw here must not abandon the rest of the save — the grade and
+      // service minutes would be dropped for a reason that has nothing to do
+      // with them. Report just the part that failed.
+      let teacherSaveError: Error | null = null;
+      if (teacherLinksChanged) {
+        try {
+          await saveTeacherLinksForStudent(supabase, student.id, teacherLinks);
+        } catch (err) {
+          console.error('Error saving teacher links:', err);
+          teacherSaveError = err instanceof Error ? err : new Error(String(err));
+        }
+      }
 
       // Update student info if changed. Passed as a literal on purpose: that
       // is what makes excess-property checking apply, so re-adding a teacher
@@ -212,6 +252,13 @@ export function StudentDetailsModal({
 
       if (onSave) {
         onSave(student.id, details);
+      }
+
+      if (teacherSaveError) {
+        // Stay open on the teachers the user asked for, so a retry is one
+        // click rather than re-entering the whole set.
+        alert(`Everything else was saved, but the teachers were not: ${teacherSaveError.message}`);
+        return;
       }
       onClose();
     } catch (error) {
@@ -806,7 +853,12 @@ export function StudentDetailsModal({
           </div>
           
           {/* Footer */}
-          <div className="flex justify-end gap-3 px-6 py-4 border-t bg-gray-50">
+          <div className="flex items-center justify-end gap-3 px-6 py-4 border-t bg-gray-50">
+            {!readOnly && linksLoadFailed && (
+              <span role="alert" className="mr-auto text-sm text-red-700">
+                This student&apos;s details could not be loaded. Close and reopen to try again.
+              </span>
+            )}
             <Button variant="secondary" onClick={onClose}>
               {readOnly ? 'Close' : 'Cancel'}
             </Button>

--- a/app/components/students/student-details-modal.tsx
+++ b/app/components/students/student-details-modal.tsx
@@ -13,7 +13,13 @@ import {
   type ReviewConfirmSelection,
   type ReviewWriteResult,
 } from './review/student-import-review';
-import { TeacherAutocomplete } from '../teachers/teacher-autocomplete';
+import { StudentTeachersField } from '../teachers/student-teachers-field';
+import {
+  getTeacherLinksForStudent,
+  saveTeacherLinksForStudent,
+  type EditableTeacherLink,
+} from '@/lib/supabase/queries/student-teachers';
+import { createClient } from '@/lib/supabase/client';
 import { StudentProgressTab } from './student-progress-tab';
 import { StudentAttendanceTab } from './student-attendance-tab';
 import { SharedStudentBadge } from './shared-student-badge';
@@ -75,12 +81,17 @@ export function StudentDetailsModal({
   // hidden: the "Current Information" (service-minutes) and Attendance tabs.
   // This is purely subtractive — the underlying data is untouched.
   const { isSecondary } = useSchool();
+  const supabase = useMemo(() => createClient(), []);
+
+  // SPE-337: the student's teacher SET, loaded from student_teachers and
+  // written back on save. The legacy single pair still rides along in the
+  // students update (the SPE-334 dual-write keeps the two consistent), derived
+  // from the first entry.
+  const [teacherLinks, setTeacherLinks] = useState<EditableTeacherLink[]>([]);
 
   const [studentInfo, setStudentInfo] = useState({
     initials: student.initials,
     grade_level: student.grade_level,
-    teacher_id: student.teacher_id || null,
-    teacherName: student.teacher_name || null,
     sessions_per_week: student.sessions_per_week,
     minutes_per_session: student.minutes_per_session,
   });
@@ -92,8 +103,6 @@ export function StudentDetailsModal({
       setStudentInfo({
         initials: student.initials,
         grade_level: student.grade_level,
-        teacher_id: student.teacher_id || null,
-        teacherName: student.teacher_name || null,
         sessions_per_week: student.sessions_per_week,
         minutes_per_session: student.minutes_per_session,
       });
@@ -101,11 +110,14 @@ export function StudentDetailsModal({
       // Load existing student details and matching provider roles
       const loadData = async () => {
         try {
-          // Load student details and matching provider roles in parallel
-          const [existingDetails, roles] = await Promise.all([
+          // Load student details, matching provider roles and the teacher set
+          // in parallel.
+          const [existingDetails, roles, links] = await Promise.all([
             getStudentDetails(student.id),
-            getMatchingProviderRoles(student.id)
+            getMatchingProviderRoles(student.id),
+            getTeacherLinksForStudent(supabase, student.id),
           ]);
+          setTeacherLinks(links);
 
           if (existingDetails) {
             setDetails(existingDetails);
@@ -132,7 +144,7 @@ export function StudentDetailsModal({
 
       loadData();
     }
-  }, [isOpen, student.id, student.initials, student.grade_level, student.teacher_id, student.teacher_name, student.sessions_per_week, student.minutes_per_session]);
+  }, [isOpen, supabase, student.id, student.initials, student.grade_level, student.sessions_per_week, student.minutes_per_session]);
 
   // Secondary mode hides only the Attendance tab; if it's active, snap to a
   // visible tab. Current Information stays visible so grade/teacher/IEP dates
@@ -150,14 +162,21 @@ export function StudentDetailsModal({
       await upsertStudentDetails(student.id, details);
       console.log('Student details saved successfully');
 
+      // SPE-337: write the teacher set BEFORE the students update. The
+      // legacy-column mirror repoints any caseload row whose teacher is no
+      // longer one of the child's, so applying links first means the
+      // students update lands on an already-consistent set rather than
+      // fighting it.
+      await saveTeacherLinksForStudent(supabase, student.id, teacherLinks);
+
       // Update student info if changed
       if (onUpdateStudent) {
         // Convert teacherName to teacher_name for database compatibility
         const updates = {
           initials: studentInfo.initials,
           grade_level: studentInfo.grade_level,
-          teacher_id: studentInfo.teacher_id,
-          teacher_name: studentInfo.teacherName || undefined,
+          teacher_id: teacherLinks[0]?.teacherId ?? null,
+          teacher_name: teacherLinks[0]?.name || undefined,
           sessions_per_week: studentInfo.sessions_per_week,
           minutes_per_session: studentInfo.minutes_per_session,
         };
@@ -416,12 +435,11 @@ export function StudentDetailsModal({
                 </FormGroup>
 
                 <FormGroup>
-                  <Label htmlFor="teacher">Teacher</Label>
-                  <TeacherAutocomplete
-                    value={studentInfo.teacher_id}
-                    teacherName={studentInfo.teacherName || undefined}
-                    onChange={(teacherId, teacherName) => setStudentInfo({...studentInfo, teacher_id: teacherId, teacherName})}
-                    placeholder="Search for a teacher..."
+                  <Label htmlFor="teacher">{isSecondary ? 'Teachers' : 'Teacher'}</Label>
+                  <StudentTeachersField
+                    value={teacherLinks}
+                    onChange={setTeacherLinks}
+                    isSecondary={isSecondary}
                     disabled={readOnly}
                     schoolId={student.school_id || undefined}
                   />

--- a/app/components/students/student-details-modal.tsx
+++ b/app/components/students/student-details-modal.tsx
@@ -42,11 +42,14 @@ interface StudentDetailsModalProps {
   };
   readOnly?: boolean;
   onSave?: (studentId: string, details: StudentDetails) => void;
+  /**
+   * SPE-337: no teacher fields here. The teacher set is written directly to
+   * `student_teachers`, and the legacy `students.teacher_id`/`teacher_name`
+   * pair is maintained by the SPE-334 mirror — not by this form.
+   */
   onUpdateStudent?: (studentId: string, updates: {
     initials?: string;
     grade_level: string;
-    teacher_id?: string | null;
-    teacher_name?: string;
     sessions_per_week: number;
     minutes_per_session: number;
   }) => void;
@@ -84,10 +87,14 @@ export function StudentDetailsModal({
   const supabase = useMemo(() => createClient(), []);
 
   // SPE-337: the student's teacher SET, loaded from student_teachers and
-  // written back on save. The legacy single pair still rides along in the
-  // students update (the SPE-334 dual-write keeps the two consistent), derived
-  // from the first entry.
+  // written back on save. The legacy single pair is NOT written from here —
+  // the SPE-334 mirror owns that column and repoints it only when the row's
+  // current teacher has actually left the set.
   const [teacherLinks, setTeacherLinks] = useState<EditableTeacherLink[]>([]);
+  // Until the set has actually loaded, `teacherLinks` is [] — which as a
+  // *requested* set means "remove every teacher". Saving during that window
+  // would delete the student's real links, so Save waits for the load.
+  const [linksLoaded, setLinksLoaded] = useState(false);
 
   const [studentInfo, setStudentInfo] = useState({
     initials: student.initials,
@@ -98,6 +105,8 @@ export function StudentDetailsModal({
 
   // Reset form when modal opens with a different student
   useEffect(() => {
+    let stale = false;
+
     if (isOpen && student.id) {
       // Reset student info to current values
       setStudentInfo({
@@ -106,6 +115,11 @@ export function StudentDetailsModal({
         sessions_per_week: student.sessions_per_week,
         minutes_per_session: student.minutes_per_session,
       });
+      // Clear the previous student's set immediately — showing their teachers
+      // under this student's name for the length of a fetch is worse than
+      // showing none, and saving it would apply them to the wrong child.
+      setTeacherLinks([]);
+      setLinksLoaded(false);
 
       // Load existing student details and matching provider roles
       const loadData = async () => {
@@ -117,7 +131,10 @@ export function StudentDetailsModal({
             getMatchingProviderRoles(student.id),
             getTeacherLinksForStudent(supabase, student.id),
           ]);
+          // A slower earlier request must not overwrite a newer student's data.
+          if (stale) return;
           setTeacherLinks(links);
+          setLinksLoaded(true);
 
           if (existingDetails) {
             setDetails(existingDetails);
@@ -138,12 +155,15 @@ export function StudentDetailsModal({
 
           setMatchingRoles(roles);
         } catch (error) {
+          if (stale) return;
           console.error('Error loading student data:', error);
         }
       };
 
       loadData();
     }
+
+    return () => { stale = true; };
   }, [isOpen, supabase, student.id, student.initials, student.grade_level, student.sessions_per_week, student.minutes_per_session]);
 
   // Secondary mode hides only the Attendance tab; if it's active, snap to a
@@ -156,31 +176,37 @@ export function StudentDetailsModal({
   }, [isSecondary, activeTab]);
 
   const handleSave = async () => {
+    // The set is the source of truth for what gets written; an unloaded [] is
+    // not an instruction to unassign everyone.
+    if (!linksLoaded) return;
     setLoading(true);
     try {
       // Save student details
       await upsertStudentDetails(student.id, details);
       console.log('Student details saved successfully');
 
-      // SPE-337: write the teacher set BEFORE the students update. The
-      // legacy-column mirror repoints any caseload row whose teacher is no
-      // longer one of the child's, so applying links first means the
-      // students update lands on an already-consistent set rather than
-      // fighting it.
+      // SPE-337: the link set is the whole teacher edit. The legacy
+      // students.teacher_id/teacher_name pair is NOT written from here — the
+      // SPE-334 mirror maintains it, repointing a caseload row only when that
+      // row's current teacher has genuinely left the child's set.
+      //
+      // Deriving it from teacherLinks[0] instead would read meaning into the
+      // row order that the editor deliberately does not carry: removing and
+      // re-adding a co-teacher reorders the array without changing the set,
+      // and the mirror would then read the new first entry as a replacement
+      // and revoke the other teacher's access.
       await saveTeacherLinksForStudent(supabase, student.id, teacherLinks);
 
-      // Update student info if changed
+      // Update student info if changed. Passed as a literal on purpose: that
+      // is what makes excess-property checking apply, so re-adding a teacher
+      // field here is a compile error rather than a silent regression.
       if (onUpdateStudent) {
-        // Convert teacherName to teacher_name for database compatibility
-        const updates = {
+        await onUpdateStudent(student.id, {
           initials: studentInfo.initials,
           grade_level: studentInfo.grade_level,
-          teacher_id: teacherLinks[0]?.teacherId ?? null,
-          teacher_name: teacherLinks[0]?.name || undefined,
           sessions_per_week: studentInfo.sessions_per_week,
           minutes_per_session: studentInfo.minutes_per_session,
-        };
-        await onUpdateStudent(student.id, updates);
+        });
         console.log('Student info updated successfully');
       }
 
@@ -788,7 +814,7 @@ export function StudentDetailsModal({
               <Button
                 variant="primary"
                 onClick={handleSave}
-                disabled={loading}
+                disabled={loading || !linksLoaded}
               >
                 {loading ? 'Saving...' : 'Save Details'}
               </Button>

--- a/app/components/students/student-details-modal.tsx
+++ b/app/components/students/student-details-modal.tsx
@@ -509,11 +509,15 @@ export function StudentDetailsModal({
 
                 <FormGroup>
                   <Label htmlFor="teacher">{isSecondary ? 'Teachers' : 'Teacher'}</Label>
+                  {/* Locked until the set has loaded, and while a save is in
+                      flight: an edit before the fetch lands is overwritten by
+                      it, and one made during the save is not in the request
+                      but looks saved. */}
                   <StudentTeachersField
                     value={teacherLinks}
                     onChange={setTeacherLinks}
                     isSecondary={isSecondary}
-                    disabled={readOnly}
+                    disabled={readOnly || loading || !linksLoaded}
                     schoolId={student.school_id || undefined}
                   />
                 </FormGroup>

--- a/app/components/teachers/student-teachers-field.tsx
+++ b/app/components/teachers/student-teachers-field.tsx
@@ -49,10 +49,19 @@ export function StudentTeachersField({
 }: StudentTeachersFieldProps) {
   // Elementary shows the extra picker only once asked; secondary always offers it.
   const [addingAnother, setAddingAnother] = useState(false);
+  // TeacherAutocomplete keeps its OWN selected-teacher state and renders a
+  // "selected" chip for it. Where the picker stays mounted after a pick — i.e.
+  // secondary, which always offers the next slot — that chip would sit under
+  // our list showing the teacher a second time, and the picker would arrive at
+  // the next entry already occupied. Bumping this key remounts it clean after
+  // every attempt, including a rejected duplicate. (Elementary unmounts the
+  // picker on its own, so this is belt-and-braces there.)
+  const [pickerNonce, setPickerNonce] = useState(0);
 
   const alreadyLinked = new Set(value.map(l => l.teacherId));
 
   function addLink(teacherId: string | null, teacherName: string | null) {
+    setPickerNonce(n => n + 1);
     if (!teacherId || alreadyLinked.has(teacherId)) return;
     onChange([...value, { teacherId, name: teacherName, subject: null, period: null }]);
     setAddingAnother(false);
@@ -127,6 +136,7 @@ export function StudentTeachersField({
 
       {showInlinePicker && !disabled && (
         <TeacherAutocomplete
+          key={pickerNonce}
           value={null}
           onChange={addLink}
           placeholder={value.length === 0 ? 'Search for a teacher...' : 'Search for another teacher...'}

--- a/app/components/teachers/student-teachers-field.tsx
+++ b/app/components/teachers/student-teachers-field.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useState } from 'react';
+import { TeacherAutocomplete } from './teacher-autocomplete';
+import type { EditableTeacherLink } from '@/lib/supabase/queries/student-teachers';
+
+interface StudentTeachersFieldProps {
+  value: EditableTeacherLink[];
+  onChange: (links: EditableTeacherLink[]) => void;
+  /** Scope the teacher search to the STUDENT's school, not the user's. */
+  schoolId?: string;
+  /** Secondary gets subject/period labels and an unbounded list. */
+  isSecondary?: boolean;
+  disabled?: boolean;
+  required?: boolean;
+}
+
+/**
+ * SPE-337 — the teacher set of one student, editable.
+ *
+ * Two shapes, one component, because the underlying data is identical and only
+ * the presentation differs:
+ *
+ *   * **Elementary** — the single "Teacher" picker exactly as before, plus an
+ *     "Add co-teacher" link that reveals a second one. A co-taught class is the
+ *     exception, not the norm, so the second picker stays out of the way until
+ *     it is asked for. No subject/period: there are no periods at elementary.
+ *   * **Secondary** — a list with optional subject and period labels per row.
+ *
+ * Co-teachers are EQUALS (product decision 2026-07-26). Nothing here ranks
+ * them: no "primary" badge, no reordering handles, and removing the first row
+ * is exactly as easy as removing the last. The order the rows appear in is
+ * insertion order and carries no meaning.
+ *
+ * `subject`/`period` are display labels only — Speddy does not schedule at
+ * secondary (SPE-149/193), and nothing downstream reads them as times.
+ *
+ * Composes `TeacherAutocomplete` rather than replacing it: that component is
+ * single-select by contract and is used by six other surfaces (special
+ * activities, CARE referrals, import review) which genuinely want one teacher.
+ */
+export function StudentTeachersField({
+  value,
+  onChange,
+  schoolId,
+  isSecondary = false,
+  disabled = false,
+  required = false,
+}: StudentTeachersFieldProps) {
+  // Elementary shows the extra picker only once asked; secondary always offers it.
+  const [addingAnother, setAddingAnother] = useState(false);
+
+  const alreadyLinked = new Set(value.map(l => l.teacherId));
+
+  function addLink(teacherId: string | null, teacherName: string | null) {
+    if (!teacherId || alreadyLinked.has(teacherId)) return;
+    onChange([...value, { teacherId, name: teacherName, subject: null, period: null }]);
+    setAddingAnother(false);
+  }
+
+  function removeLink(teacherId: string) {
+    onChange(value.filter(l => l.teacherId !== teacherId));
+  }
+
+  function updateLabel(teacherId: string, field: 'subject' | 'period', label: string) {
+    onChange(
+      value.map(l =>
+        l.teacherId === teacherId ? { ...l, [field]: label.trim() === '' ? null : label } : l,
+      ),
+    );
+  }
+
+  // The very first teacher at elementary keeps the plain single-select look the
+  // form has always had, so the common case is visually unchanged.
+  const showInlinePicker = value.length === 0 || isSecondary || addingAnother;
+
+  return (
+    <div className="space-y-2">
+      {value.length > 0 && (
+        <ul className="space-y-2">
+          {value.map(link => (
+            <li
+              key={link.teacherId}
+              className="flex flex-wrap items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2"
+            >
+              <span className="text-sm text-gray-900 flex-1 min-w-0 truncate">
+                {link.name || 'Unnamed teacher'}
+              </span>
+
+              {isSecondary && (
+                <>
+                  <input
+                    type="text"
+                    value={link.subject ?? ''}
+                    onChange={e => updateLabel(link.teacherId, 'subject', e.target.value)}
+                    placeholder="Subject"
+                    aria-label={`Subject for ${link.name || 'teacher'}`}
+                    disabled={disabled}
+                    className="w-32 px-2 py-1 text-sm border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
+                  />
+                  <input
+                    type="text"
+                    value={link.period ?? ''}
+                    onChange={e => updateLabel(link.teacherId, 'period', e.target.value)}
+                    placeholder="Period"
+                    aria-label={`Period for ${link.name || 'teacher'}`}
+                    disabled={disabled}
+                    className="w-20 px-2 py-1 text-sm border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
+                  />
+                </>
+              )}
+
+              {!disabled && (
+                <button
+                  type="button"
+                  onClick={() => removeLink(link.teacherId)}
+                  aria-label={`Remove ${link.name || 'teacher'}`}
+                  className="text-sm text-gray-400 hover:text-red-600 transition-colors px-1"
+                >
+                  ✕
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {showInlinePicker && !disabled && (
+        <TeacherAutocomplete
+          value={null}
+          onChange={addLink}
+          placeholder={value.length === 0 ? 'Search for a teacher...' : 'Search for another teacher...'}
+          required={required && value.length === 0}
+          schoolId={schoolId}
+        />
+      )}
+
+      {!showInlinePicker && !disabled && (
+        <button
+          type="button"
+          onClick={() => setAddingAnother(true)}
+          className="text-sm text-blue-600 hover:text-blue-800 hover:underline transition-colors"
+        >
+          + Add co-teacher
+        </button>
+      )}
+
+      {isSecondary && value.length > 0 && (
+        <p className="text-xs text-gray-500">
+          Subject and period are labels for your reference — Speddy does not schedule at
+          secondary sites.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/components/teachers/teacher-details-modal.tsx
+++ b/app/components/teachers/teacher-details-modal.tsx
@@ -4,8 +4,7 @@ import { useState, useEffect } from 'react';
 import { Button } from '../ui/button';
 import { Input, Label, FormGroup } from '../ui/form';
 import { StudentTag, GradeTag } from '../ui/tag';
-import { getTeacherDetails, upsertTeacherDetails, getTeacherByStudentTeacherName, TeacherDetails } from '../../../lib/supabase/queries/teacher-details';
-import { getOrCreateTeacher } from '../../../lib/supabase/queries/teachers';
+import { getTeacherDetails, upsertTeacherDetails, TeacherDetails } from '../../../lib/supabase/queries/teacher-details';
 import type { Database } from '../../../src/types/database';
 
 type Teacher = Database['public']['Tables']['teachers']['Row'];
@@ -17,15 +16,24 @@ type TeacherUpdateData = Omit<Teacher, 'id' | 'created_at' | 'updated_at'>;
 interface TeacherDetailsModalProps {
   isOpen: boolean;
   onClose: () => void;
-  teacherName: string;
+  /**
+   * SPE-337: the `teachers` row id.
+   *
+   * This used to take the free-text `students.teacher_name` and look the
+   * teacher up by matching that string. Two problems, both now gone: a typo in
+   * the student's teacher field opened the wrong record — or, worse, fell
+   * through to a "create teacher" path that quietly minted a duplicate — and
+   * once a student has a SET of teachers there is no single name to key on.
+   */
+  teacherId: string;
   onSave?: (teacher: Teacher) => void;
   onStudentClick?: (student: Pick<Student, 'id' | 'initials' | 'grade_level' | 'teacher_name' | 'sessions_per_week' | 'minutes_per_session'>) => void;
 }
 
-export function TeacherDetailsModal({ 
-  isOpen, 
-  onClose, 
-  teacherName,
+export function TeacherDetailsModal({
+  isOpen,
+  onClose,
+  teacherId,
   onSave,
   onStudentClick
 }: TeacherDetailsModalProps) {
@@ -42,85 +50,59 @@ export function TeacherDetailsModal({
     phone_number: '',
   });
 
+  const [loadError, setLoadError] = useState<string | null>(null);
+
   useEffect(() => {
     const loadTeacherData = async () => {
       setLoading(true);
+      setLoadError(null);
       try {
-        const existingTeacher = await getTeacherByStudentTeacherName(teacherName);
-        
-        if (existingTeacher) {
-          const details = await getTeacherDetails(existingTeacher.id);
-          if (details) {
-            setTeacher(existingTeacher);
-            setAssignedStudents(details.assigned_students);
-            setFormData({
-              first_name: details.first_name || '',
-              last_name: details.last_name || '',
-              email: details.email || '',
-              classroom_number: details.classroom_number || '',
-              phone_number: details.phone_number || '',
-            });
-          }
-        } else {
-          const nameParts = teacherName.trim().split(' ');
-          const lastName = nameParts[nameParts.length - 1] || '';
-          const firstName = nameParts.slice(0, -1).join(' ') || '';
-          
-          setFormData({
-            first_name: firstName,
-            last_name: lastName || teacherName,
-            email: '',
-            classroom_number: '',
-            phone_number: '',
-          });
+        // Keyed by id, so the teacher either exists or the caller handed us a
+        // stale one — there is no "maybe create it" branch any more.
+        const details = await getTeacherDetails(teacherId);
+        if (!details) {
+          setLoadError('This teacher record could not be found.');
           setAssignedStudents([]);
+          return;
         }
+        setTeacher(details);
+        setAssignedStudents(details.assigned_students);
+        setFormData({
+          first_name: details.first_name || '',
+          last_name: details.last_name || '',
+          email: details.email || '',
+          classroom_number: details.classroom_number || '',
+          phone_number: details.phone_number || '',
+        });
       } catch (error) {
         console.error('Error loading teacher data:', error);
+        setLoadError('Could not load this teacher.');
       } finally {
         setLoading(false);
       }
     };
 
-    if (isOpen && teacherName) {
+    if (isOpen && teacherId) {
       loadTeacherData();
     }
-  }, [isOpen, teacherName]);
+  }, [isOpen, teacherId]);
 
   const handleSave = async () => {
     setSaving(true);
     try {
-      let savedTeacher: Teacher;
-      
-      if (teacher) {
-        savedTeacher = await upsertTeacherDetails(teacher.id, {
-          first_name: formData.first_name || null,
-          last_name: formData.last_name || null,
-          email: formData.email || null,
-          classroom_number: formData.classroom_number || null,
-          phone_number: formData.phone_number || null,
-          school_id: teacher.school_id,
-          school_site: teacher.school_site,
-        } as TeacherUpdateData);
-      } else {
-        savedTeacher = await getOrCreateTeacher(
-          formData.first_name || formData.last_name ? 
-          `${formData.first_name} ${formData.last_name}`.trim() : 
-          teacherName
-        );
-        
-        if (formData.email || formData.classroom_number || formData.phone_number) {
-          savedTeacher = await upsertTeacherDetails(savedTeacher.id, {
-            first_name: formData.first_name || null,
-            last_name: formData.last_name || null,
-            email: formData.email || null,
-            classroom_number: formData.classroom_number || null,
-            phone_number: formData.phone_number || null,
-            school_site: savedTeacher.school_site,
-            school_id: savedTeacher.school_id,
-          } as TeacherUpdateData);
-        }
+      if (!teacher) {
+        setLoadError('This teacher record could not be found.');
+        return;
       }
+      const savedTeacher: Teacher = await upsertTeacherDetails(teacher.id, {
+        first_name: formData.first_name || null,
+        last_name: formData.last_name || null,
+        email: formData.email || null,
+        classroom_number: formData.classroom_number || null,
+        phone_number: formData.phone_number || null,
+        school_id: teacher.school_id,
+        school_site: teacher.school_site,
+      } as TeacherUpdateData);
 
       if (onSave) {
         onSave(savedTeacher);
@@ -162,9 +144,9 @@ export function TeacherDetailsModal({
         <div className="relative bg-white rounded-lg shadow-xl max-w-2xl w-full">
           <div className="flex items-center justify-between p-6 border-b">
             <h2 className="text-xl font-semibold text-gray-900">
-              Teacher Details: {formData.first_name || formData.last_name ? 
-                `${formData.first_name || ''} ${formData.last_name || ''}`.trim() : 
-                teacherName}
+              Teacher Details{formData.first_name || formData.last_name
+                ? `: ${`${formData.first_name || ''} ${formData.last_name || ''}`.trim()}`
+                : ''}
             </h2>
             <button
               onClick={onClose}
@@ -270,7 +252,8 @@ export function TeacherDetailsModal({
                                 id: student.id,
                                 initials: student.initials,
                                 grade_level: student.grade_level,
-                                teacher_name: teacherName,
+                                teacher_name:
+                                  `${formData.first_name || ''} ${formData.last_name || ''}`.trim() || null,
                                 sessions_per_week: student.sessions_per_week,
                                 minutes_per_session: student.minutes_per_session
                               });

--- a/app/components/teachers/teacher-details-modal.tsx
+++ b/app/components/teachers/teacher-details-modal.tsx
@@ -53,6 +53,23 @@ export function TeacherDetailsModal({
   const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
+    // Opening a second teacher while the first is still loading must not let
+    // the older response win: every setter below runs after an await, and
+    // `teacher` is what Save writes to.
+    let stale = false;
+
+    const clearRecord = () => {
+      setTeacher(null);
+      setAssignedStudents([]);
+      setFormData({
+        first_name: '',
+        last_name: '',
+        email: '',
+        classroom_number: '',
+        phone_number: '',
+      });
+    };
+
     const loadTeacherData = async () => {
       setLoading(true);
       setLoadError(null);
@@ -60,9 +77,12 @@ export function TeacherDetailsModal({
         // Keyed by id, so the teacher either exists or the caller handed us a
         // stale one — there is no "maybe create it" branch any more.
         const details = await getTeacherDetails(teacherId);
+        if (stale) return;
         if (!details) {
+          // Leave nothing of the previously-opened teacher behind, or Save
+          // would write this form to them.
+          clearRecord();
           setLoadError('This teacher record could not be found.');
-          setAssignedStudents([]);
           return;
         }
         setTeacher(details);
@@ -75,16 +95,20 @@ export function TeacherDetailsModal({
           phone_number: details.phone_number || '',
         });
       } catch (error) {
+        if (stale) return;
         console.error('Error loading teacher data:', error);
+        clearRecord();
         setLoadError('Could not load this teacher.');
       } finally {
-        setLoading(false);
+        if (!stale) setLoading(false);
       }
     };
 
     if (isOpen && teacherId) {
       loadTeacherData();
     }
+
+    return () => { stale = true; };
   }, [isOpen, teacherId]);
 
   const handleSave = async () => {
@@ -160,6 +184,13 @@ export function TeacherDetailsModal({
             {loading ? (
               <div className="flex justify-center py-8">
                 <p>Loading teacher details...</p>
+              </div>
+            ) : loadError ? (
+              <div
+                role="alert"
+                className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700"
+              >
+                {loadError}
               </div>
             ) : (
               <>
@@ -281,7 +312,7 @@ export function TeacherDetailsModal({
             <Button 
               variant="primary" 
               onClick={handleSave}
-              disabled={saving || loading || !formData.last_name}
+              disabled={saving || loading || !!loadError || !formData.last_name}
             >
               {saving ? 'Saving...' : 'Save Details'}
             </Button>

--- a/app/components/teachers/teacher-set-cell.tsx
+++ b/app/components/teachers/teacher-set-cell.tsx
@@ -54,6 +54,7 @@ export function TeacherSetCell({
   if (collapsed) {
     return (
       <button
+        type="button"
         onClick={() => setExpanded(true)}
         className="text-blue-600 hover:text-blue-800 hover:underline transition-colors"
         title={teachers.map(t => t.name).filter(Boolean).join(', ')}
@@ -65,20 +66,36 @@ export function TeacherSetCell({
 
   return (
     <span className="inline-flex flex-wrap items-center gap-x-1">
-      {teachers.map((teacher, i) => (
-        <span key={teacher.id} className="inline-flex items-center">
-          {i > 0 && <span className="text-gray-400 mr-1">/</span>}
-          <button
-            onClick={() => onOpenTeacher?.(teacher.id)}
-            className="text-blue-600 hover:text-blue-800 hover:underline transition-colors"
-            title={[teacher.subject, teacher.period ? `Period ${teacher.period}` : null].filter(Boolean).join(" · ") || undefined}
-          >
-            {teacher.name || 'Unnamed teacher'}
-          </button>
-        </span>
-      ))}
+      {teachers.map((teacher, i) => {
+        const labels =
+          [teacher.subject, teacher.period ? `Period ${teacher.period}` : null]
+            .filter(Boolean).join(' · ') || undefined;
+        return (
+          <span key={teacher.id} className="inline-flex items-center">
+            {i > 0 && <span className="text-gray-400 mr-1">/</span>}
+            {/* Without a handler there is nothing to open — a blue underlined
+                control that does nothing (and takes keyboard focus) is worse
+                than plain text. */}
+            {onOpenTeacher ? (
+              <button
+                type="button"
+                onClick={() => onOpenTeacher(teacher.id)}
+                className="text-blue-600 hover:text-blue-800 hover:underline transition-colors"
+                title={labels}
+              >
+                {teacher.name || 'Unnamed teacher'}
+              </button>
+            ) : (
+              <span className="text-gray-900" title={labels}>
+                {teacher.name || 'Unnamed teacher'}
+              </span>
+            )}
+          </span>
+        );
+      })}
       {isSecondary && teachers.length > 1 && (
         <button
+          type="button"
           onClick={() => setExpanded(false)}
           className="text-xs text-gray-400 hover:text-gray-600 ml-1"
           aria-label="Collapse teacher list"

--- a/app/components/teachers/teacher-set-cell.tsx
+++ b/app/components/teachers/teacher-set-cell.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  summarizeTeacherSet,
+  type LinkedTeacher,
+} from '@/lib/supabase/queries/student-teachers';
+
+interface TeacherSetCellProps {
+  teachers: LinkedTeacher[];
+  /**
+   * The legacy free-text `students.teacher_name`, shown only when the child has
+   * no links at all. One production row is in exactly that state (SPE-334 left
+   * its hand-typed name alone), and dropping to "Not assigned" would look like
+   * data loss to the provider who typed it.
+   */
+  fallbackName?: string | null;
+  isSecondary?: boolean;
+  onOpenTeacher?: (teacherId: string) => void;
+}
+
+/**
+ * SPE-337 — a student's teacher set in one table cell.
+ *
+ * Elementary lists every name ("Davis / Winbery", the way class lists are
+ * written); secondary summarises ("6 teachers") and expands on click, because
+ * six names per row turns a roster into a wall of text. A single teacher
+ * renders as a plain name at either level, so the common case is unchanged.
+ *
+ * Names are buttons keyed by teacher **id**. The old cell opened the teacher
+ * modal on the free-text name, so a typo opened the wrong record — or created
+ * a duplicate teacher.
+ */
+export function TeacherSetCell({
+  teachers,
+  fallbackName,
+  isSecondary = false,
+  onOpenTeacher,
+}: TeacherSetCellProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (teachers.length === 0) {
+    return fallbackName ? (
+      <span className="text-gray-900" title="Typed in by hand — not linked to a teacher record">
+        {fallbackName}
+      </span>
+    ) : (
+      <span className="text-gray-400 italic">Not assigned</span>
+    );
+  }
+
+  const collapsed = isSecondary && teachers.length > 1 && !expanded;
+
+  if (collapsed) {
+    return (
+      <button
+        onClick={() => setExpanded(true)}
+        className="text-blue-600 hover:text-blue-800 hover:underline transition-colors"
+        title={teachers.map(t => t.name).filter(Boolean).join(', ')}
+      >
+        {summarizeTeacherSet(teachers, true)}
+      </button>
+    );
+  }
+
+  return (
+    <span className="inline-flex flex-wrap items-center gap-x-1">
+      {teachers.map((teacher, i) => (
+        <span key={teacher.id} className="inline-flex items-center">
+          {i > 0 && <span className="text-gray-400 mr-1">/</span>}
+          <button
+            onClick={() => onOpenTeacher?.(teacher.id)}
+            className="text-blue-600 hover:text-blue-800 hover:underline transition-colors"
+            title={[teacher.subject, teacher.period ? `Period ${teacher.period}` : null].filter(Boolean).join(" · ") || undefined}
+          >
+            {teacher.name || 'Unnamed teacher'}
+          </button>
+        </span>
+      ))}
+      {isSecondary && teachers.length > 1 && (
+        <button
+          onClick={() => setExpanded(false)}
+          className="text-xs text-gray-400 hover:text-gray-600 ml-1"
+          aria-label="Collapse teacher list"
+        >
+          (hide)
+        </button>
+      )}
+    </span>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -897,6 +897,32 @@ joined set and the first link; `groupStudentsByIdentity`, rekeyed onto
 `getStudentResourceSchedule` gained caller-side scoping on top of RLS —
 defense in depth, so a policy regression alone cannot widen a teacher's reach.
 
+#### Editing the set (SPE-337)
+
+`StudentTeachersField` is the one editor, in two shapes over identical data.
+**Elementary** keeps the single "Teacher" picker the form always had, plus an
+"Add co-teacher" link that reveals a second one — a co-taught class is the
+exception, so the second picker stays out of the way until asked for.
+**Secondary** shows a list with optional subject/period labels. Nothing ranks
+the teachers: no "primary" badge, no reordering, and removing the first is as
+easy as removing the last (product decision 2026-07-26).
+
+It **composes** `TeacherAutocomplete` rather than replacing it — that component
+is single-select by contract and six other surfaces (special activities, CARE
+referrals, import review) genuinely want one teacher.
+
+Writes go through `saveTeacherLinksForStudent`, a **diff**: untouched links keep
+their `created_at`, which is the order the legacy-column mirror calls "first
+listed", so editing one label cannot silently repoint `students.teacher_id`.
+Deletes run last, because emptying the set first would make the mirror null out
+the legacy pair on every caseload row of the child mid-save.
+
+Displays follow the same split: elementary lists every name ("Davis /
+Winbery"), secondary summarises ("6 teachers") and expands on click. The
+students-page teacher modal is keyed by `teachers.id` — it used to open on the
+free-text name, so a typo opened the wrong record or minted a duplicate; the
+name-matching helper that made that possible is deleted.
+
 **IEP attendees differ by level, deliberately.** Elementary invites *every*
 linked teacher and constrains the schedule on all of them: a single-teacher
 class behaves exactly as before, a co-taught class invites both, since they
@@ -917,8 +943,11 @@ live `student_teachers` table + its four policies;
 `lib/supabase/queries/student-teachers.ts`;
 `scripts/sim-district/manifest.ts` (`studentTeacherLinkId` /
 `studentTeacherLinks` / `SECONDARY_PERIODS` / `TOTAL_STUDENT_TEACHER_LINKS`);
+`app/components/teachers/student-teachers-field.tsx`,
+`app/components/teachers/teacher-set-cell.tsx`;
 `scripts/sim-district/verify-student-teachers-rls.ts`,
-`scripts/sim-district/verify-teacher-set-reads.ts`.
+`scripts/sim-district/verify-teacher-set-reads.ts`,
+`scripts/sim-district/verify-teacher-link-writes.ts`.
 
 ### The session tables
 
@@ -1279,15 +1308,15 @@ of school (Master Schedule stays), and Internal sets the `school_type` /
 > `/dashboard/special-activities`, and `/dashboard/plan` stay reachable by direct
 > URL on a secondary site (RLS still scopes data).
 >
-> **Known gap — SPE-194 (Medium), nearly closed:** the data model holds many
-> teachers per student (`student_teachers`, SPE-334, §6) and **every read now
-> resolves through it** (SPE-336): the teacher portal roster and today view,
-> chat membership, admin directory counts, the SEA data layer, cross-provider
-> identity, and IEP-meeting attendee assembly. Every linked teacher sees their
-> student — all subject teachers at secondary, both co-teachers at elementary.
-> What remains is **writing** the links by hand: every teacher picker is still
-> single-select (**SPE-337**), and retiring `students.teacher_id` /
-> `teacher_name` is **SPE-341**. Complements the SPE-181 rostering spike.
+> **Known gap — SPE-194 (Medium): closed as of 2026-08-07**, bar the cleanup.
+> The data model holds many teachers per student (`student_teachers`, SPE-334,
+> §6), every read resolves through it (SPE-336), and the links are editable by
+> hand (SPE-337). Every linked teacher sees their student — all subject
+> teachers at secondary, both co-teachers at elementary — and a case manager
+> can add or remove one. What is left is bookkeeping, not capability: retiring
+> `students.teacher_id` / `teacher_name` (**SPE-341**) once the dual-write has
+> baked. Bulk entry at secondary scale is the SIS syncs (**SPE-342** /
+> **SPE-414**), not manual entry; complements the SPE-181 spike.
 
 **Source of truth:** `lib/school-helpers.ts` (`isSecondarySchool`,
 `classifyByType`, `parseGradeLevel`); `app/components/providers/school-context.tsx`
@@ -1310,7 +1339,7 @@ Re-check Linear for current state.
 | **SPE-188** | Low | Security | Idle logout is client-side only; no server-side session-lifetime backstop. |
 | **SPE-190** | Low | Security | Admin-created teachers get a temp password that's never force-rotated (no `must_change_password` on creation). |
 | **SPE-193** | Low | UX / robustness | Elementary/secondary feature gating is client-side only; hidden routes reachable by URL on secondary sites. |
-| **SPE-194** | Medium | Data model | Nearly closed: `student_teachers` (SPE-334) holds N teachers per child and every read resolves through it (SPE-336) — portal, chat, admin counts, SEA layer, cross-provider identity, IEP attendees. Remaining: the editing UI (SPE-337) and column retirement (SPE-341). |
+| **SPE-194** | Medium | Data model | ✅ Closed 2026-08-07 (SPE-334 + SPE-336 + SPE-337): N teachers per child, every read through the junction, and hand-editable links. Remaining bookkeeping only — column retirement (SPE-341). Bulk secondary entry comes from the SIS syncs (SPE-342/SPE-414). |
 
 **Related context tickets:** SPE-132 (middleware `getSession()` + per-nav
 profile query), SPE-134 (FERPA wording reworded to match reality), SPE-142

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -944,7 +944,9 @@ live `student_teachers` table + its four policies;
 `scripts/sim-district/manifest.ts` (`studentTeacherLinkId` /
 `studentTeacherLinks` / `SECONDARY_PERIODS` / `TOTAL_STUDENT_TEACHER_LINKS`);
 `app/components/teachers/student-teachers-field.tsx`,
-`app/components/teachers/teacher-set-cell.tsx`;
+`app/components/teachers/teacher-set-cell.tsx`,
+`app/components/teachers/teacher-details-modal.tsx`,
+`lib/supabase/queries/teacher-details.ts`;
 `scripts/sim-district/verify-student-teachers-rls.ts`,
 `scripts/sim-district/verify-teacher-set-reads.ts`,
 `scripts/sim-district/verify-teacher-link-writes.ts`.

--- a/docs/SIM_DISTRICT.md
+++ b/docs/SIM_DISTRICT.md
@@ -405,10 +405,19 @@ guard at all): `sim:verify-rls` (`profiles`), `sim:verify-children-rls`
 `sim:verify-student-teachers-rls` (SPE-334: the teacher read sets, the
 co-teacher case, the school-consistency refusal and the dual-write) and
 `sim:verify-teacher-set-reads` (SPE-336: the two teacher-set reads the portal
-walk cannot see — `get_sea_students` and the IEP-meeting caseload). All
-`npx tsx`. The two `children` guards and the `student_teachers` guard write sim
-rows — re-seed afterward to restore a pristine fixture;
+walk cannot see — `get_sea_students` and the IEP-meeting caseload) and
+`sim:verify-teacher-link-writes` (SPE-337: adding, labelling and removing a
+teacher link from a provider's own session, plus the refusals). All `npx tsx`.
+The two `children` guards and both `student_teachers` guards write sim rows —
+re-seed afterward to restore a pristine fixture;
 `sim:verify-teacher-set-reads` is read-only.
+
+> **Writing a walk that touches links? Delete only what you created.** A record
+> teacher is usually already the homeroom teacher for several seeded students,
+> so `delete().eq('teacher_id', …)` as "cleanup" destroys fixture data — and
+> the SPE-334 legacy mirror then repoints `students.teacher_name` on every
+> affected child, which is a confusing way to find out. Snapshot the link ids
+> first and remove the delta. (Learned the hard way during the SPE-337 run.)
 
 Env requirements are scoped per command. Every command needs
 `NEXT_PUBLIC_SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`. Beyond that:
@@ -417,7 +426,7 @@ Env requirements are scoped per command. Every command needs
 |---|---|---|
 | `sim:reset` | `SIM_DISTRICT_PASSWORD` | it sets the persona passwords |
 | `sim:verify`, `sim:teardown` | — | read-only / delete-only, so they never receive the credential secret |
-| the five `sim:verify-*` guards | `SIM_DISTRICT_PASSWORD` + `NEXT_PUBLIC_SUPABASE_ANON_KEY` | they sign IN as personas, which needs the same derived password and a client-side key |
+| the six `sim:verify-*` guards | `SIM_DISTRICT_PASSWORD` + `NEXT_PUBLIC_SUPABASE_ANON_KEY` | they sign IN as personas, which needs the same derived password and a client-side key |
 
 **Preflight, before any write.** Scripts hard-fail unless: **(a)** the host in
 `NEXT_PUBLIC_SUPABASE_URL` is a front for the project pinned in `manifest.ts` —

--- a/lib/supabase/queries/admin-unmatched-students.ts
+++ b/lib/supabase/queries/admin-unmatched-students.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@/lib/supabase/client';
 import { safeQuery } from '@/lib/supabase/safe-query';
+import { addTeacherLinkForStudent } from './student-teachers';
 
 /**
  * Interface for unmatched student records
@@ -101,13 +102,15 @@ export async function assignTeacherToStudent(studentId: string, teacherId: strin
     throw new Error('You must be logged in to assign teachers');
   }
 
+  // SPE-337: ADD a teacher, don't replace one. Overwriting `teacher_id` used to
+  // be the only option because a student had exactly one teacher; now that a
+  // student can have several, "assign this teacher" must not silently unassign
+  // whoever else already teaches them. The insert is idempotent — the
+  // (child_id, teacher_id) unique constraint makes a re-assign a no-op rather
+  // than an error — and the SPE-334 dual-write keeps the legacy column in step.
   const updateResult = await safeQuery(
     async () => {
-      const { error } = await supabase
-        .from('students')
-        .update({ teacher_id: teacherId })
-        .eq('id', studentId);
-      if (error) throw error;
+      await addTeacherLinkForStudent(supabase, studentId, teacherId);
       return null;
     },
     {

--- a/lib/supabase/queries/admin-unmatched-students.ts
+++ b/lib/supabase/queries/admin-unmatched-students.ts
@@ -111,6 +111,23 @@ export async function assignTeacherToStudent(studentId: string, teacherId: strin
   const updateResult = await safeQuery(
     async () => {
       await addTeacherLinkForStudent(supabase, studentId, teacherId);
+
+      // The link alone does not clear the unmatched state. An unmatched row is
+      // by definition `teacher_id IS NULL` with a hand-typed `teacher_name`,
+      // and that is the one shape `student_teachers_mirror_legacy` refuses to
+      // touch (SPE-334 protects the typed name because no link exists to
+      // replace it with). So the row would keep its NULL and reappear in this
+      // very list after a successful-looking assign.
+      //
+      // Guarded on `teacher_id IS NULL`: it resolves an unmatched row and does
+      // nothing at all to a student who already has a teacher, which is what
+      // keeps this an ADD rather than the replacement it used to be.
+      const { error } = await supabase
+        .from('students')
+        .update({ teacher_id: teacherId })
+        .eq('id', studentId)
+        .is('teacher_id', null);
+      if (error) throw error;
       return null;
     },
     {

--- a/lib/supabase/queries/student-teachers.ts
+++ b/lib/supabase/queries/student-teachers.ts
@@ -80,6 +80,9 @@ export interface LinkedTeacher {
   /** `profiles` id when the teacher has a Speddy account, else null. */
   profileId: string | null;
   email: string | null;
+  /** Display labels only (SPE-334) — secondary carries them, elementary does not. */
+  subject: string | null;
+  period: string | null;
 }
 
 /**
@@ -100,7 +103,7 @@ export async function getTeachersByChildId(
 
   const { data, error } = await supabase
     .from('student_teachers')
-    .select('child_id, created_at, id, teachers(id, first_name, last_name, email, account_id)')
+    .select('child_id, created_at, id, subject, period, teachers(id, first_name, last_name, email, account_id)')
     .in('child_id', unique)
     .order('created_at', { ascending: true })
     .order('id', { ascending: true });
@@ -115,6 +118,8 @@ export async function getTeachersByChildId(
       name: [teacher.first_name, teacher.last_name].filter(Boolean).join(' ') || null,
       profileId: teacher.account_id ?? null,
       email: teacher.email ?? null,
+      subject: link.subject,
+      period: link.period,
     });
     byChild.set(link.child_id, list);
   }
@@ -132,4 +137,192 @@ export async function getTeachersByChildId(
 export function formatTeacherSet(teachers: LinkedTeacher[]): string | null {
   const names = teachers.map(t => t.name).filter((n): n is string => !!n);
   return names.length > 0 ? names.join(' / ') : null;
+}
+
+/**
+ * SPE-337 — how a teacher set reads in a table cell.
+ *
+ * Elementary lists every name, because a class has one teacher or two and both
+ * belong on screen. Secondary summarises: a student with six subject teachers
+ * turns a roster row into a paragraph, and the individual names are not what
+ * the reader is scanning for. One teacher renders as the name at either level,
+ * so nothing changes for the single-teacher case.
+ */
+export function summarizeTeacherSet(
+  teachers: LinkedTeacher[],
+  isSecondary: boolean,
+): string | null {
+  if (teachers.length === 0) return null;
+  if (teachers.length === 1) return teachers[0].name ?? 'Unnamed teacher';
+  if (!isSecondary) return formatTeacherSet(teachers);
+  return `${teachers.length} teachers`;
+}
+
+// ---------------------------------------------------------------------------
+// SPE-337 — reading and writing a student's teacher set by hand
+// ---------------------------------------------------------------------------
+
+/** A link as the editing UI holds it. `id` is absent until it is saved. */
+export interface EditableTeacherLink {
+  id?: string;
+  teacherId: string;
+  name: string | null;
+  /** Display labels only — secondary carries them, elementary leaves them null. */
+  subject: string | null;
+  period: string | null;
+}
+
+/** The child a caseload row serves. Null only if the row predates SPE-347. */
+async function childIdForStudent(supabase: Client, studentId: string): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('students').select('child_id').eq('id', studentId).single();
+  if (error) throw error;
+  return (data?.child_id as string | null) ?? null;
+}
+
+/** The teacher set of one caseload row, in link order. */
+export async function getTeacherLinksForStudent(
+  supabase: Client,
+  studentId: string,
+): Promise<EditableTeacherLink[]> {
+  const childId = await childIdForStudent(supabase, studentId);
+  if (!childId) return [];
+
+  const { data, error } = await supabase
+    .from('student_teachers')
+    .select('id, teacher_id, subject, period, created_at, teachers(first_name, last_name)')
+    .eq('child_id', childId)
+    .order('created_at', { ascending: true })
+    .order('id', { ascending: true });
+  if (error) throw error;
+
+  return (data ?? []).map(row => {
+    const teacher = Array.isArray(row.teachers) ? row.teachers[0] : row.teachers;
+    return {
+      id: row.id,
+      teacherId: row.teacher_id,
+      name: [teacher?.first_name, teacher?.last_name].filter(Boolean).join(' ') || null,
+      subject: row.subject,
+      period: row.period,
+    };
+  });
+}
+
+/**
+ * Make the child's teacher set match `links`.
+ *
+ * A DIFF, not a replace-all: rows the user did not touch are left alone, so
+ * their `created_at` — and therefore the "first listed" link that the legacy
+ * `students.teacher_id` mirror follows (SPE-334) — does not shuffle every time
+ * somebody edits a subject label.
+ *
+ * Deletes run LAST. Removing every link before re-adding would briefly leave
+ * the child with none, and the legacy-column mirror would fire on that empty
+ * moment and null out `teacher_id` on every caseload row of the child.
+ *
+ * Not transactional — PostgREST has no client-side transaction — so a failure
+ * midway leaves a partially-applied set. The operations are individually
+ * idempotent and the UI re-reads afterwards, so a retry converges; the
+ * alternative (an RPC) is more surface than this ticket needs.
+ */
+export async function saveTeacherLinksForStudent(
+  supabase: Client,
+  studentId: string,
+  links: EditableTeacherLink[],
+): Promise<void> {
+  const childId = await childIdForStudent(supabase, studentId);
+  if (!childId) throw new Error('This student has no child record yet; reload and try again.');
+
+  const existing = await getTeacherLinksForStudent(supabase, studentId);
+  const existingByTeacher = new Map(existing.map(l => [l.teacherId, l]));
+
+  // Guard against a double-added teacher slipping through as a unique violation.
+  const wanted = new Map<string, EditableTeacherLink>();
+  for (const link of links) {
+    if (link.teacherId) wanted.set(link.teacherId, link);
+  }
+
+  const toInsert = [...wanted.values()].filter(l => !existingByTeacher.has(l.teacherId));
+  const toUpdate = [...wanted.values()].filter(l => {
+    const prev = existingByTeacher.get(l.teacherId);
+    return prev && (prev.subject !== l.subject || prev.period !== l.period);
+  });
+  const toDelete = existing.filter(l => !wanted.has(l.teacherId));
+
+  if (toInsert.length > 0) {
+    const { error } = await supabase.from('student_teachers').insert(
+      toInsert.map(l => ({
+        child_id: childId,
+        teacher_id: l.teacherId,
+        subject: l.subject,
+        period: l.period,
+      })),
+    );
+    if (error) throw error;
+  }
+
+  for (const link of toUpdate) {
+    const { error } = await supabase
+      .from('student_teachers')
+      .update({ subject: link.subject, period: link.period })
+      .eq('child_id', childId)
+      .eq('teacher_id', link.teacherId);
+    if (error) throw error;
+  }
+
+  if (toDelete.length > 0) {
+    const { error } = await supabase
+      .from('student_teachers')
+      .delete()
+      .eq('child_id', childId)
+      .in('teacher_id', toDelete.map(l => l.teacherId));
+    if (error) throw error;
+  }
+}
+
+/**
+ * Link one more teacher to a student, leaving the rest of the set alone.
+ *
+ * Idempotent: the `(child_id, teacher_id)` unique constraint means re-adding
+ * an existing teacher is a no-op rather than an error, so callers can assign
+ * without first checking.
+ */
+export async function addTeacherLinkForStudent(
+  supabase: Client,
+  studentId: string,
+  teacherId: string,
+): Promise<void> {
+  const childId = await childIdForStudent(supabase, studentId);
+  if (!childId) throw new Error('This student has no child record yet; reload and try again.');
+
+  const { error } = await supabase
+    .from('student_teachers')
+    .upsert({ child_id: childId, teacher_id: teacherId }, { onConflict: 'child_id,teacher_id', ignoreDuplicates: true });
+  if (error) throw error;
+}
+
+/**
+ * Teacher sets for a page of students, keyed by `students.id`.
+ *
+ * Two round trips for the whole table rather than one per row.
+ */
+export async function getTeacherSetsForStudents(
+  supabase: Client,
+  studentIds: string[],
+): Promise<Map<string, LinkedTeacher[]>> {
+  const byStudent = new Map<string, LinkedTeacher[]>();
+  const unique = Array.from(new Set(studentIds.filter(Boolean)));
+  if (unique.length === 0) return byStudent;
+
+  const { data: rows, error } = await supabase
+    .from('students').select('id, child_id').in('id', unique);
+  if (error) throw error;
+
+  const childIds = (rows ?? []).map(r => r.child_id).filter((c): c is string => !!c);
+  const byChild = await getTeachersByChildId(supabase, childIds);
+
+  for (const row of rows ?? []) {
+    byStudent.set(row.id, row.child_id ? (byChild.get(row.child_id) ?? []) : []);
+  }
+  return byStudent;
 }

--- a/lib/supabase/queries/teacher-details.ts
+++ b/lib/supabase/queries/teacher-details.ts
@@ -237,63 +237,13 @@ export async function getStudentsByTeacher(teacherId: string): Promise<Student[]
   return fetchResult.data || [];
 }
 
-export async function getTeacherByStudentTeacherName(teacherName: string): Promise<Teacher | null> {
-  const supabase = createClient<Database>();
-
-  const authResult = await safeQuery(
-    () => supabase.auth.getUser(),
-    { operation: 'get_user_for_fetch_teacher_by_name' }
-  );
-  
-  if (authResult.error || !authResult.data?.data.user) {
-    throw new Error('No user found');
-  }
-  
-  const user = authResult.data.data.user;
-
-  const nameParts = teacherName.trim().split(' ');
-  const lastName = nameParts[nameParts.length - 1];
-  const firstName = nameParts.slice(0, -1).join(' ');
-
-  const fetchPerf = measurePerformanceWithAlerts('fetch_teacher_by_student_name', 'database');
-  const fetchResult = await safeQuery(
-    async () => {
-      let query = supabase
-        .from('teachers')
-        .select('*');
-
-      if (firstName && lastName) {
-        query = query
-          .ilike('first_name', firstName)
-          .ilike('last_name', lastName);
-      } else {
-        query = query.or(`last_name.ilike.%${teacherName}%,first_name.ilike.%${teacherName}%`);
-      }
-
-      // Order by preference: admin-created records with complete info first
-      // This handles duplicate teacher records gracefully
-      query = query
-        .order('created_by_admin', { ascending: false })
-        .order('first_name', { ascending: true, nullsFirst: false })
-        .order('email', { ascending: true, nullsFirst: false })
-        .limit(1);
-
-      const { data, error } = await query.maybeSingle();
-      if (error) throw error;
-      return data;
-    },
-    {
-      operation: 'fetch_teacher_by_student_name',
-      userId: user.id,
-      teacherName
-    }
-  );
-  fetchPerf.end({ success: !fetchResult.error });
-
-  if (fetchResult.error) {
-    console.error('Error fetching teacher by name:', fetchResult.error);
-    return null;
-  }
-
-  return fetchResult.data;
-}
+/*
+ * SPE-337 removed `getTeacherByStudentTeacherName`.
+ *
+ * It resolved a teacher by fuzzy-matching the free-text `students.teacher_name`
+ * — how the teacher modal used to open. That contract is gone: the modal is
+ * keyed by `teachers.id`, so a typo can no longer open the wrong record, and
+ * its `.limit(1)` over "duplicate teacher records" can no longer silently pick
+ * one of several. A student with a SET of teachers has no single name to match
+ * on in any case.
+ */

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "sim:verify-child-link": "tsx scripts/sim-district/verify-child-link.ts",
     "sim:verify-student-teachers-rls": "tsx scripts/sim-district/verify-student-teachers-rls.ts",
     "sim:verify-teacher-set-reads": "tsx scripts/sim-district/verify-teacher-set-reads.ts",
+    "sim:verify-teacher-link-writes": "tsx scripts/sim-district/verify-teacher-link-writes.ts",
     "sim:verify-special-activities-rls": "tsx scripts/sim-district/verify-special-activities-rls.ts",
     "sim:verify-multi-school-rls": "tsx scripts/sim-district/verify-multi-school-rls.ts",
     "sim:verify-provider-schools-rls": "tsx scripts/sim-district/verify-provider-schools-rls.ts",

--- a/scripts/sim-district/verify-teacher-link-writes.ts
+++ b/scripts/sim-district/verify-teacher-link-writes.ts
@@ -1,0 +1,209 @@
+/**
+ * SPE-337 — writing a student's teacher set, with REAL signed-in sessions.
+ *
+ * The editing UI is the first thing in this chain that lets a person create and
+ * destroy `student_teachers` rows from the browser, so the write path sits
+ * directly on the RLS policies SPE-334 added. Mocked unit tests cannot see a
+ * policy at all (CLAUDE.md), which is exactly why this exists.
+ *
+ * The contract asserted here — the same operations the picker performs:
+ *
+ *   * the owning provider can ADD a co-teacher, and the added teacher really
+ *     gains sight of the student;
+ *   * subject/period labels round-trip (secondary);
+ *   * removing a link removes it, and the visibility with it;
+ *   * the diff leaves untouched links ALONE — editing one row must not churn
+ *     the others' created_at, because that is the order the legacy-column
+ *     mirror calls "first listed";
+ *   * a provider at another school is refused, on a FRESH target, with the
+ *     refusal reason asserted;
+ *   * `addTeacherLinkForStudent` is idempotent — re-assigning is a no-op, not
+ *     an error, and does not disturb the rest of the set.
+ *
+ * Requires a seeded sim district (`npm run sim:reset -- --yes`). It creates and
+ * removes its own links; re-seed afterwards to restore a pristine fixture.
+ *
+ * Usage: npm run sim:verify-teacher-link-writes
+ */
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createAdmin, requireEnv } from './lib';
+import { WILLOW, derivePassword, personaEmail, teacherRecordId } from './manifest';
+
+const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+const secret = requireEnv('SIM_DISTRICT_PASSWORD');
+
+const admin = createAdmin();
+
+let failures = 0;
+function check(ok: boolean, label: string, detail = ''): void {
+  if (!ok) failures++;
+  console.log(`  [${ok ? 'ok  ' : 'FAIL'}] ${label.padEnd(60)} ${detail}`);
+}
+
+async function signIn(personaKey: string): Promise<SupabaseClient> {
+  const email = personaEmail(personaKey);
+  const client = createClient(url, anon, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: derivePassword(secret, email),
+  });
+  if (error) throw new Error(`sim login failed for ${email} — is the district seeded? (${error.message})`);
+  return client;
+}
+
+async function links(childId: string) {
+  const { data, error } = await admin
+    .from('student_teachers')
+    .select('id, teacher_id, subject, period, created_at')
+    .eq('child_id', childId)
+    .order('created_at', { ascending: true })
+    .order('id', { ascending: true });
+  if (error) throw new Error(`link readback failed: ${error.message}`);
+  return data ?? [];
+}
+
+async function main(): Promise<void> {
+  const davidTeacherId = teacherRecordId('login:david');
+
+  // A Willow student on Rachel's caseload that David does NOT teach — the
+  // fresh fixture every negative check needs.
+  const rachelId = (await admin.from('profiles').select('id')
+    .eq('email', personaEmail('rachel')).single()).data!.id as string;
+  const { data: caseload } = await admin
+    .from('students').select('id, child_id').eq('provider_id', rachelId).eq('school_id', WILLOW);
+
+  let target: { id: string; child_id: string } | null = null;
+  for (const row of caseload ?? []) {
+    const current = await links(row.child_id as string);
+    if (!current.some(l => l.teacher_id === davidTeacherId)) {
+      target = { id: row.id as string, child_id: row.child_id as string };
+      break;
+    }
+  }
+  if (!target) throw new Error('no student without a David link — re-seed the fixture');
+
+  const before = await links(target.child_id);
+  console.log(`probe student ${target.id} (child ${target.child_id}), ${before.length} links to start`);
+
+  const rachel = await signIn('rachel');
+  const alicia = await signIn('alicia');
+  const david = await signIn('david');
+
+  console.log('\nthe owning provider can add a co-teacher:');
+  {
+    const { count: seenBefore } = await david.from('students')
+      .select('*', { count: 'exact', head: true }).eq('id', target.id);
+    check(seenBefore === 0, 'David cannot see the student beforehand', `count=${seenBefore}`);
+
+    const { error } = await rachel.from('student_teachers')
+      .insert({ child_id: target.child_id, teacher_id: davidTeacherId, subject: null, period: null });
+    check(!error, 'provider INSERT of a co-teacher link succeeds',
+      error ? `${error.code} ${error.message}` : 'inserted');
+
+    const after = await links(target.child_id);
+    check(after.length === before.length + 1, 'the link persisted',
+      `${before.length} -> ${after.length}`);
+
+    const { count: seenAfter } = await david.from('students')
+      .select('*', { count: 'exact', head: true }).eq('id', target.id);
+    check(seenAfter === 1, 'and the co-teacher now SEES the student', `count=${seenAfter}`);
+
+    // The untouched links must keep their identity and order — the legacy
+    // mirror follows created_at, so churn here would silently repoint
+    // students.teacher_id on every caseload row of the child.
+    const kept = after.filter(l => l.teacher_id !== davidTeacherId);
+    check(
+      kept.length === before.length &&
+        kept.every((l, i) => l.id === before[i].id && l.created_at === before[i].created_at),
+      'existing links are untouched (same ids, same created_at, same order)',
+      `${kept.length} preserved`,
+    );
+  }
+
+  console.log('\nsubject/period labels round-trip (secondary shape):');
+  {
+    const { data: updated, error } = await rachel.from('student_teachers')
+      .update({ subject: 'Algebra I', period: '3' })
+      .eq('child_id', target.child_id).eq('teacher_id', davidTeacherId)
+      .select('subject, period');
+    check(!error && updated?.[0]?.subject === 'Algebra I' && updated?.[0]?.period === '3',
+      'labels save and read back',
+      error ? error.message : `${updated?.[0]?.subject} / ${updated?.[0]?.period}`);
+  }
+
+  console.log('\nanother school\'s provider is refused (fresh target):');
+  {
+    // Alicia is at Maple with no relationship to this Willow child. Assert the
+    // REASON: 42501 is RLS, not a constraint the row happened to trip.
+    const { error: insErr } = await alicia.from('student_teachers')
+      .insert({ child_id: target.child_id, teacher_id: teacherRecordId('grace') });
+    check(insErr?.code === '42501', 'unlinked provider INSERT refused with 42501',
+      `code=${insErr?.code ?? 'none'}`);
+
+    const countBefore = (await links(target.child_id)).length;
+    const { data: delRows } = await alicia.from('student_teachers')
+      .delete().eq('child_id', target.child_id).select('id');
+    check((delRows?.length ?? 0) === 0 && (await links(target.child_id)).length === countBefore,
+      'unlinked provider DELETE affects 0 rows and destroys nothing',
+      `${delRows?.length ?? 0} rows, ${countBefore} links intact`);
+
+    const { data: updRows } = await alicia.from('student_teachers')
+      .update({ subject: 'HACKED' }).eq('child_id', target.child_id).select('id');
+    const stillClean = (await links(target.child_id)).every(l => l.subject !== 'HACKED');
+    check((updRows?.length ?? 0) === 0 && stillClean,
+      'unlinked provider UPDATE affects 0 rows and persists nothing',
+      `${updRows?.length ?? 0} rows`);
+  }
+
+  console.log('\nre-assigning the same teacher is a no-op, not an error:');
+  {
+    const countBefore = (await links(target.child_id)).length;
+    const { error } = await rachel.from('student_teachers')
+      .upsert({ child_id: target.child_id, teacher_id: davidTeacherId },
+        { onConflict: 'child_id,teacher_id', ignoreDuplicates: true });
+    const after = await links(target.child_id);
+    check(!error && after.length === countBefore,
+      'idempotent add leaves the set unchanged',
+      error ? `${error.code} ${error.message}` : `${countBefore} -> ${after.length}`);
+    // ignoreDuplicates must not have blanked the labels we set earlier.
+    const davidLink = after.find(l => l.teacher_id === davidTeacherId);
+    check(davidLink?.subject === 'Algebra I',
+      'and does not wipe the existing link\'s labels', `${davidLink?.subject}`);
+  }
+
+  console.log('\nremoving the link removes the visibility:');
+  {
+    const { data: delRows, error } = await rachel.from('student_teachers')
+      .delete().eq('child_id', target.child_id).eq('teacher_id', davidTeacherId).select('id');
+    check(!error && (delRows?.length ?? 0) === 1, 'provider DELETE of their own link succeeds',
+      error ? error.message : `${delRows?.length ?? 0} row`);
+
+    const { count: seenAfter } = await david.from('students')
+      .select('*', { count: 'exact', head: true }).eq('id', target.id);
+    check(seenAfter === 0, 'the removed co-teacher can no longer see the student',
+      `count=${seenAfter}`);
+
+    const after = await links(target.child_id);
+    check(
+      after.length === before.length &&
+        after.every((l, i) => l.id === before[i].id && l.created_at === before[i].created_at),
+      'the fixture is back exactly as it started',
+      `${after.length} links`,
+    );
+  }
+
+  if (failures === 0) {
+    console.log('\nAll checks passed. Re-seed (npm run sim:reset -- --yes) to restore the fixture.');
+  } else {
+    console.log(`\n${failures} check(s) failed.`);
+  }
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/sim-district/verify-teacher-link-writes.ts
+++ b/scripts/sim-district/verify-teacher-link-writes.ts
@@ -215,8 +215,12 @@ async function main(): Promise<void> {
     // it cannot send that column at all; this pins the layer underneath.)
     const snapshot = await links(target.child_id);
     const asEdited = await getTeacherLinksForStudent(rachel, target.id);
-    check(asEdited.length >= 2, 'the probe child has a set to reorder',
-      `${asEdited.length} links`);
+    const haveSet = asEdited.length >= 2;
+    check(haveSet, 'the probe child has a set to reorder', `${asEdited.length} links`);
+    // Without this the next line dereferences asEdited[0] anyway, and a real
+    // assertion failure would surface as a TypeError that skips the remaining
+    // checks and leaves the fixture dirty.
+    if (!haveSet) throw new Error('cannot exercise the reorder case — re-seed the fixture');
 
     const reordered = [...asEdited.slice(1), asEdited[0]];
     let saveError: string | null = null;

--- a/scripts/sim-district/verify-teacher-link-writes.ts
+++ b/scripts/sim-district/verify-teacher-link-writes.ts
@@ -15,10 +15,17 @@
  *   * the diff leaves untouched links ALONE — editing one row must not churn
  *     the others' created_at, because that is the order the legacy-column
  *     mirror calls "first listed";
+ *   * REORDERING the set is a no-op: co-teachers are equals, so removing one
+ *     and adding them back is the same set and must not revoke anybody;
  *   * a provider at another school is refused, on a FRESH target, with the
  *     refusal reason asserted;
  *   * `addTeacherLinkForStudent` is idempotent — re-assigning is a no-op, not
  *     an error, and does not disturb the rest of the set.
+ *
+ * Checks about POLICY go through the raw table, because that is the surface a
+ * policy acts on. Checks about BEHAVIOUR call the real query helpers, so their
+ * student -> child resolution and diffing are exercised too, not just the
+ * statements they end in.
  *
  * Requires a seeded sim district (`npm run sim:reset -- --yes`). It creates and
  * removes its own links; re-seed afterwards to restore a pristine fixture.
@@ -28,6 +35,12 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { createAdmin, requireEnv } from './lib';
 import { WILLOW, derivePassword, personaEmail, teacherRecordId } from './manifest';
+import {
+  addTeacherLinkForStudent,
+  getTeacherLinksForStudent,
+  saveTeacherLinksForStudent,
+} from '../../lib/supabase/queries/student-teachers';
+import type { Database } from '../../src/types/database';
 
 const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
 const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
@@ -41,9 +54,9 @@ function check(ok: boolean, label: string, detail = ''): void {
   console.log(`  [${ok ? 'ok  ' : 'FAIL'}] ${label.padEnd(60)} ${detail}`);
 }
 
-async function signIn(personaKey: string): Promise<SupabaseClient> {
+async function signIn(personaKey: string): Promise<SupabaseClient<Database>> {
   const email = personaEmail(personaKey);
-  const client = createClient(url, anon, {
+  const client = createClient<Database>(url, anon, {
     auth: { persistSession: false, autoRefreshToken: false },
   });
   const { error } = await client.auth.signInWithPassword({
@@ -70,10 +83,20 @@ async function main(): Promise<void> {
 
   // A Willow student on Rachel's caseload that David does NOT teach — the
   // fresh fixture every negative check needs.
-  const rachelId = (await admin.from('profiles').select('id')
-    .eq('email', personaEmail('rachel')).single()).data!.id as string;
-  const { data: caseload } = await admin
+  //
+  // Setup reads assert their own failures for the same reason the checks below
+  // do: an unseeded district would otherwise surface as a TypeError on `.id`,
+  // or as the "no student without a David link" message — a query failure
+  // reported as a fixture problem.
+  const { data: rachelRow, error: rachelErr } = await admin.from('profiles')
+    .select('id').eq('email', personaEmail('rachel')).single();
+  if (rachelErr || !rachelRow) {
+    throw new Error(`rachel's profile is missing — is the district seeded? (${rachelErr?.message ?? 'no row'})`);
+  }
+  const rachelId = rachelRow.id as string;
+  const { data: caseload, error: caseloadErr } = await admin
     .from('students').select('id, child_id').eq('provider_id', rachelId).eq('school_id', WILLOW);
+  if (caseloadErr) throw new Error(`caseload read failed: ${caseloadErr.message}`);
 
   let target: { id: string; child_id: string } | null = null;
   for (const row of caseload ?? []) {
@@ -161,17 +184,60 @@ async function main(): Promise<void> {
   console.log('\nre-assigning the same teacher is a no-op, not an error:');
   {
     const countBefore = (await links(target.child_id)).length;
-    const { error } = await rachel.from('student_teachers')
-      .upsert({ child_id: target.child_id, teacher_id: davidTeacherId },
-        { onConflict: 'child_id,teacher_id', ignoreDuplicates: true });
+    // Through the real helper, so its student -> child resolution is exercised
+    // too, not just the upsert it ends in.
+    let helperError: string | null = null;
+    try {
+      await addTeacherLinkForStudent(rachel, target.id, davidTeacherId);
+    } catch (err) {
+      helperError = err instanceof Error ? err.message : String(err);
+    }
     const after = await links(target.child_id);
-    check(!error && after.length === countBefore,
+    check(!helperError && after.length === countBefore,
       'idempotent add leaves the set unchanged',
-      error ? `${error.code} ${error.message}` : `${countBefore} -> ${after.length}`);
+      helperError ?? `${countBefore} -> ${after.length}`);
     // ignoreDuplicates must not have blanked the labels we set earlier.
     const davidLink = after.find(l => l.teacher_id === davidTeacherId);
     check(davidLink?.subject === 'Algebra I',
       'and does not wipe the existing link\'s labels', `${davidLink?.subject}`);
+  }
+
+  console.log('\nreordering the set is not a change (co-teachers are equals):');
+  {
+    // The editor's rows carry no rank, so "remove Ms A, then add her back"
+    // leaves the same set in a different order. That must be a no-op.
+    //
+    // It is not cosmetic. `created_at` order is what the SPE-334 legacy mirror
+    // calls the "first listed" link, so churn here silently repoints
+    // students.teacher_id — and a caller that derived that column from the
+    // first row would make the mirror read the reorder as a REPLACEMENT and
+    // revoke the demoted teacher's access. (The editing modal is now typed so
+    // it cannot send that column at all; this pins the layer underneath.)
+    const snapshot = await links(target.child_id);
+    const asEdited = await getTeacherLinksForStudent(rachel, target.id);
+    check(asEdited.length >= 2, 'the probe child has a set to reorder',
+      `${asEdited.length} links`);
+
+    const reordered = [...asEdited.slice(1), asEdited[0]];
+    let saveError: string | null = null;
+    try {
+      await saveTeacherLinksForStudent(rachel, target.id, reordered);
+    } catch (err) {
+      saveError = err instanceof Error ? err.message : String(err);
+    }
+    const after = await links(target.child_id);
+    check(
+      !saveError &&
+        after.length === snapshot.length &&
+        after.every((l, i) => l.id === snapshot[i].id && l.created_at === snapshot[i].created_at),
+      'every link survives with its id and created_at intact',
+      saveError ?? `${snapshot.length} -> ${after.length}`,
+    );
+
+    // The teacher moved to the front of the array keeps their access.
+    const demoted = asEdited[0].teacherId;
+    check(after.some(l => l.teacher_id === demoted),
+      'the teacher the user re-added is still linked', `${demoted.slice(0, 8)}…`);
   }
 
   console.log('\nremoving the link removes the visibility:');

--- a/scripts/sim-district/verify-teacher-link-writes.ts
+++ b/scripts/sim-district/verify-teacher-link-writes.ts
@@ -166,19 +166,26 @@ async function main(): Promise<void> {
     check(insErr?.code === '42501', 'unlinked provider INSERT refused with 42501',
       `code=${insErr?.code ?? 'none'}`);
 
+    // RLS filters these to zero rows and reports 2xx — so the PASS condition is
+    // "no error AND nothing changed". Without the error check, a request that
+    // failed for an unrelated reason also yields 0 rows and the guard goes
+    // green while proving nothing.
     const countBefore = (await links(target.child_id)).length;
-    const { data: delRows } = await alicia.from('student_teachers')
+    const { data: delRows, error: delErr } = await alicia.from('student_teachers')
       .delete().eq('child_id', target.child_id).select('id');
-    check((delRows?.length ?? 0) === 0 && (await links(target.child_id)).length === countBefore,
+    check(
+      !delErr && (delRows?.length ?? 0) === 0 &&
+        (await links(target.child_id)).length === countBefore,
       'unlinked provider DELETE affects 0 rows and destroys nothing',
-      `${delRows?.length ?? 0} rows, ${countBefore} links intact`);
+      delErr ? `${delErr.code} ${delErr.message}`
+             : `${delRows?.length ?? 0} rows, ${countBefore} links intact`);
 
-    const { data: updRows } = await alicia.from('student_teachers')
+    const { data: updRows, error: updErr } = await alicia.from('student_teachers')
       .update({ subject: 'HACKED' }).eq('child_id', target.child_id).select('id');
     const stillClean = (await links(target.child_id)).every(l => l.subject !== 'HACKED');
-    check((updRows?.length ?? 0) === 0 && stillClean,
+    check(!updErr && (updRows?.length ?? 0) === 0 && stillClean,
       'unlinked provider UPDATE affects 0 rows and persists nothing',
-      `${updRows?.length ?? 0} rows`);
+      updErr ? `${updErr.code} ${updErr.message}` : `${updRows?.length ?? 0} rows`);
   }
 
   console.log('\nre-assigning the same teacher is a no-op, not an error:');
@@ -198,8 +205,9 @@ async function main(): Promise<void> {
       helperError ?? `${countBefore} -> ${after.length}`);
     // ignoreDuplicates must not have blanked the labels we set earlier.
     const davidLink = after.find(l => l.teacher_id === davidTeacherId);
-    check(davidLink?.subject === 'Algebra I',
-      'and does not wipe the existing link\'s labels', `${davidLink?.subject}`);
+    check(davidLink?.subject === 'Algebra I' && davidLink?.period === '3',
+      'and does not wipe the existing link\'s labels',
+      `${davidLink?.subject} / ${davidLink?.period}`);
   }
 
   console.log('\nreordering the set is not a change (co-teachers are equals):');


### PR DESCRIPTION
Phase 3 of the multi-teacher plan ([SPE-337](https://linear.app/speddy/issue/SPE-337)) — writing the links by hand. With this, [SPE-194](https://linear.app/speddy/issue/SPE-194) is closed bar the column retirement.

## One editor, two shapes

`StudentTeachersField`, over identical data:

- **Elementary** keeps the single "Teacher" picker the form always had, plus an **"+ Add co-teacher"** link that reveals a second one. A co-taught class is the exception, not the norm, so the second picker stays out of the way until it's asked for. No subject/period — there are no periods at elementary.
- **Secondary** shows a list with optional subject and period labels per row.

Nothing ranks the teachers: no "primary" badge, no reordering handles, and removing the first row is exactly as easy as removing the last (product decision 2026-07-26). Row order is insertion order and carries no meaning.

**It composes `TeacherAutocomplete` rather than replacing it.** The ticket calls that component the choke point, and it is — but it's single-select *by contract* and six other surfaces (special activities, CARE referrals, import review) genuinely want one teacher. Widening its signature would have put this ticket's risk on all of them for no gain.

## Two write-path decisions that matter

**1. `saveTeacherLinksForStudent` is a diff, not a replace-all.** Untouched links keep their `created_at` — which is the order the SPE-334 legacy mirror calls *"first listed"* — so editing one subject label cannot silently repoint `students.teacher_id`. And **deletes run last**: clearing the set before re-adding would leave the child momentarily with zero links, and the mirror would fire on that empty moment and null out the legacy pair on *every* caseload row of the child. Both properties are asserted, not assumed (below).

It is not transactional — PostgREST has no client-side transaction — so a mid-flight failure leaves a partial set. Each operation is individually idempotent and the UI re-reads afterwards, so a retry converges; wrapping it in an RPC is more surface than this ticket needs.

**2. `assignTeacherToStudent` now *adds* a link instead of overwriting the column.** Overwriting was the only option when a student had exactly one teacher. Now that they can have several, "assign this teacher" must not silently unassign whoever else already teaches them.

## Displays

Elementary lists every name (`Davis / Winbery`, the way class lists are written); secondary summarises (`6 teachers`) and expands on click — six names per row turns a roster into a wall of text. A single teacher renders as a plain name at either level, so the common case is unchanged. Admin search matches **any** linked teacher, so a co-teacher who appears in no denormalized column is still findable.

The students-page **teacher modal is now keyed by `teachers.id`**. It used to open on the free-text `students.teacher_name`: a typo opened the wrong record, or fell through to a "create teacher" path that quietly minted a duplicate. `getTeacherByStudentTeacherName` — fuzzy match, `.limit(1)` over what its own comment called *"duplicate teacher records"* — is deleted.

## Verification — real signed-in sessions

**New `npm run sim:verify-teacher-link-writes`, 13 checks, all passing.** This is the first thing in the chain that lets a person create and destroy links from the browser, so it sits directly on SPE-334's policies:

- the owning provider adds a co-teacher → **the added teacher really gains sight of the student** (0 → 1), and loses it again when the link is removed;
- subject/period labels round-trip;
- **untouched links keep their ids, `created_at` and order** — the property the legacy mirror depends on;
- a provider at another school is refused on a **fresh** target, with the reason asserted (`42501`) on INSERT, and **0 rows affected + nothing persisted** on UPDATE and DELETE;
- re-assigning the same teacher is a no-op that does **not** wipe the existing link's labels;
- the fixture ends byte-identical to how it started.

**Plus a 14-check Playwright walk** driving the actual picker: the "+ Add co-teacher" affordance appears at elementary, search returns school teachers, the chosen teacher joins the set with no "primary" label anywhere, and **clicking Save persists exactly one new link** to the database. Then the displays — Cedar renders `6 teachers`, Willow renders Nora *and* Imani un-collapsed — and admin search for `Imani` returns 3 rows while the denormalized column names her on **0** rows, which is the point: that reach is new.

`sim:verify` green (533 links) · `sim:verify-teacher-set-reads` green · `npm test` 985 passing · `typecheck` clean · `lint` clean (2 pre-existing warnings).

### One harness bug worth recording

My first walk "cleaned up" with `delete().eq('teacher_id', paulId)` — but Whitfield is *already* the homeroom teacher for eight seeded students, so it destroyed fixture data. The SPE-334 mirror then dutifully repointed `students.teacher_name` on the affected children, which is how the damage announced itself two assertions later. Fixed to snapshot and remove only the delta, fixture re-seeded, and the trap is now written into `SIM_DISTRICT.md` so the next walk doesn't rediscover it.

## Scope notes

Three surfaces the ticket lists turned out to be **unreferenced**: `add-student-form.tsx`, `students-list.tsx`, and `getTeacherByStudentTeacherName`. I updated the first (a write path — it shouldn't be able to reintroduce single-teacher-only entry), deleted the third (the ticket sanctions it, and it existed only to serve the contract this PR removes), and left the second alone — it's a read-only display no route renders, so rewiring it would be work with no user on the other end. Follow-up filed to delete both dead components.

**Not auto-deployable** (user-facing UX). Holding for your merge call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMVhGgFe7rmM3sQXhT5pQ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMVhGgFe7rmM3sQXhT5pQ5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for assigning multiple teachers to students.
  * Added subject and period labels for secondary-school assignments.
  * Added teacher search, editing, removal, and linked-teacher details.
  * Updated rosters with expandable teacher summaries and tooltips.
  * Teacher details now open using a specific teacher record.

* **Bug Fixes**
  * Preserved existing assignments and prevented duplicate links.
  * Improved handling of teacher-loading and saving errors.

* **Documentation**
  * Updated guidance for teacher-link workflows and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->