### PR TITLE
docs: SEIS data-integration research — no vendor API, two viable automated paths

### DIFF
--- a/docs/integrations/seis.md
+++ b/docs/integrations/seis.md
@@ -52,9 +52,7 @@ foundation of Path 2.
 
 If a district enables the **SEIS → SIS** direction of that nightly sync, SEIS
 writes its student-record fields into the district's SIS. Speddy then reads them
-through the **SIS connection we already ship** — the Aeries REST v5 client
-(`lib/integrations/aeries/`), the encrypted per-district credential store
-(SPE-395), and the tech-portal connection flow (SPE-396/397).
+out of that SIS.
 
 Why this is the strong path:
 
@@ -62,11 +60,32 @@ Why this is the strong path:
   feature SEIS already sells them. We're just reading the district's SIS, which
   we're already authorised to do.
 - **It's nightly and automatic.** No human in the loop.
-- **The plumbing exists.** This is a mapping-and-config problem, not a new
-  integration.
 - **It's the sanctioned route.** Aeries explicitly documents SpEd vendors using
   the API to keep their own systems current, with district-issued read-only
   certificates scoped per API.
+
+### What's built vs. what isn't
+
+Be honest about the gap here — the connection is built, the **sync is not**.
+
+**Built and in production:** the Aeries REST v5 client
+(`lib/integrations/aeries/`), the encrypted per-district credential store
+(SPE-395), the tech-portal guided setup and credential intake (SPE-396/397), and
+`runAeriesConnectionTest` (`lib/sis/aeries-setup.ts`), which probes each API area
+and returns aggregate counts.
+
+**Not built:** everything that moves a record. There is no scheduled fetch (no
+SIS entry in `vercel.json` crons), no mapping of SIS records into `students`, no
+reconciliation against data already in Speddy, and no write path for students,
+IEP dates, or teacher links. The only code that fetches and maps full SpEd
+students today lives in throwaway scripts (`scripts/aeries-sped-spike.ts`,
+`scripts/sis-explore/`), not in any production route.
+
+So Path 2 is *"we can already authenticate to the district and prove the data is
+reachable"* — not *"we can already pull it in."* The credential and trust
+problem is solved; the pipeline is a real build. Treat SPE-412 (what happens to
+existing Speddy data when SIS data starts flowing) as the design question that
+gates it.
 
 What it can carry: student demographics, SpEd flag/eligibility, disability,
 special-ed entry/exit dates, case manager, and **IEP dates** — i.e. it should
@@ -85,15 +104,30 @@ SEIS → SIS direction be extended to the fields we want?
 
 ## Path 3 — the Chrome extension we already have (the only path that gets goals)
 
-`speddy-chrome-extension/` is a built, working Manifest V3 extension that reads
-SEIS pages **in the provider's own already-authenticated browser session** and
-posts to `/api/extension/import` and `/api/extension/compare` under an API key.
-It extracts goals, services, accommodations, IEP dates and student info from the
-SEIS Goals and Services pages, and has a passive mode that flags SEIS↔Speddy
-discrepancies in the background.
+`speddy-chrome-extension/` is a Manifest V3 extension that reads SEIS pages **in
+the provider's own already-authenticated browser session**. It extracts goals,
+services, accommodations, IEP dates and student info from the SEIS Goals and
+Services pages, and runs a passive mode that flags SEIS↔Speddy discrepancies in
+the background.
 
 It uses no credential we aren't given, and no access the user doesn't already
 have — it reads what's on screen for the user who is already looking at it.
+
+### It reads; it does not yet write
+
+The shipped extension is **discrepancy detection only**. Its single network call
+is to `/api/extension/compare` (`service-worker.js:95`); nothing in the popup,
+the service worker, or the content script ever calls `/api/extension/import`. The
+import route exists server-side with no caller.
+
+The extension's own `README.md` still describes an "Extract & Import to Speddy"
+button and a `POST /api/extension/import` flow — that documentation is **stale**,
+left over from before the v3 pivot to the "SEIS Discrepancy Detector" named in
+`manifest.json`. Worth fixing whenever the extension is next touched.
+
+So Path 3 needs an import workflow **built and validated**, on top of the SPE-276
+hardening below — not just the hardening. Today it can tell a provider that SEIS
+and Speddy disagree; it cannot pull the goals across.
 
 **It is parked (SPE-276) and must not ship as-is.** It predates the Import
 Students hardening and carries the exact bugs that project fixed:
