### PR TITLE
SPE-431: a 400 that names no reason is a wrong address, not a bad credential

### DIFF
--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -216,6 +216,67 @@ describe('resolving the token endpoint when the stored one is wrong (SPE-426)', 
     expect(report.usedTokenUrl).toBe(`${origin}/admin/oauth/token`);
   });
 
+  it('keeps looking past a 400 that names NO reason (SPE-431)', async () => {
+    // The live-district case. RFC 6749 §5.2 requires a token endpoint to name
+    // why it refused, so a bare 400 is evidence we are not at a token endpoint
+    // at all. Reading it as "your credentials were rejected" stopped the search
+    // and blamed a district for an address that could not judge credentials —
+    // the SPE-426 failure, one connector over.
+    handler = (req) => {
+      if (req.url.startsWith('/admin/token')) return { status: 400, body: { message: 'nope' } };
+      if (req.url.includes('/oauth/token')) {
+        return { status: 200, body: { access_token: TOKEN, token_type: 'bearer', expires_in: 3600 } };
+      }
+      return { status: 200, body: { orgs: [{ sourcedId: 'org-1', name: 'Sim USD', type: 'district' }] } };
+    };
+
+    const report = await runWith(`${origin}/admin/token`);
+
+    expect(stepOf(report, 'token').status).toBe('ok');
+    expect(report.usedTokenUrl).toBe(`${origin}/admin/oauth/token`);
+  });
+
+  it('points at the ADDRESS when every candidate answers a bare 400', async () => {
+    // The exhausted case has to agree with the new reading. Reporting
+    // "credentials rejected" here would put the district back on the hook for
+    // an endpoint we do not believe judged their credentials at all.
+    handler = () => ({ status: 400, body: { message: 'nope' } });
+
+    const report = await runWith(`${origin}/admin/token`);
+
+    expect(report.ok).toBe(false);
+    expect(stepOf(report, 'token').message).toMatch(/under your OneRoster address/i);
+    expect(stepOf(report, 'token').message).not.toMatch(/Consumer ID/i);
+  });
+
+  it('STILL stops on a 400 that DOES name invalid_client', async () => {
+    // The load-bearing half. A compliant endpoint saying "your credentials are
+    // wrong" must end the search — walking on would replace the district's real
+    // problem with "check your address", and would post their consumer secret
+    // somewhere new for nothing.
+    handler = (req) =>
+      req.url.includes('/token')
+        ? { status: 400, body: { error: 'invalid_client' } }
+        : allGood(req);
+
+    const report = await runWith(`${origin}/admin/token`);
+
+    expect(stepOf(report, 'token').message).toMatch(/Consumer ID and Consumer Secret/i);
+    expect(seen.filter((r) => r.url.includes('token'))).toHaveLength(1);
+  });
+
+  it('STILL stops at a 401 that names nothing — auth verdicts are not addresses', async () => {
+    // Deliberately NOT extended to 401. A 401 is a strong authentication
+    // verdict from any server, compliant or not, and treating it as "wrong
+    // address" would walk past a genuine credential failure.
+    handler = () => ({ status: 401, body: { message: 'nope' } });
+
+    const report = await runWith(`${origin}/admin/token`);
+
+    expect(stepOf(report, 'token').message).toMatch(/Consumer ID and Consumer Secret/i);
+    expect(seen.filter((r) => r.url.includes('token'))).toHaveLength(1);
+  });
+
   it('STOPS at a real upstream 502 — their endpoint exists and is broken', async () => {
     // Raised by CodeRabbit, and it was right. `fetchToken` marks "answered but
     // the body is not a token" with a SYNTHETIC 502, and `dial` raises a real
@@ -509,8 +570,10 @@ describe('the OneRoster exchange over real HTTP', () => {
       expect(logged).toContain('OneRoster API request failed');
       expect(logged).not.toContain(CLIENT_SECRET);
       expect(logged).not.toContain('leaked-');
-      // And the district still gets the ordinary credential advice.
-      expect(stepOf(report, 'token').message).toMatch(/Consumer ID and Consumer Secret/i);
+      // A dropped code leaves a BARE 400, which now reads as "not a sign-in
+      // endpoint" rather than a credential verdict (SPE-431) — so the district
+      // is pointed at the address, not at credentials that were never judged.
+      expect(stepOf(report, 'token').message).toMatch(/under your OneRoster address/i);
     } finally {
       spy.mockRestore();
     }

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -245,8 +245,32 @@ describe('resolving the token endpoint when the stored one is wrong (SPE-426)', 
     const report = await runWith(`${origin}/admin/token`);
 
     expect(report.ok).toBe(false);
-    expect(stepOf(report, 'token').message).toMatch(/under your OneRoster address/i);
+    // They DID give us a token address, so the advice must not tell them to
+    // enter one — it says what we tried instead.
+    expect(stepOf(report, 'token').message).toMatch(/Nothing at your token address/i);
+    expect(stepOf(report, 'token').message).toContain(`${origin}/admin/token`);
+    expect(stepOf(report, 'token').message).toContain(`${origin}/admin/oauth/token`);
+    expect(stepOf(report, 'token').message).not.toMatch(/enter it above/i);
     expect(stepOf(report, 'token').message).not.toMatch(/Consumer ID/i);
+  });
+
+  it('words the SAME failure differently when no token address was supplied', async () => {
+    // The distinction the message builder exists for. With nothing on file,
+    // "enter it above" is useful advice; with their field already filled in and
+    // that very address among the ones that just answered, it is a false
+    // statement dressed as advice.
+    handler = () => ({ status: 400, body: { message: 'nope' } });
+
+    const report = await runOneRosterConnectionTest({
+      baseUrl: `${origin}/admin`,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    expect(stepOf(report, 'token').message).toMatch(/enter it above/i);
+    expect(stepOf(report, 'token').message).not.toMatch(/Nothing at your token address/i);
+    // Still names what was tried, either way.
+    expect(stepOf(report, 'token').message).toContain(`${origin}/admin/token`);
   });
 
   it('STILL stops on a 400 that DOES name invalid_client', async () => {
@@ -351,9 +375,10 @@ describe('resolving the token endpoint when the stored one is wrong (SPE-426)', 
 
     expect(report.ok).toBe(false);
     expect(report.usedTokenUrl).toBeUndefined();
-    // Points at the address they DID give us. Telling them to fix the token
-    // address would send them to correct the field we tell them to leave blank.
-    expect(stepOf(report, 'token').message).toMatch(/under your OneRoster address/i);
+    // Points at the addresses, not the credentials — and, because this district
+    // DID supply a token address, without telling them to enter one.
+    expect(stepOf(report, 'token').message).toMatch(/Nothing at your token address/i);
+    expect(stepOf(report, 'token').message).not.toMatch(/Consumer ID/i);
   });
 });
 
@@ -573,7 +598,8 @@ describe('the OneRoster exchange over real HTTP', () => {
       // A dropped code leaves a BARE 400, which now reads as "not a sign-in
       // endpoint" rather than a credential verdict (SPE-431) — so the district
       // is pointed at the address, not at credentials that were never judged.
-      expect(stepOf(report, 'token').message).toMatch(/under your OneRoster address/i);
+      expect(stepOf(report, 'token').message).toMatch(/behaved like a OneRoster sign-in endpoint/i);
+      expect(stepOf(report, 'token').message).not.toMatch(/Consumer ID/i);
     } finally {
       spy.mockRestore();
     }

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -198,7 +198,10 @@ function explain(err: unknown, step: string): { status: 'denied' | 'error'; mess
       // looks like a sign-in endpoint. Only ever surfaces when EVERY candidate
       // failed, because a bare 400 no longer stops the search.
       if (err.status === 400 && !err.oauthError) {
-        return { status: 'error', message: NO_TOKEN_ENDPOINT };
+        // Placeholder: neither a 404 nor a bare 400 stops the search, so this
+        // is always replaced by `noTokenEndpointMessage` once the candidates
+        // are exhausted and we know what was actually dialled.
+        return { status: 'error', message: noTokenEndpointMessage('', []) };
       }
       if (err.status === 401 || err.status === 400) {
         // OUR fault, not theirs. Every code here describes the REQUEST: it was
@@ -226,7 +229,10 @@ function explain(err: unknown, step: string): { status: 'denied' | 'error'; mess
         // address has 404'd too, so "check the token address" is the wrong
         // advice — it is the field we now tell them to leave blank. The address
         // still worth checking is the one they DID give us.
-        return { status: 'error', message: NO_TOKEN_ENDPOINT };
+        // Placeholder: neither a 404 nor a bare 400 stops the search, so this
+        // is always replaced by `noTokenEndpointMessage` once the candidates
+        // are exhausted and we know what was actually dialled.
+        return { status: 'error', message: noTokenEndpointMessage('', []) };
       }
       if (err.status === 408) {
         return {
@@ -306,20 +312,30 @@ const NOT_REACHED = 'Not checked — the previous step has to work first.';
  * than `invalid_scope`, so omitting it would leave the single likeliest
  * our-fault case still blaming the district.
  */
-/**
- * Said when nothing under the district's OneRoster address looks like a sign-in
- * endpoint — whether every candidate 404'd, or answered 400 without naming a
- * reason. One string because it is one conclusion, and because the advice must
- * not drift apart between the two ways of reaching it.
- */
-const NO_TOKEN_ENDPOINT =
-  'No sign-in endpoint answered under your OneRoster address. Check that address first; if your OneRoster settings do show a separate token address, enter it above.';
-
 const REQUEST_SHAPE_ERRORS = new Set([
   'invalid_request',
   'invalid_scope',
   'unsupported_grant_type',
 ]);
+
+/**
+ * Said when nothing we dialled behaved like a sign-in endpoint.
+ *
+ * Two shapes, because one sentence cannot be true for both. "Enter a token
+ * address above" is a false statement to a district whose field is already
+ * filled in and whose address was one of the ones that just answered — which is
+ * exactly JSUSD's situation. So when they supplied one, say so; and either way
+ * name what was actually tried rather than leaving them to guess at it.
+ *
+ * Reached only from the report level, once the candidates are exhausted: it
+ * needs to know what was dialled, which `explain` cannot see from one error.
+ */
+function noTokenEndpointMessage(storedTokenUrl: string, dialled: string[]): string {
+  const tried = dialled.length ? ` We tried ${dialled.join(' and ')}.` : '';
+  return storedTokenUrl
+    ? `Nothing at your token address behaved like a OneRoster sign-in endpoint.${tried} Check both addresses against your OneRoster settings — the sign-in address is often not the one the data lives at.`
+    : `No sign-in endpoint answered under your OneRoster address.${tried} Check that address first; if your OneRoster settings do show a separate token address, enter it above.`;
+}
 
 /**
  * Whether a token-step failure means "no token endpoint here" (keep looking)
@@ -342,9 +358,13 @@ const REQUEST_SHAPE_ERRORS = new Set([
  * district's consumer secret to two more paths would neither find it nor say
  * anything useful. Keying on the status alone conflated them (caught in review).
  *
- * What must NOT continue: 400, 401 and 403 — the endpoint telling us the
- * CREDENTIALS are wrong, which is the district's real problem, and walking on
- * would replace it with "check your address" and hide it. Nor any real 5xx.
+ * And one more that the body explains in full: a 400 naming NO reason at all,
+ * which RFC 6749 §5.2 says a real token endpoint must never send.
+ *
+ * What must NOT continue: 401, 403, and a 400 that DOES name a credential
+ * problem — the endpoint telling us the CREDENTIALS are wrong, which is the
+ * district's real problem, and walking on would replace it with "check your
+ * address" and hide it. Nor any real 5xx.
  *
  * Every extra candidate posts the consumer secret somewhere new, so the set
  * stays as small as the failure modes allow.
@@ -439,6 +459,10 @@ export async function runOneRosterConnectionTest(params: {
   // Kept so a candidate list the guard refused outright reports WHY, rather
   // than a generic "cannot be used" the district can do nothing with.
   let guardRefusal: string | null = null;
+  // Every address actually dialled, in order. Reported when none of them turn
+  // out to be a sign-in endpoint, because "check your token address" is not
+  // advice a district can act on without knowing what we already tried.
+  const dialled: string[] = [];
 
   for (const candidate of tokenCandidates) {
     // Re-guarded per candidate: a credential is about to be posted to it.
@@ -449,6 +473,7 @@ export async function runOneRosterConnectionTest(params: {
       continue;
     }
 
+    dialled.push(candidate);
     const attemptClient = new OneRosterClient({ ...params, tokenUrl: candidate });
     let missing = false;
     const attempt = await step('token', 'Sign-in', async () => {
@@ -481,6 +506,13 @@ export async function runOneRosterConnectionTest(params: {
     // left the field blank there IS no stored address, and reporting a failure
     // against an empty string tells them nothing about what was tried.
     resolvedTokenUrl = tokenFallback.url;
+    // Nothing that answered behaved like a sign-in endpoint, so the conclusion
+    // is a report-level one and only now can it be worded truthfully — it needs
+    // to know whether the district supplied a token address, and which
+    // addresses were tried. Telling someone to "enter a token address above"
+    // when theirs is already filled in, and was one of the ones that just
+    // answered, is a false statement dressed as advice.
+    token = { ...token, message: noTokenEndpointMessage(storedTokenUrl, dialled) };
   }
   if (!token) {
     return {

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -194,6 +194,12 @@ function explain(err: unknown, step: string): { status: 'denied' | 'error'; mess
       // candidate that 404'd with `{"error":"invalid_scope"}` in its body would
       // claim "nothing for you to change" and then override the correct "no
       // sign-in endpoint answered under your OneRoster address" advice.
+      // Same conclusion as a 404, reached by a different route: nothing here
+      // looks like a sign-in endpoint. Only ever surfaces when EVERY candidate
+      // failed, because a bare 400 no longer stops the search.
+      if (err.status === 400 && !err.oauthError) {
+        return { status: 'error', message: NO_TOKEN_ENDPOINT };
+      }
       if (err.status === 401 || err.status === 400) {
         // OUR fault, not theirs. Every code here describes the REQUEST: it was
         // malformed, asked for a scope they do not offer, or used a grant type
@@ -220,11 +226,7 @@ function explain(err: unknown, step: string): { status: 'denied' | 'error'; mess
         // address has 404'd too, so "check the token address" is the wrong
         // advice — it is the field we now tell them to leave blank. The address
         // still worth checking is the one they DID give us.
-        return {
-          status: 'error',
-          message:
-            'No sign-in endpoint answered under your OneRoster address. Check that address first; if your OneRoster settings do show a separate token address, enter it above.',
-        };
+        return { status: 'error', message: NO_TOKEN_ENDPOINT };
       }
       if (err.status === 408) {
         return {
@@ -304,6 +306,15 @@ const NOT_REACHED = 'Not checked — the previous step has to work first.';
  * than `invalid_scope`, so omitting it would leave the single likeliest
  * our-fault case still blaming the district.
  */
+/**
+ * Said when nothing under the district's OneRoster address looks like a sign-in
+ * endpoint — whether every candidate 404'd, or answered 400 without naming a
+ * reason. One string because it is one conclusion, and because the advice must
+ * not drift apart between the two ways of reaching it.
+ */
+const NO_TOKEN_ENDPOINT =
+  'No sign-in endpoint answered under your OneRoster address. Check that address first; if your OneRoster settings do show a separate token address, enter it above.';
+
 const REQUEST_SHAPE_ERRORS = new Set([
   'invalid_request',
   'invalid_scope',
@@ -340,7 +351,26 @@ const REQUEST_SHAPE_ERRORS = new Set([
  */
 function isNotATokenEndpoint(err: unknown): boolean {
   if (!(err instanceof OneRosterApiError) || err.phase !== 'token') return false;
-  return err.unusableTokenResponse || err.status === 404 || err.status === 405;
+  if (err.unusableTokenResponse || err.status === 404 || err.status === 405) return true;
+
+  // A 400 that names no reason. RFC 6749 §5.2 REQUIRES a token endpoint to
+  // return an error code in the body when it refuses — `invalid_client`,
+  // `invalid_scope`, and so on. A bare 400 is therefore evidence that whatever
+  // answered is not a token endpoint at all, rather than a token endpoint
+  // refusing a credential.
+  //
+  // Learned from a live district (SPE-431). Their guessed `<base>/token`
+  // answered 400 with no code, we read that as "your credentials were
+  // rejected", and we stopped — so we never tried `<base>/oauth/token` and may
+  // never have found their real sign-in endpoint at all. That is the SPE-426
+  // failure exactly, one connector over: assume an address, stop early, blame
+  // the district for it.
+  //
+  // Deliberately NOT extended to 401. A 401 is a strong authentication verdict
+  // from any server, compliant or not, and treating it as "wrong address" would
+  // walk past a genuine credential failure — the misdiagnosis running the other
+  // way, which is the one this module was built to prevent.
+  return err.status === 400 && !err.oauthError;
 }
 
 /**


### PR DESCRIPTION
Closes [SPE-431](https://linear.app/speddy/issue/SPE-431/oneroster-a-400-that-names-no-reason-is-a-wrong-address-not-a-rejected). **JSUSD is still blocked on OneRoster.**

## What the error code told us

Found by [SPE-430](https://linear.app/speddy/issue/SPE-430) on its first production run — which is exactly what it was built to do. JSUSD's OneRoster test produced:

```
[ERROR] OneRoster API request failed {
  status: 400, path: 'token endpoint', phase: 'token', oauthError: undefined
}
```

**A 400 with no OAuth error code at all.** RFC 6749 §5.2 *requires* a token endpoint to name why it refused — `invalid_client`, `invalid_scope`, and so on. This one named nothing.

That is not a token endpoint refusing a credential. That is evidence we are **not at a token endpoint.**

## Why this matters more than it sounds

Nick **guessed** `https://jsusdapi.aeries.net/admin/token`. He said outright he had never seen a "token address" before — which is why SPE-426 made the field optional in the first place.

His guess *answered* rather than 404'ing. So we read its 400 as *"your credentials were rejected"* and **stopped** — never trying `<base>/oauth/token`. We may never have found their real sign-in endpoint at all, while telling them their Consumer ID and Secret were wrong.

**That is the SPE-426 failure, one connector over:** assume an address, stop early, blame the district for it. The resolver exists to stop doing this.

## The change

`isNotATokenEndpoint` now also continues past a **400 carrying no recognised OAuth error code**, and `explain` reports that case as *"No sign-in endpoint answered under your OneRoster address"* — the same conclusion as a 404, reached a different way, sharing one string so the two cannot drift apart.

## The boundary, deliberately not crossed

**401 still stops, named or not.** A 401 is a strong authentication verdict from any server, compliant or not; treating it as "wrong address" would walk past a genuine credential failure and report an address problem instead — the same misdiagnosis running the other direction. **A 400 that *does* name `invalid_client` also still stops.**

Both are pinned by tests, because that boundary is the part most likely to be "simplified" later by someone who sees two adjacent status codes treated differently.

## Verification

Mutation-checked in both directions, because a loosened stop-rule is exactly the kind of change that looks fine and quietly breaks the opposite case:

| mutation | result |
|---|---|
| remove the bare-400 rule | the SPE-431 test fails |
| extend the rule to 401 as well | **three** tests fail, including the two pinning "a 401 ends the search" |
| unmodified | 254 SIS tests pass |

One pre-existing test needed its behavioural assertion updated: a body whose `error` value the allow-list drops now leaves a bare 400, which correctly reads as an address problem rather than a credential one. Its safety purpose — that a non-allow-listed value never reaches the log — is unchanged and still asserted.

No database behaviour changes, so the real-session rule is not triggered.

## Still unknown

Whether their real token endpoint is `<base>/oauth/token` or somewhere we still don't try. The staff button settles that in seconds once this deploys.

**Aeries is unaffected and its story is closed on our side:** the address is solved (`/admin/api/v5`), and the certificate is genuinely rejected by Aeries. We verified our own handling is clean — what we send is byte-for-byte what the district typed, 32 characters, correct format, last four matching the stored hint — so that one is theirs to fix.

## Gates

Typecheck clean, lint clean, full suite 1086 passed / 12 skipped. Three integration suites fail (`tests/integration/{key-check,basic-workflows,minimal}`) — pre-existing, confirmed against the base commit earlier.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT)_