### PR TITLE
SPE-420: let staff check whether this deployment can encrypt SIS credentials

### DIFF
--- a/__tests__/unit/app/api/internal/sis-key-health.test.ts
+++ b/__tests__/unit/app/api/internal/sis-key-health.test.ts
@@ -1,0 +1,139 @@
+/**
+ * SPE-420 · GET /api/internal/sis-key-health — the staff gate and the wire contract.
+ *
+ * Why this file has to exist rather than lean on a sim-district walk: the
+ * allowed branch cannot be walked. `docs/SIM_DISTRICT.md` invariant 5 states
+ * "No sim user is ever `is_speddy_admin`", so no persona can ever reach the
+ * staff side of this route through the UI. A handler test is the only coverage
+ * that branch will ever have.
+ *
+ * What is pinned here, and why each one is load-bearing:
+ *
+ *  - the gate, in BOTH directions. `speddyAdminDenialReason` returns null for
+ *    allowed and a string for denied, and its own docstring records that the
+ *    obvious reading of that inverts the guard and "let everyone through,
+ *    silently". Middleware cannot catch the inversion — middleware.ts's matcher
+ *    excludes `api` — so this is the only layer that would.
+ *  - 200 on a FAILED self-test. The intuitive refactor is to return 5xx, which
+ *    would silently break the client: the panel routes non-2xx to "the check
+ *    could not run" and would stop reporting the very failure this exists for.
+ *  - the denial body carries no verdict. A 403 that leaked `ok` would hand
+ *    deployment state to a non-staff caller.
+ */
+import { NextRequest } from 'next/server';
+
+const STAFF_ID = '11111111-1111-4111-8111-111111111111';
+const NON_STAFF_ID = '22222222-2222-4222-8222-222222222222';
+
+let currentUserId: string | null = STAFF_ID;
+let profileRow: { data: unknown; error: unknown } = {
+  data: { is_speddy_admin: true },
+  error: null,
+};
+
+// withRoute resolves the caller through createClient().auth.getUser(), and the
+// staff gate reads `profiles` through the service client — both are driven by
+// the mutable state above so every branch is representable.
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: async () =>
+        currentUserId
+          ? { data: { user: { id: currentUserId } }, error: null }
+          : { data: { user: null }, error: { message: 'no session' } },
+    },
+  }),
+  createServiceClient: () => ({
+    from: () => {
+      const q: Record<string, unknown> = {};
+      q.select = () => q;
+      q.eq = () => q;
+      q.maybeSingle = () => Promise.resolve(profileRow);
+      return q;
+    },
+  }),
+}));
+
+import { GET } from '@/app/api/internal/sis-key-health/route';
+import { randomBytes } from 'crypto';
+
+const req = () => new NextRequest('http://localhost/api/internal/sis-key-health');
+
+describe('GET /api/internal/sis-key-health', () => {
+  const originalKey = process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+
+  beforeEach(() => {
+    currentUserId = STAFF_ID;
+    profileRow = { data: { is_speddy_admin: true }, error: null };
+    process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = randomBytes(32).toString('base64');
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+    else process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = originalKey;
+  });
+
+  it('401s an unauthenticated caller', async () => {
+    currentUserId = null;
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+
+  it('403s an authenticated non-staff caller', async () => {
+    currentUserId = NON_STAFF_ID;
+    profileRow = { data: { is_speddy_admin: false }, error: null };
+    const res = await GET(req());
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Forbidden: Speddy admin access required' });
+  });
+
+  it('does not leak the verdict to a refused caller', async () => {
+    // The refusal must carry no deployment state at all — not `ok`, not a
+    // problem string, not the build identity.
+    currentUserId = NON_STAFF_ID;
+    profileRow = { data: { is_speddy_admin: false }, error: null };
+    const body = await (await GET(req())).json();
+    expect(body).not.toHaveProperty('ok');
+    expect(body).not.toHaveProperty('problem');
+    expect(body).not.toHaveProperty('deployment');
+  });
+
+  it('answers a staff caller with the verdict on a healthy key', async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true });
+  });
+
+  it('answers 200 — NOT 5xx — when the self-test fails', async () => {
+    // The contract the client depends on: non-2xx means "the check could not
+    // run", so a broken key must not arrive that way or it stops being reported.
+    delete process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      ok: false,
+      problem: expect.stringMatching(/SIS_CREDENTIAL_ENCRYPTION_KEY is not set/),
+    });
+  });
+
+  it('never serves a cached verdict', async () => {
+    expect((await GET(req())).headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('names the build that answered', async () => {
+    const body = await (await GET(req())).json();
+    expect(body.deployment).toEqual({
+      commit: expect.any(String),
+      environment: expect.any(String),
+      checkedAt: expect.any(String),
+    });
+  });
+
+  it('never puts key material in the response', async () => {
+    const key = randomBytes(32).toString('base64');
+    process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = `${key}\n`; // malformed on paste
+    const raw = JSON.stringify(await (await GET(req())).json());
+    expect(raw).toMatch(/must be canonical base64/);
+    expect(raw).not.toContain(key);
+  });
+});

--- a/__tests__/unit/lib/sis/credential-crypto.test.ts
+++ b/__tests__/unit/lib/sis/credential-crypto.test.ts
@@ -5,6 +5,7 @@ import {
   encryptSisCredential,
   sisCredentialEncryptionProblem,
   sisCredentialEncryptionSelfTest,
+  SELF_TEST_ROUND_TRIP_FAILED,
 } from '@/lib/sis/credential-crypto';
 
 describe('SIS credential crypto', () => {
@@ -239,15 +240,41 @@ describe('SIS credential crypto', () => {
       process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = randomBytes(32).toString('base64');
 
       expect(sisCredentialEncryptionSelfTest()).toEqual({ ok: true });
-      // Meanwhile the credential encrypted under the previous key is gone.
-      expect(() => decryptSisCredential(ciphertext)).toThrow();
+      // Matched on the AUTH-TAG failure specifically, not a bare .toThrow():
+      // decryptSisCredential also throws for a missing key, a non-canonical
+      // key, and a malformed envelope. Any of those would keep this green while
+      // proving nothing about key isolation — the false-negative shape CLAUDE.md
+      // records from SPE-332.
+      expect(() => decryptSisCredential(ciphertext)).toThrow(
+        /unable to authenticate|bad decrypt/i,
+      );
     });
 
-    it('never puts the key value in the self-test problem', () => {
-      process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = `${key}\n`;
-      const result = sisCredentialEncryptionSelfTest();
-      expect(result.ok).toBe(false);
-      expect(result.ok === false && result.problem).not.toContain(key);
+    it('reports a cipher that cannot run WITHOUT blaming the key, and without upstream text', () => {
+      // The one problem string this function ORIGINATES rather than forwards —
+      // and previously the only path that interpolated a message this module
+      // does not author into a value served to a browser. Reached by making the
+      // cipher itself fail on a key that is already known good.
+      //
+      // Landmine for anyone editing this: under Jest's VM realm a thrown crypto
+      // Error can fail `err instanceof Error`, so a test aimed at the message
+      // branch can silently land on a fallback instead. The assertion below is
+      // on the fixed string, which both paths now produce — that is the point.
+      const crypto = jest.requireActual('crypto') as typeof import('crypto');
+      const spy = jest
+        .spyOn(crypto, 'createCipheriv')
+        .mockImplementation(() => {
+          throw new Error('error:0308010C:digital envelope routines::unsupported');
+        });
+      try {
+        const result = sisCredentialEncryptionSelfTest();
+        expect(result).toEqual({ ok: false, problem: SELF_TEST_ROUND_TRIP_FAILED });
+        expect(result.ok === false && result.problem).not.toMatch(/digital envelope|0308010C/);
+        // Names the deployment, not the key — the key passed getKey() to get here.
+        expect(SELF_TEST_ROUND_TRIP_FAILED).toMatch(/could not run the cipher/i);
+      } finally {
+        spy.mockRestore();
+      }
     });
 
     it('never puts the key value in the reported problem', () => {

--- a/__tests__/unit/lib/sis/credential-crypto.test.ts
+++ b/__tests__/unit/lib/sis/credential-crypto.test.ts
@@ -4,6 +4,7 @@ import {
   decryptSisCredential,
   encryptSisCredential,
   sisCredentialEncryptionProblem,
+  sisCredentialEncryptionSelfTest,
 } from '@/lib/sis/credential-crypto';
 
 describe('SIS credential crypto', () => {
@@ -203,6 +204,50 @@ describe('SIS credential crypto', () => {
       expect(absent).toMatch(/is not set/);
       expect(malformed).toMatch(/must be canonical base64/);
       expect(absent).not.toEqual(malformed);
+    });
+
+    it('self-test passes with a working key', () => {
+      expect(sisCredentialEncryptionSelfTest()).toEqual({ ok: true });
+    });
+
+    it('self-test reports WHY, distinguishing absent from malformed', () => {
+      // Same reasoning as the problem-string test above: the two faults have
+      // opposite fixes, so a self-test that collapsed them would leave an
+      // operator exactly where the "not configured" message left us.
+      delete process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+      const absent = sisCredentialEncryptionSelfTest();
+
+      process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = `${key}\n`;
+      const malformed = sisCredentialEncryptionSelfTest();
+
+      expect(absent).toEqual({ ok: false, problem: expect.stringMatching(/is not set/) });
+      expect(malformed).toEqual({
+        ok: false,
+        problem: expect.stringMatching(/must be canonical base64/),
+      });
+    });
+
+    it('self-test passes on a DIFFERENT key — it cannot detect a wrong-but-valid key', () => {
+      // Pinning the limit, not a feature. The self-test encrypts and decrypts
+      // with whatever key is currently set, so any well-formed key round-trips.
+      // It answers "can this deployment encrypt", NOT "is this the key that
+      // encrypted the credentials already stored" — nothing without real
+      // ciphertext can answer that, and a green check must not be read as if it
+      // had. Asserted so the day someone widens the claim, this fails and sends
+      // them here.
+      const ciphertext = encryptSisCredential('spe417-stored-under-the-old-key');
+      process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = randomBytes(32).toString('base64');
+
+      expect(sisCredentialEncryptionSelfTest()).toEqual({ ok: true });
+      // Meanwhile the credential encrypted under the previous key is gone.
+      expect(() => decryptSisCredential(ciphertext)).toThrow();
+    });
+
+    it('never puts the key value in the self-test problem', () => {
+      process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = `${key}\n`;
+      const result = sisCredentialEncryptionSelfTest();
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.problem).not.toContain(key);
     });
 
     it('never puts the key value in the reported problem', () => {

--- a/__tests__/unit/lib/sis/key-boot-check.test.ts
+++ b/__tests__/unit/lib/sis/key-boot-check.test.ts
@@ -1,0 +1,152 @@
+/**
+ * SPE-420 · the boot-time SIS key report.
+ *
+ * The point of this file is the two behaviours that make a boot check safe to
+ * add at all: it must ESCALATE on a real deployment (or it is the same silence
+ * that let SPE-417 run), and it must NOT escalate locally (or it becomes noise
+ * everyone learns to scroll past, which is the same silence wearing a hat).
+ * Both are asserted, in both directions.
+ *
+ * It must also never throw: this runs before the server can answer a request,
+ * so a bug here would take a deployment down over a diagnostic.
+ */
+import { randomBytes } from 'crypto';
+
+const captured: { message: string; error: unknown; meta: unknown }[] = [];
+
+jest.mock('@/lib/logger', () => {
+  const child = () => ({
+    error: (message: string, error: unknown, meta: unknown) =>
+      captured.push({ message, error, meta }),
+    warn: () => {},
+    info: () => {},
+  });
+  return { logger: { child } };
+});
+
+// Delegates to the real self-test for every test but one; the flag lets a
+// single case force the unexpected-throw path without weakening the others.
+let selfTestThrows = false;
+jest.mock('@/lib/sis/credential-crypto', () => {
+  const actual = jest.requireActual('@/lib/sis/credential-crypto');
+  return {
+    ...actual,
+    sisCredentialEncryptionSelfTest: () => {
+      if (selfTestThrows) throw new Error('unexpected');
+      return actual.sisCredentialEncryptionSelfTest();
+    },
+  };
+});
+
+import { reportSisKeyStatusOnBoot } from '@/lib/sis/key-boot-check';
+
+describe('reportSisKeyStatusOnBoot', () => {
+  const key = randomBytes(32).toString('base64');
+  const original = {
+    sis: process.env.SIS_CREDENTIAL_ENCRYPTION_KEY,
+    vercel: process.env.VERCEL_ENV,
+  };
+  let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    captured.length = 0;
+    selfTestThrows = false;
+    process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = key;
+    delete process.env.VERCEL_ENV;
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    for (const [name, value] of [
+      ['SIS_CREDENTIAL_ENCRYPTION_KEY', original.sis],
+      ['VERCEL_ENV', original.vercel],
+    ] as const) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  });
+
+  it('announces a healthy key once, and raises nothing', () => {
+    reportSisKeyStatusOnBoot();
+    expect(logSpy).toHaveBeenCalledWith('[sis] credential encryption key is live on this build');
+    expect(captured).toHaveLength(0);
+  });
+
+  it('escalates on a real deployment when the key is missing', () => {
+    // The whole reason this exists: a build that goes live without the key must
+    // produce a signal with no human involved.
+    process.env.VERCEL_ENV = 'production';
+    delete process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+
+    reportSisKeyStatusOnBoot();
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].message).toMatch(/districts cannot save SIS credentials/);
+    // Carried as an Error so lib/logger forwards it to Sentry — a warn would be
+    // dropped, which is the failure mode this replaces.
+    expect(captured[0].error).toBeInstanceOf(Error);
+    expect((captured[0].error as Error).message).toMatch(/is not set/);
+  });
+
+  it('escalates on a real deployment when the key is malformed, and says which', () => {
+    process.env.VERCEL_ENV = 'preview';
+    process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = `${key}\n`;
+
+    reportSisKeyStatusOnBoot();
+
+    expect(captured).toHaveLength(1);
+    expect((captured[0].error as Error).message).toMatch(/must be canonical base64/);
+  });
+
+  it('does NOT escalate locally — a developer without a SIS key is healthy', () => {
+    // Asserted in its own right: if this ever starts raising events from
+    // `npm run dev`, the production signal above stops being believed.
+    delete process.env.SIS_CREDENTIAL_ENCRYPTION_KEY;
+
+    reportSisKeyStatusOnBoot();
+
+    expect(captured).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/not usable locally/));
+  });
+
+  it('never leaks the key value, on any path', () => {
+    process.env.VERCEL_ENV = 'production';
+    process.env.SIS_CREDENTIAL_ENCRYPTION_KEY = `${key}\n`;
+
+    reportSisKeyStatusOnBoot();
+
+    const everythingItSaid = JSON.stringify([
+      captured.map(c => [c.message, (c.error as Error)?.message, c.meta]),
+      logSpy.mock.calls,
+      warnSpy.mock.calls,
+    ]);
+    expect(everythingItSaid).not.toContain(key);
+  });
+
+  it('never throws, even if the self-test itself blows up', () => {
+    // A boot check that can crash the server is worse than the gap it fills.
+    //
+    // The failure is injected at the self-test itself, not deeper: the self-test
+    // catches its own errors, so anything thrown inside it never reaches this
+    // module and a test aimed there would pass without exercising the outer
+    // guard at all. Asserting the fallback message is what proves the guard ran
+    // rather than the call simply having succeeded.
+    process.env.VERCEL_ENV = 'production';
+    selfTestThrows = true;
+    try {
+      expect(() => reportSisKeyStatusOnBoot()).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/boot check could not run/),
+        'unexpected',
+      );
+      // And it stays quiet rather than raising a misleading "key is broken".
+      expect(captured).toHaveLength(0);
+    } finally {
+      selfTestThrows = false;
+    }
+  });
+});

--- a/app/api/internal/sis-key-health/route.ts
+++ b/app/api/internal/sis-key-health/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { withRoute } from '@/lib/api/with-route';
+import { speddyAdminDenialReason } from '@/lib/api/speddy-admin-denial-reason';
+import { logger } from '@/lib/logger';
+import { sisCredentialEncryptionSelfTest } from '@/lib/sis/credential-crypto';
+
+const log = logger.child({ module: 'internal-sis-key-health' });
+
+/**
+ * GET /api/internal/sis-key-health — can this deployment encrypt SIS credentials?
+ *
+ * Exists because the failure it reports on is invisible from everywhere else
+ * (SPE-420, after SPE-417). A district's Aeries certificate was refused in
+ * production because SIS_CREDENTIAL_ENCRYPTION_KEY was not live on the running
+ * build; the Vercel dashboard showed the variable present, because it WAS
+ * present — just not on the build serving traffic. A missing key and a key
+ * damaged by a stray newline on paste produce the same symptom there too. This
+ * route is the one place that tells those apart on the deployment actually
+ * answering requests.
+ *
+ * Deliberately reports on the ENVIRONMENT, never on anyone's data:
+ *
+ *  - no district is named, accepted, or read — there is no input at all;
+ *  - no credential is written, read, or decrypted; the round trip uses a fixed
+ *    non-secret probe and never leaves memory;
+ *  - it grants no new power. Credentials still never come through /internal —
+ *    only a district's own tech admin enters those, which is the boundary that
+ *    keeps a mistake in the staff panel from reaching a district's row.
+ *
+ * A GET with no parameters, so it is safe to click twice.
+ */
+export const GET = withRoute({}, async ({ userId }) => {
+  const denied = await speddyAdminDenialReason(userId);
+  if (denied) {
+    log.warn('Non-speddy-admin tried to read SIS key health', { userId, denied });
+    return NextResponse.json(
+      { error: 'Forbidden: Speddy admin access required' },
+      { status: 403 },
+    );
+  }
+
+  const result = sisCredentialEncryptionSelfTest();
+
+  // Logged either way: a staff member checking this during an incident wants the
+  // check itself in the record, not just its answer.
+  if (result.ok) {
+    log.info('SIS encryption key self-test passed');
+  } else {
+    log.warn('SIS encryption key self-test failed', { problem: result.problem });
+  }
+
+  // 200 on a failed self-test on purpose: the request succeeded and its answer
+  // is "the key is broken". A 500 here would be indistinguishable from the
+  // route itself failing, which is the exact ambiguity this route exists to end.
+  return NextResponse.json(result);
+});

--- a/app/api/internal/sis-key-health/route.ts
+++ b/app/api/internal/sis-key-health/route.ts
@@ -41,16 +41,38 @@ export const GET = withRoute({}, async ({ userId }) => {
 
   const result = sisCredentialEncryptionSelfTest();
 
-  // Logged either way: a staff member checking this during an incident wants the
-  // check itself in the record, not just its answer.
+  // Logged either way, with the actor: during an incident with several staff in
+  // the panel, a verdict nobody can be matched to is half a record.
   if (result.ok) {
-    log.info('SIS encryption key self-test passed');
+    log.info('SIS encryption key self-test passed', { userId });
   } else {
-    log.warn('SIS encryption key self-test failed', { problem: result.problem });
+    // error, not warn: lib/logger.ts only forwards to Sentry from error, so a
+    // warn here would make the purpose-built detector quieter than the accident
+    // it replaced — a broken key would produce 200s and no alert anywhere.
+    log.error('SIS encryption key self-test failed', new Error(result.problem), { userId });
   }
 
   // 200 on a failed self-test on purpose: the request succeeded and its answer
   // is "the key is broken". A 500 here would be indistinguishable from the
   // route itself failing, which is the exact ambiguity this route exists to end.
-  return NextResponse.json(result);
+  //
+  // The build is named in the answer because "which deployment said this?" is
+  // the same question one level down: a staff member who clicks this on a
+  // preview URL while verifying an env-var fix would otherwise get a green that
+  // says nothing about the build serving districts.
+  return NextResponse.json(
+    {
+      ...result,
+      deployment: {
+        commit: process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ?? 'unknown',
+        environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'unknown',
+        checkedAt: new Date().toISOString(),
+      },
+    },
+    // A point-in-time diagnostic must never be answered from a cache: a replayed
+    // verdict from before an env-var fix is precisely the false reassurance this
+    // route exists to end. Next adds no cache header of its own here, and the
+    // response is per-user authorized (403 vs 200 on one URL).
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
 });

--- a/app/components/internal/sis-connections-panel.tsx
+++ b/app/components/internal/sis-connections-panel.tsx
@@ -49,6 +49,9 @@ const SIS_LABELS: Record<SisType, string> = {
   oneroster: 'OneRoster',
 };
 
+/** Whether THIS deployment can encrypt a credential. Not about any district. */
+type KeyHealth = { ok: true } | { ok: false; problem: string };
+
 function formatDate(value: string | null): string {
   if (!value) return '—';
   return new Date(value).toLocaleDateString(undefined, {
@@ -64,6 +67,29 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [creating, setCreating] = useState<SisType | null>(null);
+  // Deliberately not loaded on mount: this reports on the deployment, not on
+  // the district being viewed, and a green badge nobody asked for is the kind
+  // of thing that goes stale on screen and gets believed anyway.
+  const [keyHealth, setKeyHealth] = useState<KeyHealth | null>(null);
+  const [checkingKey, setCheckingKey] = useState(false);
+
+  const checkKey = async () => {
+    setCheckingKey(true);
+    setKeyHealth(null);
+    try {
+      const res = await fetch('/api/internal/sis-key-health');
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || 'Could not run the check');
+      setKeyHealth(json as KeyHealth);
+    } catch (err) {
+      setKeyHealth({
+        ok: false,
+        problem: err instanceof Error ? err.message : 'Could not run the check',
+      });
+    } finally {
+      setCheckingKey(false);
+    }
+  };
 
   const load = useCallback(async () => {
     setError(null);
@@ -174,6 +200,51 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
           {error}
         </div>
       )}
+
+      {/* Encryption-key check. Sits apart from the connection list on purpose:
+          it says nothing about this district, only about whether the running
+          deployment can encrypt at all. */}
+      <div className="mt-4 rounded-md border border-slate-700 bg-slate-900/40 px-4 py-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-medium text-white">Credential encryption</p>
+            <p className="mt-0.5 text-xs text-slate-400">
+              Checks whether this deployment can encrypt SIS credentials. No district
+              data is read and nothing is saved.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={checkKey}
+            disabled={checkingKey}
+            className="px-3 py-2 text-sm bg-slate-600 hover:bg-slate-500 disabled:opacity-50 text-white rounded-md transition-colors"
+          >
+            {checkingKey ? 'Checking…' : 'Check encryption key'}
+          </button>
+        </div>
+
+        {keyHealth && (
+          <div
+            role="status"
+            className={`mt-3 rounded-md border px-3 py-2 text-sm ${
+              keyHealth.ok
+                ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'
+                : 'border-red-500/30 bg-red-500/10 text-red-300'
+            }`}
+          >
+            {keyHealth.ok ? (
+              'Working — districts can save SIS credentials.'
+            ) : (
+              <>
+                <span className="font-medium">
+                  Not working — districts cannot save SIS credentials.
+                </span>
+                <span className="mt-1 block text-red-200/80">{keyHealth.problem}</span>
+              </>
+            )}
+          </div>
+        )}
+      </div>
 
       {loading ? (
         <p className="mt-6 text-sm text-slate-400">Loading…</p>

--- a/app/components/internal/sis-connections-panel.tsx
+++ b/app/components/internal/sis-connections-panel.tsx
@@ -3,6 +3,23 @@
 import { useCallback, useEffect, useState } from 'react';
 
 /**
+ * The key-health payload is imported, never re-declared: a hand-copy of the
+ * union would let the two sides drift with nothing failing the build, and the
+ * drift renders as a red verdict on a healthy key. `import type` is erased at
+ * compile time, so no server-only crypto reaches the bundle — the same thing
+ * app/components/tech/aeries-connection-card.tsx does with AeriesTestReport.
+ */
+import type { SisKeySelfTest } from '@/lib/sis/credential-crypto';
+
+/**
+ * The verdict plus which build produced it. Extends the shared union rather
+ * than restating it, so the ok/problem contract still has exactly one owner.
+ */
+type KeyHealthResponse = SisKeySelfTest & {
+  deployment?: { commit: string; environment: string; checkedAt: string };
+};
+
+/**
  * Speddy-staff control for a district's SIS connections (SPE-395).
  *
  * Its one job is the DPA switch. Credentials are never entered, shown, or
@@ -49,8 +66,6 @@ const SIS_LABELS: Record<SisType, string> = {
   oneroster: 'OneRoster',
 };
 
-/** Whether THIS deployment can encrypt a credential. Not about any district. */
-type KeyHealth = { ok: true } | { ok: false; problem: string };
 
 function formatDate(value: string | null): string {
   if (!value) return '—';
@@ -70,23 +85,57 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
   // Deliberately not loaded on mount: this reports on the deployment, not on
   // the district being viewed, and a green badge nobody asked for is the kind
   // of thing that goes stale on screen and gets believed anyway.
-  const [keyHealth, setKeyHealth] = useState<KeyHealth | null>(null);
+  const [keyHealth, setKeyHealth] = useState<KeyHealthResponse | null>(null);
   const [checkingKey, setCheckingKey] = useState(false);
 
   const checkKey = async () => {
     setCheckingKey(true);
     setKeyHealth(null);
+    setError(null);
+    // Bounded: without this a wedged deployment leaves the button disabled with
+    // no way to retry — at exactly the moment an operator needs to re-run the
+    // check after changing an env var.
+    const abort = new AbortController();
+    const timer = setTimeout(() => abort.abort(), 15_000);
     try {
-      const res = await fetch('/api/internal/sis-key-health');
-      const json = await res.json();
-      if (!res.ok) throw new Error(json.error || 'Could not run the check');
-      setKeyHealth(json as KeyHealth);
-    } catch (err) {
-      setKeyHealth({
-        ok: false,
-        problem: err instanceof Error ? err.message : 'Could not run the check',
+      const res = await fetch('/api/internal/sis-key-health', {
+        cache: 'no-store',
+        signal: abort.signal,
       });
+
+      // Status BEFORE parsing, and a failure to reach the check goes to the
+      // page's `error` banner — never to `keyHealth`. A 401, a 5xx or an HTML
+      // gateway page means the self-test never ran, and rendering that as
+      // "districts cannot save SIS credentials" would state the strongest
+      // possible claim about a key nobody asked about. The route returns 200
+      // even when the key IS broken precisely so these stay distinguishable;
+      // collapsing them here would undo that at the one moment it matters.
+      if (!res.ok) {
+        setError(`Could not run the encryption check (HTTP ${res.status}). The key was not tested.`);
+        return;
+      }
+
+      const json: unknown = await res.json().catch(() => null);
+      // The body is the whole answer, so it is validated rather than asserted:
+      // an off-shape 200 would otherwise render the red verdict with a blank
+      // reason, which reads as a diagnosis and is not one.
+      if (
+        typeof json !== 'object' || json === null ||
+        typeof (json as { ok?: unknown }).ok !== 'boolean'
+      ) {
+        setError('The encryption check returned an unreadable response. The key was not tested.');
+        return;
+      }
+      setKeyHealth(json as KeyHealthResponse);
+    } catch (err) {
+      const timedOut = err instanceof DOMException && err.name === 'AbortError';
+      setError(
+        timedOut
+          ? 'The encryption check timed out. The key was not tested.'
+          : 'Could not reach the encryption check. The key was not tested.',
+      );
     } finally {
+      clearTimeout(timer);
       setCheckingKey(false);
     }
   };
@@ -223,27 +272,41 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
           </button>
         </div>
 
-        {keyHealth && (
-          <div
-            role="status"
-            className={`mt-3 rounded-md border px-3 py-2 text-sm ${
-              keyHealth.ok
-                ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'
-                : 'border-red-500/30 bg-red-500/10 text-red-300'
-            }`}
-          >
-            {keyHealth.ok ? (
-              'Working — districts can save SIS credentials.'
-            ) : (
-              <>
-                <span className="font-medium">
-                  Not working — districts cannot save SIS credentials.
+        {/* The live region is mounted unconditionally and only its CONTENT is
+            conditional: a region inserted in the same commit as its text is the
+            classic aria-live pitfall where nothing is announced at all. */}
+        <div role="status" aria-live="polite" className="contents">
+          {keyHealth && (
+            <div
+              className={`mt-3 rounded-md border px-3 py-2 text-sm ${
+                keyHealth.ok
+                  ? STATUS_STYLES.connected
+                  : STATUS_STYLES.error
+              }`}
+            >
+              {keyHealth.ok ? (
+                'Working — this deployment can encrypt SIS credentials, so a district with a recorded DPA can save them.'
+              ) : (
+                <>
+                  <span className="font-medium">
+                    Not working — districts cannot save SIS credentials.
+                  </span>
+                  <span className="mt-1 block text-red-200/80">{keyHealth.problem}</span>
+                </>
+              )}
+              {keyHealth.deployment && (
+                // Which build answered. Without it a green from a preview URL
+                // is indistinguishable from a green from the build serving
+                // districts — the same "which deployment?" ambiguity one level
+                // down from the one this check exists to settle.
+                <span className="mt-2 block text-xs opacity-70">
+                  {keyHealth.deployment.environment} · {keyHealth.deployment.commit} ·{' '}
+                  {new Date(keyHealth.deployment.checkedAt).toLocaleTimeString()}
                 </span>
-                <span className="mt-1 block text-red-200/80">{keyHealth.problem}</span>
-              </>
-            )}
-          </div>
-        )}
+              )}
+            </div>
+          )}
+        </div>
       </div>
 
       {loading ? (

--- a/app/components/internal/sis-connections-panel.tsx
+++ b/app/components/internal/sis-connections-panel.tsx
@@ -20,6 +20,17 @@ type KeyHealthResponse = SisKeySelfTest & {
 };
 
 /**
+ * Validates the whole discriminated union, not just `ok`. A body of
+ * `{ ok: false }` with no reason would otherwise pass and render the strongest
+ * claim on the page above an empty line — a verdict with nothing behind it.
+ */
+function isKeyHealthResponse(value: unknown): value is KeyHealthResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const body = value as { ok?: unknown; problem?: unknown };
+  return body.ok === true || (body.ok === false && typeof body.problem === 'string');
+}
+
+/**
  * Speddy-staff control for a district's SIS connections (SPE-395).
  *
  * Its one job is the DPA switch. Credentials are never entered, shown, or
@@ -119,14 +130,11 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
       // The body is the whole answer, so it is validated rather than asserted:
       // an off-shape 200 would otherwise render the red verdict with a blank
       // reason, which reads as a diagnosis and is not one.
-      if (
-        typeof json !== 'object' || json === null ||
-        typeof (json as { ok?: unknown }).ok !== 'boolean'
-      ) {
+      if (!isKeyHealthResponse(json)) {
         setError('The encryption check returned an unreadable response. The key was not tested.');
         return;
       }
-      setKeyHealth(json as KeyHealthResponse);
+      setKeyHealth(json);
     } catch (err) {
       const timedOut = err instanceof DOMException && err.name === 'AbortError';
       setError(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -261,9 +261,22 @@ Verified against a real signed-in session, not assumed:
   remaining hole — DNS rebinding between the check and the connection — is
   documented in that file and tracked as **SPE-406**.
 
+- **Staff can ask whether the key is live** (SPE-420). `GET
+  /api/internal/sis-key-health`, behind the `is_speddy_admin` gate, round-trips
+  a fixed non-secret probe in memory and reports *working* / *key missing* /
+  *key malformed*, naming the build that answered. It exists because the failure
+  is invisible elsewhere: the Vercel dashboard shows a variable is set but not
+  whether the **running build** has it, and a value damaged by a trailing
+  newline on paste looks identical to a missing one — which is what refused a
+  live district's certificate in SPE-417. It reads no district data and writes
+  nothing. Note the limit: it round-trips the *current* key, so after a
+  **rotation** a green result means new credentials can be saved, never that
+  ones already stored are still readable.
+
 **Source of truth:** `lib/sis/credential-crypto.ts`; `lib/sis/connections.ts`;
 `lib/sis/ssrf-guard.ts`; `lib/sis/aeries-setup.ts`;
-`app/api/tech/sis/aeries/`; `app/api/internal/sis-connections/`.
+`app/api/tech/sis/aeries/`; `app/api/internal/sis-connections/`;
+`app/api/internal/sis-key-health/`.
 
 ### `profiles` self-updates: policy + trigger (SPE-332)
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -3,6 +3,15 @@ import * as Sentry from '@sentry/nextjs';
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     await import('./sentry.server.config');
+
+    // After Sentry is initialised, so a failure here can actually raise an
+    // event. Imported dynamically and only on the nodejs runtime: the check
+    // reaches Node crypto, which the edge bundle has no business pulling in.
+    // Says once per cold start whether this build can encrypt SIS credentials —
+    // the deploy-time signal whose absence let SPE-417 run until a district
+    // hit it. Never throws; see lib/sis/key-boot-check.ts.
+    const { reportSisKeyStatusOnBoot } = await import('./lib/sis/key-boot-check');
+    reportSisKeyStatusOnBoot();
   }
 
   if (process.env.NEXT_RUNTIME === 'edge') {

--- a/lib/sis/connections.ts
+++ b/lib/sis/connections.ts
@@ -1,7 +1,12 @@
 /**
  * Server-side access to `district_sis_connections` (SPE-395).
  *
- * This is the ONLY place credentials are encrypted, decrypted, or written. The
+ * This is the ONLY place a real credential is encrypted, decrypted, or written.
+ * (One other caller touches the cipher: `sisCredentialEncryptionSelfTest()`,
+ * behind the /internal staff gate, which round-trips a fixed non-secret probe
+ * in memory — it reads and writes no credential and no row, so the audit-trail
+ * guarantee below is unaffected. Stated here because "grep the encrypt/decrypt
+ * call sites" is how a rotation runbook or a security review starts.) The
  * tech-portal flows (SPE-396 Aeries, SPE-397 OneRoster) and the exploration
  * tooling (SPE-398) call in here rather than touching the table, so there is a
  * single audited path and a single place holding the key.

--- a/lib/sis/credential-crypto.ts
+++ b/lib/sis/credential-crypto.ts
@@ -76,6 +76,14 @@ export function sisCredentialEncryptionProblem(): string | null {
  */
 const SELF_TEST_PROBE = 'speddy-sis-key-self-test';
 
+/**
+ * The one failure this function originates. Names the cipher rather than the
+ * key: by the time it can be reached the key has already passed getKey(), so
+ * blaming the key would send an operator to rotate a healthy one.
+ */
+export const SELF_TEST_ROUND_TRIP_FAILED =
+  'The encryption key is present and well-formed, but this deployment could not run the cipher.';
+
 export type SisKeySelfTest =
   | { ok: true }
   | { ok: false; problem: string };
@@ -84,8 +92,15 @@ export type SisKeySelfTest =
  * Prove the configured key can actually encrypt AND decrypt, right now.
  *
  * `sisCredentialEncryptionProblem()` answers "is the key well-formed"; this
- * answers "does it work" — it catches a key that parses but blows up in the
- * cipher, which a format check cannot see.
+ * additionally runs the cipher.
+ *
+ * Be precise about what that buys, because it is less than it sounds. getKey()
+ * admits only canonical base64 decoding to exactly 32 bytes, and every 32-byte
+ * value is a valid AES-256 key — so NO accepted key can fail the round trip.
+ * What the round trip actually catches is the crypto provider being unusable
+ * (a FIPS-mode build where aes-256-gcm is unavailable makes createCipheriv
+ * throw), which a format check cannot see and which would otherwise surface as
+ * a district's failed save. Real, but narrower than "the key is wrong".
  *
  * What it deliberately does NOT prove: that this is the SAME key that encrypted
  * credentials already in the database. The round trip uses the current key for
@@ -101,31 +116,30 @@ export type SisKeySelfTest =
  * environment, never on anyone's data.
  *
  * Safe to return to a caller: `problem` is either a message from getKey() (which
- * names the variable, never its value) or a fixed string from here.
+ * names the variable, never its value) or one of the fixed strings below. No
+ * upstream error text is interpolated — the same rule the sibling /internal
+ * routes state as "Fixed message, not `message`: the detail belongs in the log
+ * line". The detail is not lost; the route logs the thrown error.
  */
 export function sisCredentialEncryptionSelfTest(): SisKeySelfTest {
   const problem = sisCredentialEncryptionProblem();
   if (problem) return { ok: false, problem };
 
   try {
-    const roundTripped = decryptSisCredential(encryptSisCredential(SELF_TEST_PROBE));
-    if (roundTripped !== SELF_TEST_PROBE) {
-      // Belt and braces: GCM's auth tag should make a silent mismatch
-      // impossible, so reaching here means an assumption broke rather than a
-      // key being wrong. Report it instead of returning a false ok.
-      return { ok: false, problem: 'The encryption key round trip returned different data.' };
+    if (decryptSisCredential(encryptSisCredential(SELF_TEST_PROBE)) !== SELF_TEST_PROBE) {
+      // GCM's auth tag makes a silent mismatch impossible, so this is a
+      // belt-and-braces guard against an assumption breaking — not a state any
+      // key can produce. Kept because returning a false `ok` is the one outcome
+      // this function must never have.
+      return { ok: false, problem: SELF_TEST_ROUND_TRIP_FAILED };
     }
     return { ok: true };
-  } catch (err) {
-    // A well-formed key that cannot decrypt its own ciphertext. Report the
-    // shape of the failure, never the underlying value.
-    return {
-      ok: false,
-      problem:
-        err instanceof Error
-          ? `The encryption key failed a round trip: ${err.message}`
-          : 'The encryption key failed a round trip.',
-    };
+  } catch {
+    // Deliberately does NOT carry `err.message`. Reaching here means the cipher
+    // itself is unusable, so the message is a Node/OpenSSL string this module
+    // does not author and cannot audit — and it is returned to a browser and
+    // written to logs. The route logs the real error alongside this.
+    return { ok: false, problem: SELF_TEST_ROUND_TRIP_FAILED };
   }
 }
 

--- a/lib/sis/credential-crypto.ts
+++ b/lib/sis/credential-crypto.ts
@@ -70,6 +70,65 @@ export function sisCredentialEncryptionProblem(): string | null {
   }
 }
 
+/**
+ * A fixed, non-secret probe. Never a real credential and never stored — it
+ * exists only to be encrypted and decrypted back inside a single function call.
+ */
+const SELF_TEST_PROBE = 'speddy-sis-key-self-test';
+
+export type SisKeySelfTest =
+  | { ok: true }
+  | { ok: false; problem: string };
+
+/**
+ * Prove the configured key can actually encrypt AND decrypt, right now.
+ *
+ * `sisCredentialEncryptionProblem()` answers "is the key well-formed"; this
+ * answers "does it work" — it catches a key that parses but blows up in the
+ * cipher, which a format check cannot see.
+ *
+ * What it deliberately does NOT prove: that this is the SAME key that encrypted
+ * credentials already in the database. The round trip uses the current key for
+ * both halves, so any well-formed key passes. Only real stored ciphertext could
+ * answer that, and this function touches none. After a key ROTATION a green
+ * result therefore means "new credentials can be saved", never "existing ones
+ * can still be read" — those come apart exactly when a rotation went wrong,
+ * which is when someone is most likely to be looking at this.
+ *
+ * Touches nothing: no database, no district, no stored credential. The probe is
+ * a constant, and the round trip lives entirely in memory. That is what makes
+ * this safe to expose behind the /internal staff gate — it reports on the
+ * environment, never on anyone's data.
+ *
+ * Safe to return to a caller: `problem` is either a message from getKey() (which
+ * names the variable, never its value) or a fixed string from here.
+ */
+export function sisCredentialEncryptionSelfTest(): SisKeySelfTest {
+  const problem = sisCredentialEncryptionProblem();
+  if (problem) return { ok: false, problem };
+
+  try {
+    const roundTripped = decryptSisCredential(encryptSisCredential(SELF_TEST_PROBE));
+    if (roundTripped !== SELF_TEST_PROBE) {
+      // Belt and braces: GCM's auth tag should make a silent mismatch
+      // impossible, so reaching here means an assumption broke rather than a
+      // key being wrong. Report it instead of returning a false ok.
+      return { ok: false, problem: 'The encryption key round trip returned different data.' };
+    }
+    return { ok: true };
+  } catch (err) {
+    // A well-formed key that cannot decrypt its own ciphertext. Report the
+    // shape of the failure, never the underlying value.
+    return {
+      ok: false,
+      problem:
+        err instanceof Error
+          ? `The encryption key failed a round trip: ${err.message}`
+          : 'The encryption key failed a round trip.',
+    };
+  }
+}
+
 /** Returns `v1.<iv>.<ciphertext>.<tag>`, each part base64. */
 export function encryptSisCredential(plaintext: string): string {
   const iv = randomBytes(12);

--- a/lib/sis/key-boot-check.ts
+++ b/lib/sis/key-boot-check.ts
@@ -1,0 +1,73 @@
+/**
+ * Say on every server boot whether this deployment can encrypt SIS credentials
+ * (SPE-420).
+ *
+ * The /internal button answers the same question, but only when a human both
+ * suspects a key problem and remembers the button exists. That is a pull; this
+ * is the push. In SPE-417 a build went live without the key and nothing emitted
+ * a single signal — the failure window stayed open until a district tried to
+ * save a certificate and failed. This closes it at deploy time with no human
+ * action.
+ *
+ * Modelled on `logSentryStatus()`, which exists for the same reason (SPE-175: a
+ * config value wrong on the running build, with nothing saying so).
+ *
+ * Two things it must never do, because a boot-time check that misbehaves is
+ * worse than the problem it reports:
+ *
+ *  - throw. Anything raised here happens before the server can serve a request,
+ *    so a bug would take the whole deployment down over a diagnostic. Every
+ *    path is wrapped.
+ *  - cry wolf locally. A developer with no SIS key is a normal, healthy state;
+ *    raising a Sentry event on every `npm run dev` would train everyone to
+ *    ignore the one that matters. It escalates only on a real deployment.
+ *
+ * Server-only: pulls in Node crypto through the self-test, so it must be
+ * imported dynamically from the nodejs branch of instrumentation, never the
+ * edge one.
+ */
+import { logger } from '@/lib/logger';
+import { sisCredentialEncryptionSelfTest } from './credential-crypto';
+
+const log = logger.child({ module: 'sis-key-boot-check' });
+
+/**
+ * Runs the same self-test the /internal check does, so the boot log and the
+ * button can never disagree. Returns nothing: this is a report, and no caller
+ * should branch on it.
+ */
+export function reportSisKeyStatusOnBoot(): void {
+  try {
+    const result = sisCredentialEncryptionSelfTest();
+
+    if (result.ok) {
+      // One line per cold start, matching the Sentry status line. Cheap to
+      // ignore when healthy, and the thing you grep for when it is not.
+      console.log('[sis] credential encryption key is live on this build');
+      return;
+    }
+
+    // `VERCEL_ENV` is set on every Vercel deployment and on none of the local
+    // runs, which is exactly the line between "this is a real problem" and "a
+    // developer does not happen to need SIS today".
+    if (process.env.VERCEL_ENV) {
+      // error, not warn: lib/logger only forwards to Sentry from error, and an
+      // alert nobody receives is the failure mode this whole ticket is about.
+      log.error(
+        'SIS credential encryption is not usable on this build — districts cannot save SIS credentials',
+        new Error(result.problem),
+        { vercelEnv: process.env.VERCEL_ENV },
+      );
+    } else {
+      console.warn(`[sis] credential encryption key not usable locally: ${result.problem}`);
+    }
+  } catch (err) {
+    // Should be unreachable — the self-test catches its own failures — but this
+    // runs before the server can answer anything, so it fails quiet rather than
+    // taking a deployment down to report on a key.
+    console.warn(
+      '[sis] credential encryption boot check could not run:',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}


### PR DESCRIPTION
Closes [SPE-420](https://linear.app/speddy/issue/SPE-420/internal-check-whether-the-running-deployment-can-encrypt-sis). Follow-up to SPE-417 (#815).

## Why

When a district's Aeries certificate was refused in production, the cause was that `SIS_CREDENTIAL_ENCRYPTION_KEY` was not live on the build serving traffic — and nothing in the product could say so. Both places you would look are blind to it:

- **The Vercel dashboard** shows the variable exists. It did. It cannot show whether the *running build* has it, and it cannot show whether the value is damaged — `getKey()` does not trim, so a trailing newline from `openssl rand -base64 32` looks identical to a missing key.
- **A sim-district walk** cannot reach production from the Claude sandbox: Chromium's connections to `www.speddy.xyz` are refused, and a synthetic session cookie is rejected there. (The same cookie authenticates against the same code on localhost, so that is a sandbox limit, not a product defect.)

So the only way to find out whether districts could save credentials was to ask a district to try and fail. That is how we found out.

## What this adds

**A pull and a push.**

**Pull —** `GET /api/internal/sis-key-health` behind the existing Speddy-staff gate, plus a **Check encryption key** button on the internal SIS panel. It answers *working* / *key missing* / *key malformed* — the distinction whose absence sent the original investigation the wrong way — and names the build that answered, so a green from a preview URL is not mistaken for the build serving districts.

**Push —** a boot-time report (`lib/sis/key-boot-check.ts`, called from `instrumentation.ts`). The button only helps someone who already suspects a key problem and remembers the button exists; this emits a signal on every cold start with no human involved, which is what was missing in SPE-417. It escalates to Sentry on a real deployment and deliberately stays quiet locally — a developer without a SIS key is a healthy state, and an alert that fires on every `npm run dev` is one nobody reads. It cannot take a deployment down: every path is guarded, and a test fails if the guard is removed.

Both run the same `sisCredentialEncryptionSelfTest()`, so the boot log and the button cannot disagree.

**Deliberately narrow.** No input, so no district is named, accepted, or read. No credential written, read, or decrypted. No new power: credentials still never come through `/internal` — only a district's own tech admin enters those, and keeping that boundary is why this reports on the *environment* rather than adding a credential-write path to the staff surface.

**200 with `{ok:false}`** on a failed self-test rather than a 5xx. The request succeeded; its answer is "the key is broken". A 5xx would be indistinguishable from the route itself failing — the exact ambiguity this exists to end.

## The limit, stated on purpose

The self-test round-trips with the **current** key, so any well-formed key passes. It cannot prove the key is the one that encrypted credentials already stored — only real ciphertext could, and this touches none. After a **rotation**, green means *"new credentials can be saved"*, never *"existing ones can still be read"*, and those come apart exactly when a rotation has gone wrong. A test pins the limit, named for the limit rather than a feature, so the claim cannot be widened silently.

## Deep self-review

`/code-review` was run at high effort and its confirmed findings are fixed in `8bdbc8e`. The most serious: **the client turned "the check could not run" into "the key is broken"** — a 401 from an expired session rendered *"Not working — districts cannot save SIS credentials"* about a key that was never tested, rebuilding the SPE-417 misdiagnosis inside the tool meant to end it. Also fixed: `res.json()` before the status check, a raw `err.message` reaching the browser against the rule both sibling routes state, a failed check logged at a level `lib/logger` never forwards to Sentry, an unvalidated response cast, a missing timeout, and a docstring that justified the feature on detection power it does not have.

Four findings were **refuted on verification and deliberately not acted on** — a missing rate limit (0 of 7 `/internal` routes set one; adding it would take the honest path from 1 DB round trip to 4), a "shared" `forbidden()` helper (file-local and unexported; 5 of 6 siblings inline the literal), state surviving district navigation (Next keys the subtree by the dynamic segment), and half the rotation-copy claim. Reasons are recorded in `8bdbc8e`'s message.

CodeRabbit found nothing on that diff, and one real thing on the next one (`{ok:false}` with no `problem` rendering a blank reason) — fixed in `8e1aa3a`.

## Verification

**Real signed-in sessions**, which the unit suite cannot substitute for — it mocks the Supabase client, so the staff gate is invisible to it:

| check | result |
|---|---|
| unauthenticated | 401 |
| real `district_tech` session | 403 |
| real `district_admin` session | 403 |
| refusal names the staff requirement (not an incidental error) | ✅ |
| refused body leaks no verdict | ✅ |

**Real server boots**, both directions: with a key, `[sis] credential encryption key is live on this build`; with the key stripped via `env -u`, `not usable locally: SIS_CREDENTIAL_ENCRYPTION_KEY is not set`, server still serving. The first attempt at that second check was invalid — the key was inherited into the process, so it reported healthy — which is why it is now run with `env -u`.

**Not verified live, on purpose:** the production escalation path. Booting with `VERCEL_ENV=production` would fire a false production alert into Sentry; three unit tests cover it instead.

Gates: 97 suites, 1006 passed, 12 skipped; typecheck, lint and a production `next build` all clean.

## Follow-ups

- [SPE-419](https://linear.app/speddy/issue/SPE-419/sis-credential-intake-stop-blaming-the-district-for-a-speddy-side) — the district-facing message still reads as a complaint about their certificate.
- [SPE-421](https://linear.app/speddy/issue/SPE-421/internal-routes-pin-the-staff-gate-with-handler-tests-the-sim-district) — rewritten. Its original plan (a sim Speddy-staff persona) is forbidden by `docs/SIM_DISTRICT.md` invariant 5, *"No sim user is ever `is_speddy_admin`"*, which is exactly why the handler test in this PR is the only coverage that branch will ever have.