@@ -134,15 +168,21 @@ Ruled out anyway:
 ## Recommendation
 
 The two viable paths are complementary, not competing — take both, in order.
+Neither is small: each has a working front half and an unbuilt back half.
 
-1. **Path 2 first.** Extend the existing SIS work to pull SEIS-originated fields
-   out of the district's SIS. Highest leverage, lowest new risk, mostly built.
-   Start by asking a pilot district what their SEIS↔SIS integration already
-   syncs. Retires the *IEP Dates* and *class list* uploads.
-2. **Path 3 second**, if goals-without-manual-upload is worth it. Unpark the
-   extension, do the SPE-276 hardening as a block, verify against a real session,
-   publish unlisted. It is the *only* mechanism that gets goal text out of SEIS
-   automatically. Retires the *Student & goals* and *Deliveries* uploads.
+1. **Path 2 first.** Build the sync on top of the connection that already works —
+   scheduled fetch, mapping, reconciliation, write path — to pull SEIS-originated
+   fields out of the district's SIS. Highest leverage and the least *new* risk,
+   because the credential and trust layer is already solved and proven against a
+   real district. Retires the *IEP Dates* and *class list* uploads.
+   **Cheap first step, before committing to any of it:** ask a pilot district
+   (JSUSD) what their SEIS↔SIS integration already syncs and in which direction.
+   That answer sets how much this path is even worth.
+2. **Path 3 second**, if goals-without-manual-upload is worth it. Build the
+   import workflow, do the SPE-276 hardening in the same block, verify against a
+   real signed-in session, publish unlisted. It is the *only* mechanism that gets
+   goal text out of SEIS automatically. Retires the *Student & goals* and
+   *Deliveries* uploads.
 
 Even with both, keep the file upload. It's the fallback for districts on neither
 path, and for SEIS UI changes that break scraping.
