### PR TITLE
SPE-430: tell a OneRoster credential failure apart from our own bad request

### DIFF
--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -27,6 +27,7 @@ jest.mock('@/lib/sis/ssrf-guard', () => ({
 }));
 
 import { runOneRosterConnectionTest } from '@/lib/sis/oneroster-setup';
+import { logger } from '@/lib/logger';
 
 const CLIENT_ID = 'speddy-consumer-id';
 const CLIENT_SECRET = 'sup3r-s3cret-consumer-key';
@@ -415,6 +416,106 @@ describe('the OneRoster exchange over real HTTP', () => {
     handler = allGood;
     await run();
     expect(seen.filter((r) => r.url.includes('/token'))).toHaveLength(1);
+  });
+
+  it('blames OURSELVES, not the district, when the endpoint rejects the SCOPE', async () => {
+    // The distinction the error code exists for (SPE-430). `invalid_scope` means
+    // the endpoint understood the request and objected to how WE built it — the
+    // credentials were never evaluated. A 400 alone cannot tell that apart from
+    // a real credential failure, and we were about to ask a live district to
+    // re-enter credentials that may have been correct all along.
+    handler = (req) =>
+      req.url.includes('/token')
+        ? { status: 400, body: { error: 'invalid_scope', error_description: 'no such scope' } }
+        : allGood(req);
+
+    const report = await run();
+
+    expect(report.ok).toBe(false);
+    expect(stepOf(report, 'token').message).toMatch(/not your credentials/i);
+    expect(stepOf(report, 'token').message).toMatch(/ours to fix/i);
+    // And emphatically NOT the "re-copy your Consumer ID" advice.
+    expect(stepOf(report, 'token').message).not.toMatch(/Consumer ID/i);
+  });
+
+  it('still blames the credentials on invalid_client', async () => {
+    // The other half. A change that reported everything as our fault would pass
+    // the test above while hiding every genuine credential problem.
+    handler = (req) =>
+      req.url.includes('/token')
+        ? { status: 400, body: { error: 'invalid_client' } }
+        : allGood(req);
+
+    const report = await run();
+
+    expect(stepOf(report, 'token').message).toMatch(/Consumer ID and Consumer Secret/i);
+  });
+
+  it('IGNORES an error code outside the RFC allow-list — checked at the LOG', async () => {
+    // The safety property, asserted where the value actually travels. A token
+    // endpoint's error body can echo the submitted credentials, so only the six
+    // RFC 6749 codes are ever read out of it.
+    //
+    // The first version of this test asserted over the returned report and was
+    // VACUOUS: an unrecognised code never reaches the report either way,
+    // because `explain` only branches on two known values. Deleting the
+    // allow-list left it green. The log line is the real path — it is where the
+    // code goes, and it is written to Vercel's logs.
+    const spy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+    try {
+      handler = (req) =>
+        req.url.includes('/token')
+          ? { status: 400, body: { error: `leaked-${CLIENT_SECRET}` } }
+          : allGood(req);
+
+      const report = await run();
+
+      const logged = JSON.stringify(spy.mock.calls);
+      expect(logged).toContain('OneRoster API request failed');
+      expect(logged).not.toContain(CLIENT_SECRET);
+      expect(logged).not.toContain('leaked-');
+      // And the district still gets the ordinary credential advice.
+      expect(stepOf(report, 'token').message).toMatch(/Consumer ID and Consumer Secret/i);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('DOES log a recognised code, so the allow-list is not just "log nothing"', async () => {
+    // The other half of the property above. A readOAuthErrorCode that always
+    // returned undefined would pass every safety assertion while making the
+    // whole feature useless — this is the diagnostic we built it for.
+    const spy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+    try {
+      handler = (req) =>
+        req.url.includes('/token')
+          ? { status: 400, body: { error: 'invalid_scope' } }
+          : allGood(req);
+
+      await run();
+
+      expect(JSON.stringify(spy.mock.calls)).toContain('invalid_scope');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('never surfaces the error_description, only the code', async () => {
+    // `error_description` is free text straight from the district's server. It
+    // is the obvious next thing to reach for and the one that could carry
+    // anything, so it is asserted absent rather than merely not used.
+    handler = (req) =>
+      req.url.includes('/token')
+        ? {
+            status: 400,
+            body: { error: 'invalid_client', error_description: `secret=${CLIENT_SECRET}` },
+          }
+        : allGood(req);
+
+    const report = await run();
+
+    expect(JSON.stringify(report)).not.toContain(CLIENT_SECRET);
+    expect(JSON.stringify(report)).not.toContain('error_description');
   });
 
   it('a 401 at the token step blames the credential MIX-UP, not the network', async () => {

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -438,6 +438,41 @@ describe('the OneRoster exchange over real HTTP', () => {
     expect(stepOf(report, 'token').message).not.toMatch(/Consumer ID/i);
   });
 
+  it('also blames ourselves on invalid_request — the likeliest our-fault code', async () => {
+    // Raised by Codex, and it is the one that mattered most: a token endpoint
+    // that does not implement the `scope` parameter we always send commonly
+    // answers `invalid_request` rather than `invalid_scope`. Omitting it left
+    // the single most probable our-fault case still blaming the district — in
+    // a change whose entire purpose was to stop doing that.
+    handler = (req) =>
+      req.url.includes('/token')
+        ? { status: 400, body: { error: 'invalid_request' } }
+        : allGood(req);
+
+    const report = await run();
+
+    expect(stepOf(report, 'token').message).toMatch(/not your credentials/i);
+    expect(stepOf(report, 'token').message).not.toMatch(/Consumer ID/i);
+  });
+
+  it('does NOT let an OAuth body override the address advice on a 404', async () => {
+    // The code is only meaningful on the statuses a token endpoint uses to
+    // report one. Checked at the top level it also caught 404/405/5xx, so a
+    // candidate that 404'd with an OAuth-shaped body would claim "nothing for
+    // you to change" and bury the true problem: nothing answered at all.
+    handler = () => ({ status: 404, body: { error: 'invalid_scope' } });
+
+    const report = await runOneRosterConnectionTest({
+      baseUrl: `${origin}/admin`,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(stepOf(report, 'token').message).toMatch(/under your OneRoster address/i);
+    expect(stepOf(report, 'token').message).not.toMatch(/ours to fix/i);
+  });
+
   it('still blames the credentials on invalid_client', async () => {
     // The other half. A change that reported everything as our fault would pass
     // the test above while hiding every genuine credential problem.

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -63,6 +63,47 @@ function formEncode(value: string): string {
 /** Which half of the exchange failed. The district-facing advice differs entirely. */
 export type OneRosterPhase = 'token' | 'request';
 
+/**
+ * The complete set of OAuth 2.0 token-endpoint error codes (RFC 6749 §5.2).
+ *
+ * An ALLOW-LIST, and that is the entire safety argument. A token endpoint's
+ * error body can echo the credentials that were submitted to it, so the body is
+ * never read, logged or surfaced — except for a single `error` field, and only
+ * when its value is one of these six constants. A hostile or malformed body
+ * cannot smuggle a secret through a fixed set of six strings.
+ */
+const OAUTH_ERROR_CODES = new Set([
+  'invalid_request',
+  'invalid_client',
+  'invalid_grant',
+  'unauthorized_client',
+  'unsupported_grant_type',
+  'invalid_scope',
+]);
+
+/**
+ * Pull the RFC 6749 error code out of a failed token response, or nothing.
+ *
+ * Why this exists: a 400 from a token endpoint is ambiguous in the one way that
+ * matters. `invalid_client` means the district's Consumer ID and Secret are
+ * wrong; `invalid_scope` or `unsupported_grant_type` means OUR request is wrong
+ * and their credentials are fine. Without this, both produce "your credentials
+ * were rejected" — and a live district was about to be asked to re-enter
+ * credentials that may have been correct all along (SPE-430).
+ *
+ * Never throws: a diagnostic that can fail the request it is diagnosing is
+ * worse than no diagnostic.
+ */
+async function readOAuthErrorCode(res: Response): Promise<string | undefined> {
+  try {
+    const body: unknown = await res.json();
+    const code = (body as { error?: unknown } | null)?.error;
+    return typeof code === 'string' && OAUTH_ERROR_CODES.has(code) ? code : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Raised on a non-2xx from either the token endpoint or a data endpoint. */
 export class OneRosterApiError extends Error {
   constructor(
@@ -81,6 +122,15 @@ export class OneRosterApiError extends Error {
      * another candidate. Without this flag the two are indistinguishable.
      */
     readonly unusableTokenResponse = false,
+    /**
+     * The RFC 6749 error code the token endpoint returned, when it returned a
+     * recognised one. Always one of `OAUTH_ERROR_CODES` or undefined — never
+     * free text from the response body, which can echo the credentials.
+     *
+     * This is what tells "your credentials are wrong" apart from "our request
+     * is wrong", which a 400 alone cannot.
+     */
+    readonly oauthError?: string,
   ) {
     super(message);
     this.name = 'OneRosterApiError';
@@ -352,18 +402,25 @@ export class OneRosterClient {
       });
 
       if (!res.ok) {
-        // Status and path only. A OneRoster error body can echo the submitted
-        // credentials, so it is never logged and never surfaced.
+        // The body is still never logged or surfaced — it can echo the
+        // submitted credentials. The one exception is the token endpoint's
+        // RFC 6749 `error` code, and only when it matches the fixed six-value
+        // allow-list, which cannot carry a secret. Reading it here is safe
+        // because a failed response is thrown, never returned to a caller.
+        const oauthError = phase === 'token' ? await readOAuthErrorCode(res) : undefined;
         logger.error('OneRoster API request failed', {
           status: res.status,
           path,
           phase,
+          oauthError,
         });
         throw new OneRosterApiError(
           `OneRoster responded ${res.status} for ${path}`,
           res.status,
           path,
           phase,
+          false,
+          oauthError,
         );
       }
 

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -13,8 +13,16 @@
  *
  * SECRETS. Three things here must never leave the server or reach a log: the
  * client secret, the bearer token, and any response body (OneRoster error
- * bodies can echo the request). Every log call in this file is status + path +
- * phase, and there is no branch that widens that.
+ * bodies can echo the request).
+ *
+ * There is exactly ONE thing read out of a response body, and it is worth
+ * stating precisely because it is the only hole in the rule above: on a failed
+ * TOKEN request, the RFC 6749 `error` code — and only when its value is one of
+ * the six constants in `OAUTH_ERROR_CODES`. An allow-list of six known strings
+ * cannot carry a secret, however hostile or malformed the body. Nothing else
+ * from any body is read, logged or surfaced; `error_description`, which is free
+ * text from the district's server, deliberately is not. Every log call is
+ * status + path + phase, plus that one allow-listed code.
  *
  * Auth layering note (SPE-397 asks for this explicitly): the token request is
  * isolated in `fetchToken` so that OneRoster 1.2's scoped client-credentials

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -188,20 +188,27 @@ export interface OneRosterTestReport {
 function explain(err: unknown, step: string): { status: 'denied' | 'error'; message: string } {
   if (err instanceof OneRosterApiError) {
     if (err.phase === 'token') {
-      // OUR fault, not theirs. `invalid_scope` and `unsupported_grant_type`
-      // mean the endpoint understood the request and objected to how WE built
-      // it — the credentials were never even evaluated. Telling a district to
-      // re-enter correct credentials because of our own malformed request is
-      // the exact misdiagnosis this whole area keeps producing (SPE-419), and
-      // a 400 alone cannot tell it apart from a real credential failure.
-      if (err.oauthError === 'invalid_scope' || err.oauthError === 'unsupported_grant_type') {
-        return {
-          status: 'error',
-          message:
-            'Your OneRoster refused the way Speddy asked for access, not your credentials. Nothing for you to change — this is ours to fix, and we can see it.',
-        };
-      }
+      // NESTED inside the credential-status check on purpose. An OAuth error
+      // object is only meaningful on the statuses a token endpoint uses to
+      // report one; at the top level this branch also caught 404/405/5xx, so a
+      // candidate that 404'd with `{"error":"invalid_scope"}` in its body would
+      // claim "nothing for you to change" and then override the correct "no
+      // sign-in endpoint answered under your OneRoster address" advice.
       if (err.status === 401 || err.status === 400) {
+        // OUR fault, not theirs. Every code here describes the REQUEST: it was
+        // malformed, asked for a scope they do not offer, or used a grant type
+        // they do not support. In each case the endpoint objected before it
+        // ever evaluated the credentials. Telling a district to re-enter
+        // correct credentials because of our own bad request is the exact
+        // misdiagnosis this area keeps producing (SPE-419), and a 400 alone
+        // cannot tell it apart from a real credential failure.
+        if (err.oauthError && REQUEST_SHAPE_ERRORS.has(err.oauthError)) {
+          return {
+            status: 'error',
+            message:
+              'Your OneRoster refused the way Speddy asked for access, not your credentials. Nothing for you to change — this is ours to fix, and we can see it.',
+          };
+        }
         return {
           status: 'error',
           message:
@@ -285,6 +292,23 @@ async function step(
 }
 
 const NOT_REACHED = 'Not checked — the previous step has to work first.';
+
+/**
+ * RFC 6749 error codes that mean OUR request was wrong, not their credentials.
+ *
+ * `invalid_request` belongs here and is easy to miss — RFC 6749 §5.2 defines it
+ * as "the request is missing a required parameter, includes an unsupported
+ * parameter value, repeats a parameter, or is otherwise malformed". Every one
+ * of those is something we did. A token endpoint that does not implement the
+ * `scope` parameter we always send commonly answers `invalid_request` rather
+ * than `invalid_scope`, so omitting it would leave the single likeliest
+ * our-fault case still blaming the district.
+ */
+const REQUEST_SHAPE_ERRORS = new Set([
+  'invalid_request',
+  'invalid_scope',
+  'unsupported_grant_type',
+]);
 
 /**
  * Whether a token-step failure means "no token endpoint here" (keep looking)

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -188,6 +188,19 @@ export interface OneRosterTestReport {
 function explain(err: unknown, step: string): { status: 'denied' | 'error'; message: string } {
   if (err instanceof OneRosterApiError) {
     if (err.phase === 'token') {
+      // OUR fault, not theirs. `invalid_scope` and `unsupported_grant_type`
+      // mean the endpoint understood the request and objected to how WE built
+      // it — the credentials were never even evaluated. Telling a district to
+      // re-enter correct credentials because of our own malformed request is
+      // the exact misdiagnosis this whole area keeps producing (SPE-419), and
+      // a 400 alone cannot tell it apart from a real credential failure.
+      if (err.oauthError === 'invalid_scope' || err.oauthError === 'unsupported_grant_type') {
+        return {
+          status: 'error',
+          message:
+            'Your OneRoster refused the way Speddy asked for access, not your credentials. Nothing for you to change — this is ours to fix, and we can see it.',
+        };
+      }
       if (err.status === 401 || err.status === 400) {
         return {
           status: 'error',


### PR DESCRIPTION
Closes [SPE-430](https://linear.app/speddy/issue/SPE-430/oneroster-tell-your-credentials-are-wrong-apart-from-our-request-is).

## The problem

JSUSD's OneRoster sign-in has returned **400** on every attempt — six from the district, and every staff run since:

```
[ERROR] OneRoster API request failed { status: 400, path: 'token endpoint', phase: 'token' }
```

We report that as *"Those credentials were rejected"* — advice that sends the district to re-enter their Consumer ID and Secret.

**A 400 cannot mean only that.** RFC 6749 §5.2 gives a token endpoint six error codes, and they fall on opposite sides of the line that matters most:

| code | whose problem |
|---|---|
| `invalid_client`, `invalid_grant`, `unauthorized_client` | **theirs** — the credentials really are wrong |
| `invalid_scope`, `unsupported_grant_type`, `invalid_request` | **ours** — the endpoint objected to how *we* built the request and never evaluated their credentials |

We ask for a specific scope (`…/scope/roster-core.readonly`) and `grant_type=client_credentials`, so that second branch is live, not theoretical.

**The next step before this was to ask Nick to re-check credentials that may have been correct all along.** That is the same misdiagnosis as [SPE-417](https://linear.app/speddy/issue/SPE-417), [SPE-419](https://linear.app/speddy/issue/SPE-419) and [SPE-426](https://linear.app/speddy/issue/SPE-426): blaming a district for something on our side.

## The change

Capture the RFC 6749 `error` code, and use it:

```ts
const OAUTH_ERROR_CODES = new Set([
  'invalid_request', 'invalid_client', 'invalid_grant',
  'unauthorized_client', 'unsupported_grant_type', 'invalid_scope',
]);
```

`invalid_scope` / `unsupported_grant_type` now produce *"Your OneRoster refused the way Speddy asked for access, not your credentials. Nothing for you to change — this is ours to fix, and we can see it."* Everything else keeps the existing credential advice.

## Why reading that body is safe

**A token endpoint's error body can echo the credentials submitted to it.** That is why it has never been logged or surfaced — and still is not.

- Exactly **one** field is read, and only when its value is one of **six fixed constants**. A hostile or sloppy body cannot smuggle a secret through an allow-list of six known strings.
- **`error_description` is never read.** It is free text straight from the district's server and the obvious next thing to reach for — so it is asserted absent, not merely unused.
- Mechanically safe too: the read happens only on a non-2xx, which is always thrown and never returned to a caller, so no response stream is consumed out from under one.

## Verification

Four tests over a real HTTP server, every guard mutation-checked:

| mutation | result |
|---|---|
| remove the allow-list | leak test fails |
| disable the capture entirely | scope test + "does log a real code" test fail |
| remove the `invalid_scope` branch | "blames ourselves" test fails |
| unmodified | 33 pass |

**One of these tests was vacuous as first written, and the mutation check is what caught it.** It asserted over the returned *report* — where an unrecognised code never appears anyway, because `explain()` branches on two known values — so deleting the allow-list left it green. The value's real path is the **log line**, so the test now spies on the logger.

Same failure mode as the fake HTML test caught in SPE-426, and worth naming: **a report-level assertion is the wrong altitude for a property about logging.** There is also a deliberate second test that a *recognised* code IS logged — an extraction that always returned `undefined` would satisfy every safety assertion while making the feature useless.

No database behaviour changes, so the real-session rule is not triggered — this is transport and copy only.

## What this does not do

**It does not fix JSUSD.** It tells us, on the next staff test run, *whose problem* the 400 is — which is exactly what is currently blocking the decision about what to ask the district.

## Gates

Typecheck clean, lint clean, full suite 1080 passed / 12 skipped. Three integration suites fail (`tests/integration/{key-check,basic-workflows,minimal}`) — pre-existing, confirmed against the base commit earlier today.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT)_