### PR TITLE
SPE-432: keep the trailing slash Aeries documents on the token address

### DIFF
--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -159,9 +159,10 @@ describe('resolving the token endpoint when the stored one is wrong (SPE-426)', 
     });
 
     expect(report.ok).toBe(true);
-    // The documented form leads, so that is what a blank field now resolves to.
-    expect(report.usedTokenUrl).toBe(`${origin}/admin/token/`);
-    expect(stepOf(report, 'token').message).toContain(`${origin}/admin/token/`);
+    // `/token` still leads — the documented slashed form sits behind it so that
+    // it cannot absorb a failure the search is unable to continue past.
+    expect(report.usedTokenUrl).toBe(`${origin}/admin/token`);
+    expect(stepOf(report, 'token').message).toContain(`${origin}/admin/token`);
   });
 
   it('never guesses a token endpoint OUTSIDE the path the district gave us', async () => {
@@ -235,6 +236,34 @@ describe('resolving the token endpoint when the stored one is wrong (SPE-426)', 
 
     expect(stepOf(report, 'token').status).toBe('ok');
     expect(report.usedTokenUrl).toBe(`${origin}/admin/token/`);
+  });
+
+  it('does not let the slashed candidate abort a district whose /token works', async () => {
+    // The regression the ordering guards against. A gateway that canonicalises
+    // `/token/` to `/token` answers with a redirect, which `redirect: 'error'`
+    // turns into a plain TypeError — NOT a "keep looking" signal. Leading with
+    // the slashed form would abort the search there and tell a district with a
+    // perfectly good endpoint that we could not reach them.
+    handler = (req) => {
+      if (req.url === '/admin/token/') {
+        return { status: 308, headers: { Location: `${origin}/admin/token` } };
+      }
+      if (req.url === '/admin/token') {
+        return { status: 200, body: { access_token: TOKEN, token_type: 'bearer', expires_in: 3600 } };
+      }
+      return { status: 200, body: { orgs: [{ sourcedId: 'org-1', name: 'Sim USD', type: 'district' }] } };
+    };
+
+    const report = await runOneRosterConnectionTest({
+      baseUrl: `${origin}/admin`,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    expect(report.ok).toBe(true);
+    // The redirecting address was never dialled at all, because /token came
+    // first and answered.
+    expect(seen.every((r) => r.url !== '/admin/token/')).toBe(true);
   });
 
   it('dials the stored token address VERBATIM, trailing slash and all', async () => {

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -266,6 +266,36 @@ describe('resolving the token endpoint when the stored one is wrong (SPE-426)', 
     expect(seen.every((r) => r.url !== '/admin/token/')).toBe(true);
   });
 
+  it('does not let the slashed candidate abort a district on the /oauth/token fallback', async () => {
+    // Raised by Codex against the first ordering. Placing the slashed probe
+    // between `/token` and `/oauth/token` broke the districts the OAuth
+    // fallback exists for: `/token` says keep looking, `/token/` redirects, the
+    // redirect ends the loop, and `/oauth/token` is never reached — a
+    // regression against behaviour that already worked, to help a district that
+    // did not. Appended last, it cannot come between them.
+    handler = (req) => {
+      if (req.url === '/admin/token') return { status: 404, body: { message: 'nope' } };
+      if (req.url === '/admin/token/') {
+        return { status: 308, headers: { Location: `${origin}/admin/token` } };
+      }
+      if (req.url === '/admin/oauth/token') {
+        return { status: 200, body: { access_token: TOKEN, token_type: 'bearer', expires_in: 3600 } };
+      }
+      return { status: 200, body: { orgs: [{ sourcedId: 'org-1', name: 'Sim USD', type: 'district' }] } };
+    };
+
+    const report = await runOneRosterConnectionTest({
+      baseUrl: `${origin}/admin`,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.usedTokenUrl).toBe(`${origin}/admin/oauth/token`);
+    // The redirecting probe was never dialled — it sits behind the fallback.
+    expect(seen.every((r) => r.url !== '/admin/token/')).toBe(true);
+  });
+
   it('dials the stored token address VERBATIM, trailing slash and all', async () => {
     // The other half of SPE-432: if a district has the documented address on
     // file, we must send it as given rather than normalising the slash off and

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -159,8 +159,9 @@ describe('resolving the token endpoint when the stored one is wrong (SPE-426)', 
     });
 
     expect(report.ok).toBe(true);
-    expect(report.usedTokenUrl).toBe(`${origin}/admin/token`);
-    expect(stepOf(report, 'token').message).toContain(`${origin}/admin/token`);
+    // The documented form leads, so that is what a blank field now resolves to.
+    expect(report.usedTokenUrl).toBe(`${origin}/admin/token/`);
+    expect(stepOf(report, 'token').message).toContain(`${origin}/admin/token/`);
   });
 
   it('never guesses a token endpoint OUTSIDE the path the district gave us', async () => {
@@ -214,6 +215,44 @@ describe('resolving the token endpoint when the stored one is wrong (SPE-426)', 
 
     expect(stepOf(report, 'token').status).toBe('ok');
     expect(report.usedTokenUrl).toBe(`${origin}/admin/oauth/token`);
+  });
+
+  it("finds the DOCUMENTED /token/ when the slashless one answers a bare 400 (SPE-432)", async () => {
+    // JSUSD's real shape. Aeries documents the token endpoint WITH a trailing
+    // slash; their tech admin typed exactly that; we stripped it before saving.
+    // Aeries runs on ASP.NET, where the two spellings can route to different
+    // handlers — so `/admin/token` answered 400 from something that is not a
+    // token endpoint, and `/admin/token/` was never once dialled.
+    handler = (req) => {
+      if (req.url === '/admin/token/') {
+        return { status: 200, body: { access_token: TOKEN, token_type: 'bearer', expires_in: 3600 } };
+      }
+      if (req.url.startsWith('/admin/token')) return { status: 400, body: { message: 'nope' } };
+      return { status: 200, body: { orgs: [{ sourcedId: 'org-1', name: 'Sim USD', type: 'district' }] } };
+    };
+
+    const report = await runWith(`${origin}/admin/token`);
+
+    expect(stepOf(report, 'token').status).toBe('ok');
+    expect(report.usedTokenUrl).toBe(`${origin}/admin/token/`);
+  });
+
+  it('dials the stored token address VERBATIM, trailing slash and all', async () => {
+    // The other half of SPE-432: if a district has the documented address on
+    // file, we must send it as given rather than normalising the slash off and
+    // dialling something they never entered.
+    handler = (req) =>
+      req.url === '/admin/token/'
+        ? { status: 200, body: { access_token: TOKEN, token_type: 'bearer', expires_in: 3600 } }
+        : { status: 404, body: { message: 'not here' } };
+
+    const report = await runWith(`${origin}/admin/token/`);
+
+    expect(stepOf(report, 'token').status).toBe('ok');
+    // The FIRST request went to the address on file, unmodified.
+    expect(seen[0].url).toBe('/admin/token/');
+    // And it is not reported as a correction, because nothing was corrected.
+    expect(report.usedTokenUrl).toBeUndefined();
   });
 
   it('keeps looking past a 400 that names NO reason (SPE-431)', async () => {

--- a/__tests__/unit/lib/sis/oneroster-setup.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.test.ts
@@ -115,12 +115,16 @@ describe('normalizeOneRosterBaseUrl', () => {
 });
 
 describe('normalizeOneRosterTokenUrl', () => {
-  it('keeps the vendor-specific token path intact', () => {
-    // Unlike the base URL there is no version segment to strip, and the path
-    // genuinely varies: /token, /token/, /oauth/token.
+  it('keeps the vendor-specific token path intact, TRAILING SLASH INCLUDED', () => {
+    // Aeries documents its token endpoint WITH the slash
+    // (https://<district>api.aeries.net/admin/token/), and on ASP.NET the two
+    // spellings can route to different endpoints. Stripping it cost a live
+    // district their integration (SPE-432): they typed the documented address,
+    // we saved a different one, and the documented one was never dialled.
     expect(normalizeOneRosterTokenUrl('https://jsusdapi.aeries.net/admin/token/')).toBe(
-      'https://jsusdapi.aeries.net/admin/token',
+      'https://jsusdapi.aeries.net/admin/token/',
     );
+    // And a path without one is left equally alone.
     expect(normalizeOneRosterTokenUrl('https://vendor.example.com/oauth/token')).toBe(
       'https://vendor.example.com/oauth/token',
     );
@@ -153,10 +157,11 @@ describe('runOneRosterConnectionTest guards both URLs before sending a credentia
 
     // Never built for the private address, so nothing was posted to it.
     expect(mockClientTokenUrls).not.toContain('https://token.example.com/token');
-    // And the derived candidate under the district's own base was tried.
-    expect(mockClientTokenUrls).toContain('https://data.example.com/admin/token');
+    // And the derived candidates under the district's own base were tried,
+    // starting with the form Aeries documents.
+    expect(mockClientTokenUrls).toContain('https://data.example.com/admin/token/');
     expect(report.ok).toBe(true);
-    expect(report.usedTokenUrl).toBe('https://data.example.com/admin/token');
+    expect(report.usedTokenUrl).toBe('https://data.example.com/admin/token/');
   });
 
   it('refuses outright when EVERY candidate resolves privately', async () => {

--- a/__tests__/unit/lib/sis/oneroster-setup.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.test.ts
@@ -157,11 +157,10 @@ describe('runOneRosterConnectionTest guards both URLs before sending a credentia
 
     // Never built for the private address, so nothing was posted to it.
     expect(mockClientTokenUrls).not.toContain('https://token.example.com/token');
-    // And the derived candidates under the district's own base were tried,
-    // starting with the form Aeries documents.
-    expect(mockClientTokenUrls).toContain('https://data.example.com/admin/token/');
+    // And the derived candidates under the district's own base were tried.
+    expect(mockClientTokenUrls).toContain('https://data.example.com/admin/token');
     expect(report.ok).toBe(true);
-    expect(report.usedTokenUrl).toBe('https://data.example.com/admin/token/');
+    expect(report.usedTokenUrl).toBe('https://data.example.com/admin/token');
   });
 
   it('refuses outright when EVERY candidate resolves privately', async () => {

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -89,6 +89,12 @@ export function oneRosterTokenUrlCandidates(baseUrl: string): string[] {
   try {
     // Parsed for validation only — an unparseable base has no safe guesses.
     new URL(trimmed);
+    // Documented form first: Aeries publishes its token endpoint as
+    // `https://<district>api.aeries.net/admin/token/`, with the trailing slash,
+    // and on ASP.NET that slash can select a different route entirely. It was
+    // absent from this list — and stripped from what districts typed — which is
+    // why we never dialled the one address the vendor actually documents.
+    add(`${trimmed}/token/`);
     add(`${trimmed}/token`);
     add(`${trimmed}/oauth/token`);
   } catch {
@@ -98,17 +104,28 @@ export function oneRosterTokenUrlCandidates(baseUrl: string): string[] {
 }
 
 /**
- * Normalize a token endpoint the district DID supply.
+ * Normalize a token endpoint the district DID supply — which now means barely
+ * touching it.
  *
- * Kept whole — unlike the base URL there is no version segment to strip, and
- * the path genuinely varies between vendors (`/token`, `/token/`, `/oauth/token`).
- * Only the trailing slash is normalized, so two districts who typed the same
- * endpoint differently don't produce two different stored rows.
+ * The path is kept EXACTLY as given, trailing slash and all. This used to strip
+ * the trailing slash, so that two districts typing the same endpoint differently
+ * did not produce two different stored rows. That tidiness cost a live district
+ * their integration (SPE-432).
+ *
+ * Aeries documents its OneRoster token endpoint as
+ * `https://<district>api.aeries.net/admin/token/` — WITH the slash. JSUSD's tech
+ * admin entered exactly that, we stripped it, and `/admin/token` answered 400
+ * from some other handler while `/admin/token/` was never once dialled. Aeries
+ * runs on ASP.NET, where the two can route to genuinely different endpoints.
+ *
+ * The rule this file keeps re-learning: when a district tells us an address,
+ * believe them. Normalising away what they typed is how SPE-426 happened on the
+ * Aeries side, and this is the same mistake on the OneRoster side.
  */
 export function normalizeOneRosterTokenUrl(input: string): string {
   return normalizeSisUrl(
     input,
-    (url) => `${url.origin}${url.pathname.replace(/\/+$/, '')}`,
+    (url) => `${url.origin}${url.pathname}`,
     'OneRoster token address',
   );
 }
@@ -442,9 +459,12 @@ export async function runOneRosterConnectionTest(params: {
   // credential error as an address error. On the happy path this is exactly one
   // request, because the stored value is tried first.
   //
-  // Trimmed, so a stored value that differs only by a trailing slash is not
-  // tried twice and does not later read as "we found a different endpoint".
-  const storedTokenUrl = (params.tokenUrl ?? '').trim().replace(/\/+$/, '');
+  // Whitespace only. The trailing slash is NOT stripped: `/token` and `/token/`
+  // are two different addresses on the servers this has to work against, so
+  // collapsing them is how we ended up never dialling the documented one
+  // (SPE-432). Dedup below is exact-match for the same reason — the two
+  // spellings are candidates in their own right, not duplicates.
+  const storedTokenUrl = (params.tokenUrl ?? '').trim();
   const tokenCandidates = [
     ...(storedTokenUrl ? [storedTokenUrl] : []),
     ...oneRosterTokenUrlCandidates(params.baseUrl).filter((u) => u !== storedTokenUrl),

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -90,23 +90,27 @@ export function oneRosterTokenUrlCandidates(baseUrl: string): string[] {
     // Parsed for validation only — an unparseable base has no safe guesses.
     new URL(trimmed);
     add(`${trimmed}/token`);
+    add(`${trimmed}/oauth/token`);
     // The form Aeries documents — `https://<district>api.aeries.net/admin/token/`,
     // with the trailing slash. On ASP.NET that slash can select a different
     // route entirely. It was absent from this list, and stripped from what
     // districts typed, which is why the one address the vendor documents was
     // never dialled (SPE-432).
     //
-    // SECOND, not first, and that ordering is load-bearing. Whichever candidate
-    // leads absorbs every failure the search cannot continue past — and a
-    // gateway that canonicalises `/token/` to `/token` answers with a redirect,
-    // which `redirect: 'error'` turns into a plain TypeError rather than a
-    // OneRosterApiError. That is not a "keep looking" signal, so leading with
-    // the slashed form would abort the whole search before `/token` was ever
-    // tried, and report "could not reach OneRoster" to a district whose
-    // slashless endpoint works perfectly. Reached second, it costs nothing when
-    // `/token` is right and still rescues the districts where it is not.
+    // LAST, and that position is load-bearing. Any candidate absorbs the
+    // failures the search cannot continue past — chiefly a redirect, which
+    // `redirect: 'error'` turns into a plain TypeError rather than a
+    // OneRosterApiError, and which therefore ends the loop (SPE-433). A gateway
+    // that canonicalises `/token/` to `/token` answers with exactly that.
+    //
+    // So this probe is placed where it can only ever help: after both
+    // established candidates. Ahead of `/token` it would abort the search for a
+    // district whose slashless endpoint works; between the two it would abort
+    // it for a district relying on the `/oauth/token` fallback — a regression
+    // against behaviour that already worked, to fix a district that did not.
+    // Appended, it is reached only once both have failed in a continuable way,
+    // which is precisely JSUSD's case.
     add(`${trimmed}/token/`);
-    add(`${trimmed}/oauth/token`);
   } catch {
     // Unparseable base: the caller's guard reports it properly.
   }

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -89,13 +89,23 @@ export function oneRosterTokenUrlCandidates(baseUrl: string): string[] {
   try {
     // Parsed for validation only — an unparseable base has no safe guesses.
     new URL(trimmed);
-    // Documented form first: Aeries publishes its token endpoint as
-    // `https://<district>api.aeries.net/admin/token/`, with the trailing slash,
-    // and on ASP.NET that slash can select a different route entirely. It was
-    // absent from this list — and stripped from what districts typed — which is
-    // why we never dialled the one address the vendor actually documents.
-    add(`${trimmed}/token/`);
     add(`${trimmed}/token`);
+    // The form Aeries documents — `https://<district>api.aeries.net/admin/token/`,
+    // with the trailing slash. On ASP.NET that slash can select a different
+    // route entirely. It was absent from this list, and stripped from what
+    // districts typed, which is why the one address the vendor documents was
+    // never dialled (SPE-432).
+    //
+    // SECOND, not first, and that ordering is load-bearing. Whichever candidate
+    // leads absorbs every failure the search cannot continue past — and a
+    // gateway that canonicalises `/token/` to `/token` answers with a redirect,
+    // which `redirect: 'error'` turns into a plain TypeError rather than a
+    // OneRosterApiError. That is not a "keep looking" signal, so leading with
+    // the slashed form would abort the whole search before `/token` was ever
+    // tried, and report "could not reach OneRoster" to a district whose
+    // slashless endpoint works perfectly. Reached second, it costs nothing when
+    // `/token` is right and still rescues the districts where it is not.
+    add(`${trimmed}/token/`);
     add(`${trimmed}/oauth/token`);
   } catch {
     // Unparseable base: the caller's guard reports it properly.


### PR DESCRIPTION
Closes [SPE-432](https://linear.app/speddy/issue/SPE-432/oneroster-we-stripped-the-trailing-slash-aeries-documents-and-never). **JSUSD is still blocked on OneRoster.**

## What Aeries documents

> **Token URL:** `https://yourdistrictnameapi.aeries.net/admin/token/`
>
> — [OneRoster API Authentication Process](https://support.aeries.com/support/solutions/articles/14000065677-oneroster-api-authentication-process)

**With a trailing slash.**

## What we did to it

`normalizeOneRosterTokenUrl` stripped it. The comment defending that read *"so two districts who typed the same endpoint differently don't produce two different stored rows."* Tidiness of stored values, bought with a district's integration.

Worse, it was stripped **twice**: once at save time, and again in the resolver when building candidates. And `oneRosterTokenUrlCandidates` never offered the slashed form at all. So **the one address the vendor actually documents was never dialled** — not from what the district typed, and not from our own guesses.

JSUSD's tech admin typed `https://jsusdapi.aeries.net/admin/token`. We saved a different address.

Aeries runs on ASP.NET, where `/admin/token` and `/admin/token/` can route to genuinely different handlers. That fits the evidence exactly — from the run after SPE-431 shipped:

```
400  /admin/token        oauthError: undefined   ← something's there, not a token endpoint
404  /admin/oauth/token  oauthError: undefined   ← nothing there
```

Both candidates exhausted, neither a sign-in endpoint, because the real one has a slash on the end.

## The change

Three parts, because any one alone would have been insufficient:

1. **`normalizeOneRosterTokenUrl` keeps the path exactly as given**, trailing slash and all.
2. **The resolver dials the stored value verbatim** — it stripped the slash a second time, so preserving it at save time would not have been enough.
3. **`/token/` joins the derived candidates**, after `/token` and before `/oauth/token`.

Dedup between stored and derived is now exact-match: `/token` and `/token/` are two real candidates, not two spellings of one.

## Why the documented form goes SECOND

The deep review caught a regression I introduced here and verified it against a live server, so it's worth stating plainly.

**Whichever candidate leads absorbs every failure the search cannot continue past.** A gateway that canonicalises `/token/` → `/token` answers with a redirect; `redirect: 'error'` turns that into a plain `TypeError` rather than a `OneRosterApiError`, which is not a "keep looking" signal. Leading with the slashed form aborted the search before `/token` was ever dialled — telling a district with a perfectly working endpoint that we couldn't reach them.

Verified: on the previous commit that district got `ok: true`; with the slashed form leading, the only address dialled was `/admin/token/`.

Ordered second, it keeps the entire win — it's reached exactly when `/token` turns out not to be a token endpoint, which is JSUSD's case — while leaving the well-understood slashless form to absorb those failures as it always has. Pinned by a test that serves a 308 from `/token/` and a working token from `/token`.

## The pattern, for the third time

SPE-426 discarded the Aeries path a district typed and replaced it with our default. This discarded a character. Both times the district entered the correct thing, we normalised it into something that could not work, and our error message then told them to check the address they had got right.

**When a district tells us an address, believe them.**

## Verification

Each part mutation-checked separately:

| mutation | result |
|---|---|
| strip the slash at save time again | 1 test fails |
| remove the documented `/token/` candidate | 3 tests fail |
| strip the slash in the resolver again | 1 test fails |
| put `/token/` back in front | 2 tests fail |
| unmodified | 258 SIS tests pass |

New tests cover JSUSD's exact shape, that a stored documented address is dialled **verbatim as the first request**, and the redirect-ordering regression above.

No database behaviour changes, so the real-session rule is not triggered.

## Follow-up logged, not bolted on

[SPE-433](https://linear.app/speddy/issue/SPE-433/sis-resolvers-a-refused-redirect-aborts-the-search-instead-of) — a refused redirect at *any* candidate aborts the search, because it arrives as a bare `TypeError`. Pre-existing, and distinguishing it from a DNS or connection failure means matching on error shape across runtimes. SPE-426 already contains one hard-won lesson there (`err instanceof SyntaxError` is false across realms, so a first attempt never fired once), so it wants its own change with evidence-based matching and a real-redirect test.

## Still a hypothesis

Aeries' published documentation is much stronger evidence than the `/api/v5` inference that turned out wrong earlier tonight — but it isn't proof for *this* district until the staff button is clicked. If `/admin/token/` also fails, we stop guessing and ask Nick, with all four addresses we've tried.

## Gates

Typecheck clean, lint clean, full suite 1090 passed / 12 skipped. Three integration suites fail (`tests/integration/{key-check,basic-workflows,minimal}`) — pre-existing, confirmed against the base commit earlier.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OneRoster connection setup to recognize token endpoints with or without a trailing slash.
  - Added fallback handling when a slashless token endpoint is unavailable.
  - Preserved the exact token URL provided, preventing unintended URL changes.
  - Avoided unnecessary endpoint checks when the initial token URL is valid.
  - Improved reporting of which token endpoint was successfully used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->