### PR TITLE
SPE-427: let Speddy staff run a district's SIS connection test

### DIFF
--- a/__tests__/unit/app/api/internal/sis-connection-test.test.ts
+++ b/__tests__/unit/app/api/internal/sis-connection-test.test.ts
@@ -1,0 +1,281 @@
+/**
+ * SPE-427 · POST /api/internal/sis-connections/[connectionId]/test — the staff
+ * gate, and what a refused caller does NOT set in motion.
+ *
+ * Why a handler test rather than a sim-district walk: the allowed branch cannot
+ * be walked. `docs/SIM_DISTRICT.md` invariant 5 states "No sim user is ever
+ * `is_speddy_admin`", so no persona can ever reach the staff side of this route
+ * through the UI. This is the only coverage that branch will ever have.
+ *
+ * The load-bearing assertion is not the 403 — it is that **no request reaches
+ * the district's SIS** when the caller is refused. This route exists to let
+ * Speddy staff use a district's stored credential against that district's
+ * server; a gate that returned 403 *after* firing the probes would be a gate in
+ * name only, and the status code alone cannot tell the two apart.
+ *
+ * `speddyAdminDenialReason` returns null for allowed and a string for denied.
+ * Its own docstring records that the obvious reading of that inverts the guard
+ * and lets everyone through silently. Middleware cannot catch the inversion —
+ * middleware.ts's matcher excludes `api` — so this layer is the only one that
+ * would.
+ */
+import { NextRequest } from 'next/server';
+
+const STAFF_ID = '11111111-1111-4111-8111-111111111111';
+const NON_STAFF_ID = '22222222-2222-4222-8222-222222222222';
+const CONNECTION_ID = '33333333-3333-4333-8333-333333333333';
+const CERT = 'aeriescert00000000000000000000ab';
+
+let currentUserId: string | null = STAFF_ID;
+let profileRow: { data: unknown; error: unknown } = {
+  data: { is_speddy_admin: true },
+  error: null,
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: async () =>
+        currentUserId
+          ? { data: { user: { id: currentUserId } }, error: null }
+          : { data: { user: null }, error: { message: 'no session' } },
+    },
+  }),
+  createServiceClient: () => ({
+    from: () => {
+      const q: Record<string, unknown> = {};
+      q.select = () => q;
+      q.eq = () => q;
+      q.maybeSingle = () => Promise.resolve(profileRow);
+      return q;
+    },
+  }),
+}));
+
+// Rate limiting writes to the database; it is not what this file is about.
+jest.mock('@/lib/api/rate-limit-user', () => ({
+  checkUserRateLimit: jest.fn().mockResolvedValue({ allowed: true }),
+}));
+
+const mockGetConnection = jest.fn();
+const mockGetCredential = jest.fn();
+const mockRecordTestResult = jest.fn();
+jest.mock('@/lib/sis/connections', () => ({
+  ...jest.requireActual('@/lib/sis/connections'),
+  getConnection: (...a: unknown[]) => mockGetConnection(...a),
+  getDecryptedCredential: (...a: unknown[]) => mockGetCredential(...a),
+  recordTestResult: (...a: unknown[]) => mockRecordTestResult(...a),
+}));
+
+// These are the functions that actually dial the district's server. Counting
+// their calls is how "nothing reached the SIS" becomes an assertion rather than
+// an assumption.
+const mockAeriesTest = jest.fn();
+jest.mock('@/lib/sis/aeries-setup', () => ({
+  ...jest.requireActual('@/lib/sis/aeries-setup'),
+  runAeriesConnectionTest: (...a: unknown[]) => mockAeriesTest(...a),
+}));
+const mockOneRosterTest = jest.fn();
+jest.mock('@/lib/sis/oneroster-setup', () => ({
+  ...jest.requireActual('@/lib/sis/oneroster-setup'),
+  runOneRosterConnectionTest: (...a: unknown[]) => mockOneRosterTest(...a),
+}));
+
+import { POST } from '@/app/api/internal/sis-connections/[connectionId]/test/route';
+
+const AERIES_CONNECTION = {
+  id: CONNECTION_ID,
+  district_id: '0618990',
+  sis_type: 'aeries',
+  base_url: 'https://district.aeries.net/aeries/api/v5',
+  token_url: null,
+  credential_hint: '••••eddf',
+  status: 'testing',
+};
+
+const AERIES_REPORT = {
+  ok: true,
+  summary: 'All areas granted. Aeries is ready.',
+  areas: [
+    { key: 'connection', label: 'Connection', status: 'ok', message: 'Speddy can reach it.' },
+    { key: 'schools', label: 'Schools', status: 'ok', message: 'Granted.', count: 12 },
+  ],
+  usedBaseUrl: 'https://district.aeries.net/api/v5',
+};
+
+const call = () =>
+  POST(
+    new NextRequest(`http://localhost/api/internal/sis-connections/${CONNECTION_ID}/test`, {
+      method: 'POST',
+    }),
+    { params: Promise.resolve({ connectionId: CONNECTION_ID }) },
+  );
+
+/** Every path that reaches a district's server, in one place. */
+const sisWasDialled = () =>
+  mockAeriesTest.mock.calls.length + mockOneRosterTest.mock.calls.length > 0;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  currentUserId = STAFF_ID;
+  profileRow = { data: { is_speddy_admin: true }, error: null };
+  mockGetConnection.mockResolvedValue(AERIES_CONNECTION);
+  mockGetCredential.mockResolvedValue({ sisType: 'aeries', certificate: CERT });
+  mockAeriesTest.mockResolvedValue(AERIES_REPORT);
+  mockRecordTestResult.mockResolvedValue(undefined);
+});
+
+describe('the staff gate', () => {
+  it('401s an unauthenticated caller, and dials nothing', async () => {
+    currentUserId = null;
+    const res = await call();
+    expect(res.status).toBe(401);
+    expect(sisWasDialled()).toBe(false);
+  });
+
+  it('403s an authenticated NON-staff caller, and dials nothing', async () => {
+    // The case the whole file exists for. A district admin, a teacher, or any
+    // signed-in user must not be able to make Speddy send that district's SIS
+    // credential anywhere — and must not be able to use this route to probe
+    // another district's server at all.
+    currentUserId = NON_STAFF_ID;
+    profileRow = { data: { is_speddy_admin: false }, error: null };
+
+    const res = await call();
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Forbidden: Speddy admin access required' });
+    expect(sisWasDialled()).toBe(false);
+    // Nor was the credential even decrypted.
+    expect(mockGetCredential).not.toHaveBeenCalled();
+    expect(mockRecordTestResult).not.toHaveBeenCalled();
+  });
+
+  it('403s when the profile lookup fails, rather than falling open', async () => {
+    profileRow = { data: null, error: { message: 'boom' } };
+    const res = await call();
+    expect(res.status).toBe(403);
+    expect(sisWasDialled()).toBe(false);
+  });
+
+  it('lets a Speddy admin through', async () => {
+    // The other half. A gate that refused everyone would pass every test above
+    // while making the feature useless.
+    const res = await call();
+    expect(res.status).toBe(200);
+    expect(mockAeriesTest).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('nothing to test', () => {
+  it('404s an unknown connection without dialling', async () => {
+    mockGetConnection.mockResolvedValue(null);
+    const res = await call();
+    expect(res.status).toBe(404);
+    expect(sisWasDialled()).toBe(false);
+  });
+
+  it('409s when no credential is stored, and says so rather than erroring', async () => {
+    mockGetCredential.mockResolvedValue(null);
+    const res = await call();
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toMatch(/not entered credentials/i);
+    expect(sisWasDialled()).toBe(false);
+  });
+
+  it('409s a credential that cannot be decrypted, not a 500', async () => {
+    // The plausible cause is an encryption-key rotation. To an operator that
+    // reads the same as "no credential stored" and has the same fix.
+    mockGetCredential.mockRejectedValue(new Error('bad ciphertext'));
+    const res = await call();
+    expect(res.status).toBe(409);
+    expect(sisWasDialled()).toBe(false);
+  });
+
+  it('409s when the connection has no address saved', async () => {
+    mockGetConnection.mockResolvedValue({ ...AERIES_CONNECTION, base_url: null });
+    const res = await call();
+    expect(res.status).toBe(409);
+    expect(sisWasDialled()).toBe(false);
+  });
+});
+
+describe('the report it returns', () => {
+  it('runs the district’s own Aeries test and flattens areas to checks', async () => {
+    const res = await call();
+    const body = await res.json();
+
+    expect(mockAeriesTest).toHaveBeenCalledWith({
+      baseUrl: AERIES_CONNECTION.base_url,
+      certificate: CERT,
+    });
+    expect(body.sisType).toBe('aeries');
+    expect(body.ok).toBe(true);
+    expect(body.checks).toEqual(AERIES_REPORT.areas);
+    // The answer SPE-426 could not get without asking the district.
+    expect(body.usedAddress).toBe('https://district.aeries.net/api/v5');
+  });
+
+  it('flattens OneRoster steps to the same shape', async () => {
+    // One renderer in the panel, so the two connectors cannot drift apart on
+    // screen. If either report is renamed, this fails.
+    mockGetConnection.mockResolvedValue({
+      ...AERIES_CONNECTION,
+      sis_type: 'oneroster',
+      base_url: 'https://district.aeries.net/admin',
+      token_url: null,
+    });
+    mockGetCredential.mockResolvedValue({
+      sisType: 'oneroster',
+      clientId: 'consumer-id',
+      clientSecret: 'consumer-secret',
+    });
+    const steps = [{ key: 'token', label: 'Sign-in', status: 'ok', message: 'Working.' }];
+    mockOneRosterTest.mockResolvedValue({ ok: true, summary: 'Ready.', steps });
+
+    const body = await (await call()).json();
+
+    expect(body.sisType).toBe('oneroster');
+    expect(body.checks).toEqual(steps);
+    expect(mockAeriesTest).not.toHaveBeenCalled();
+  });
+
+  it('records the result against the STAFF user, so the audit trail names who ran it', async () => {
+    await call();
+    expect(mockRecordTestResult).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: CONNECTION_ID, actorId: STAFF_ID, ok: true }),
+    );
+  });
+
+  it('still returns the report when recording it fails', async () => {
+    // Every probe already ran. A 500 here would hide a completed report and
+    // invite another run, sending more requests at a district's server to learn
+    // what we already know.
+    mockRecordTestResult.mockRejectedValue(new Error('db down'));
+    const res = await call();
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  it('never returns the credential', async () => {
+    // Asserted over the whole serialized body rather than field by field, so a
+    // future field cannot quietly carry it.
+    mockGetConnection.mockResolvedValue({
+      ...AERIES_CONNECTION,
+      sis_type: 'oneroster',
+      base_url: 'https://district.aeries.net/admin',
+    });
+    mockGetCredential.mockResolvedValue({
+      sisType: 'oneroster',
+      clientId: 'consumer-id-xyz',
+      clientSecret: 'consumer-secret-xyz',
+    });
+    mockOneRosterTest.mockResolvedValue({ ok: false, summary: 'Rejected.', steps: [] });
+
+    const text = await (await call()).text();
+
+    expect(text).not.toContain('consumer-secret-xyz');
+    expect(text).not.toContain('consumer-id-xyz');
+    expect(text).not.toContain(CERT);
+  });
+});

--- a/__tests__/unit/app/api/internal/sis-connection-test.test.ts
+++ b/__tests__/unit/app/api/internal/sis-connection-test.test.ts
@@ -214,6 +214,37 @@ describe('the report it returns', () => {
     expect(body.checks).toEqual(AERIES_REPORT.areas);
     // The answer SPE-426 could not get without asking the district.
     expect(body.usedAddress).toBe('https://district.aeries.net/api/v5');
+    // Returned alongside it so the panel can say "not THIS one" rather than
+    // guessing whether an address was ever on file.
+    expect(body.storedAddress).toBe(AERIES_CONNECTION.base_url);
+  });
+
+  it('reports a null storedAddress when the district gave us no token address', async () => {
+    // The distinction the panel words differently. A OneRoster token address is
+    // normally blank, so treating "we used an address" as "not the one on file"
+    // would fire a warning on every healthy test until it meant nothing.
+    mockGetConnection.mockResolvedValue({
+      ...AERIES_CONNECTION,
+      sis_type: 'oneroster',
+      base_url: 'https://district.aeries.net/admin',
+      token_url: null,
+    });
+    mockGetCredential.mockResolvedValue({
+      sisType: 'oneroster',
+      clientId: 'consumer-id',
+      clientSecret: 'consumer-secret',
+    });
+    mockOneRosterTest.mockResolvedValue({
+      ok: true,
+      summary: 'Ready.',
+      steps: [],
+      usedTokenUrl: 'https://district.aeries.net/admin/token',
+    });
+
+    const body = await (await call()).json();
+
+    expect(body.usedAddress).toBe('https://district.aeries.net/admin/token');
+    expect(body.storedAddress).toBeNull();
   });
 
   it('flattens OneRoster steps to the same shape', async () => {

--- a/__tests__/unit/lib/sis/connections.test.ts
+++ b/__tests__/unit/lib/sis/connections.test.ts
@@ -27,6 +27,7 @@ interface QueryRecord {
   select?: string;
   values?: Record<string, unknown>;
   eq?: [string, unknown];
+  not?: [string, string, unknown];
 }
 
 const results: Array<{ data: unknown; error: unknown }> = [];
@@ -56,6 +57,14 @@ function builder(record: QueryRecord): any {
     },
     eq: (col: string, val: unknown) => {
       record.eq = [col, val];
+      return chain;
+    },
+    // PostgREST's IS NOT NULL. Recorded rather than swallowed, so a test can
+    // assert that recordTestResult's write is CONDITIONAL — a mock that merely
+    // tolerated `.not()` would stay green if the condition were deleted, and
+    // that condition is what makes a DPA revocation beat an in-flight test.
+    not: (col: string, op: string, val: unknown) => {
+      record.not = [col, op, val];
       return chain;
     },
     order: () => nextResult(),
@@ -518,7 +527,7 @@ describe('lib/sis/connections', () => {
 
   describe('recordTestResult', () => {
     it('marks a failing test as error and audits the outcome', async () => {
-      results.push({ data: null, error: null });
+      results.push({ data: { id: CONNECTION_ID }, error: null });
 
       await recordTestResult({
         connectionId: CONNECTION_ID,
@@ -533,6 +542,60 @@ describe('lib/sis/connections', () => {
       expect(mockAudit).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'sis_connection_tested', metadata: { ok: false } })
       );
+    });
+
+    it('writes only while the DPA is still on file', async () => {
+      // The condition travels WITH the update, which is the whole point: a
+      // connection test can run for minutes, and a revocation landing mid-test
+      // has to win. A read-then-write check would not close that window.
+      results.push({ data: { id: CONNECTION_ID }, error: null });
+
+      await recordTestResult({
+        connectionId: CONNECTION_ID,
+        actorId: ACTOR_ID,
+        ok: true,
+        result: { message: 'ok' },
+      });
+
+      const write = calls.find((c) => c.op === 'update')!;
+      expect(write.not).toEqual(['dpa_cleared_at', 'is', null]);
+    });
+
+    it('records NOTHING when the DPA was revoked while the test ran', async () => {
+      // The row still exists, so this is not "not found" — the revocation
+      // simply won. Recording over it would leave a row claiming a working
+      // integration for a district with no DPA and no credentials.
+      results.push({ data: null, error: null }); // the conditional update matched nothing
+      results.push({ data: { id: CONNECTION_ID }, error: null }); // ...but the row is there
+
+      await expect(
+        recordTestResult({
+          connectionId: CONNECTION_ID,
+          actorId: ACTOR_ID,
+          ok: true,
+          result: { message: 'ok' },
+        })
+      ).resolves.toBeUndefined();
+
+      // Not audited: no test result was stored, so a record saying one was
+      // would be the false entry this guard exists to prevent.
+      expect(mockAudit).not.toHaveBeenCalled();
+    });
+
+    it('refuses an unknown id instead of auditing a no-op', async () => {
+      results.push({ data: null, error: null }); // update matched nothing
+      results.push({ data: null, error: null }); // and the row does not exist
+
+      await expect(
+        recordTestResult({
+          connectionId: CONNECTION_ID,
+          actorId: ACTOR_ID,
+          ok: true,
+          result: { message: 'ok' },
+        })
+      ).rejects.toThrow('SIS connection not found');
+
+      expect(mockAudit).not.toHaveBeenCalled();
     });
 
     it('surfaces a write failure rather than reporting success', async () => {

--- a/app/api/internal/sis-connections/[connectionId]/test/route.ts
+++ b/app/api/internal/sis-connections/[connectionId]/test/route.ts
@@ -113,6 +113,13 @@ export const POST = withRoute<{ connectionId: string }>(
     let checks: StaffCheck[];
     let stored: SisTestResult;
     let usedAddress: string | undefined;
+    // The value ON FILE that `usedAddress` differs from. Returned alongside it
+    // because the two cases read completely differently to an operator: we used
+    // an address other than the one they gave us (notable), versus they gave us
+    // none and we worked one out (ordinary). Without it the panel has to guess,
+    // and for OneRoster — where the token address is normally blank — it would
+    // guess wrong on every healthy test.
+    let storedAddress: string | null;
 
     if (credential.sisType === 'aeries') {
       const report = await runAeriesConnectionTest({
@@ -123,6 +130,7 @@ export const POST = withRoute<{ connectionId: string }>(
       checks = report.areas;
       stored = toStoredTestResult(report);
       usedAddress = report.usedBaseUrl;
+      storedAddress = connection.base_url;
     } else {
       const report = await runOneRosterConnectionTest({
         baseUrl: connection.base_url,
@@ -134,6 +142,7 @@ export const POST = withRoute<{ connectionId: string }>(
       checks = report.steps;
       stored = toStoredOneRosterTestResult(report);
       usedAddress = report.usedTokenUrl;
+      storedAddress = connection.token_url;
     }
 
     try {
@@ -169,6 +178,7 @@ export const POST = withRoute<{ connectionId: string }>(
       summary,
       checks,
       usedAddress,
+      storedAddress,
     });
   },
 );

--- a/app/api/internal/sis-connections/[connectionId]/test/route.ts
+++ b/app/api/internal/sis-connections/[connectionId]/test/route.ts
@@ -1,0 +1,174 @@
+import { NextResponse } from 'next/server';
+import { withRoute } from '@/lib/api/with-route';
+import { speddyAdminDenialReason } from '@/lib/api/speddy-admin-denial-reason';
+import { logger } from '@/lib/logger';
+import { getConnection, getDecryptedCredential, recordTestResult } from '@/lib/sis/connections';
+import { runAeriesConnectionTest, toStoredTestResult } from '@/lib/sis/aeries-setup';
+import {
+  runOneRosterConnectionTest,
+  toStoredOneRosterTestResult,
+} from '@/lib/sis/oneroster-setup';
+import type { SisTestResult } from '@/lib/sis/connections';
+
+const log = logger.child({ module: 'internal-sis-test' });
+
+/** One probed area or step, flattened across the two connectors (SPE-427). */
+interface StaffCheck {
+  key: string;
+  label: string;
+  status: 'ok' | 'denied' | 'error' | 'untested';
+  message: string;
+  count?: number;
+}
+
+/**
+ * POST /api/internal/sis-connections/[connectionId]/test — run a district's
+ * connection test from the Speddy side (SPE-427).
+ *
+ * WHY THIS EXISTS. Until now only the district's own `district_tech` could run
+ * the test, so every check cost a round-trip to a person at the district.
+ * SPE-426 is that cost measured: a tech admin ran the test nine times in six
+ * minutes against a bug he could not have fixed, and after shipping the fix we
+ * still had no way to confirm it worked without asking him to click again.
+ *
+ * IT RUNS THE DISTRICT'S OWN TEST, deliberately — the same
+ * `runAeriesConnectionTest` / `runOneRosterConnectionTest` behind their button.
+ * A separate staff-side implementation could disagree with theirs, and then a
+ * green check here would prove nothing about what they see.
+ *
+ * WHAT IT CAN REACH. This lets Speddy staff cause requests to a district's SIS
+ * using that district's stored credential, which is worth naming rather than
+ * burying. It is bounded by what the test already is: read-only probes,
+ * aggregate-only (one non-identifying field, one row), so no student record is
+ * ever read (SPE-393). The decrypted credential exists only inside this request
+ * and is never returned.
+ *
+ * Rate-limited to match the district's own test route: each call fans out to
+ * several requests against a school district's production server.
+ */
+export const POST = withRoute<{ connectionId: string }>(
+  { rateLimit: { requests: 6, windowSeconds: 60, name: 'internal-sis-test' } },
+  async ({ userId, params }) => {
+    const denied = await speddyAdminDenialReason(userId);
+    if (denied) {
+      log.warn('Non-speddy-admin tried to run a SIS connection test', {
+        userId,
+        connectionId: params.connectionId,
+        denied,
+      });
+      return NextResponse.json(
+        { error: 'Forbidden: Speddy admin access required' },
+        { status: 403 },
+      );
+    }
+
+    // Wrapped rather than left to the route wrapper: withRoute's catch echoes
+    // error.message to the client when NODE_ENV=development, and a Supabase
+    // error names tables and constraints.
+    let connection;
+    try {
+      connection = await getConnection(params.connectionId);
+    } catch (err) {
+      log.error('Failed to load the SIS connection', err, {
+        connectionId: params.connectionId,
+      });
+      return NextResponse.json({ error: 'Could not load that connection.' }, { status: 500 });
+    }
+    if (!connection) {
+      return NextResponse.json({ error: 'No such SIS connection.' }, { status: 404 });
+    }
+
+    // Decryption throws when the ciphertext cannot be opened — most plausibly
+    // after an encryption-key rotation. To an operator that reads the same as
+    // "no credential stored" and has the same fix, so say so rather than
+    // returning a 500 they can do nothing with.
+    let credential: Awaited<ReturnType<typeof getDecryptedCredential>> = null;
+    try {
+      credential = await getDecryptedCredential(connection.id);
+    } catch (err) {
+      log.error('Could not decrypt the stored SIS credential', err, {
+        connectionId: connection.id,
+      });
+    }
+    if (!credential) {
+      // Not an error state: a connection legitimately exists with no credential
+      // until the district enters one.
+      return NextResponse.json(
+        { error: 'This district has not entered credentials yet, so there is nothing to test.' },
+        { status: 409 },
+      );
+    }
+    if (!connection.base_url) {
+      return NextResponse.json(
+        { error: 'This connection has no address saved, so there is nothing to test.' },
+        { status: 409 },
+      );
+    }
+
+    // The two reports are the same shape under different names — Aeries calls
+    // them `areas`, OneRoster calls them `steps`. Flattened to one list here so
+    // the panel has a single renderer; the district-facing shapes are untouched.
+    let ok: boolean;
+    let summary: string;
+    let checks: StaffCheck[];
+    let stored: SisTestResult;
+    let usedAddress: string | undefined;
+
+    if (credential.sisType === 'aeries') {
+      const report = await runAeriesConnectionTest({
+        baseUrl: connection.base_url,
+        certificate: credential.certificate,
+      });
+      ({ ok, summary } = report);
+      checks = report.areas;
+      stored = toStoredTestResult(report);
+      usedAddress = report.usedBaseUrl;
+    } else {
+      const report = await runOneRosterConnectionTest({
+        baseUrl: connection.base_url,
+        tokenUrl: connection.token_url ?? undefined,
+        clientId: credential.clientId,
+        clientSecret: credential.clientSecret,
+      });
+      ({ ok, summary } = report);
+      checks = report.steps;
+      stored = toStoredOneRosterTestResult(report);
+      usedAddress = report.usedTokenUrl;
+    }
+
+    try {
+      await recordTestResult({
+        connectionId: connection.id,
+        actorId: userId,
+        ok,
+        result: stored,
+      });
+    } catch (err) {
+      // Every probe already ran. Turning a bookkeeping failure into a 500 would
+      // hide a completed report AND invite another run, sending more requests at
+      // a district's SIS to learn what we already know.
+      log.error('Failed to record the SIS test result', err, {
+        connectionId: connection.id,
+      });
+    }
+
+    log.info('SIS connection tested by Speddy staff', {
+      connectionId: connection.id,
+      districtId: connection.district_id,
+      sisType: credential.sisType,
+      actorId: userId,
+      ok,
+      // Which address answered, when resolution had to move off the stored one.
+      // The reason we can now see this without asking the district (SPE-426).
+      usedAddress,
+    });
+
+    return NextResponse.json({
+      sisType: credential.sisType,
+      ok,
+      summary,
+      checks,
+      usedAddress,
+    });
+  },
+);

--- a/app/components/internal/sis-connections-panel.tsx
+++ b/app/components/internal/sis-connections-panel.tsx
@@ -77,6 +77,57 @@ const SIS_LABELS: Record<SisType, string> = {
   oneroster: 'OneRoster',
 };
 
+/**
+ * One probed area or step, as the internal test route flattens them (SPE-427).
+ *
+ * Aeries reports `areas` and OneRoster reports `steps`; the route normalizes
+ * both to this, so there is one renderer here rather than two that could drift.
+ */
+interface StaffCheck {
+  key: string;
+  label: string;
+  status: 'ok' | 'denied' | 'error' | 'untested';
+  message: string;
+  count?: number;
+}
+
+interface StaffTestResult {
+  sisType: SisType;
+  ok: boolean;
+  summary: string;
+  checks: StaffCheck[];
+  /** Present only when resolution had to move off the stored address. */
+  usedAddress?: string;
+}
+
+/**
+ * Validated rather than asserted, for the same reason the key-health payload is:
+ * an off-shape 200 would otherwise render a verdict with nothing behind it.
+ */
+function isStaffTestResult(value: unknown): value is StaffTestResult {
+  if (typeof value !== 'object' || value === null) return false;
+  const body = value as { ok?: unknown; summary?: unknown; checks?: unknown };
+  return (
+    typeof body.ok === 'boolean' &&
+    typeof body.summary === 'string' &&
+    Array.isArray(body.checks)
+  );
+}
+
+const CHECK_STYLES: Record<StaffCheck['status'], string> = {
+  ok: 'text-emerald-300',
+  denied: 'text-amber-300',
+  error: 'text-red-300',
+  untested: 'text-slate-400',
+};
+
+const CHECK_MARKS: Record<StaffCheck['status'], string> = {
+  ok: '✓',
+  denied: '!',
+  error: '✕',
+  untested: '·',
+};
+
 
 function formatDate(value: string | null): string {
   if (!value) return '—';
@@ -98,6 +149,10 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
   // of thing that goes stale on screen and gets believed anyway.
   const [keyHealth, setKeyHealth] = useState<KeyHealthResponse | null>(null);
   const [checkingKey, setCheckingKey] = useState(false);
+  // Keyed by connection id so two connections' results cannot be confused for
+  // one another — the whole point is telling Aeries and OneRoster apart.
+  const [testing, setTesting] = useState<string | null>(null);
+  const [testResults, setTestResults] = useState<Record<string, StaffTestResult>>({});
 
   const checkKey = async () => {
     setCheckingKey(true);
@@ -145,6 +200,69 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
     } finally {
       clearTimeout(timer);
       setCheckingKey(false);
+    }
+  };
+
+  /**
+   * Run the district's own connection test from here (SPE-427).
+   *
+   * Reaches the district's SIS with their stored credential, which is why it is
+   * a deliberate click rather than something that happens on load. It is the
+   * same test their tech admin runs, so a green result here means what a green
+   * result means to them.
+   */
+  const runTest = async (connection: SisConnection) => {
+    setTesting(connection.id);
+    setError(null);
+    setTestResults((prev) => {
+      // Drop the previous verdict before running. Leaving it on screen while a
+      // new run is in flight shows a stale answer next to a spinner, and a
+      // stale green is the one nobody re-reads.
+      const next = { ...prev };
+      delete next[connection.id];
+      return next;
+    });
+
+    // Bounded: the test fans out to several requests against a district's
+    // server, and without this a hung SIS leaves the button disabled with no
+    // way to retry.
+    const abort = new AbortController();
+    const timer = setTimeout(() => abort.abort(), 60_000);
+    try {
+      const res = await fetch(`/api/internal/sis-connections/${connection.id}/test`, {
+        method: 'POST',
+        cache: 'no-store',
+        signal: abort.signal,
+      });
+      const json: unknown = await res.json().catch(() => null);
+
+      if (!res.ok) {
+        const message =
+          typeof (json as { error?: unknown })?.error === 'string'
+            ? (json as { error: string }).error
+            : `The test could not be run (HTTP ${res.status}).`;
+        setError(message);
+        return;
+      }
+      if (!isStaffTestResult(json)) {
+        setError('The test returned an unreadable response. Nothing was tested.');
+        return;
+      }
+      setTestResults((prev) => ({ ...prev, [connection.id]: json }));
+      // The run writes last_tested_at and status, so the row above it is now
+      // stale — refresh rather than leave the chip disagreeing with the result
+      // printed directly beneath it.
+      await load();
+    } catch (err) {
+      const timedOut = err instanceof DOMException && err.name === 'AbortError';
+      setError(
+        timedOut
+          ? 'The test timed out waiting for the district\u2019s SIS.'
+          : 'Could not reach the test. Nothing was tested.',
+      );
+    } finally {
+      clearTimeout(timer);
+      setTesting(null);
     }
   };
 
@@ -328,6 +446,7 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
           {connections.map((connection) => {
             const dpaCleared = Boolean(connection.dpa_cleared_at);
             const busy = busyId === connection.id;
+            const result = testResults[connection.id];
             return (
               <li
                 key={connection.id}
@@ -370,18 +489,86 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
                     </dl>
                   </div>
 
-                  <button
-                    type="button"
-                    onClick={() => setDpa(connection, !dpaCleared)}
-                    disabled={busy}
-                    className={`px-4 py-2 text-sm rounded-md transition-colors disabled:opacity-50 ${
-                      dpaCleared
-                        ? 'bg-slate-700 hover:bg-slate-600 text-slate-200'
-                        : 'bg-purple-600 hover:bg-purple-700 text-white'
-                    }`}
-                  >
-                    {busy ? 'Saving…' : dpaCleared ? 'Revoke DPA' : 'Record signed DPA'}
-                  </button>
+                  <div className="flex gap-2">
+                    {/* Only offered when there is something to test. Without a
+                        credential the route returns 409, and a button whose only
+                        outcome is an error message is worse than no button. */}
+                    {connection.credential_hint && (
+                      <button
+                        type="button"
+                        onClick={() => runTest(connection)}
+                        disabled={testing !== null}
+                        className="px-4 py-2 text-sm bg-slate-600 hover:bg-slate-500 disabled:opacity-50 text-white rounded-md transition-colors"
+                      >
+                        {testing === connection.id ? 'Testing…' : 'Run connection test'}
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => setDpa(connection, !dpaCleared)}
+                      disabled={busy}
+                      className={`px-4 py-2 text-sm rounded-md transition-colors disabled:opacity-50 ${
+                        dpaCleared
+                          ? 'bg-slate-700 hover:bg-slate-600 text-slate-200'
+                          : 'bg-purple-600 hover:bg-purple-700 text-white'
+                      }`}
+                    >
+                      {busy ? 'Saving…' : dpaCleared ? 'Revoke DPA' : 'Record signed DPA'}
+                    </button>
+                  </div>
+                </div>
+
+                {/* Mounted unconditionally with only its CONTENT conditional —
+                    a live region inserted in the same commit as its text is the
+                    classic aria-live pitfall where nothing is announced. */}
+                <div role="status" aria-live="polite" className="contents">
+                  {result && (
+                    <div className="mt-4 rounded-md border border-slate-700 bg-slate-900/40 px-4 py-3">
+                      <p
+                        className={`text-sm font-medium ${
+                          result.ok ? 'text-emerald-300' : 'text-amber-200'
+                        }`}
+                      >
+                        {result.summary}
+                      </p>
+
+                      {result.usedAddress && (
+                        // The answer SPE-426 could not get without asking the
+                        // district: which address actually responded, when it is
+                        // not the one on file.
+                        <p className="mt-1 break-all text-xs text-slate-400">
+                          Answered at <span className="font-mono">{result.usedAddress}</span>, not
+                          the address on file.
+                        </p>
+                      )}
+
+                      <ul className="mt-3 space-y-1">
+                        {result.checks.map((check) => (
+                          <li key={check.key} className="flex gap-2 text-sm">
+                            <span
+                              aria-hidden="true"
+                              className={`w-3 shrink-0 ${CHECK_STYLES[check.status]}`}
+                            >
+                              {CHECK_MARKS[check.status]}
+                            </span>
+                            <span className="text-slate-300">
+                              <span className={`font-medium ${CHECK_STYLES[check.status]}`}>
+                                {check.label}
+                              </span>
+                              {' — '}
+                              {check.message}
+                              {/* Only the school count is a real total; the rest
+                                  are capped at one row on purpose, so printing
+                                  them would read as "1 student". */}
+                              {check.key === 'schools' && typeof check.count === 'number' && (
+                                <span className="text-slate-400"> ({check.count} schools)</span>
+                              )}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
                 </div>
               </li>
             );

--- a/app/components/internal/sis-connections-panel.tsx
+++ b/app/components/internal/sis-connections-panel.tsx
@@ -527,7 +527,12 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
                     <button
                       type="button"
                       onClick={() => setDpa(connection, !dpaCleared)}
-                      disabled={busy}
+                      // Also disabled while THIS connection is being tested.
+                      // The server refuses to record a result over a revocation
+                      // either way, but a test can run for minutes, and letting
+                      // someone revoke mid-run means watching a spinner resolve
+                      // into a report about a connection they just cut.
+                      disabled={busy || testing === connection.id}
                       className={`px-4 py-2 text-sm rounded-md transition-colors disabled:opacity-50 ${
                         dpaCleared
                           ? 'bg-slate-700 hover:bg-slate-600 text-slate-200'

--- a/app/components/internal/sis-connections-panel.tsx
+++ b/app/components/internal/sis-connections-panel.tsx
@@ -98,6 +98,8 @@ interface StaffTestResult {
   checks: StaffCheck[];
   /** Present only when resolution had to move off the stored address. */
   usedAddress?: string;
+  /** The address on file that `usedAddress` differs from, if there was one. */
+  storedAddress?: string | null;
 }
 
 /**
@@ -223,11 +225,15 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
       return next;
     });
 
-    // Bounded: the test fans out to several requests against a district's
-    // server, and without this a hung SIS leaves the button disabled with no
-    // way to retry.
+    // Bounded, but ABOVE the server's own worst case, not below it. The Aeries
+    // test can make two resolution attempts plus three area probes at a 30s
+    // client timeout each — around 150s against a district whose server hangs.
+    // A shorter deadline here would report "nothing was tested" while the
+    // server went on to complete the report and write status/last_tested_at,
+    // and would invite a re-click that fans out more traffic at a school
+    // district's production server.
     const abort = new AbortController();
-    const timer = setTimeout(() => abort.abort(), 60_000);
+    const timer = setTimeout(() => abort.abort(), 180_000);
     try {
       const res = await fetch(`/api/internal/sis-connections/${connection.id}/test`, {
         method: 'POST',
@@ -255,11 +261,17 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
       await load();
     } catch (err) {
       const timedOut = err instanceof DOMException && err.name === 'AbortError';
-      setError(
-        timedOut
-          ? 'The test timed out waiting for the district\u2019s SIS.'
-          : 'Could not reach the test. Nothing was tested.',
-      );
+      if (timedOut) {
+        // Deliberately NOT "nothing was tested": we stopped waiting, the server
+        // did not stop working. It may yet finish and record a result, so say
+        // that and re-read the row rather than assert something we cannot know.
+        setError(
+          'Gave up waiting for the district\u2019s SIS. The test may still be running — reload in a moment before trying again.',
+        );
+        await load().catch(() => {});
+      } else {
+        setError('Could not reach the test. Nothing was tested.');
+      }
     } finally {
       clearTimeout(timer);
       setTesting(null);
@@ -319,6 +331,15 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
 
     setBusyId(connection.id);
     setError(null);
+    // Revoking wipes the credential and hides the test button, so a verdict left
+    // on screen would sit under a row reading "Disconnected / None stored" — the
+    // same stale-green hazard runTest guards against before a re-run, one
+    // control over.
+    setTestResults((prev) => {
+      const next = { ...prev };
+      delete next[connection.id];
+      return next;
+    });
     try {
       const res = await fetch(`/api/internal/sis-connections/${connection.id}/dpa`, {
         method: 'PATCH',
@@ -534,11 +555,26 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
 
                       {result.usedAddress && (
                         // The answer SPE-426 could not get without asking the
-                        // district: which address actually responded, when it is
-                        // not the one on file.
+                        // district: which address actually responded.
+                        //
+                        // Two different facts, worded differently on purpose. A
+                        // OneRoster token address is normally blank, so a single
+                        // "not the address on file" line would fire on every
+                        // healthy test and stop meaning anything.
                         <p className="mt-1 break-all text-xs text-slate-400">
-                          Answered at <span className="font-mono">{result.usedAddress}</span>, not
-                          the address on file.
+                          {result.storedAddress ? (
+                            <>
+                              Answered at{' '}
+                              <span className="font-mono">{result.usedAddress}</span> — not{' '}
+                              <span className="font-mono">{result.storedAddress}</span>, the address
+                              on file.
+                            </>
+                          ) : (
+                            <>
+                              No address was on file, so we worked one out:{' '}
+                              <span className="font-mono">{result.usedAddress}</span>.
+                            </>
+                          )}
                         </p>
                       )}
 
@@ -557,12 +593,17 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
                               </span>
                               {' — '}
                               {check.message}
-                              {/* Only the school count is a real total; the rest
-                                  are capped at one row on purpose, so printing
-                                  them would read as "1 student". */}
-                              {check.key === 'schools' && typeof check.count === 'number' && (
-                                <span className="text-slate-400"> ({check.count} schools)</span>
-                              )}
+                              {/* Aeries' school count is a real total. Every
+                                  other count in either report is capped at one
+                                  row on purpose — including OneRoster's Schools
+                                  step, which uses limit: 1 — so printing them
+                                  would render a district sharing 40 schools as
+                                  "(1 schools)". */}
+                              {result.sisType === 'aeries' &&
+                                check.key === 'schools' &&
+                                typeof check.count === 'number' && (
+                                  <span className="text-slate-400"> ({check.count} schools)</span>
+                                )}
                             </span>
                           </li>
                         ))}

--- a/lib/sis/connections.ts
+++ b/lib/sis/connections.ts
@@ -353,16 +353,44 @@ export async function recordTestResult(params: {
   result: SisTestResult;
 }): Promise<void> {
   const supabase = createServiceClient();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from('district_sis_connections')
     .update({
       status: params.ok ? 'connected' : 'error',
       last_tested_at: new Date().toISOString(),
       last_test_result: params.result,
     })
-    .eq('id', params.connectionId);
+    .eq('id', params.connectionId)
+    // Conditional on the DPA still being on file, and enforced HERE rather than
+    // by reading first: a connection test can take minutes, and a revocation
+    // that lands while one is in flight must win. Without this, the late write
+    // would set `connected` and a fresh `last_tested_at` on a row whose DPA had
+    // just been revoked and whose credentials had just been deleted — a record
+    // claiming a working integration for a district that has neither. A
+    // read-then-write check would not close it; only the condition travelling
+    // with the UPDATE does.
+    .not('dpa_cleared_at', 'is', null)
+    // `.select().maybeSingle()` for the same reason disconnect() does it: an
+    // UPDATE matching no row reports no error, so without this every miss —
+    // revoked, or a connection id that does not exist at all — would still
+    // write an `sis_connection_tested` audit record for something that was
+    // never recorded.
+    .select('id')
+    .maybeSingle();
 
   if (error) throw new Error(`Failed to record test result: ${error.message}`);
+
+  if (!data) {
+    // Nothing matched, and the two reasons are completely different. One extra
+    // read, on a path that is already rare, to avoid reporting them as the same
+    // thing.
+    const existing = await getConnection(params.connectionId);
+    if (!existing) throw new Error(SIS_CONNECTION_NOT_FOUND);
+    // The DPA was revoked while the test ran. Not an error: the revocation is
+    // the newer truth and it is meant to win. Nothing is recorded and nothing
+    // is audited, because no test result was stored.
+    return;
+  }
 
   await logServerAuditEvent({
     user_id: params.actorId,


### PR DESCRIPTION
Closes [SPE-427](https://linear.app/speddy/issue/SPE-427/internal-let-speddy-staff-run-a-districts-sis-connection-test).

## Why

Until now, only a district's own tech admin could run the SIS connection test. There was no staff-side way to check whether a district's integration works, so **every verification cost a round-trip to a person at the district**.

[SPE-426](https://linear.app/speddy/issue/SPE-426) is that cost measured. JSUSD's tech admin ran the test **nine times in six minutes** against a bug he could not have fixed. We diagnosed it from production logs hours later, shipped the fix — and *still* have no way to confirm it worked without asking him to click the button again, because this sandbox cannot reach `jsusdapi.aeries.net`.

That loop is what this closes. A day-long human round-trip becomes a five-second check we can run ourselves, as often as we need, while iterating.

## What

A **Run connection test** button on each connection in the internal district panel, and the route behind it:

`POST /api/internal/sis-connections/[connectionId]/test`

- Gated by `speddyAdminDenialReason` — the same gate as the DPA switch.
- Loads the connection, decrypts the stored credential, runs the test, records the outcome with the staff user as actor.

**It runs the district's own test, deliberately** — the same `runAeriesConnectionTest` / `runOneRosterConnectionTest` behind their button. A separate staff-side implementation could disagree with theirs, and then a green check here would prove nothing about what they see.

The two reports are the same shape under different names (Aeries `areas`, OneRoster `steps`), so the route flattens both to one `checks` array and the panel gets a single renderer. The district-facing shapes are untouched.

## Security

Worth naming rather than burying: **this lets Speddy staff cause requests to a district's SIS using that district's stored credential.** Approved explicitly, on the reasoning that holding the credential already implies being able to use it on the district's behalf.

Bounded by what the test already is:

- **Read-only probes.** No write reaches the district's SIS.
- **Aggregate only.** `fields` pinned to one non-identifying column and pagination to a single row, so the students/teachers/programs checks return 0 or 1 — never a record. No student PII is read, by construction ([SPE-393](https://linear.app/speddy/issue/SPE-393)).
- **The credential never leaves the request.** It is decrypted, used, dropped, and never returned. Pinned by a test that asserts over the whole serialized body, so a future field cannot quietly carry it.
- **Rate-limited** like the district's own test route — each call fans out to several requests against a school district's production server.
- **Audited** via `recordTestResult`, with the staff user as actor.

A staff run *does* update `last_tested_at` / `status`, the same as a district run. That is the truth about the connection, and a status chip that only some tests update would be worse than one that reflects every test. The audit row distinguishes who ran it.

## Verification

`/internal` cannot be walked in the sim district — `docs/SIM_DISTRICT.md` invariant 5 says no sim user is ever `is_speddy_admin`, and that invariant is not up for negotiation to make a test easier. So:

**13 handler tests.** The load-bearing assertion is *not* the 403 — it is that **nothing reaches the district's SIS** when a caller is refused. A gate that returned 403 *after* firing the probes would be a gate in name only, and a status code alone cannot tell those apart.

**Mutation-checked rather than assumed**, because a gate test that passes against a broken gate is worse than none:

| mutation | result |
|---|---|
| `if (denied)` → `if (!denied)` (the inversion `speddyAdminDenialReason`'s own docstring warns about) | **11 of 13 fail** |
| gate deleted entirely | **2 fail** — exactly the two that should |
| unmodified | 13 pass |

**Real database.** Unit tests mock the Supabase client, so they prove the gate and the response shape and nothing about whether the writes are permitted or land where they should. The route's whole database surface — load, decrypt, resolve off a 404 root, record — was run against real rows in the sim district, asserting `status` and `last_tested_at` move, the audit row lands naming the actor, and the stored address and ciphertext are still untouched (the SPE-426 property has to keep holding on this path too).

Sim lifecycle closed clean (`--expect-empty` all zeros, reseeded green).

## Deep self-review

Run at high effort before opening this, per the standing rule. It found four defects, all in what the operator sees — which for a diagnostic tool is most of what it is. Fixed in `e4d1d66`:

1. **The "not the address on file" line fired on every healthy OneRoster test.** A token address is normally blank, so the resolved endpoint always differed from the stored empty string. A warning that always fires stops meaning anything. The route now returns the stored address too, and the panel words the two cases differently.
2. **The schools count was printed for both connectors**, but OneRoster's Schools step runs with `limit: 1` — a district sharing 40 schools rendered as "(1 schools)". Only Aeries' count is a real total.
3. **The client gave up after 60s, below the route's worst case of ~150s.** Against a hung SIS the panel claimed "nothing was tested" while the server went on to finish and write `status`/`last_tested_at` — inviting a re-click that fans out more traffic at a district's production server. Raised to 180s, and the timeout message no longer asserts what it cannot know.
4. **Revoking a DPA left a stale green report on screen** under a row now reading "Disconnected / None stored".

## Out of scope, and worth being explicit about

**This does not make data flow.** Nothing in Speddy imports Aeries data today — the Aeries client is used by the connection test and two exploration scripts, there is no sync job, and no SIS cron exists. A green test proves reachability and permissions, nothing more. Actual roster sync is separate, unbuilt, and much larger.

## Gates

Typecheck clean, lint clean, full suite 1070 passed / 12 skipped. Three integration suites fail (`tests/integration/{key-check,basic-workflows,minimal}`) — pre-existing, confirmed by stashing and re-running on the base commit.

## Follow-up noticed, not fixed here

`recordTestResult` does a bare `.update().eq()` with no `.select().maybeSingle()`, so a bogus connection id would report success and write a false `sis_connection_tested` audit row — the exact trap `disconnect()` carries a comment about guarding against. Not reachable from this route (it 404s upstream when `getConnection` returns null) and pre-existing, so it is logged rather than folded into this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT)_