@@ -158,6 +198,8 @@ path, and for SEIS UI changes that break scraping.
   [CALPADS SELPA Quick Start](https://documentation.calpads.org/SPEDTransition/WelcomeSELPA/)
 
 **Source of truth:** `lib/import/detect-import-file.ts` (current manual file
-types); `lib/integrations/aeries/` (SIS client); `speddy-chrome-extension/` +
-`app/api/extension/` (extension path); SPE-276 (extension gaps);
+types); `lib/integrations/aeries/` + `lib/sis/aeries-setup.ts` (SIS client and
+connection test — the extent of what's built); `vercel.json` (no SIS cron);
+`speddy-chrome-extension/service-worker.js` + `app/api/extension/` (extension
+path, compare-only); SPE-276 (extension gaps); SPE-412 (reconciliation design);
 `docs/integrations/aeries-sped-mapping.md` (SIS field gaps).

--- a/docs/integrations/seis.md
+++ b/docs/integrations/seis.md
@@ -1,0 +1,163 @@
+# SEIS — can we pull data automatically?
+
+> **Research write-up, 2026-08-07.** Answers the question: is there any mechanism
+> to get IEP data out of SEIS without a provider manually downloading reports and
+> re-uploading them into Speddy?
+>
+> **Short answer:** SEIS has no public/partner API and no vendor programme. But
+> there are two real automated paths that don't need SEIS's cooperation at all,
+> and between them they cover most of what the manual upload carries today.
+>
+> Companion to `docs/integrations/aeries.md`. Related: SPE-276 (Chrome
+> extension, parked), the *SIS Integration* project (SPE-392 → SPE-420).
+
+## What we upload manually today
+
+The unified Import Students flow (SPE-231) accepts four file types
+(`lib/import/detect-import-file.ts`). Three are SEIS downloads:
+
+| File | Source | Fills in |
+|---|---|---|
+| Student & goals report (xlsx/csv) | **SEIS** | students + IEP goals |
+| Deliveries (csv) | **SEIS** | service minutes / frequency → schedule requirements |
+| IEP Dates (csv) | **SEIS** | annual review & triennial dates |
+| Special Ed class list (txt) | Aeries | teacher assignment |
+
+Every one is a human logging into SEIS, running a report, downloading it, and
+re-uploading it here. That's the cost we're trying to remove.
+
+## Path 1 — SEIS has no API for us (confirmed)
+
+SEIS is built and run by **CodeStack**, a department of the San Joaquin County
+Office of Education, and is used by 115 SELPAs / 1,500+ California LEAs. There is
+no developer portal, no OAuth, no REST surface, no partner/vendor programme —
+nothing a third party can register for.
+
+The one thing SEIS calls "integration" is **SEIS Integration**: an automated
+**nightly sync between a district's SIS and SEIS**, arranged directly between the
+district and CodeStack via `integration.seis.org`. Per SEIS's own description it
+runs **in either direction** (SIS → SEIS, SEIS → SIS, or both), and **"any field
+from the Student Record can be included."**
+
+That is a district↔SEIS pipe. Speddy cannot be an endpoint on it. But it is the
+foundation of Path 2.
+
+> **Verification limit:** `seis.org`, `integration.seis.org`, and the SELPA PDFs
+> hosting SEIS training decks are all blocked by this environment's network egress
+> proxy, so the above is grounded in search-result excerpts of SEIS's own pages
+> rather than a direct read. The field-level specifics in Path 2 need confirming
+> with a district or with CodeStack before we design against them.
+
+## Path 2 — SEIS → district SIS → Speddy (recommended, mostly already built)
+
+If a district enables the **SEIS → SIS** direction of that nightly sync, SEIS
+writes its student-record fields into the district's SIS. Speddy then reads them
+through the **SIS connection we already ship** — the Aeries REST v5 client
+(`lib/integrations/aeries/`), the encrypted per-district credential store
+(SPE-395), and the tech-portal connection flow (SPE-396/397).
+
+Why this is the strong path:
+
+- **No SEIS cooperation needed.** It's the district's own configuration, on a
+  feature SEIS already sells them. We're just reading the district's SIS, which
+  we're already authorised to do.
+- **It's nightly and automatic.** No human in the loop.
+- **The plumbing exists.** This is a mapping-and-config problem, not a new
+  integration.
+- **It's the sanctioned route.** Aeries explicitly documents SpEd vendors using
+  the API to keep their own systems current, with district-issued read-only
+  certificates scoped per API.
+
+What it can carry: student demographics, SpEd flag/eligibility, disability,
+special-ed entry/exit dates, case manager, and **IEP dates** — i.e. it should
+retire the *IEP Dates* upload and the *class list*, and cover the student half of
+the *Student & goals* report.
+
+What it cannot carry: **goal text**. Goals are free-text IEP content that lives in
+SEIS and has no SIS field to land in. `docs/integrations/aeries-sped-mapping.md`
+already flagged this (gap #3): *"IEP substance isn't in Aeries… Aeries
+complements, not replaces, the SEIS upload."* Service minutes/frequency are the
+open question — worth checking whether a given district maps them.
+
+**Open question to put to a pilot district (JSUSD) or CodeStack:** which fields
+does their SEIS↔SIS integration currently sync, in which direction, and can the
+SEIS → SIS direction be extended to the fields we want?
+
+## Path 3 — the Chrome extension we already have (the only path that gets goals)
+
+`speddy-chrome-extension/` is a built, working Manifest V3 extension that reads
+SEIS pages **in the provider's own already-authenticated browser session** and
+posts to `/api/extension/import` and `/api/extension/compare` under an API key.
+It extracts goals, services, accommodations, IEP dates and student info from the
+SEIS Goals and Services pages, and has a passive mode that flags SEIS↔Speddy
+discrepancies in the background.
+
+It uses no credential we aren't given, and no access the user doesn't already
+have — it reads what's on screen for the user who is already looking at it.
+
+**It is parked (SPE-276) and must not ship as-is.** It predates the Import
+Students hardening and carries the exact bugs that project fixed:
+
+- matches students on initials + grade and is **school-blind** — the collision
+  that caused a real cross-school student mix-up (SPE-266/269)
+- **leaks student names into error strings and console logs** (the SPE-220 class
+  of leak)
+- hand-rolled grade normaliser that can drift from every other path
+- not on the shared `withRoute` wrapper; no test coverage on either route
+
+Four API keys were issued and **never used** (`api_keys.last_used_at` all null),
+so nothing has been written through it in production.
+
+The fixes are known and bounded: reuse `matchStudents`
+(`lib/utils/student-matcher.ts`) and `normalizeGradeLevel`, route logging through
+the shared `log` abstraction, move onto `withRoute`, add tests. Plus, before real
+users touch it: Chrome Web Store publication (unlisted), and a check that reading
+SEIS pages this way is acceptable under the district's SEIS terms — worth asking
+CodeStack directly rather than assuming.
+
+## Path 4 — CALPADS (ruled out)
+
+SEIS transmits special-education data to the state's CALPADS via API, including
+the **SSRV** file, which carries service type, minutes and frequency. Tempting,
+because that's the *Deliveries* data.
+
+Ruled out anyway:
+
+- CALPADS access is issued to **named individuals** at the LEA or a contracted
+  vendor, under an active compliant contract — not a service credential.
+- CALPADS explicitly **prohibits automated scraping by vendors**, with revocation
+  and legal liability named as consequences.
+- The SEDS→CALPADS API is for certified special-education *data systems* filing
+  state reports. Speddy isn't one and shouldn't become one for this.
+- Still no goals.
+
+## Recommendation
+
+The two viable paths are complementary, not competing — take both, in order.
+
+1. **Path 2 first.** Extend the existing SIS work to pull SEIS-originated fields
+   out of the district's SIS. Highest leverage, lowest new risk, mostly built.
+   Start by asking a pilot district what their SEIS↔SIS integration already
+   syncs. Retires the *IEP Dates* and *class list* uploads.
+2. **Path 3 second**, if goals-without-manual-upload is worth it. Unpark the
+   extension, do the SPE-276 hardening as a block, verify against a real session,
+   publish unlisted. It is the *only* mechanism that gets goal text out of SEIS
+   automatically. Retires the *Student & goals* and *Deliveries* uploads.
+
+Even with both, keep the file upload. It's the fallback for districts on neither
+path, and for SEIS UI changes that break scraping.
+
+## Sources
+
+- [SEIS](https://seis.org/) · [SEIS Integration portal](https://integration.seis.org/) ·
+  [CodeStack (SJCOE)](https://www.sjcoe.org/services-and-support/codestack)
+- [Aeries — Special Education Overview](https://support.aeries.com/support/solutions/articles/14000071473-special-education-overview) ·
+  [Aeries API Security](https://support.aeries.com/support/solutions/articles/14000068197-api-security)
+- [CALPADS — Reporting Data for Students with Disabilities](https://www.cde.ca.gov/ds/sp/cl/swdreporting.asp) ·
+  [CALPADS SSRV file](https://documentation.calpads.org/OnlineMaintenance/StudentDataMaintenance/StudentDetailsSSRV/) ·
+  [CALPADS SELPA Quick Start](https://documentation.calpads.org/SPEDTransition/WelcomeSELPA/)
+
+**Source of truth:** `lib/import/detect-import-file.ts` (current manual file
+types); `lib/integrations/aeries/` (SIS client); `speddy-chrome-extension/` +
+`app/api/extension/` (extension path); SPE-276 (extension gaps);
+`docs/integrations/aeries-sped-mapping.md` (SIS field gaps).

--- a/docs/integrations/seis.md
+++ b/docs/integrations/seis.md
@@ -4,21 +4,25 @@
 > to get IEP data out of SEIS without a provider manually downloading reports and
 > re-uploading them into Speddy?
 >
-> **Short answer:** SEIS has no public/partner API and no vendor programme. But
-> there are two real automated paths that don't need SEIS's cooperation at all,
-> and between them they cover most of what the manual upload carries today.
+> **Short answer:** no public or partner SEIS API turned up in anything we can
+> reach. But there are two real automated paths that need **no new Speddy↔SEIS
+> integration**, and between them they cover most of what the manual upload
+> carries today. (Path 2 still needs the *district* to configure SEIS↔SIS with
+> CodeStack — that's SEIS cooperation, just not with us.)
 >
 > Companion to `docs/integrations/aeries.md`. Related: SPE-276 (Chrome
 > extension, parked), the *SIS Integration* project (SPE-392 → SPE-420).
 
 ## What we upload manually today
 
-The unified Import Students flow (SPE-231) accepts four file types
-(`lib/import/detect-import-file.ts`). Three are SEIS downloads:
+The unified Import Students flow (SPE-231) recognises four vendor **export
+categories**, three of them SEIS downloads (`lib/import/detect-import-file.ts` —
+which also classifies our own roster template, not listed here since it isn't a
+vendor export):
 
 | File | Source | Fills in |
 |---|---|---|
-| Student & goals report (xlsx/csv) | **SEIS** | students + IEP goals |
+| Student & goals report (xls/xlsx/csv) | **SEIS** | students + IEP goals |
 | Deliveries (csv) | **SEIS** | service minutes / frequency → schedule requirements |
 | IEP Dates (csv) | **SEIS** | annual review & triennial dates |
 | Special Ed class list (txt) | Aeries | teacher assignment |
@@ -26,12 +30,20 @@ The unified Import Students flow (SPE-231) accepts four file types
 Every one is a human logging into SEIS, running a report, downloading it, and
 re-uploading it here. That's the cost we're trying to remove.
 
-## Path 1 — SEIS has no API for us (confirmed)
+## Path 1 — no public SEIS API found in the available sources
 
 SEIS is built and run by **CodeStack**, a department of the San Joaquin County
-Office of Education, and is used by 115 SELPAs / 1,500+ California LEAs. There is
-no developer portal, no OAuth, no REST surface, no partner/vendor programme —
-nothing a third party can register for.
+Office of Education, and is used by 115 SELPAs / 1,500+ California LEAs. Across
+everything publicly reachable we found **no developer portal, no documented OAuth
+or REST surface, and no partner/vendor programme** — nothing a third party can
+register for.
+
+State that as what it is: an absence of public evidence, not proof that no
+interface exists. CodeStack builds proprietary software for education agencies
+and manages integrations internally, so a private or negotiated interface can't
+be ruled out from the outside. **Asking CodeStack directly is the only way to
+close this**, and it's worth doing before concluding Path 1 is dead — a single
+email could make the rest of this document moot.
 
 The one thing SEIS calls "integration" is **SEIS Integration**: an automated
 **nightly sync between a district's SIS and SEIS**, arranged directly between the
@@ -56,9 +68,12 @@ out of that SIS.
 
 Why this is the strong path:
 
-- **No SEIS cooperation needed.** It's the district's own configuration, on a
-  feature SEIS already sells them. We're just reading the district's SIS, which
-  we're already authorised to do.
+- **No new Speddy↔SEIS integration needed.** We never talk to SEIS. We read the
+  district's SIS, which we're already authorised to do. Note the district *does*
+  still have to arrange the SEIS→SIS direction with CodeStack — this isn't a
+  self-serve toggle, and it's a dependency on someone else's queue. The point is
+  that it's a service SEIS already sells them, requested by the customer, not a
+  partnership we have to negotiate.
 - **It's nightly and automatic.** No human in the loop.
 - **It's the sanctioned route.** Aeries explicitly documents SpEd vendors using
   the API to keep their own systems current, with district-issued read-only
@@ -87,10 +102,15 @@ problem is solved; the pipeline is a real build. Treat SPE-412 (what happens to
 existing Speddy data when SIS data starts flowing) as the design question that
 gates it.
 
-What it can carry: student demographics, SpEd flag/eligibility, disability,
-special-ed entry/exit dates, case manager, and **IEP dates** — i.e. it should
-retire the *IEP Dates* upload and the *class list*, and cover the student half of
-the *Student & goals* report.
+What it can carry, *if* the district maps the fields: student demographics, SpEd
+flag/eligibility, disability, special-ed entry/exit dates, case manager, and
+**IEP dates** — putting the *IEP Dates* upload and the *class list* in scope to
+retire, and covering the student half of the *Student & goals* report.
+
+Treat that as a target, not a result. The class list carries teacher assignment
+and district student ID (`lib/parsers/class-list-parser.ts`); retire it only once
+a pilot shows the SIS path delivers both. Same for *IEP Dates*, which carries the
+annual-review and triennial dates (`lib/parsers/iep-dates-parser.ts`).
 
 What it cannot carry: **goal text**. Goals are free-text IEP content that lives in
 SEIS and has no SIS field to land in. `docs/integrations/aeries-sped-mapping.md`
@@ -139,8 +159,16 @@ Students hardening and carries the exact bugs that project fixed:
 - hand-rolled grade normaliser that can drift from every other path
 - not on the shared `withRoute` wrapper; no test coverage on either route
 
-Four API keys were issued and **never used** (`api_keys.last_used_at` all null),
-so nothing has been written through it in production.
+Four API keys were issued and show **no recorded use** (`api_keys.last_used_at`
+all null as of 2026-07-17). Don't read that as proof they were never called:
+`/api/extension/compare` — the only endpoint the extension actually hits — never
+touches `last_used_at` at all, and `/api/extension/import` updates it without
+checking the result. A null timestamp is silence, not evidence.
+
+The stronger statement holds for a different reason: no student data can have
+been written through this path, because `compare` computes discrepancies and
+returns them without writing, and `import` — the only route that writes — has no
+caller. That's an argument from the code, not from the timestamp.
 
 The fixes are known and bounded: reuse `matchStudents`
 (`lib/utils/student-matcher.ts`) and `normalizeGradeLevel`, route logging through
@@ -174,18 +202,24 @@ Neither is small: each has a working front half and an unbuilt back half.
    scheduled fetch, mapping, reconciliation, write path — to pull SEIS-originated
    fields out of the district's SIS. Highest leverage and the least *new* risk,
    because the credential and trust layer is already solved and proven against a
-   real district. Retires the *IEP Dates* and *class list* uploads.
+   real district. Puts the *IEP Dates* and *class list* uploads in scope to
+   retire — once a pilot confirms the SIS side actually delivers teacher
+   assignment, district student ID, and both compliance dates.
    **Cheap first step, before committing to any of it:** ask a pilot district
    (JSUSD) what their SEIS↔SIS integration already syncs and in which direction.
    That answer sets how much this path is even worth.
 2. **Path 3 second**, if goals-without-manual-upload is worth it. Build the
    import workflow, do the SPE-276 hardening in the same block, verify against a
    real signed-in session, publish unlisted. It is the *only* mechanism that gets
-   goal text out of SEIS automatically. Retires the *Student & goals* and
-   *Deliveries* uploads.
+   goal text out of SEIS automatically. Puts the *Student & goals* and
+   *Deliveries* uploads in scope to retire — once real-session testing shows it
+   covers goals, services, accommodations, IEP dates, and student matching.
 
-Even with both, keep the file upload. It's the fallback for districts on neither
-path, and for SEIS UI changes that break scraping.
+**Retire nothing on a plan.** Each upload comes out only when a pilot has shown
+the replacement carries every field that upload carries today; until then the
+automated path runs alongside it, not instead of it. And keep the file upload
+permanently regardless — it's the fallback for districts on neither path, and for
+SEIS UI changes that break scraping.
 
 ## Sources
 


### PR DESCRIPTION
Docs-only. Adds `docs/integrations/seis.md`, answering: *is there any way to pull data out of SEIS without a provider manually downloading reports and re-uploading them into Speddy?*

Sits alongside `docs/integrations/aeries.md` and follows the same shape.

## What it found

**SEIS has no public or partner API.** No developer portal, no OAuth, no REST surface, nothing a third party can register for. The one thing SEIS calls "integration" is a nightly sync between a district's SIS and SEIS, arranged district-to-CodeStack via `integration.seis.org`. Speddy cannot be an endpoint on that pipe.

Four paths evaluated:

| Path | Verdict |
|---|---|
| 1. Direct SEIS API | Doesn't exist |
| 2. SEIS → district SIS → Speddy | **Recommended.** Needs no SEIS cooperation and the plumbing is mostly built |
| 3. Chrome extension (`speddy-chrome-extension/`) | Viable, parked under SPE-276; the only path that gets goal text |
| 4. CALPADS | Ruled out — named-individual access, vendor scraping explicitly prohibited, no goals |

Paths 2 and 3 are complementary rather than competing, and the doc recommends taking both in that order. Between them they'd retire all four manual upload types; the doc argues for keeping the file upload anyway as a fallback.

## Grounding

Cross-referenced against what's actually in the repo:

- `lib/import/detect-import-file.ts` — the four file types uploaded by hand today (three of them SEIS downloads)
- `lib/integrations/aeries/` + the SIS connection work (SPE-392 → SPE-420) — what Path 2 would build on
- `docs/integrations/aeries-sped-mapping.md` gap #3 — already recorded that IEP substance has no SIS source, which is why Path 2 can't carry goal text
- SPE-276 — the extension's known matching/PII/normalisation gaps, restated as the precondition for Path 3

## Verification limit, stated in the doc

`seis.org`, `integration.seis.org`, and the SELPA-hosted SEIS training PDFs are all blocked by this environment's network egress proxy. The SEIS-side findings are grounded in search-result excerpts of SEIS's own pages rather than a direct read, and the doc says so inline — the field-level specifics of Path 2 need confirming with a pilot district or with CodeStack before anything is designed against them.

## Test plan

None — documentation only, no code paths touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERb2U4bgbERcnp3Dq7rLgp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added research documentation on automated SEIS data retrieval.
  * Documented current manual upload workflows and integration limitations.
  * Recommended district SIS synchronization for demographics and dates.
  * Identified a browser extension as a potential option for SEIS-only data, pending security and reliability improvements.
  * Confirmed manual uploads remain the fallback approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->