### PR TITLE
SPE-429: try an /admin application root for the Aeries API

### DIFF
--- a/__tests__/unit/lib/sis/aeries-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/aeries-setup.http.test.ts
@@ -56,10 +56,13 @@ let server: Server;
 let baseUrl: string;
 let handler: Handler;
 let seenCertHeaders: (string | undefined)[] = [];
+/** Every path dialled, in order — so candidate ORDER can be asserted. */
+let seenPaths: string[] = [];
 
 beforeAll(async () => {
   server = createServer((req, res) => {
     seenCertHeaders.push(req.headers['aeries-cert'] as string | undefined);
+    seenPaths.push(req.url ?? '');
     const { status, body, headers, raw } = handler(req.url ?? '');
     res.writeHead(status, {
       'Content-Type': raw ? 'text/html' : 'application/json',
@@ -77,6 +80,7 @@ afterAll(async () => {
 
 beforeEach(() => {
   seenCertHeaders = [];
+  seenPaths = [];
 });
 
 const run = () => runAeriesConnectionTest({ baseUrl, certificate: CERT });
@@ -240,9 +244,24 @@ describe('resolving the API root when the stored one is wrong (SPE-426)', () => 
 
     expect(report.ok).toBe(true);
     expect(report.usedBaseUrl).toBe(baseUrl.replace('/aeries/api/v5', '/admin/api/v5'));
+
+    // ORDER, not just the outcome. Without this a regression that moved
+    // /admin/api/v5 to the front of the list would still pass — and that
+    // ordering is the whole reason a healthy district pays nothing for the
+    // candidates added for an unhealthy one.
+    //
+    // Distinct roots in order of first use: once resolution settles, the three
+    // area probes run against the SAME root, and folding those in would assert
+    // the shape of the probe list rather than the shape of the search.
+    const roots: string[] = [];
+    for (const path of seenPaths) {
+      const root = path.match(/^(.*\/api\/v\d+)/)?.[1] ?? path;
+      if (roots[roots.length - 1] !== root) roots.push(root);
+    }
+    expect(roots).toEqual(['/aeries/api/v5', '/api/v5', '/admin/api/v5']);
   });
 
-  it('still makes exactly ONE request for a district already on the default root', async () => {
+  it('accepts the FIRST candidate when the stored root works, dialling no other', async () => {
     // The cost of every added candidate falls only on districts whose stored
     // address is wrong. A district that already works must not start paying for
     // our search — that would be a regression for everyone to fix one district.
@@ -250,8 +269,12 @@ describe('resolving the API root when the stored one is wrong (SPE-426)', () => 
 
     await run();
 
-    const schoolsProbes = seenCertHeaders.length;
-    expect(schoolsProbes).toBe(4); // schools + students + teachers + programs
+    // Four probes, one per area — and every one of them on the stored root.
+    // Asserting the ROOTS rather than a count is what makes this specific: a
+    // count of four would also hold if resolution had wandered and the areas
+    // happened to be four.
+    expect(seenPaths).toHaveLength(4);
+    for (const path of seenPaths) expect(path.startsWith('/aeries/api/v5')).toBe(true);
   });
 
   it('reports a 404 honestly when no known layout answers', async () => {

--- a/__tests__/unit/lib/sis/aeries-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/aeries-setup.http.test.ts
@@ -221,6 +221,39 @@ describe('resolving the API root when the stored one is wrong (SPE-426)', () => 
     expect(area(report, 'schools').status).toBe('denied');
   });
 
+  it('finds an API under an /admin application root (SPE-429)', async () => {
+    // JSUSD's real shape, learned the hard way: /aeries/api/v5 AND /api/v5 both
+    // 404'd on their host. Their OneRoster address is https://<host>/admin, so
+    // /admin is their Aeries application root and the API sits under it — the
+    // one place they ever told us, because the Aeries field discards the path.
+    handler = (path) => {
+      if (path.startsWith('/admin/api/v5')) {
+        if (path.includes('/programs')) return { status: 200, body: [{ ProgramCode: '144' }] };
+        if (path.includes('/teachers')) return { status: 200, body: [{ TeacherNumber: 7 }] };
+        if (path.includes('/students')) return { status: 200, body: [{ StudentID: 1 }] };
+        return { status: 200, body: [{ SchoolCode: 1, Name: 'Sim High' }] };
+      }
+      return { status: 404, body: { message: 'not found' } };
+    };
+
+    const report = await run();
+
+    expect(report.ok).toBe(true);
+    expect(report.usedBaseUrl).toBe(baseUrl.replace('/aeries/api/v5', '/admin/api/v5'));
+  });
+
+  it('still makes exactly ONE request for a district already on the default root', async () => {
+    // The cost of every added candidate falls only on districts whose stored
+    // address is wrong. A district that already works must not start paying for
+    // our search — that would be a regression for everyone to fix one district.
+    handler = allGranted;
+
+    await run();
+
+    const schoolsProbes = seenCertHeaders.length;
+    expect(schoolsProbes).toBe(4); // schools + students + teachers + programs
+  });
+
   it('reports a 404 honestly when no known layout answers', async () => {
     // Nothing to correct: say the address did not work rather than inventing a
     // root, and leave the stored value alone.

--- a/lib/sis/aeries-setup.ts
+++ b/lib/sis/aeries-setup.ts
@@ -50,10 +50,12 @@ export const AERIES_API_PATH = '/aeries/api/v5';
  * root and their Aeries API should sit under it. Their OneRoster row is the
  * only place they ever told us, because the Aeries field discards the path.
  *
- * Order is deliberate — the documented default stays first, so a district that
- * already works still makes exactly one request. Only a district whose stored
- * address is wrong pays for the extra candidates, and only on the way to an
- * answer it could not otherwise get.
+ * Order is deliberate — the documented default stays first, so a working root
+ * is accepted on the FIRST candidate and no later one is ever dialled. (That is
+ * about resolution only: the test as a whole still probes four endpoints, one
+ * per permission area.) Only a district whose stored address is wrong pays for
+ * the extra candidates, and only on the way to an answer it could not otherwise
+ * get.
  */
 export const AERIES_API_PATHS = [AERIES_API_PATH, '/api/v5', '/admin/api/v5'] as const;
 

--- a/lib/sis/aeries-setup.ts
+++ b/lib/sis/aeries-setup.ts
@@ -30,20 +30,32 @@ export const AERIES_API_PATH = '/aeries/api/v5';
 /**
  * The API roots we know Aeries serves, in the order we try them.
  *
- * Two real deployment shapes, both ordinary:
- *   - `/aeries/api/v5` — a district running Aeries on its own web server, where
- *     `/aeries` is the application root. `demo.aeries.net` is one of these, and
- *     it is what this integration was originally built and tested against.
- *   - `/api/v5` — an Aeries-HOSTED dedicated API host (`<district>api.aeries.net`),
- *     where the API is the whole point of the host and has no app prefix.
+ * The API lives under the Aeries APPLICATION ROOT, and that root varies by
+ * deployment — which is the whole reason this is a list rather than a constant.
+ * Aeries' own documentation uses `demo.aeries.net/aeries/api/v5`, where
+ * `/aeries` is the app root.
+ *
+ *   - `/aeries/api/v5`  — the documented default, and what this integration was
+ *                         originally built and tested against.
+ *   - `/api/v5`         — no app prefix at all.
+ *   - `/admin/api/v5`   — an app root of `/admin`.
  *
  * Assuming the first cost a live district a morning (SPE-426): their server
  * answered every probe with 404, and because `normalizeAeriesBaseUrl` replaced
  * whatever they typed, there was no address they could have entered to fix it.
- * Order is deliberate — the historical default stays first, so nothing changes
- * for a district that already works.
+ *
+ * `/admin/api/v5` was added after the first two BOTH 404'd for that district
+ * (SPE-429), on evidence rather than another guess: the same district gave us
+ * `https://<host>/admin` as their OneRoster address, so `/admin` is their app
+ * root and their Aeries API should sit under it. Their OneRoster row is the
+ * only place they ever told us, because the Aeries field discards the path.
+ *
+ * Order is deliberate — the documented default stays first, so a district that
+ * already works still makes exactly one request. Only a district whose stored
+ * address is wrong pays for the extra candidates, and only on the way to an
+ * answer it could not otherwise get.
  */
-export const AERIES_API_PATHS = [AERIES_API_PATH, '/api/v5'] as const;
+export const AERIES_API_PATHS = [AERIES_API_PATH, '/api/v5', '/admin/api/v5'] as const;
 
 /**
  * Every base URL worth trying for a district, most-likely first.


### PR DESCRIPTION
Closes [SPE-429](https://linear.app/speddy/issue/SPE-429/aeries-try-an-admin-application-root-jsusds-api-is-under-neither-known). **JSUSD is still blocked.**

## What happened

This is the first finding from the staff test button ([SPE-427](https://linear.app/speddy/issue/SPE-427)) — and the finding is that [SPE-426](https://linear.app/speddy/issue/SPE-426)'s fix **did not work**.

Blair ran the button against JSUSD. Both known Aeries roots 404'd. From the production logs for that one run:

```
[ERROR] Aeries API request failed { status: 404, path: 'schools' }
[ERROR] Aeries API request failed { status: 404, path: 'schools' }
```

Two requests, two 404s, then the honest fallback — the resolver did exactly what it was built to do. The candidate list was simply wrong.

So SPE-426 was **half right**: the address genuinely was the problem, and the district genuinely could not fix it themselves. The guess about *which* address was wrong.

Worth noting what did work: we learned this in **seconds, without involving the district**. Before SPE-427 this would have been another round-trip to a tech admin who had already lost a day.

## Why `/admin`, and why this is not another shot in the dark

The Aeries API sits under the **application root**, and that root varies by deployment. Aeries' own documentation uses `demo.aeries.net/aeries/api/v5`, where `/aeries` is that root.

**The same district already told us their root — in the OneRoster field.** Their stored OneRoster base URL is:

```
https://jsusdapi.aeries.net/admin
```

Their Aeries row holds `https://jsusdapi.aeries.net/aeries/api/v5` instead — our default, applied over whatever Nick typed, because the Aeries field discards the path. So their OneRoster row is the *only* place their real application root survives, and it says `/admin`.

Their Aeries API should therefore be at `https://jsusdapi.aeries.net/admin/api/v5`.

## The change

One candidate:

```ts
export const AERIES_API_PATHS = [AERIES_API_PATH, '/api/v5', '/admin/api/v5'] as const;
```

**The order matters more than the addition.** The documented default stays first, so a district that already works still makes exactly one request. Only a district whose stored address is wrong pays for the extra probe — and only on the way to an answer it could not otherwise get.

## Verification

| test | what it pins |
|---|---|
| JSUSD's shape: both known roots 404, `/admin/api/v5` serves | resolution finds it and names it in the report |
| happy path makes exactly 4 requests (schools + 3 areas) | the added candidates cannot tax a working district |

Mutation-checked rather than assumed — with the candidate removed, the JSUSD-shape test fails. "Add a candidate" is exactly the kind of change that quietly regresses every healthy district to help one, which is why the second test exists.

## Honest status

**This is a hypothesis, not a confirmation.** This sandbox cannot reach `jsusdapi.aeries.net`, so the only thing that settles it is one click on the staff button after this deploys.

If it is still red, the next step is deliberately **not** another guess: ask Nick for the exact API URL on his **Security → API Security** page. By then we can tell him precisely which three addresses we tried and what each returned — which turns his answer into a 30-second lookup rather than a debugging session.

**OneRoster is untouched by this** and still fails with a 400 at the token endpoint — credentials rejected, or our own request malformed. Separate problem, separate decision still open.

## Gates

Typecheck clean, lint clean, full suite 1075 passed / 12 skipped. Three integration suites fail (`tests/integration/{key-check,basic-workflows,minimal}`) — pre-existing, confirmed against the base commit earlier today.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Aeries API setup to discover installations using the `/admin/api/v5` path when standard API paths are unavailable.
  * Preserved the documented default API path behavior.
* **Tests**
  * Added coverage for API root discovery and endpoint probing across supported paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->