### PR TITLE
SPE-426: work out the SIS API address instead of assuming it (or asking a district for it)

### DIFF
--- a/__tests__/unit/lib/sis/aeries-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/aeries-setup.http.test.ts
@@ -38,7 +38,19 @@ import { runAeriesConnectionTest } from '@/lib/sis/aeries-setup';
 const CERT = '477abe9e7d27439681d62f4e0de1f5e1';
 
 /** Route table keyed by the path segment the probe hits. */
-type Handler = (path: string) => { status: number; body?: unknown; headers?: Record<string, string> };
+type Handler = (path: string) => {
+  status: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+  /**
+   * Send `body` verbatim as text/html instead of JSON-encoding it.
+   *
+   * Needed because a wrong path on a district's own web server answers with a
+   * real HTML page, and `JSON.stringify('<html>…')` is still valid JSON — so a
+   * test written without this proves nothing about the case it claims to cover.
+   */
+  raw?: boolean;
+};
 
 let server: Server;
 let baseUrl: string;
@@ -48,9 +60,12 @@ let seenCertHeaders: (string | undefined)[] = [];
 beforeAll(async () => {
   server = createServer((req, res) => {
     seenCertHeaders.push(req.headers['aeries-cert'] as string | undefined);
-    const { status, body, headers } = handler(req.url ?? '');
-    res.writeHead(status, { 'Content-Type': 'application/json', ...(headers ?? {}) });
-    res.end(body === undefined ? '' : JSON.stringify(body));
+    const { status, body, headers, raw } = handler(req.url ?? '');
+    res.writeHead(status, {
+      'Content-Type': raw ? 'text/html' : 'application/json',
+      ...(headers ?? {}),
+    });
+    res.end(body === undefined ? '' : raw ? String(body) : JSON.stringify(body));
   });
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
   baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}/aeries/api/v5`;
@@ -125,20 +140,51 @@ describe('resolving the API root when the stored one is wrong (SPE-426)', () => 
     expect(report.usedBaseUrl).toBeUndefined();
   });
 
-  it('keeps looking when the stored root answers 200 with something that is not a list', async () => {
+  it('keeps looking when the stored root answers 200 with a real HTML page', async () => {
     // The commonest wrong-path shape after a 404, and the one a status-code-only
-    // check misses: a district web server that serves its login page, or an
-    // error page, for any path its API does not handle. Indistinguishable from
-    // a working endpoint by status alone, and just as wrong.
+    // check misses: a district web server that serves its login page for any
+    // path its API does not handle. Indistinguishable from a working endpoint by
+    // status alone, and just as wrong.
+    //
+    // `raw` matters. Served as JSON this is a valid JSON string and the
+    // non-array branch catches it; served as real text/html the JSON parse
+    // THROWS, which is a completely different path through the client and the
+    // one a district actually hits. The first version of this test used the
+    // JSON encoding and passed against code that had the real gap.
     handler = (path) =>
       path.startsWith('/aeries/api/v5')
-        ? { status: 200, body: '<html>Sign in</html>' }
+        ? { status: 200, body: '<!doctype html><html><body>Sign in</body></html>', raw: true }
         : allGranted(path);
 
     const report = await run();
 
     expect(report.ok).toBe(true);
     expect(report.usedBaseUrl).toBe(baseUrl.replace('/aeries/api/v5', '/api/v5'));
+  });
+
+  it('keeps looking when the stored root answers 200 with JSON that is not a list', async () => {
+    handler = (path) =>
+      path.startsWith('/aeries/api/v5')
+        ? { status: 200, body: { error: 'not the API' } }
+        : allGranted(path);
+
+    const report = await run();
+
+    expect(report.ok).toBe(true);
+    expect(report.usedBaseUrl).toBe(baseUrl.replace('/aeries/api/v5', '/api/v5'));
+  });
+
+  it('says the host ANSWERED when every root serves HTML, not that it is unreachable', async () => {
+    // The two failures need opposite fixes: "we could not reach you" sends a
+    // district to their firewall, when in fact their server replied and the
+    // address is wrong. Getting this backwards is what SPE-419 is about.
+    handler = () => ({ status: 200, body: '<html>Sign in</html>', raw: true });
+
+    const report = await run();
+
+    expect(report.ok).toBe(false);
+    expect(area(report, 'connection').message).toMatch(/answered, but not with Aeries data/i);
+    expect(area(report, 'connection').message).not.toMatch(/could not reach/i);
   });
 
   it('STOPS at a 401 instead of walking on to another root', async () => {

--- a/__tests__/unit/lib/sis/aeries-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/aeries-setup.http.test.ts
@@ -91,24 +91,54 @@ describe('resolving the API root when the stored one is wrong (SPE-426)', () => 
     return { status: 404, body: { message: 'not found' } };
   };
 
-  it('finds the working root when the stored one 404s, and reports it for persisting', async () => {
+  it('finds the working root when the stored one 404s, and names it in the report', async () => {
     handler = hostedOnly;
     const report = await run();
 
     expect(report.ok).toBe(true);
-    // Reported so the caller can correct the stored row once, rather than
-    // re-deriving it on every test and leaving a later sync pointed at a 404.
-    expect(report.resolvedBaseUrl).toBe(baseUrl.replace('/aeries/api/v5', '/api/v5'));
+    const hosted = baseUrl.replace('/aeries/api/v5', '/api/v5');
+    expect(report.usedBaseUrl).toBe(hosted);
+    // Surfaced to the district too. Being told the connection is fine about an
+    // address they cannot find in their own settings is its own confusion.
+    expect(area(report, 'connection').message).toContain(hosted);
   });
 
-  it('does not report a correction when the stored root already works', async () => {
+  it('reports nothing extra when the stored root already works', async () => {
     handler = allGranted;
     const report = await run();
 
     expect(report.ok).toBe(true);
-    // Absent, not equal-to-stored: a caller that persisted on every pass would
-    // write an audit record for a change that did not happen.
-    expect(report.resolvedBaseUrl).toBeUndefined();
+    // Absent, not equal-to-stored — the field means "we had to look elsewhere",
+    // so a caller cannot mistake a normal pass for a discovery.
+    expect(report.usedBaseUrl).toBeUndefined();
+    expect(area(report, 'connection').message).toBe('Speddy can reach your Aeries instance.');
+  });
+
+  it('does not treat a trailing slash on the stored address as a different root', async () => {
+    // The stored value and the candidate differ only by punctuation. Reporting
+    // that as "we found another address" would put a meaningless correction in
+    // front of a district whose configuration is already right.
+    handler = allGranted;
+    const report = await runAeriesConnectionTest({ baseUrl: `${baseUrl}/`, certificate: CERT });
+
+    expect(report.ok).toBe(true);
+    expect(report.usedBaseUrl).toBeUndefined();
+  });
+
+  it('keeps looking when the stored root answers 200 with something that is not a list', async () => {
+    // The commonest wrong-path shape after a 404, and the one a status-code-only
+    // check misses: a district web server that serves its login page, or an
+    // error page, for any path its API does not handle. Indistinguishable from
+    // a working endpoint by status alone, and just as wrong.
+    handler = (path) =>
+      path.startsWith('/aeries/api/v5')
+        ? { status: 200, body: '<html>Sign in</html>' }
+        : allGranted(path);
+
+    const report = await run();
+
+    expect(report.ok).toBe(true);
+    expect(report.usedBaseUrl).toBe(baseUrl.replace('/aeries/api/v5', '/api/v5'));
   });
 
   it('STOPS at a 401 instead of walking on to another root', async () => {
@@ -125,7 +155,7 @@ describe('resolving the API root when the stored one is wrong (SPE-426)', () => 
     const report = await run();
 
     expect(report.ok).toBe(false);
-    expect(report.resolvedBaseUrl).toBeUndefined();
+    expect(report.usedBaseUrl).toBeUndefined();
     expect(area(report, 'connection').message).toMatch(/re-copy it/i);
     expect(area(report, 'connection').message).not.toMatch(/address/i);
   });
@@ -141,7 +171,7 @@ describe('resolving the API root when the stored one is wrong (SPE-426)', () => 
     const report = await run();
 
     expect(report.ok).toBe(false);
-    expect(report.resolvedBaseUrl).toBeUndefined();
+    expect(report.usedBaseUrl).toBeUndefined();
     expect(area(report, 'schools').status).toBe('denied');
   });
 
@@ -153,7 +183,7 @@ describe('resolving the API root when the stored one is wrong (SPE-426)', () => 
     const report = await run();
 
     expect(report.ok).toBe(false);
-    expect(report.resolvedBaseUrl).toBeUndefined();
+    expect(report.usedBaseUrl).toBeUndefined();
     expect(report.summary).toMatch(/could not connect/i);
   });
 });

--- a/__tests__/unit/lib/sis/aeries-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/aeries-setup.http.test.ts
@@ -75,6 +75,89 @@ const allGranted: Handler = (path) => {
   return { status: 200, body: [{ SchoolCode: 1, Name: 'Sim High' }] };
 };
 
+describe('resolving the API root when the stored one is wrong (SPE-426)', () => {
+  /**
+   * The JSUSD shape: the district is on an Aeries-HOSTED api host, where the
+   * API lives at /api/v5, but we stored the self-hosted default /aeries/api/v5.
+   * Their server answered every probe with 404 and the form gave them no way to
+   * correct it, so resolution has to do it for them.
+   */
+  const hostedOnly: Handler = (path) => {
+    if (path.startsWith('/aeries/api/v5')) return { status: 404, body: { message: 'not found' } };
+    if (path.includes('/programs')) return { status: 200, body: [{ ProgramCode: '144' }] };
+    if (path.includes('/teachers')) return { status: 200, body: [{ TeacherNumber: 7 }] };
+    if (path.includes('/students')) return { status: 200, body: [{ StudentID: 1 }] };
+    if (path.startsWith('/api/v5')) return { status: 200, body: [{ SchoolCode: 1, Name: 'Sim High' }] };
+    return { status: 404, body: { message: 'not found' } };
+  };
+
+  it('finds the working root when the stored one 404s, and reports it for persisting', async () => {
+    handler = hostedOnly;
+    const report = await run();
+
+    expect(report.ok).toBe(true);
+    // Reported so the caller can correct the stored row once, rather than
+    // re-deriving it on every test and leaving a later sync pointed at a 404.
+    expect(report.resolvedBaseUrl).toBe(baseUrl.replace('/aeries/api/v5', '/api/v5'));
+  });
+
+  it('does not report a correction when the stored root already works', async () => {
+    handler = allGranted;
+    const report = await run();
+
+    expect(report.ok).toBe(true);
+    // Absent, not equal-to-stored: a caller that persisted on every pass would
+    // write an audit record for a change that did not happen.
+    expect(report.resolvedBaseUrl).toBeUndefined();
+  });
+
+  it('STOPS at a 401 instead of walking on to another root', async () => {
+    // The load-bearing case. A 401 means the endpoint EXISTS and refused the
+    // certificate. If resolution treated that as "wrong address" it would move
+    // on, and the district would be told to fix an address that was correct
+    // while the real problem — their certificate — went unmentioned. That is
+    // the SPE-417 misdiagnosis shape, which this whole ticket exists to stop.
+    handler = (path) =>
+      path.startsWith('/aeries/api/v5')
+        ? { status: 401, body: { message: 'bad cert' } }
+        : { status: 200, body: [{ SchoolCode: 1, Name: 'Sim High' }] };
+
+    const report = await run();
+
+    expect(report.ok).toBe(false);
+    expect(report.resolvedBaseUrl).toBeUndefined();
+    expect(area(report, 'connection').message).toMatch(/re-copy it/i);
+    expect(area(report, 'connection').message).not.toMatch(/address/i);
+  });
+
+  it('STOPS at a 403 instead of walking on to another root', async () => {
+    // Same reasoning: 403 means the endpoint exists and a permission box is
+    // unticked. Walking past it would hide the checkbox they need to tick.
+    handler = (path) =>
+      path.startsWith('/aeries/api/v5')
+        ? { status: 403, body: { message: 'forbidden' } }
+        : { status: 200, body: [{ SchoolCode: 1, Name: 'Sim High' }] };
+
+    const report = await run();
+
+    expect(report.ok).toBe(false);
+    expect(report.resolvedBaseUrl).toBeUndefined();
+    expect(area(report, 'schools').status).toBe('denied');
+  });
+
+  it('reports a 404 honestly when no known layout answers', async () => {
+    // Nothing to correct: say the address did not work rather than inventing a
+    // root, and leave the stored value alone.
+    handler = () => ({ status: 404, body: { message: 'not found' } });
+
+    const report = await run();
+
+    expect(report.ok).toBe(false);
+    expect(report.resolvedBaseUrl).toBeUndefined();
+    expect(report.summary).toMatch(/could not connect/i);
+  });
+});
+
 describe('runAeriesConnectionTest over real HTTP', () => {
   it('reports every area granted, and sends the certificate as a header', async () => {
     handler = allGranted;

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -126,15 +126,57 @@ describe('resolving the token endpoint when the stored one is wrong (SPE-426)', 
     const report = await runWith(`${origin}/admin/token`);
 
     expect(stepOf(report, 'token').status).toBe('ok');
-    expect(report.resolvedTokenUrl).toBe(`${origin}/admin/oauth/token`);
+    expect(report.usedTokenUrl).toBe(`${origin}/admin/oauth/token`);
   });
 
-  it('does not report a correction when the stored endpoint already works', async () => {
+  it('reports nothing extra when the stored endpoint already works', async () => {
     handler = allGood;
     const report = await runWith(`${origin}/admin/token`);
 
     expect(stepOf(report, 'token').status).toBe('ok');
-    expect(report.resolvedTokenUrl).toBeUndefined();
+    // Absent, not equal-to-stored — the field means "we had to look elsewhere".
+    expect(report.usedTokenUrl).toBeUndefined();
+    expect(stepOf(report, 'token').message).toBe('Working.');
+  });
+
+  it('does not treat a trailing slash on the stored endpoint as a different one', async () => {
+    handler = allGood;
+    const report = await runWith(`${origin}/admin/token/`);
+
+    expect(stepOf(report, 'token').status).toBe('ok');
+    expect(report.usedTokenUrl).toBeUndefined();
+  });
+
+  it('derives the endpoint when the district gave us none, and says which it used', async () => {
+    // The field is optional now precisely because an Aeries OneRoster console
+    // never shows it. Left blank, a district must still get a working test.
+    handler = allGood;
+    const report = await runOneRosterConnectionTest({
+      baseUrl: `${origin}/admin`,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.usedTokenUrl).toBe(`${origin}/admin/token`);
+    expect(stepOf(report, 'token').message).toContain(`${origin}/admin/token`);
+  });
+
+  it('never guesses a token endpoint OUTSIDE the path the district gave us', async () => {
+    // A district on a shared host — `https://sis.example.org/aeries` — does not
+    // own `https://sis.example.org/`. Climbing to the origin to look for a
+    // token endpoint would hand their consumer secret to whatever application
+    // answers at the root. Every candidate stays under their own path.
+    handler = () => ({ status: 404, body: { message: 'nope' } });
+
+    await runOneRosterConnectionTest({
+      baseUrl: `${origin}/admin`,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    expect(seen.length).toBeGreaterThan(0);
+    for (const r of seen) expect(r.url.startsWith('/admin/')).toBe(true);
   });
 
   it('STOPS at a 401 rather than trying other endpoints with the same credentials', async () => {
@@ -148,21 +190,23 @@ describe('resolving the token endpoint when the stored one is wrong (SPE-426)', 
     const report = await runWith(`${origin}/admin/token`);
 
     expect(report.ok).toBe(false);
-    expect(report.resolvedTokenUrl).toBeUndefined();
+    expect(report.usedTokenUrl).toBeUndefined();
     expect(stepOf(report, 'token').message).toMatch(/Consumer ID and Consumer Secret/i);
 
     const tokenPosts = seen.filter((r) => r.url.includes('token'));
     expect(tokenPosts).toHaveLength(1);
   });
 
-  it('corrects nothing when no candidate serves a token endpoint', async () => {
+  it('names nothing when no candidate serves a token endpoint', async () => {
     handler = () => ({ status: 404, body: { message: 'nope' } });
 
     const report = await runWith(`${origin}/admin/token`);
 
     expect(report.ok).toBe(false);
-    expect(report.resolvedTokenUrl).toBeUndefined();
-    expect(stepOf(report, 'token').message).toMatch(/Nothing answered at that token address/i);
+    expect(report.usedTokenUrl).toBeUndefined();
+    // Points at the address they DID give us. Telling them to fix the token
+    // address would send them to correct the field we tell them to leave blank.
+    expect(stepOf(report, 'token').message).toMatch(/under your OneRoster address/i);
   });
 });
 

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -103,6 +103,69 @@ const allGood: Handler = (req) => {
   return { status: 200, body: { orgs: [{ sourcedId: 'org-1', name: 'Sim USD', type: 'district' }] } };
 };
 
+describe('resolving the token endpoint when the stored one is wrong (SPE-426)', () => {
+  const runWith = (tokenUrl: string) =>
+    runOneRosterConnectionTest({
+      baseUrl: `${origin}/admin`,
+      tokenUrl,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+  it('finds the working token endpoint when the stored one 404s', async () => {
+    // The district could only ever guess this field — their console does not
+    // show it — so a wrong guess must not be a dead end.
+    handler = (req) => {
+      if (req.url.startsWith('/admin/token')) return { status: 404, body: { message: 'nope' } };
+      if (req.url.includes('/oauth/token')) {
+        return { status: 200, body: { access_token: TOKEN, token_type: 'bearer', expires_in: 3600 } };
+      }
+      return { status: 200, body: { orgs: [{ sourcedId: 'org-1', name: 'Sim USD', type: 'district' }] } };
+    };
+
+    const report = await runWith(`${origin}/admin/token`);
+
+    expect(stepOf(report, 'token').status).toBe('ok');
+    expect(report.resolvedTokenUrl).toBe(`${origin}/admin/oauth/token`);
+  });
+
+  it('does not report a correction when the stored endpoint already works', async () => {
+    handler = allGood;
+    const report = await runWith(`${origin}/admin/token`);
+
+    expect(stepOf(report, 'token').status).toBe('ok');
+    expect(report.resolvedTokenUrl).toBeUndefined();
+  });
+
+  it('STOPS at a 401 rather than trying other endpoints with the same credentials', async () => {
+    // Two reasons this matters. A 401 means the endpoint exists and the
+    // credentials are wrong — the district's real problem, which walking on
+    // would replace with "check your address". And every extra candidate posts
+    // the consumer secret somewhere new; there is no reason to keep spraying it
+    // once an endpoint has answered.
+    handler = () => ({ status: 401, body: { message: 'bad creds' } });
+
+    const report = await runWith(`${origin}/admin/token`);
+
+    expect(report.ok).toBe(false);
+    expect(report.resolvedTokenUrl).toBeUndefined();
+    expect(stepOf(report, 'token').message).toMatch(/Consumer ID and Consumer Secret/i);
+
+    const tokenPosts = seen.filter((r) => r.url.includes('token'));
+    expect(tokenPosts).toHaveLength(1);
+  });
+
+  it('corrects nothing when no candidate serves a token endpoint', async () => {
+    handler = () => ({ status: 404, body: { message: 'nope' } });
+
+    const report = await runWith(`${origin}/admin/token`);
+
+    expect(report.ok).toBe(false);
+    expect(report.resolvedTokenUrl).toBeUndefined();
+    expect(stepOf(report, 'token').message).toMatch(/Nothing answered at that token address/i);
+  });
+});
+
 describe('the OneRoster exchange over real HTTP', () => {
   it('reports every step working', async () => {
     handler = allGood;

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -215,6 +215,23 @@ describe('resolving the token endpoint when the stored one is wrong (SPE-426)', 
     expect(report.usedTokenUrl).toBe(`${origin}/admin/oauth/token`);
   });
 
+  it('STOPS at a real upstream 502 — their endpoint exists and is broken', async () => {
+    // Raised by CodeRabbit, and it was right. `fetchToken` marks "answered but
+    // the body is not a token" with a SYNTHETIC 502, and `dial` raises a real
+    // gateway 502 with the same number. Keyed on the status alone the two were
+    // indistinguishable, so a district whose token endpoint was briefly behind
+    // a broken gateway had their consumer secret posted to two more paths for
+    // nothing. Now separated by a flag on the error, not by the number.
+    handler = () => ({ status: 502, body: { message: 'bad gateway' } });
+
+    const report = await runWith(`${origin}/admin/token`);
+
+    expect(report.ok).toBe(false);
+    // Exactly one. The whole point of the finding.
+    expect(seen.filter((r) => r.url.includes('token'))).toHaveLength(1);
+    expect(report.usedTokenUrl).toBeUndefined();
+  });
+
   it('names the endpoint it CHOSE when sign-in fails, not just that sign-in failed', async () => {
     // The district left the field blank, so we picked an address for them. Being
     // told the Consumer ID and Secret are wrong, with no mention that an address

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -179,6 +179,74 @@ describe('resolving the token endpoint when the stored one is wrong (SPE-426)', 
     for (const r of seen) expect(r.url.startsWith('/admin/')).toBe(true);
   });
 
+  it('keeps looking past a 405 — something is there, but it is not a token endpoint', async () => {
+    // A vendor's data path answers a POST exactly like this. A 404-only check
+    // stops here and tells the district their credentials are wrong.
+    handler = (req) => {
+      if (req.url.startsWith('/admin/token')) return { status: 405, body: { message: 'nope' } };
+      if (req.url.includes('/oauth/token')) {
+        return { status: 200, body: { access_token: TOKEN, token_type: 'bearer', expires_in: 3600 } };
+      }
+      return { status: 200, body: { orgs: [{ sourcedId: 'org-1', name: 'Sim USD', type: 'district' }] } };
+    };
+
+    const report = await runWith(`${origin}/admin/token`);
+
+    expect(stepOf(report, 'token').status).toBe('ok');
+    expect(report.usedTokenUrl).toBe(`${origin}/admin/oauth/token`);
+  });
+
+  it('keeps looking past a 200 that carries no token', async () => {
+    // The wrong endpoint wearing a success status — a landing page, a data
+    // collection, a proxy's maintenance body. Stopping here would report
+    // "the token endpoint answered but returned no access token" about an
+    // address that was never the token endpoint.
+    handler = (req) => {
+      if (req.url.startsWith('/admin/token')) return { status: 200, body: { hello: 'world' } };
+      if (req.url.includes('/oauth/token')) {
+        return { status: 200, body: { access_token: TOKEN, token_type: 'bearer', expires_in: 3600 } };
+      }
+      return { status: 200, body: { orgs: [{ sourcedId: 'org-1', name: 'Sim USD', type: 'district' }] } };
+    };
+
+    const report = await runWith(`${origin}/admin/token`);
+
+    expect(stepOf(report, 'token').status).toBe('ok');
+    expect(report.usedTokenUrl).toBe(`${origin}/admin/oauth/token`);
+  });
+
+  it('names the endpoint it CHOSE when sign-in fails, not just that sign-in failed', async () => {
+    // The district left the field blank, so we picked an address for them. Being
+    // told the Consumer ID and Secret are wrong, with no mention that an address
+    // was guessed, is the same dead end one field over.
+    handler = () => ({ status: 401, body: { error: 'invalid_client' } });
+
+    const report = await runOneRosterConnectionTest({
+      baseUrl: `${origin}/admin`,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(stepOf(report, 'token').message).toMatch(/Consumer ID and Consumer Secret/i);
+    expect(stepOf(report, 'token').message).toContain(`${origin}/admin/token`);
+  });
+
+  it('names what it tried when NOTHING answers and the field was left blank', async () => {
+    // With no stored address there is nothing to report the failure against, so
+    // reporting against an empty string would tell them nothing at all.
+    handler = () => ({ status: 404, body: { message: 'nope' } });
+
+    const report = await runOneRosterConnectionTest({
+      baseUrl: `${origin}/admin`,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(stepOf(report, 'token').message).toContain(`${origin}/admin/token`);
+  });
+
   it('STOPS at a 401 rather than trying other endpoints with the same credentials', async () => {
     // Two reasons this matters. A 401 means the endpoint exists and the
     // credentials are wrong — the district's real problem, which walking on

--- a/__tests__/unit/lib/sis/oneroster-setup.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.test.ts
@@ -16,11 +16,24 @@ jest.mock('dns/promises', () => ({ lookup: (...a: unknown[]) => mockLookup(...a)
 
 const mockFetchToken = jest.fn();
 const mockGetOrgs = jest.fn();
+/**
+ * Every token endpoint a client was actually built for.
+ *
+ * The guard runs per candidate and BEFORE the client is constructed, so this
+ * list is precisely the set of addresses that passed. Asserting on it is how
+ * "the secret was never sent there" gets checked by address rather than by
+ * "no request happened at all" — which stopped being the right property once
+ * a refused token address means "try the derived ones" instead of "give up".
+ */
+const mockClientTokenUrls: string[] = [];
 jest.mock('@/lib/integrations/oneroster', () => {
   const actual = jest.requireActual('@/lib/integrations/oneroster');
   return {
     ...actual,
     OneRosterClient: class {
+      constructor(config: { tokenUrl: string }) {
+        mockClientTokenUrls.push(config.tokenUrl);
+      }
       fetchToken = (...a: unknown[]) => mockFetchToken(...a);
       getOrgs = (...a: unknown[]) => mockGetOrgs(...a);
       getSchools = jest.fn().mockResolvedValue([{ sourcedId: 'school-1' }]);
@@ -39,6 +52,7 @@ const CREDS = { clientId: 'consumer-id', clientSecret: 'consumer-secret' };
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockClientTokenUrls.length = 0;
   mockFetchToken.mockResolvedValue('token');
   mockGetOrgs.mockResolvedValue([{ sourcedId: 'org-1' }]);
 });
@@ -119,17 +133,45 @@ describe('normalizeOneRosterTokenUrl', () => {
 });
 
 describe('runOneRosterConnectionTest guards both URLs before sending a credential', () => {
-  it('makes NO request when the TOKEN url resolves to a private address', async () => {
+  it('never posts the secret to a TOKEN url that resolves privately — but keeps looking', async () => {
+    // Both halves matter. The private endpoint must never receive the consumer
+    // secret; and a refused token address must not end the run, because that is
+    // exactly the case resolution exists for — the district was asked for a
+    // field their console never shows them (SPE-426), so a bad value there has
+    // to be recoverable rather than terminal.
+    mockLookup.mockImplementation((host: string) =>
+      host === 'token.example.com'
+        ? Promise.resolve([{ address: '10.0.0.5', family: 4 }])
+        : Promise.resolve([{ address: '104.16.0.1', family: 4 }]),
+    );
+
+    const report = await runOneRosterConnectionTest({
+      baseUrl: 'https://data.example.com/admin',
+      tokenUrl: 'https://token.example.com/token',
+      ...CREDS,
+    });
+
+    // Never built for the private address, so nothing was posted to it.
+    expect(mockClientTokenUrls).not.toContain('https://token.example.com/token');
+    // And the derived candidate under the district's own base was tried.
+    expect(mockClientTokenUrls).toContain('https://data.example.com/admin/token');
+    expect(report.ok).toBe(true);
+    expect(report.usedTokenUrl).toBe('https://data.example.com/admin/token');
+  });
+
+  it('refuses outright when EVERY candidate resolves privately', async () => {
+    // The other end of the same behaviour: recovering from a bad token address
+    // must not become a way to reach a private host by another path.
     mockLookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
 
     const report = await runOneRosterConnectionTest({
-      baseUrl: 'https://jsusdapi.aeries.net/admin',
+      baseUrl: 'https://data.example.com/admin',
       tokenUrl: 'https://token.example.com/token',
       ...CREDS,
     });
 
     expect(report.ok).toBe(false);
-    expect(report.steps[0].message).toMatch(/token address/i);
+    expect(mockClientTokenUrls).toHaveLength(0);
     expect(mockFetchToken).not.toHaveBeenCalled();
   });
 

--- a/app/api/tech/sis/aeries/test/route.ts
+++ b/app/api/tech/sis/aeries/test/route.ts
@@ -2,12 +2,7 @@ import { NextResponse } from 'next/server';
 import { withRoute } from '@/lib/api/with-route';
 import { resolveDistrictSisCaller } from '@/lib/api/district-sis-caller';
 import { logger } from '@/lib/logger';
-import {
-  getDecryptedCredential,
-  listConnections,
-  recordTestResult,
-  updateConnectionUrls,
-} from '@/lib/sis/connections';
+import { getDecryptedCredential, listConnections, recordTestResult } from '@/lib/sis/connections';
 import { runAeriesConnectionTest, toStoredTestResult } from '@/lib/sis/aeries-setup';
 
 const log = logger.child({ module: 'tech-sis-aeries-test' });
@@ -80,29 +75,26 @@ export const POST = withRoute(
       certificate: credential.certificate,
     });
 
-    // Persist a corrected address before the verdict. Resolution only moves off
-    // the stored value when that value produced a 404 and another layout
-    // answered, so this makes the fix once rather than re-deriving it on every
-    // test — and points a later sync at the address that actually works.
-    // Non-fatal: the report is already complete and is worth returning even if
-    // the correction cannot be written.
-    if (report.resolvedBaseUrl) {
-      try {
-        await updateConnectionUrls({
-          connectionId: connection.id,
-          actorId: userId,
-          baseUrl: report.resolvedBaseUrl,
-        });
-        log.info('Corrected the stored Aeries base URL', {
-          connectionId: connection.id,
-          from: connection.base_url,
-          to: report.resolvedBaseUrl,
-        });
-      } catch (err) {
-        log.error('Could not persist the corrected Aeries base URL', err, {
-          connectionId: connection.id,
-        });
-      }
+    // Resolution is REPORTED, never written back. The stored address stays
+    // exactly as the district entered it, and each test re-derives which layout
+    // answers — one extra request on a connection whose stored value is wrong,
+    // and none at all once it is right.
+    //
+    // The earlier cut of this persisted the resolved address, and the trap is
+    // worth recording so it does not get re-added: resolution runs on failing
+    // tests too, so a district whose correct address had a bad minute could
+    // have had it overwritten with one that never worked — and because the
+    // search only continues past a 404, the replacement answering 401 or 403
+    // would then stop resolution from ever moving off it. Logged instead, so we
+    // can see which districts are on a non-default layout without touching
+    // their configuration.
+    if (report.usedBaseUrl) {
+      log.info('Aeries answered at a different API root than the one stored', {
+        connectionId: connection.id,
+        stored: connection.base_url,
+        answered: report.usedBaseUrl,
+        ok: report.ok,
+      });
     }
 
     try {

--- a/app/api/tech/sis/aeries/test/route.ts
+++ b/app/api/tech/sis/aeries/test/route.ts
@@ -6,6 +6,7 @@ import {
   getDecryptedCredential,
   listConnections,
   recordTestResult,
+  updateConnectionUrls,
 } from '@/lib/sis/connections';
 import { runAeriesConnectionTest, toStoredTestResult } from '@/lib/sis/aeries-setup';
 
@@ -78,6 +79,31 @@ export const POST = withRoute(
       baseUrl: connection.base_url,
       certificate: credential.certificate,
     });
+
+    // Persist a corrected address before the verdict. Resolution only moves off
+    // the stored value when that value produced a 404 and another layout
+    // answered, so this makes the fix once rather than re-deriving it on every
+    // test — and points a later sync at the address that actually works.
+    // Non-fatal: the report is already complete and is worth returning even if
+    // the correction cannot be written.
+    if (report.resolvedBaseUrl) {
+      try {
+        await updateConnectionUrls({
+          connectionId: connection.id,
+          actorId: userId,
+          baseUrl: report.resolvedBaseUrl,
+        });
+        log.info('Corrected the stored Aeries base URL', {
+          connectionId: connection.id,
+          from: connection.base_url,
+          to: report.resolvedBaseUrl,
+        });
+      } catch (err) {
+        log.error('Could not persist the corrected Aeries base URL', err, {
+          connectionId: connection.id,
+        });
+      }
+    }
 
     try {
       await recordTestResult({

--- a/app/api/tech/sis/oneroster/route.ts
+++ b/app/api/tech/sis/oneroster/route.ts
@@ -61,14 +61,19 @@ export const POST = withRoute(
     }
 
     let baseUrl: string;
-    let tokenUrl: string | undefined;
+    let tokenUrl: string | null;
     try {
       baseUrl = normalizeOneRosterBaseUrl(body.baseUrl);
       // Stored only when the district actually gave us one. Left blank the
-      // column stays empty and the connection test derives the endpoint on each
-      // run, which is more honest than recording our own guess in the field
-      // that is supposed to hold what they told us.
-      tokenUrl = body.tokenUrl ? normalizeOneRosterTokenUrl(body.tokenUrl) : undefined;
+      // column is CLEARED — `null`, not `undefined` — and the connection test
+      // derives the endpoint on each run.
+      //
+      // The clear is the load-bearing half. We tell districts to leave this
+      // blank, so the first thing one with a bad earlier guess will do is empty
+      // the field; if that only meant "leave the column alone", their stale
+      // value would go on being tried first by the resolver and they would be
+      // back in the dead end this ticket exists to remove.
+      tokenUrl = body.tokenUrl ? normalizeOneRosterTokenUrl(body.tokenUrl) : null;
     } catch (err) {
       // Written for the district administrator and containing nothing
       // sensitive — passing them through is the point.

--- a/app/api/tech/sis/oneroster/route.ts
+++ b/app/api/tech/sis/oneroster/route.ts
@@ -7,6 +7,7 @@ import { listConnections, storeCredential } from '@/lib/sis/connections';
 import {
   normalizeOneRosterBaseUrl,
   normalizeOneRosterTokenUrl,
+  oneRosterTokenUrlCandidates,
 } from '@/lib/sis/oneroster-setup';
 
 const log = logger.child({ module: 'tech-sis-oneroster' });
@@ -29,7 +30,13 @@ export const POST = withRoute(
   {
     body: z.object({
       baseUrl: z.string().min(1, 'Enter your OneRoster address'),
-      tokenUrl: z.string().min(1, 'Enter your OneRoster token address'),
+      // OPTIONAL on purpose. An Aeries OneRoster console shows a URL, a
+      // consumer ID and a secret — never a token endpoint — so requiring this
+      // asked districts for something they could only guess at (SPE-426).
+      // Left blank, it is derived from the base URL and settled by the
+      // connection test; supplied, it is honoured verbatim, because a district
+      // that knows its endpoint should never be second-guessed.
+      tokenUrl: z.string().trim().optional(),
       // No format regex on either credential, unlike the Aeries certificate's
       // 32-character shape. OneRoster consumer IDs and secrets have no length
       // or character set defined by the standard, and they differ per vendor —
@@ -58,7 +65,12 @@ export const POST = withRoute(
     let tokenUrl: string;
     try {
       baseUrl = normalizeOneRosterBaseUrl(body.baseUrl);
-      tokenUrl = normalizeOneRosterTokenUrl(body.tokenUrl);
+      // Falls back to the most common shape so the row is never left without a
+      // token URL; the connection test resolves it properly against the
+      // candidates and corrects the row with whichever answered.
+      tokenUrl = body.tokenUrl
+        ? normalizeOneRosterTokenUrl(body.tokenUrl)
+        : (oneRosterTokenUrlCandidates(baseUrl)[0] ?? `${baseUrl}/token`);
     } catch (err) {
       // Written for the district administrator and containing nothing
       // sensitive — passing them through is the point.

--- a/app/api/tech/sis/oneroster/route.ts
+++ b/app/api/tech/sis/oneroster/route.ts
@@ -7,7 +7,6 @@ import { listConnections, storeCredential } from '@/lib/sis/connections';
 import {
   normalizeOneRosterBaseUrl,
   normalizeOneRosterTokenUrl,
-  oneRosterTokenUrlCandidates,
 } from '@/lib/sis/oneroster-setup';
 
 const log = logger.child({ module: 'tech-sis-oneroster' });
@@ -62,15 +61,14 @@ export const POST = withRoute(
     }
 
     let baseUrl: string;
-    let tokenUrl: string;
+    let tokenUrl: string | undefined;
     try {
       baseUrl = normalizeOneRosterBaseUrl(body.baseUrl);
-      // Falls back to the most common shape so the row is never left without a
-      // token URL; the connection test resolves it properly against the
-      // candidates and corrects the row with whichever answered.
-      tokenUrl = body.tokenUrl
-        ? normalizeOneRosterTokenUrl(body.tokenUrl)
-        : (oneRosterTokenUrlCandidates(baseUrl)[0] ?? `${baseUrl}/token`);
+      // Stored only when the district actually gave us one. Left blank the
+      // column stays empty and the connection test derives the endpoint on each
+      // run, which is more honest than recording our own guess in the field
+      // that is supposed to hold what they told us.
+      tokenUrl = body.tokenUrl ? normalizeOneRosterTokenUrl(body.tokenUrl) : undefined;
     } catch (err) {
       // Written for the district administrator and containing nothing
       // sensitive — passing them through is the point.

--- a/app/api/tech/sis/oneroster/test/route.ts
+++ b/app/api/tech/sis/oneroster/test/route.ts
@@ -2,12 +2,7 @@ import { NextResponse } from 'next/server';
 import { withRoute } from '@/lib/api/with-route';
 import { resolveDistrictSisCaller } from '@/lib/api/district-sis-caller';
 import { logger } from '@/lib/logger';
-import {
-  getDecryptedCredential,
-  listConnections,
-  recordTestResult,
-  updateConnectionUrls,
-} from '@/lib/sis/connections';
+import { getDecryptedCredential, listConnections, recordTestResult } from '@/lib/sis/connections';
 import {
   runOneRosterConnectionTest,
   toStoredOneRosterTestResult,
@@ -82,45 +77,35 @@ export const POST = withRoute(
         { status: 409 },
       );
     }
-    if (!connection.base_url || !connection.token_url) {
-      // Both are required, and which one is missing changes nothing the district
-      // would do differently — they re-enter the pair either way.
+    if (!connection.base_url) {
       return NextResponse.json(
         {
-          error:
-            'This connection is missing its OneRoster or token address. Re-enter them and save again.',
+          error: 'This connection has no OneRoster address saved. Re-enter it and save again.',
         },
         { status: 409 },
       );
     }
+    // A missing token address is NOT an error any more. It is a field the
+    // district's own console never shows them (SPE-426), so it is optional on
+    // the form and derived from the base URL here.
 
     const report = await runOneRosterConnectionTest({
       baseUrl: connection.base_url,
-      tokenUrl: connection.token_url,
+      tokenUrl: connection.token_url ?? undefined,
       clientId: credential.clientId,
       clientSecret: credential.clientSecret,
     });
 
-    // Persist a corrected token endpoint before the verdict, for the same
-    // reason as the Aeries base URL: make the fix once instead of re-deriving
-    // it on every test. Non-fatal — the report is already complete.
-    if (report.resolvedTokenUrl) {
-      try {
-        await updateConnectionUrls({
-          connectionId: connection.id,
-          actorId: userId,
-          tokenUrl: report.resolvedTokenUrl,
-        });
-        log.info('Corrected the stored OneRoster token URL', {
-          connectionId: connection.id,
-          from: connection.token_url,
-          to: report.resolvedTokenUrl,
-        });
-      } catch (err) {
-        log.error('Could not persist the corrected OneRoster token URL', err, {
-          connectionId: connection.id,
-        });
-      }
+    // Reported, never written back — see the note in the Aeries test route for
+    // why persisting a resolved address is a trap. Logged so we can see which
+    // districts are on a non-default token endpoint without touching their row.
+    if (report.usedTokenUrl) {
+      log.info('OneRoster signed in at a different token endpoint than the one stored', {
+        connectionId: connection.id,
+        stored: connection.token_url,
+        answered: report.usedTokenUrl,
+        ok: report.ok,
+      });
     }
 
     try {

--- a/app/api/tech/sis/oneroster/test/route.ts
+++ b/app/api/tech/sis/oneroster/test/route.ts
@@ -6,6 +6,7 @@ import {
   getDecryptedCredential,
   listConnections,
   recordTestResult,
+  updateConnectionUrls,
 } from '@/lib/sis/connections';
 import {
   runOneRosterConnectionTest,
@@ -99,6 +100,28 @@ export const POST = withRoute(
       clientId: credential.clientId,
       clientSecret: credential.clientSecret,
     });
+
+    // Persist a corrected token endpoint before the verdict, for the same
+    // reason as the Aeries base URL: make the fix once instead of re-deriving
+    // it on every test. Non-fatal — the report is already complete.
+    if (report.resolvedTokenUrl) {
+      try {
+        await updateConnectionUrls({
+          connectionId: connection.id,
+          actorId: userId,
+          tokenUrl: report.resolvedTokenUrl,
+        });
+        log.info('Corrected the stored OneRoster token URL', {
+          connectionId: connection.id,
+          from: connection.token_url,
+          to: report.resolvedTokenUrl,
+        });
+      } catch (err) {
+        log.error('Could not persist the corrected OneRoster token URL', err, {
+          connectionId: connection.id,
+        });
+      }
+    }
 
     try {
       await recordTestResult({

--- a/app/components/tech/oneroster-connection-card.tsx
+++ b/app/components/tech/oneroster-connection-card.tsx
@@ -74,7 +74,11 @@ export default function OneRosterConnectionCard({
 
   const hasCredential = Boolean(connection.credential_hint);
   const canSave =
-    baseUrl.trim() && tokenUrl.trim() && clientId.trim() && clientSecret.trim();
+    // The token address is deliberately NOT required. An Aeries OneRoster
+    // console shows a URL, a Consumer ID and a Secret — never a token endpoint
+    // — so demanding it forced districts to guess (SPE-426). Left blank, the
+    // server derives it and the connection test settles which shape is right.
+    baseUrl.trim() && clientId.trim() && clientSecret.trim();
 
   const save = async () => {
     // setSaving(true) does not disable the button until the next render, so a
@@ -161,7 +165,7 @@ export default function OneRosterConnectionCard({
 
           <div>
             <label htmlFor="oneroster-token-url" className="block text-sm font-medium text-gray-900">
-              Your token address
+              Your token address <span className="font-normal text-gray-500">(optional)</span>
             </label>
             <input
               id="oneroster-token-url"
@@ -173,8 +177,8 @@ export default function OneRosterConnectionCard({
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             />
             <p className="mt-1 text-xs text-gray-500">
-              Usually the same address as above with <span className="font-mono">/token/</span> on
-              the end.
+              Leave this blank unless your OneRoster settings show one — we will work it out
+              from the address above and confirm it when you test the connection.
             </p>
           </div>
 

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -70,6 +70,17 @@ export class OneRosterApiError extends Error {
     readonly status: number,
     readonly path: string,
     readonly phase: OneRosterPhase,
+    /**
+     * The endpoint answered, but its response could not be used as a token —
+     * not JSON, or JSON with no `access_token`.
+     *
+     * Distinct from `status`, deliberately. Both of those are raised with a
+     * synthetic 502, and a real upstream 502 from a gateway is a completely
+     * different situation: the token endpoint EXISTS and is broken, so
+     * resolution must stop rather than post the district's consumer secret to
+     * another candidate. Without this flag the two are indistinguishable.
+     */
+    readonly unusableTokenResponse = false,
   ) {
     super(message);
     this.name = 'OneRosterApiError';
@@ -147,6 +158,7 @@ export class OneRosterClient {
         502,
         'token endpoint',
         'token',
+        true,
       );
     }
 
@@ -158,6 +170,7 @@ export class OneRosterClient {
         502,
         'token endpoint',
         'token',
+        true,
       );
     }
 

--- a/lib/sis/aeries-setup.ts
+++ b/lib/sis/aeries-setup.ts
@@ -84,10 +84,29 @@ export function aeriesBaseUrlCandidates(storedBaseUrl: string): string[] {
  * to stop repeating.
  *
  * The caller adds one more case the status code cannot express: a 200 whose
- * body is not a list. See the probe below.
+ * body is not a list of schools. See the probe below.
  */
 function isWrongAddress(err: unknown): boolean {
-  return err instanceof AeriesApiError && err.status === 404;
+  if (err instanceof AeriesApiError) return err.status === 404;
+
+  // A 200 whose body will not parse as JSON at all. `AeriesClient` calls
+  // `res.json()` and lets the parse error through raw, so this arrives as a
+  // SyntaxError with no status attached — and without this it falls into
+  // `explain`'s network branch, telling a district we "could not reach" a host
+  // that answered perfectly well.
+  //
+  // This is the ordinary shape of a wrong path on a district's own web server:
+  // an HTML login page, an error page, or whatever a redirect landed on. Not a
+  // rare case, and a 404-only check misses all of it.
+  //
+  // Matched on SHAPE, not `instanceof`. The parse error is raised inside the
+  // fetch implementation's own realm, so `err instanceof SyntaxError` — and
+  // even `err instanceof Error` — is false. The first version of this check
+  // used `instanceof` and therefore never fired once against a real HTML body.
+  const e = err as { name?: unknown; message?: unknown } | null | undefined;
+  const name = typeof e?.name === 'string' ? e.name : '';
+  const message = typeof e?.message === 'string' ? e.message : '';
+  return name === 'SyntaxError' || /JSON/i.test(message);
 }
 
 /**
@@ -218,6 +237,16 @@ function explain(err: unknown, area: string): { status: 'denied' | 'error'; mess
     }
     return { status: 'error', message: `Aeries returned an unexpected error (${err.status}).` };
   }
+  // Answered, but not with Aeries API data — a login or error page where the
+  // API should be. Reported separately from a network failure because the fixes
+  // are opposite: this host is reachable, the address is wrong.
+  if (isWrongAddress(err)) {
+    return {
+      status: 'error',
+      message:
+        'That address answered, but not with Aeries data. Check the Aeries web address — it should look like https://yourdistrict.aeries.net',
+    };
+  }
   // Network-level: DNS, TLS, refused connection. No status to report.
   return {
     status: 'error',
@@ -289,6 +318,10 @@ export async function runAeriesConnectionTest(params: {
   // to be tried last, blaming an address that is just as wrong as the one we
   // started with.
   let exhaustedFallback: { client: AeriesClient; schools: AeriesAreaResult } | null = null;
+  // Kept so a candidate list the guard refused outright reports WHY — the
+  // resolved-to-a-private-address or unreachable-name reason — instead of a
+  // bare "cannot be used" the district can do nothing with.
+  let guardRefusal: string | null = null;
 
   const candidates = aeriesBaseUrlCandidates(params.baseUrl);
   for (const candidate of candidates) {
@@ -297,7 +330,8 @@ export async function runAeriesConnectionTest(params: {
     // quietly stops covering one of its call sites.
     try {
       await assertSafeSisUrl(candidate, AERIES_URL_LABELS);
-    } catch {
+    } catch (err) {
+      guardRefusal ??= err instanceof Error ? err.message : null;
       continue;
     }
 
@@ -365,7 +399,7 @@ export async function runAeriesConnectionTest(params: {
           key: 'connection',
           label: 'Connection',
           status: 'error',
-          message: 'That address cannot be used.',
+          message: guardRefusal ?? 'That address cannot be used.',
         },
       ],
       summary: 'Could not connect to Aeries.',

--- a/lib/sis/aeries-setup.ts
+++ b/lib/sis/aeries-setup.ts
@@ -82,6 +82,9 @@ export function aeriesBaseUrlCandidates(storedBaseUrl: string): string[] {
  * correct address and then report a credential problem as an address problem —
  * the same class of misdiagnosis as SPE-417, which is what this ticket exists
  * to stop repeating.
+ *
+ * The caller adds one more case the status code cannot express: a 200 whose
+ * body is not a list. See the probe below.
  */
 function isWrongAddress(err: unknown): boolean {
   return err instanceof AeriesApiError && err.status === 404;
@@ -167,12 +170,17 @@ export interface AeriesTestReport {
   /**
    * The base URL that actually answered, when it differs from the one stored.
    *
-   * Present only when resolution had to move off the stored value. The caller
-   * persists it so the correction is made once rather than re-derived on every
-   * test — and so a later sync uses the address that works. Never contains a
-   * credential; it is a URL on the host the district already gave us.
+   * REPORTING ONLY — deliberately not written back to the connection row.
+   * An earlier cut of SPE-426 persisted this, and the review found the trap it
+   * sets: resolution runs on failures too, so a district whose correct address
+   * had a bad minute could have had it overwritten with one that never worked,
+   * and the replacement's 401/403 would then stop resolution from ever moving
+   * off it again. One extra request per test is a trivial price next to
+   * silently rewriting a working district's configuration.
+   *
+   * Never contains a credential; it is a URL on the host the district gave us.
    */
-  resolvedBaseUrl?: string;
+  usedBaseUrl?: string;
 }
 
 /**
@@ -268,14 +276,18 @@ export async function runAeriesConnectionTest(params: {
   // On the happy path this is exactly one request, as before: the stored base
   // is tried first and anything other than a 404 ends the search.
   let schoolCodes: number[] = [];
-  let client = new AeriesClient({ baseUrl: params.baseUrl, certificate: params.certificate });
-  let resolvedBaseUrl = params.baseUrl;
+  let client!: AeriesClient;
   let schools!: AeriesAreaResult;
 
+  // Compared against the TRIMMED stored value, so a trailing slash alone never
+  // reads as "we found a different address".
+  const storedBaseUrl = params.baseUrl.trim().replace(/\/+$/, '');
+  let resolvedBaseUrl = storedBaseUrl;
+
   // The stored value's own verdict, kept in case nothing answers. Without it,
-  // exhausting every candidate would report against — and correct the row to —
-  // whichever layout happened to be tried last, inventing an address that is
-  // just as wrong as the one we started with.
+  // exhausting every candidate would report against whichever layout happened
+  // to be tried last, blaming an address that is just as wrong as the one we
+  // started with.
   let exhaustedFallback: { client: AeriesClient; schools: AeriesAreaResult } | null = null;
 
   const candidates = aeriesBaseUrlCandidates(params.baseUrl);
@@ -297,10 +309,15 @@ export async function runAeriesConnectionTest(params: {
     const attempt = await probe('schools', 'Schools', async () => {
       try {
         const list = await attemptClient.getSchools({ fields: ['SchoolCode', 'Name'] });
-        // Without this, a non-array body makes `.map` throw a TypeError, which
-        // `explain` reads as a network failure — telling a district their
-        // reachable instance is unreachable.
         if (!Array.isArray(list)) {
+          // Two things at once. Without the throw, `.map` raises a TypeError
+          // that `explain` reads as a network failure — telling a district
+          // their reachable instance is unreachable. And a 200 carrying
+          // something that is not a list of schools is what a district's *web*
+          // server returns for a path its API does not serve: a login page, an
+          // error page, the landing page a redirect ended on. That is the same
+          // "wrong address" as a 404, wearing a 200, so keep looking.
+          wrongAddress = true;
           throw new AeriesApiError(
             'Aeries returned an unexpected response for Schools.',
             502,
@@ -310,7 +327,7 @@ export async function runAeriesConnectionTest(params: {
         schoolCodes = list.map((s) => s.SchoolCode).filter((c) => Number.isFinite(c));
         return list.length;
       } catch (err) {
-        wrongAddress = isWrongAddress(err);
+        wrongAddress ||= isWrongAddress(err);
         throw err;
       }
     });
@@ -330,13 +347,13 @@ export async function runAeriesConnectionTest(params: {
     break;
   }
 
-  // Nothing answered. Report the stored address's own 404 and correct nothing:
-  // "we could not find your API at any layout we know" is the truth, and
-  // rewriting the row to a guess would bury it.
+  // Nothing answered. Report the stored address's own 404: "we could not find
+  // your API at any layout we know" is the truth, and naming a guess we also
+  // failed to reach would bury it.
   if (!schools && exhaustedFallback) {
     client = exhaustedFallback.client;
     schools = exhaustedFallback.schools;
-    resolvedBaseUrl = params.baseUrl;
+    resolvedBaseUrl = storedBaseUrl;
   }
 
   // Every candidate was refused by the guard: nothing was dialled at all.
@@ -355,10 +372,20 @@ export async function runAeriesConnectionTest(params: {
     };
   }
 
-  const corrected = resolvedBaseUrl !== params.baseUrl ? resolvedBaseUrl : undefined;
+  const usedBaseUrl = resolvedBaseUrl !== storedBaseUrl ? resolvedBaseUrl : undefined;
   areas.push(
     schools.status === 'ok'
-      ? { key: 'connection', label: 'Connection', status: 'ok', message: 'Speddy can reach your Aeries instance.' }
+      ? {
+          key: 'connection',
+          label: 'Connection',
+          status: 'ok',
+          // Named when it is not the address they typed, so a district can see
+          // what worked instead of being told everything is fine about a value
+          // they cannot find anywhere in their own settings.
+          message: usedBaseUrl
+            ? `Speddy can reach your Aeries instance at ${usedBaseUrl}.`
+            : 'Speddy can reach your Aeries instance.',
+        }
       : { key: 'connection', label: 'Connection', status: schools.status, message: schools.message },
     schools,
   );
@@ -382,7 +409,7 @@ export async function runAeriesConnectionTest(params: {
     return {
       ok: false,
       areas,
-      resolvedBaseUrl: corrected,
+      usedBaseUrl,
       summary:
         schools.status === 'ok'
           ? 'Connected, but Aeries returned no schools.'
@@ -449,7 +476,7 @@ export async function runAeriesConnectionTest(params: {
     summary = `${failed.length} of ${permissionAreas.length} areas need attention in Aeries.`;
   }
 
-  return { ok: failed.length === 0, areas, summary, resolvedBaseUrl: corrected };
+  return { ok: failed.length === 0, areas, summary, usedBaseUrl };
 }
 
 /**

--- a/lib/sis/aeries-setup.ts
+++ b/lib/sis/aeries-setup.ts
@@ -28,6 +28,66 @@ import type { SisTestResult } from './connections';
 export const AERIES_API_PATH = '/aeries/api/v5';
 
 /**
+ * The API roots we know Aeries serves, in the order we try them.
+ *
+ * Two real deployment shapes, both ordinary:
+ *   - `/aeries/api/v5` — a district running Aeries on its own web server, where
+ *     `/aeries` is the application root. `demo.aeries.net` is one of these, and
+ *     it is what this integration was originally built and tested against.
+ *   - `/api/v5` — an Aeries-HOSTED dedicated API host (`<district>api.aeries.net`),
+ *     where the API is the whole point of the host and has no app prefix.
+ *
+ * Assuming the first cost a live district a morning (SPE-426): their server
+ * answered every probe with 404, and because `normalizeAeriesBaseUrl` replaced
+ * whatever they typed, there was no address they could have entered to fix it.
+ * Order is deliberate — the historical default stays first, so nothing changes
+ * for a district that already works.
+ */
+export const AERIES_API_PATHS = [AERIES_API_PATH, '/api/v5'] as const;
+
+/**
+ * Every base URL worth trying for a district, most-likely first.
+ *
+ * The stored value leads: if a district (or a previous resolution) gave us a
+ * specific path, it is tried before anything we would guess. The known layouts
+ * follow, on the same host — only the PATH ever varies, so this widens no
+ * egress beyond the host the district supplied and the guard already cleared.
+ */
+export function aeriesBaseUrlCandidates(storedBaseUrl: string): string[] {
+  const trimmed = storedBaseUrl.trim().replace(/\/+$/, '');
+  const candidates: string[] = [];
+  const add = (value: string) => {
+    if (!candidates.includes(value)) candidates.push(value);
+  };
+
+  add(trimmed);
+  try {
+    const { origin } = new URL(trimmed);
+    for (const path of AERIES_API_PATHS) add(`${origin}${path}`);
+  } catch {
+    // Unparseable stored value: the caller's SSRF check will reject it and
+    // report properly. Nothing to add.
+  }
+  return candidates;
+}
+
+/**
+ * Whether a failure means "wrong address" (keep looking) or "right address"
+ * (stop).
+ *
+ * This is the load-bearing distinction in the whole resolver. A 404 is the only
+ * status that says the endpoint is not there. A 401 means the server HAS that
+ * endpoint and refused the certificate; a 403 means it has it and a permission
+ * box is unticked. Treating either as "keep looking" would walk past the
+ * correct address and then report a credential problem as an address problem —
+ * the same class of misdiagnosis as SPE-417, which is what this ticket exists
+ * to stop repeating.
+ */
+function isWrongAddress(err: unknown): boolean {
+  return err instanceof AeriesApiError && err.status === 404;
+}
+
+/**
  * Turn whatever a district administrator pasted into the base URL the client
  * needs.
  *
@@ -72,7 +132,15 @@ export function normalizeAeriesBaseUrl(input: string): string {
   // what the store and test paths actually await.
   assertPublicSisHostSyntax(url.hostname, AERIES_URL_LABELS);
 
-  // Strip whatever path they landed on and append the API path ourselves.
+  // An explicit API root is KEPT. Overriding it is what left a district unable
+  // to enter a working address at all (SPE-426): their API lives at `/api/v5`,
+  // and pasting exactly that still produced `/aeries/api/v5`. If they have told
+  // us where their API is, believe them — the connection test will find out
+  // soon enough, and it can try the other layouts if this one 404s.
+  const path = url.pathname.replace(/\/+$/, '');
+  if (/\/api\/v\d+$/i.test(path)) return `${url.origin}${path}`;
+
+  // Otherwise strip whatever page they landed on and apply the default root.
   // /admin, /student, a deep link — none of it is the API root, and guessing
   // from their path is how you end up with .../admin/aeries/api/v5.
   return `${url.origin}${AERIES_API_PATH}`;
@@ -96,6 +164,15 @@ export interface AeriesTestReport {
   areas: AeriesAreaResult[];
   /** One-line summary for the connection row and the status chip. */
   summary: string;
+  /**
+   * The base URL that actually answered, when it differs from the one stored.
+   *
+   * Present only when resolution had to move off the stored value. The caller
+   * persists it so the correction is made once rather than re-derived on every
+   * test — and so a later sync uses the address that works. Never contains a
+   * credential; it is a URL on the host the district already gave us.
+   */
+  resolvedBaseUrl?: string;
 }
 
 /**
@@ -180,28 +257,105 @@ export async function runAeriesConnectionTest(params: {
     };
   }
 
-  const client = new AeriesClient({
-    baseUrl: params.baseUrl,
-    certificate: params.certificate,
-  });
-
   const areas: AeriesAreaResult[] = [];
 
-  // 1. Reachability + certificate. `schools` doubles as the auth check: it is
-  // the smallest endpoint that requires a valid cert, and it carries no
-  // student data, so a failed connection never touches PII.
+  // 1. Reachability + certificate, across the known API layouts. `schools`
+  // doubles as the auth check: it is the smallest endpoint that requires a
+  // valid cert, and it carries no student data, so a failed connection never
+  // touches PII. It is also what resolution is decided on — a 404 here is the
+  // signal that the address, not the credential, is wrong.
+  //
+  // On the happy path this is exactly one request, as before: the stored base
+  // is tried first and anything other than a 404 ends the search.
   let schoolCodes: number[] = [];
-  const schools = await probe('schools', 'Schools', async () => {
-    const list = await client.getSchools({ fields: ['SchoolCode', 'Name'] });
-    // Without this, a non-array body makes `.map` throw a TypeError, which
-    // `explain` reads as a network failure — telling a district their reachable
-    // instance is unreachable.
-    if (!Array.isArray(list)) {
-      throw new AeriesApiError('Aeries returned an unexpected response for Schools.', 502, 'schools');
+  let client = new AeriesClient({ baseUrl: params.baseUrl, certificate: params.certificate });
+  let resolvedBaseUrl = params.baseUrl;
+  let schools!: AeriesAreaResult;
+
+  // The stored value's own verdict, kept in case nothing answers. Without it,
+  // exhausting every candidate would report against — and correct the row to —
+  // whichever layout happened to be tried last, inventing an address that is
+  // just as wrong as the one we started with.
+  let exhaustedFallback: { client: AeriesClient; schools: AeriesAreaResult } | null = null;
+
+  const candidates = aeriesBaseUrlCandidates(params.baseUrl);
+  for (const candidate of candidates) {
+    // Each candidate is re-guarded. Only the path varies, but the check is
+    // cheap and skipping it on the strength of "same host" is how a guard
+    // quietly stops covering one of its call sites.
+    try {
+      await assertSafeSisUrl(candidate, AERIES_URL_LABELS);
+    } catch {
+      continue;
     }
-    schoolCodes = list.map((s) => s.SchoolCode).filter((c) => Number.isFinite(c));
-    return list.length;
-  });
+
+    const attemptClient = new AeriesClient({
+      baseUrl: candidate,
+      certificate: params.certificate,
+    });
+    let wrongAddress = false;
+    const attempt = await probe('schools', 'Schools', async () => {
+      try {
+        const list = await attemptClient.getSchools({ fields: ['SchoolCode', 'Name'] });
+        // Without this, a non-array body makes `.map` throw a TypeError, which
+        // `explain` reads as a network failure — telling a district their
+        // reachable instance is unreachable.
+        if (!Array.isArray(list)) {
+          throw new AeriesApiError(
+            'Aeries returned an unexpected response for Schools.',
+            502,
+            'schools',
+          );
+        }
+        schoolCodes = list.map((s) => s.SchoolCode).filter((c) => Number.isFinite(c));
+        return list.length;
+      } catch (err) {
+        wrongAddress = isWrongAddress(err);
+        throw err;
+      }
+    });
+
+    // Keep looking only while the server says "not here". Anything else — a
+    // success, a rejected certificate, an unticked permission, a timeout — is
+    // an answer FROM this address, so it is the address to report against.
+    if (wrongAddress) {
+      exhaustedFallback ??= { client: attemptClient, schools: attempt };
+      schoolCodes = [];
+      continue;
+    }
+
+    client = attemptClient;
+    resolvedBaseUrl = candidate;
+    schools = attempt;
+    break;
+  }
+
+  // Nothing answered. Report the stored address's own 404 and correct nothing:
+  // "we could not find your API at any layout we know" is the truth, and
+  // rewriting the row to a guess would bury it.
+  if (!schools && exhaustedFallback) {
+    client = exhaustedFallback.client;
+    schools = exhaustedFallback.schools;
+    resolvedBaseUrl = params.baseUrl;
+  }
+
+  // Every candidate was refused by the guard: nothing was dialled at all.
+  if (!schools) {
+    return {
+      ok: false,
+      areas: [
+        {
+          key: 'connection',
+          label: 'Connection',
+          status: 'error',
+          message: 'That address cannot be used.',
+        },
+      ],
+      summary: 'Could not connect to Aeries.',
+    };
+  }
+
+  const corrected = resolvedBaseUrl !== params.baseUrl ? resolvedBaseUrl : undefined;
   areas.push(
     schools.status === 'ok'
       ? { key: 'connection', label: 'Connection', status: 'ok', message: 'Speddy can reach your Aeries instance.' }
@@ -228,6 +382,7 @@ export async function runAeriesConnectionTest(params: {
     return {
       ok: false,
       areas,
+      resolvedBaseUrl: corrected,
       summary:
         schools.status === 'ok'
           ? 'Connected, but Aeries returned no schools.'
@@ -294,7 +449,7 @@ export async function runAeriesConnectionTest(params: {
     summary = `${failed.length} of ${permissionAreas.length} areas need attention in Aeries.`;
   }
 
-  return { ok: failed.length === 0, areas, summary };
+  return { ok: failed.length === 0, areas, summary, resolvedBaseUrl: corrected };
 }
 
 /**

--- a/lib/sis/connections.ts
+++ b/lib/sis/connections.ts
@@ -327,56 +327,6 @@ export async function storeCredential(
 }
 
 /**
- * Correct a connection's addresses after resolution found which one answers.
- *
- * Exists because until now `storeCredential()` was the ONLY writer of
- * `base_url`, and it requires a credential — so a district could not fix a
- * wrong address without re-pasting their certificate. That is not a
- * hypothetical: SPE-426 left a live district with an address they could not
- * correct and a certificate they had already entered twice that day.
- *
- * Deliberately cannot touch a credential. It accepts only URLs and writes only
- * URL columns, so the one path that exists to repair a connection can never
- * become a second way to write a secret. Callers pass what actually answered.
- */
-export async function updateConnectionUrls(params: {
-  connectionId: string;
-  actorId: string;
-  baseUrl?: string;
-  tokenUrl?: string;
-}): Promise<void> {
-  const patch: Record<string, string> = {};
-  if (params.baseUrl !== undefined) patch.base_url = params.baseUrl;
-  if (params.tokenUrl !== undefined) patch.token_url = params.tokenUrl;
-  if (Object.keys(patch).length === 0) return;
-
-  const supabase = createServiceClient();
-  // `.select().maybeSingle()` for the same reason disconnect() does it: an
-  // UPDATE matching no row reports no error, so without this a correction
-  // against a bogus id would report success and write an audit record for a
-  // change that never happened.
-  const { data, error } = await supabase
-    .from('district_sis_connections')
-    .update(patch)
-    .eq('id', params.connectionId)
-    .select('id')
-    .maybeSingle();
-
-  if (error) throw new Error(`Failed to update SIS connection URLs: ${error.message}`);
-  if (!data) throw new Error(SIS_CONNECTION_NOT_FOUND);
-
-  // Audited: this silently changes where a district's credential gets sent, so
-  // it belongs in the same log as the credential events themselves.
-  await logServerAuditEvent({
-    user_id: params.actorId,
-    action: 'sis_connection_url_corrected',
-    resource_type: 'district_sis_connection',
-    resource_id: params.connectionId,
-    metadata: patch,
-  });
-}
-
-/**
  * Record the outcome of a connection test. Never stores anything sensitive.
  *
  * NOTE for SPE-396/397, which will be the first real callers: `last_test_result`

--- a/lib/sis/connections.ts
+++ b/lib/sis/connections.ts
@@ -327,6 +327,56 @@ export async function storeCredential(
 }
 
 /**
+ * Correct a connection's addresses after resolution found which one answers.
+ *
+ * Exists because until now `storeCredential()` was the ONLY writer of
+ * `base_url`, and it requires a credential — so a district could not fix a
+ * wrong address without re-pasting their certificate. That is not a
+ * hypothetical: SPE-426 left a live district with an address they could not
+ * correct and a certificate they had already entered twice that day.
+ *
+ * Deliberately cannot touch a credential. It accepts only URLs and writes only
+ * URL columns, so the one path that exists to repair a connection can never
+ * become a second way to write a secret. Callers pass what actually answered.
+ */
+export async function updateConnectionUrls(params: {
+  connectionId: string;
+  actorId: string;
+  baseUrl?: string;
+  tokenUrl?: string;
+}): Promise<void> {
+  const patch: Record<string, string> = {};
+  if (params.baseUrl !== undefined) patch.base_url = params.baseUrl;
+  if (params.tokenUrl !== undefined) patch.token_url = params.tokenUrl;
+  if (Object.keys(patch).length === 0) return;
+
+  const supabase = createServiceClient();
+  // `.select().maybeSingle()` for the same reason disconnect() does it: an
+  // UPDATE matching no row reports no error, so without this a correction
+  // against a bogus id would report success and write an audit record for a
+  // change that never happened.
+  const { data, error } = await supabase
+    .from('district_sis_connections')
+    .update(patch)
+    .eq('id', params.connectionId)
+    .select('id')
+    .maybeSingle();
+
+  if (error) throw new Error(`Failed to update SIS connection URLs: ${error.message}`);
+  if (!data) throw new Error(SIS_CONNECTION_NOT_FOUND);
+
+  // Audited: this silently changes where a district's credential gets sent, so
+  // it belongs in the same log as the credential events themselves.
+  await logServerAuditEvent({
+    user_id: params.actorId,
+    action: 'sis_connection_url_corrected',
+    resource_type: 'district_sis_connection',
+    resource_id: params.connectionId,
+    metadata: patch,
+  });
+}
+
+/**
  * Record the outcome of a connection test. Never stores anything sensitive.
  *
  * NOTE for SPE-396/397, which will be the first real callers: `last_test_result`

--- a/lib/sis/connections.ts
+++ b/lib/sis/connections.ts
@@ -218,7 +218,16 @@ export interface StoreCredentialInput {
   connectionId: string;
   actorId: string;
   baseUrl?: string;
-  tokenUrl?: string;
+  /**
+   * Pass `null` to CLEAR a stored token address.
+   *
+   * `undefined` means "leave whatever is there", which is right for the Aeries
+   * flow that never sends this field. It is wrong for OneRoster, where the
+   * field is optional and we tell districts to leave it blank: without an
+   * explicit clear, a district cannot remove an earlier wrong guess, and that
+   * stale value goes on being tried first by the resolver (SPE-426).
+   */
+  tokenUrl?: string | null;
   /** Aeries */
   certificate?: string;
   /** OneRoster */
@@ -279,7 +288,7 @@ export async function storeCredential(
     last_test_result: null,
   };
   if (input.baseUrl !== undefined) patch.base_url = input.baseUrl;
-  if (input.tokenUrl !== undefined) patch.token_url = input.tokenUrl;
+  if (input.tokenUrl !== undefined) patch.token_url = input.tokenUrl;   // null clears it
 
   if (existing.sis_type === 'aeries') {
     if (!input.certificate) throw new Error('Aeries connection requires a certificate');

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -274,6 +274,34 @@ async function step(
 const NOT_REACHED = 'Not checked — the previous step has to work first.';
 
 /**
+ * Whether a token-step failure means "no token endpoint here" (keep looking)
+ * or "this IS the endpoint" (stop).
+ *
+ * Deliberately wider than a bare 404, and deliberately narrower than "any
+ * failure". Each status earns its place:
+ *
+ *   404 — nothing served at that path.
+ *   405 — something is there, but it does not take a POST. Not a token
+ *         endpoint; a vendor's data path answers exactly like this.
+ *   502 — OUR OWN marker, raised by `fetchToken` when the response is not JSON
+ *         or carries no `access_token`. A login page or a data collection
+ *         returning 200 is a wrong endpoint wearing a success status.
+ *
+ * What must NOT continue: 400, 401 and 403. Those are the endpoint telling us
+ * the CREDENTIALS are wrong, which is the district's real problem — walking on
+ * would replace it with "check your address" and hide it. Nor 5xx other than
+ * our own marker: their token endpoint exists and is broken, and trying two
+ * more paths would neither find it nor say anything useful.
+ *
+ * Every extra candidate also posts the consumer secret somewhere new, so the
+ * set stays as small as the failure modes allow.
+ */
+function isNotATokenEndpoint(err: unknown): boolean {
+  if (!(err instanceof OneRosterApiError) || err.phase !== 'token') return false;
+  return err.status === 404 || err.status === 405 || err.status === 502;
+}
+
+/**
  * Run the connection test: token grant, then orgs, then schools.
  *
  * Strictly sequential and short-circuiting. If the token grant fails, the two
@@ -333,7 +361,9 @@ export async function runOneRosterConnectionTest(params: {
   let client!: OneRosterClient;
   let resolvedTokenUrl = storedTokenUrl;
   let token!: OneRosterStepResult;
-  let tokenFallback: { client: OneRosterClient; step: OneRosterStepResult } | null = null;
+  let tokenFallback:
+    | { client: OneRosterClient; step: OneRosterStepResult; url: string }
+    | null = null;
   // Kept so a candidate list the guard refused outright reports WHY, rather
   // than a generic "cannot be used" the district can do nothing with.
   let guardRefusal: string | null = null;
@@ -354,14 +384,13 @@ export async function runOneRosterConnectionTest(params: {
         await attemptClient.fetchToken();
         return 1;
       } catch (err) {
-        missing =
-          err instanceof OneRosterApiError && err.phase === 'token' && err.status === 404;
+        missing = isNotATokenEndpoint(err);
         throw err;
       }
     });
 
     if (missing) {
-      tokenFallback ??= { client: attemptClient, step: attempt };
+      tokenFallback ??= { client: attemptClient, step: attempt, url: candidate };
       continue;
     }
 
@@ -371,12 +400,15 @@ export async function runOneRosterConnectionTest(params: {
     break;
   }
 
-  // Nothing served a token endpoint. Report the stored address's own failure —
-  // naming a guess we also could not reach would bury the truth.
+  // Nothing served a token endpoint. Report the FIRST candidate's own failure —
+  // naming the last guess we also could not reach would bury the truth.
   if (!token && tokenFallback) {
     client = tokenFallback.client;
     token = tokenFallback.step;
-    resolvedTokenUrl = storedTokenUrl;
+    // The address we actually dialled, not the stored one. When the district
+    // left the field blank there IS no stored address, and reporting a failure
+    // against an empty string tells them nothing about what was tried.
+    resolvedTokenUrl = tokenFallback.url;
   }
   if (!token) {
     return {
@@ -394,10 +426,15 @@ export async function runOneRosterConnectionTest(params: {
   }
 
   const usedTokenUrl = resolvedTokenUrl !== storedTokenUrl ? resolvedTokenUrl : undefined;
-  if (token.status === 'ok' && usedTokenUrl) {
-    // Named when it is not the address they gave us — most often because they
-    // gave us none at all. A district should be able to see what we used.
-    token = { ...token, message: `Working — signed in at ${usedTokenUrl}.` };
+  if (usedTokenUrl) {
+    // Named whether it worked or not, and most of all when it did NOT. A
+    // district who left the field blank and is then told their Consumer ID and
+    // Secret are wrong has no way to know we picked an address for them — which
+    // is the same dead end, one field over, that this ticket exists to remove.
+    token =
+      token.status === 'ok'
+        ? { ...token, message: `Working — signed in at ${usedTokenUrl}.` }
+        : { ...token, message: `${token.message} (Tried ${usedTokenUrl}.)` };
   }
   steps.push(token);
 

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -61,7 +61,38 @@ export function normalizeOneRosterBaseUrl(input: string): string {
 }
 
 /**
- * Normalize the token endpoint.
+ * Token endpoints to try when the district did not give us one, in order.
+ *
+ * Districts are asked for a "token address" their admin console never shows
+ * them. An Aeries OneRoster screen presents a URL, a consumer ID and a secret —
+ * no token endpoint — so the field could only ever be answered with a guess
+ * (SPE-426: a live district guessed, and their guess went untested for hours).
+ * Deriving it is strictly better than demanding it: the shapes below are the
+ * ones vendors actually serve, and the connection test settles which is right
+ * rather than asking someone to know.
+ *
+ * Always on the host the district already supplied — these vary the PATH only.
+ */
+export function oneRosterTokenUrlCandidates(baseUrl: string): string[] {
+  const trimmed = baseUrl.trim().replace(/\/+$/, '');
+  const candidates: string[] = [];
+  const add = (value: string) => {
+    if (!candidates.includes(value)) candidates.push(value);
+  };
+
+  try {
+    const { origin } = new URL(trimmed);
+    add(`${trimmed}/token`);
+    add(`${trimmed}/oauth/token`);
+    add(`${origin}/token`);
+  } catch {
+    // Unparseable base: the caller's guard reports it properly.
+  }
+  return candidates;
+}
+
+/**
+ * Normalize a token endpoint the district DID supply.
  *
  * Kept whole — unlike the base URL there is no version segment to strip, and
  * the path genuinely varies between vendors (`/token`, `/token/`, `/oauth/token`).
@@ -126,6 +157,13 @@ export interface OneRosterTestReport {
   ok: boolean;
   steps: OneRosterStepResult[];
   summary: string;
+  /**
+   * The token endpoint that actually answered, when it differs from the stored
+   * one. Present only when resolution had to move off the stored value; the
+   * caller persists it so the correction is made once. Never a credential —
+   * a URL on the host the district already gave us.
+   */
+  resolvedTokenUrl?: string;
 }
 
 /**
@@ -253,13 +291,73 @@ export async function runOneRosterConnectionTest(params: {
     }
   }
 
-  const client = new OneRosterClient(params);
   const steps: OneRosterStepResult[] = [];
 
-  const token = await step('token', 'Sign-in', async () => {
-    await client.fetchToken();
-    return 1;
-  });
+  // Sign in, resolving the token endpoint if the stored one is not there.
+  //
+  // Same discriminator as the Aeries resolver: a 404 means nothing serves that
+  // path, so keep looking. A 401 means the endpoint EXISTS and rejected the
+  // credentials — the district's real problem — so stop, or we would report a
+  // credential error as an address error. On the happy path this is exactly one
+  // request, because the stored value is tried first.
+  const tokenCandidates = [
+    params.tokenUrl,
+    ...oneRosterTokenUrlCandidates(params.baseUrl).filter((u) => u !== params.tokenUrl),
+  ];
+
+  let client = new OneRosterClient(params);
+  let resolvedTokenUrl = params.tokenUrl;
+  let token!: OneRosterStepResult;
+  let tokenFallback: { client: OneRosterClient; step: OneRosterStepResult } | null = null;
+
+  for (const candidate of tokenCandidates) {
+    // Re-guarded per candidate: a credential is about to be posted to it.
+    try {
+      await assertSafeSisUrl(candidate, ONEROSTER_URL_LABELS);
+    } catch {
+      continue;
+    }
+
+    const attemptClient = new OneRosterClient({ ...params, tokenUrl: candidate });
+    let missing = false;
+    const attempt = await step('token', 'Sign-in', async () => {
+      try {
+        await attemptClient.fetchToken();
+        return 1;
+      } catch (err) {
+        missing =
+          err instanceof OneRosterApiError && err.phase === 'token' && err.status === 404;
+        throw err;
+      }
+    });
+
+    if (missing) {
+      tokenFallback ??= { client: attemptClient, step: attempt };
+      continue;
+    }
+
+    client = attemptClient;
+    resolvedTokenUrl = candidate;
+    token = attempt;
+    break;
+  }
+
+  // Nothing served a token endpoint. Report the stored address's own failure
+  // and correct nothing — rewriting the row to a guess would bury the truth.
+  if (!token && tokenFallback) {
+    client = tokenFallback.client;
+    token = tokenFallback.step;
+    resolvedTokenUrl = params.tokenUrl;
+  }
+  if (!token) {
+    return {
+      ok: false,
+      steps: [{ key: 'token', label: 'Connection', status: 'error', message: 'That address cannot be used.' }],
+      summary: 'Could not connect to OneRoster.',
+    };
+  }
+
+  const correctedTokenUrl = resolvedTokenUrl !== params.tokenUrl ? resolvedTokenUrl : undefined;
   steps.push(token);
 
   if (token.status !== 'ok') {
@@ -267,7 +365,7 @@ export async function runOneRosterConnectionTest(params: {
       { key: 'orgs', label: 'Districts and schools', status: 'untested', message: NOT_REACHED },
       { key: 'schools', label: 'Schools', status: 'untested', message: NOT_REACHED },
     );
-    return { ok: false, steps, summary: 'Could not connect to OneRoster.' };
+    return { ok: false, steps, summary: 'Could not connect to OneRoster.', resolvedTokenUrl: correctedTokenUrl };
   }
 
   // One record is enough to prove the collection is readable. Walking it would
@@ -301,7 +399,7 @@ export async function runOneRosterConnectionTest(params: {
       ? 'Could not connect to OneRoster.'
       : `Connected, but ${failed.length} of ${steps.length} checks need attention.`;
 
-  return { ok: failed.length === 0, steps, summary };
+  return { ok: failed.length === 0, steps, summary, resolvedTokenUrl: correctedTokenUrl };
 }
 
 /**

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -71,7 +71,13 @@ export function normalizeOneRosterBaseUrl(input: string): string {
  * ones vendors actually serve, and the connection test settles which is right
  * rather than asking someone to know.
  *
- * Always on the host the district already supplied — these vary the PATH only.
+ * Always UNDER the base URL the district supplied — these append to their path,
+ * they never climb out of it. An earlier cut also tried `<origin>/token`, and
+ * that is a different thing entirely: a district whose OneRoster lives at
+ * `https://sis.example.org/aeries` shares that host with other applications,
+ * and posting their consumer secret to `https://sis.example.org/token` would
+ * hand it to whatever answers at the root. Staying under the path they gave us
+ * keeps every guess inside the application they pointed us at.
  */
 export function oneRosterTokenUrlCandidates(baseUrl: string): string[] {
   const trimmed = baseUrl.trim().replace(/\/+$/, '');
@@ -81,10 +87,10 @@ export function oneRosterTokenUrlCandidates(baseUrl: string): string[] {
   };
 
   try {
-    const { origin } = new URL(trimmed);
+    // Parsed for validation only — an unparseable base has no safe guesses.
+    new URL(trimmed);
     add(`${trimmed}/token`);
     add(`${trimmed}/oauth/token`);
-    add(`${origin}/token`);
   } catch {
     // Unparseable base: the caller's guard reports it properly.
   }
@@ -159,11 +165,16 @@ export interface OneRosterTestReport {
   summary: string;
   /**
    * The token endpoint that actually answered, when it differs from the stored
-   * one. Present only when resolution had to move off the stored value; the
-   * caller persists it so the correction is made once. Never a credential —
-   * a URL on the host the district already gave us.
+   * one.
+   *
+   * REPORTING ONLY — deliberately not written back to the connection row, for
+   * the same reason as `AeriesTestReport.usedBaseUrl`: resolution runs on
+   * failures too, so persisting it would let a bad minute overwrite a working
+   * district's configuration with an endpoint that never worked.
+   *
+   * Never a credential — a URL under the base the district already gave us.
    */
-  resolvedTokenUrl?: string;
+  usedTokenUrl?: string;
 }
 
 /**
@@ -185,10 +196,14 @@ function explain(err: unknown, step: string): { status: 'denied' | 'error'; mess
         };
       }
       if (err.status === 404) {
+        // Reached only after every candidate under the district's OneRoster
+        // address has 404'd too, so "check the token address" is the wrong
+        // advice — it is the field we now tell them to leave blank. The address
+        // still worth checking is the one they DID give us.
         return {
           status: 'error',
           message:
-            'Nothing answered at that token address. It usually ends in /token/ — check it against your Aeries OneRoster settings.',
+            'No sign-in endpoint answered under your OneRoster address. Check that address first; if your OneRoster settings do show a separate token address, enter it above.',
         };
       }
       if (err.status === 408) {
@@ -267,29 +282,35 @@ const NOT_REACHED = 'Not checked — the previous step has to work first.';
  */
 export async function runOneRosterConnectionTest(params: {
   baseUrl: string;
-  tokenUrl: string;
+  /** Optional: blank means "we were never told one", and it gets derived. */
+  tokenUrl?: string;
   clientId: string;
   clientSecret: string;
 }): Promise<OneRosterTestReport> {
-  // Both URLs are re-checked here, not just at write time: a stored row could
-  // predate the guard, and a name's addresses can change after it was saved.
-  // Checked BEFORE the client is constructed, so no credential is ever sent to
-  // an address that has not passed.
-  for (const [url, what] of [
-    [params.tokenUrl, 'token address'],
-    [params.baseUrl, 'OneRoster address'],
-  ] as const) {
-    try {
-      await assertSafeSisUrl(url, ONEROSTER_URL_LABELS);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'That address cannot be used.';
-      return {
-        ok: false,
-        steps: [{ key: 'token', label: 'Connection', status: 'error', message: `${what}: ${message}` }],
-        summary: 'Could not connect to OneRoster.',
-      };
-    }
+  // The BASE URL is checked up front, before any client exists: every token
+  // candidate is derived from it, so if it cannot be used there is nothing safe
+  // to try. Re-checked here rather than trusted from write time, because a
+  // stored row can predate the guard and a name's addresses can change.
+  try {
+    await assertSafeSisUrl(params.baseUrl, ONEROSTER_URL_LABELS);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'That address cannot be used.';
+    return {
+      ok: false,
+      steps: [
+        { key: 'token', label: 'Connection', status: 'error', message: `OneRoster address: ${message}` },
+      ],
+      summary: 'Could not connect to OneRoster.',
+    };
   }
+
+  // The TOKEN address is deliberately NOT checked here. It is guarded per
+  // candidate inside the loop below, which is the only place it can be: a
+  // stored token address the guard refuses is exactly the case resolution
+  // exists for, and failing here would return before the derived candidates
+  // were ever tried — leaving the district stuck on a guess they were asked to
+  // make and cannot correct. Nothing is sent to any candidate that has not
+  // passed; the guard simply runs later, per address.
 
   const steps: OneRosterStepResult[] = [];
 
@@ -300,21 +321,29 @@ export async function runOneRosterConnectionTest(params: {
   // credentials — the district's real problem — so stop, or we would report a
   // credential error as an address error. On the happy path this is exactly one
   // request, because the stored value is tried first.
+  //
+  // Trimmed, so a stored value that differs only by a trailing slash is not
+  // tried twice and does not later read as "we found a different endpoint".
+  const storedTokenUrl = (params.tokenUrl ?? '').trim().replace(/\/+$/, '');
   const tokenCandidates = [
-    params.tokenUrl,
-    ...oneRosterTokenUrlCandidates(params.baseUrl).filter((u) => u !== params.tokenUrl),
+    ...(storedTokenUrl ? [storedTokenUrl] : []),
+    ...oneRosterTokenUrlCandidates(params.baseUrl).filter((u) => u !== storedTokenUrl),
   ];
 
-  let client = new OneRosterClient(params);
-  let resolvedTokenUrl = params.tokenUrl;
+  let client!: OneRosterClient;
+  let resolvedTokenUrl = storedTokenUrl;
   let token!: OneRosterStepResult;
   let tokenFallback: { client: OneRosterClient; step: OneRosterStepResult } | null = null;
+  // Kept so a candidate list the guard refused outright reports WHY, rather
+  // than a generic "cannot be used" the district can do nothing with.
+  let guardRefusal: string | null = null;
 
   for (const candidate of tokenCandidates) {
     // Re-guarded per candidate: a credential is about to be posted to it.
     try {
       await assertSafeSisUrl(candidate, ONEROSTER_URL_LABELS);
-    } catch {
+    } catch (err) {
+      guardRefusal ??= err instanceof Error ? err.message : null;
       continue;
     }
 
@@ -342,22 +371,34 @@ export async function runOneRosterConnectionTest(params: {
     break;
   }
 
-  // Nothing served a token endpoint. Report the stored address's own failure
-  // and correct nothing — rewriting the row to a guess would bury the truth.
+  // Nothing served a token endpoint. Report the stored address's own failure —
+  // naming a guess we also could not reach would bury the truth.
   if (!token && tokenFallback) {
     client = tokenFallback.client;
     token = tokenFallback.step;
-    resolvedTokenUrl = params.tokenUrl;
+    resolvedTokenUrl = storedTokenUrl;
   }
   if (!token) {
     return {
       ok: false,
-      steps: [{ key: 'token', label: 'Connection', status: 'error', message: 'That address cannot be used.' }],
+      steps: [
+        {
+          key: 'token',
+          label: 'Connection',
+          status: 'error',
+          message: guardRefusal ?? 'That address cannot be used.',
+        },
+      ],
       summary: 'Could not connect to OneRoster.',
     };
   }
 
-  const correctedTokenUrl = resolvedTokenUrl !== params.tokenUrl ? resolvedTokenUrl : undefined;
+  const usedTokenUrl = resolvedTokenUrl !== storedTokenUrl ? resolvedTokenUrl : undefined;
+  if (token.status === 'ok' && usedTokenUrl) {
+    // Named when it is not the address they gave us — most often because they
+    // gave us none at all. A district should be able to see what we used.
+    token = { ...token, message: `Working — signed in at ${usedTokenUrl}.` };
+  }
   steps.push(token);
 
   if (token.status !== 'ok') {
@@ -365,7 +406,7 @@ export async function runOneRosterConnectionTest(params: {
       { key: 'orgs', label: 'Districts and schools', status: 'untested', message: NOT_REACHED },
       { key: 'schools', label: 'Schools', status: 'untested', message: NOT_REACHED },
     );
-    return { ok: false, steps, summary: 'Could not connect to OneRoster.', resolvedTokenUrl: correctedTokenUrl };
+    return { ok: false, steps, summary: 'Could not connect to OneRoster.', usedTokenUrl };
   }
 
   // One record is enough to prove the collection is readable. Walking it would
@@ -399,7 +440,7 @@ export async function runOneRosterConnectionTest(params: {
       ? 'Could not connect to OneRoster.'
       : `Connected, but ${failed.length} of ${steps.length} checks need attention.`;
 
-  return { ok: failed.length === 0, steps, summary, resolvedTokenUrl: correctedTokenUrl };
+  return { ok: failed.length === 0, steps, summary, usedTokenUrl };
 }
 
 /**

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -283,22 +283,27 @@ const NOT_REACHED = 'Not checked — the previous step has to work first.';
  *   404 — nothing served at that path.
  *   405 — something is there, but it does not take a POST. Not a token
  *         endpoint; a vendor's data path answers exactly like this.
- *   502 — OUR OWN marker, raised by `fetchToken` when the response is not JSON
- *         or carries no `access_token`. A login page or a data collection
+ *   `unusableTokenResponse` — the endpoint answered 2xx but the body was not
+ *         JSON, or carried no `access_token`. A login page or a data collection
  *         returning 200 is a wrong endpoint wearing a success status.
  *
- * What must NOT continue: 400, 401 and 403. Those are the endpoint telling us
- * the CREDENTIALS are wrong, which is the district's real problem — walking on
- * would replace it with "check your address" and hide it. Nor 5xx other than
- * our own marker: their token endpoint exists and is broken, and trying two
- * more paths would neither find it nor say anything useful.
+ * That last one is a FLAG, not a status, and the distinction is the point.
+ * `fetchToken` raises those two cases with a synthetic 502, and `dial` raises a
+ * real upstream 502 with the same number — but they mean opposite things. A
+ * gateway 502 says the token endpoint exists and is broken; posting the
+ * district's consumer secret to two more paths would neither find it nor say
+ * anything useful. Keying on the status alone conflated them (caught in review).
  *
- * Every extra candidate also posts the consumer secret somewhere new, so the
- * set stays as small as the failure modes allow.
+ * What must NOT continue: 400, 401 and 403 — the endpoint telling us the
+ * CREDENTIALS are wrong, which is the district's real problem, and walking on
+ * would replace it with "check your address" and hide it. Nor any real 5xx.
+ *
+ * Every extra candidate posts the consumer secret somewhere new, so the set
+ * stays as small as the failure modes allow.
  */
 function isNotATokenEndpoint(err: unknown): boolean {
   if (!(err instanceof OneRosterApiError) || err.phase !== 'token') return false;
-  return err.status === 404 || err.status === 405 || err.status === 502;
+  return err.unusableTokenResponse || err.status === 404 || err.status === 405;
 }
 
 /**


### PR DESCRIPTION
Closes [SPE-426](https://linear.app/speddy/issue/SPE-426/sis-setup-work-out-the-api-address-ourselves-instead-of-assuming-it-or). **A live district (John Swett Unified) is blocked on this right now.**

> **Changed since first push.** The first cut of this PR *persisted* the resolved address back to the district's connection row. Deep review found that dangerous and I cut it — see [Course correction](#course-correction). A second review pass then found five gaps in the recovery paths, all fixed in the third commit — see [Second review pass](#second-review-pass).

## What happened

Third failure in one day on the same onboarding, each uncovered by fixing the one before it:

1. **SPE-417** — the encryption key was not live on the running build; the certificate would not save. Fixed, deployed.
2. **SPE-420** — nothing could tell staff whether the key was live. Fixed, deployed; the check reads green on production.
3. **This** — the certificate saves, and the *connection test* fails.

At 20:12 UTC the district's tech admin saved his Aeries certificate successfully (`credential_hint = ••••eddf`, `v1.…` envelope, DPA on file). He then ran the connection test **nine times in six minutes**, and OneRoster four times after that. Every one failed.

## Root cause

**Aeries answered. It returned `404`** — every attempt, from the production logs:

```
[ERROR] Aeries API request failed { status: 404, path: 'schools' }
```

Decisive: DNS resolves (`jsusdapi.aeries.net` → 54.219.14.250 / 52.8.11.153, public AWS), TLS completed, the request arrived, the server replied. Never a connectivity or credential problem — **we asked for a path that does not exist on their server.**

```ts
export const AERIES_API_PATH = '/aeries/api/v5';
…
return `${url.origin}${AERIES_API_PATH}`;   // origin = scheme + host + port ONLY
```

That default is right for a district running Aeries on its own web server (`demo.aeries.net`, which this was built against). JSUSD is on a **dedicated Aeries-hosted API host** — `jsusdapi.aeries.net`, note the `api` — where the API has no app prefix. Both are ordinary Aeries deployments; we handled one.

**And the district could not tell us.** Verified:

```
district types the CORRECT url: https://jsusdapi.aeries.net/api/v5
what we store instead:          https://jsusdapi.aeries.net/aeries/api/v5
```

Our own 404 copy said *"Check the Aeries web address"* — advice he could not act on, because the form could not accept a correct address. Nine attempts is what that dead end looks like from the outside.

### Second problem: the OneRoster token address

Per the district, via Blair: he *"didn't know what the 'token address' was — he's only ever entered AERIES/OneRoster field, consumer ID and secret key."* He is right, and `tokenUrl` was **required**. An Aeries OneRoster console shows a URL, a Consumer ID and a Secret — never a token endpoint. We demanded a value their console does not display, so the best available answer was a guess.

## What changed

**Principle: never demand a URL detail a district cannot know, never override one they do, and never rewrite their configuration behind their back.**

| | |
|---|---|
| **Keep an explicit root** | `normalizeAeriesBaseUrl` preserves a path matching `/api/v{n}`; the default applies only to a bare host. |
| **Resolve at test time** | Candidates tried most-likely-first, starting with the stored value — so a working district still sends exactly one request. |
| **Derive the token endpoint** | `tokenUrl` optional in API and form; derived when blank, honoured when given, and **cleared when emptied**. |
| **Report what answered** | Named in the report and in the logs. **Nothing is written back.** |

### The discriminator is the whole design

**Aeries** — keep looking on a 404, or on a 200 whose body is not a list of schools (HTML login page, error page, whatever a redirect landed on). Stop on 401 / 403 / success / timeout.

**OneRoster** — keep looking on 404, 405, or a 200 carrying no token. Stop on 400 / 401 / 403 (credential verdicts) and on their server's own 5xx.

A 401 means the endpoint exists and refused the credential. A 403 means it exists and a permission box is unticked. Walking past either would report a credential problem as an address problem — the SPE-417 misdiagnosis shape, which is what this ticket exists to stop repeating. Both directions are pinned by tests.

For OneRoster this is also a security bound: every extra candidate posts the consumer secret somewhere new, so the continue-set stays as small as the failure modes allow. A test asserts **exactly one** token request on a 401.

<a name="course-correction"></a>
## Course correction: the persistence is gone

The first push resolved the address and then wrote it to `district_sis_connections.base_url` via a new `updateConnectionUrls()`. That was the wrong instinct, and the review was right to stop it. **I confirmed the failure mode with a probe** against a server where the stored root 404s and the alternative returns 500:

```
ok: false
resolvedBaseUrl: http://127.0.0.1:44207/api/v5
=> route would PERSIST: true
```

An address that **never worked** would have been written over a district's stored value. Resolution runs on failing tests too, so a district whose *correct* address had a bad minute could have been rewritten to a broken one — and because the search only continues past a literal 404, the replacement answering 401 or 403 would then stop resolution from ever moving off it. A one-way trap door, with `metadata: patch` recording only the new value, so the original was unrecoverable from the audit log.

Removed, along with everything downstream of it: `updateConnectionUrls()`, both persist call sites, the correction audit action, and the stale-form-state hazard where the card's `useState` initial value would have silently reverted the correction on the district's next save.

**What we lose:** the resolution is re-derived on each test — one extra request on a connection whose stored value is wrong, none once it is right. There is no automated sync yet that would care.

**What we keep:** the district is unblocked by one click, and the report names the address that answered.

Two other findings fixed in the same pass:

- **`<origin>/token` dropped from the OneRoster candidates.** A district whose OneRoster lives at `https://sis.example.org/aeries` does not own `https://sis.example.org/` — posting their consumer secret to the root would hand it to whatever application answers there. Every candidate now stays under the base URL they gave us, and a test enforces it.
- **The OneRoster token address is guarded per candidate, not up front.** The pre-loop guard returned *before* the resolver, so a stored token address the guard refused dead-ended the district on exactly the field they were asked to guess at. Nothing is sent to an address that has not passed; the guard simply runs per candidate.

<a name="second-review-pass"></a>
## Second review pass: five gaps in the recovery paths

Run after the persistence was removed, on the new diff. All five sit in the paths a district only reaches when something has already gone wrong — which is exactly where a gap goes unnoticed.

**1. Clearing the OneRoster token address did not clear it.** The field is optional and we *tell* districts to leave it blank, so the first thing one with a bad earlier guess does is empty it — and `undefined` meant "leave the column alone". Their stale value went on being tried first by the resolver, and if it answered anything but a literal 404 the search stopped there. `storeCredential` now accepts `null` to clear, and the route sends it.

**2. A real HTML page was not recognised as a wrong address.** `res.json()` raises the parse error inside the fetch implementation's own realm, so `err instanceof SyntaxError` — and even `err instanceof Error` — is **false**. The check added in the previous commit never fired once against real HTML. Now matched on shape.

**And the test that "covered" it was fake.** The harness JSON-encoded the HTML, and `JSON.stringify('<html>…')` is valid JSON that takes a completely different path through the client. The harness now serves real `text/html`, and the test failed against the shipped code until the fix landed.

**3. A host serving a login page was reported as unreachable.** Opposite fixes: "we could not reach you" sends a district to a firewall that is working perfectly. It now says the address answered but not with Aeries data.

**4. OneRoster resolution only continued past a literal 404.** 405 and a 200-with-no-token both mean "something is here, but it is not the token endpoint" — a vendor's data path answers a POST exactly like the former. Both now continue; 400/401/403 and their own 5xx still stop.

**5. Neither resolver named the endpoint it dialled on failure.** A district who left the field blank and is then told their Consumer ID and Secret are wrong had no way to see that we picked an address for them. Both now name it, and Aeries preserves the SSRF guard's actual refusal reason instead of a bare "that address cannot be used".

## Why this needs nothing from the district

Their certificate and OneRoster ID/secret are **stored, encrypted and correct** — the address problem never touched them. Their next action is **one click on "Test connection"**.

## Verification against the real database

Unit tests mock the Supabase client, so they cannot see what a connection test does to a district's row, and cannot tell `undefined` from `null` on a write. Both claims here are exactly those, so they ran for real in the sim district, reproducing JSUSD's exact state — a good credential behind a `base_url` that 404s — and running the test route's entire database surface in the route's own order.

| check | success path | failure path |
|---|---|---|
| resolution finds the working root | ✅ | n/a (both roots broken) |
| report names the address that answered | ✅ | ✅ |
| `base_url` byte-identical afterwards | ✅ | ✅ |
| `token_url` unchanged | ✅ | ✅ |
| credential ciphertext + hint unchanged | ✅ | ✅ |
| no `sis_connection_url_corrected` audit record | ✅ | ✅ |
| **row genuinely written this request** (`last_tested_at` moved, `status` changed) | ✅ | ✅ |

The last row matters: without it the "unchanged" assertions would pass just as well if nothing had run at all. The failure-path case is the one that had to be proven — the stored root 404s *and* the alternative answers 500, the exact scenario the old code would have persisted.

Separately, for the token-address clear: emptying the field writes **NULL**; the credential ciphertext, hint and base URL all survive it; and *omitting* the field still leaves the column alone, because the Aeries flow never sends it and must not wipe anything.

Sim lifecycle closed clean (`--expect-empty` all zeros, reseeded green). **JSUSD's rows were never touched.**

## Honest uncertainty

**I cannot confirm `/api/v5` is the correct root for JSUSD.** This sandbox cannot reach their host (production can). That is precisely why this is built as *resolution* rather than a corrected constant — the system finds out at test time and reports which root answered, instead of trading one guess for another. If nothing answers, it says so plainly instead of blaming their address.

The OneRoster token candidates (`/token`, `/oauth/token`) are informed guesses under the same treatment: try, report, never assert.

## Security

- Every candidate goes through `assertSafeSisUrl` before it is dialled. Candidates vary the **path** only; the host is always the one the district supplied, so this widens no egress. For OneRoster the path is additionally constrained to stay *under* the base URL the district gave us.
- The connection test writes no URL, so there is no new write path onto the table holding districts' SIS secrets.

## Gates

Typecheck clean, lint clean, 233 SIS unit tests green, full suite 1055 passed / 12 skipped. Three integration suites fail (`tests/integration/{key-check,basic-workflows,minimal}`); confirmed pre-existing by stashing this branch's changes and re-running — they fail identically on the base commit.

## Follow-ups

- [SPE-419](https://linear.app/speddy/issue/SPE-419/sis-credential-intake-stop-blaming-the-district-for-a-speddy-side) — the district-facing copy still blames their input in places. Two of the worst offenders are fixed here (the OneRoster token 404, and "could not reach" for a host that answered), but the pattern deserves its own pass.
- [SPE-421](https://linear.app/speddy/issue/SPE-421) — handler tests for the `/internal` staff gate. These SIS routes have no handler tests either, which is why the two DB-behaviour claims above were verified with a real database rather than a route test.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OneRoster credentials can now be saved without a token URL; the system derives and verifies a suitable endpoint during connection testing.
  * Aeries connections automatically detect supported API roots and report the endpoint that successfully responds.
* **Bug Fixes**
  * Improved handling of invalid, unavailable, malformed, or unauthorized responses during Aeries and OneRoster connection tests.
  * Normalized endpoint URLs and improved failure reporting for connection setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->