### PR TITLE
SPE-434: log the SHAPE of a token refusal — kinds and field names, never values

### DIFF
--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -1018,6 +1018,21 @@ describe('the SHAPE of a refusal is logged — its CONTENT never is (SPE-434)', 
     expect(logged()).toContain('"bodyKind":"empty"');
   });
 
+  it('a JSON array refusal is "json-nonobject" — no field names from indices', async () => {
+    // Raised by CodeRabbit on PR #826. The regression it guards: drop the
+    // Array.isArray check and Object.keys on an array yields "0", "1", … —
+    // and the array's CONTENTS would be one refactor away from the log.
+    const rawBody = JSON.stringify([{ error: 'invalid_client' }]);
+    handler = (req) => (req.url.includes('/token') ? { status: 400, raw: rawBody } : allGood(req));
+
+    await run();
+
+    expect(logged()).toContain('"bodyKind":"json-nonobject"');
+    expect(logged()).toContain(`"bodyChars":${rawBody.length}`);
+    expect(logged()).not.toContain('fieldNames');
+    expect(logged()).not.toContain('invalid_client');
+  });
+
   it('an unrecognised content-type logs as "other", never verbatim', async () => {
     // The header is server-controlled text, same as the body — one more place
     // a credential echo could hide, so it faces the same allow-list.

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -46,7 +46,19 @@ interface Seen {
 const everything = (r: Seen) =>
   [r.url, r.body, ...Object.entries(r.headers).map(([k, v]) => `${k}: ${v}`)].join('\n');
 
-type Handler = (req: Seen) => { status: number; body?: unknown; headers?: Record<string, string> };
+type Handler = (req: Seen) => {
+  status: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+  /**
+   * Served VERBATIM, not JSON-encoded. Without this, an "HTML body" test would
+   * actually serve the page through JSON.stringify — which is valid JSON and
+   * takes a different code path entirely. The Aeries harness learned this the
+   * hard way (SPE-426): its stringified-HTML test stayed green while the real
+   * behaviour was broken.
+   */
+  raw?: string;
+};
 
 let server: Server;
 let origin: string;
@@ -68,9 +80,9 @@ beforeAll(async () => {
         body,
       };
       seen.push(entry);
-      const { status, body: out, headers } = handler(entry);
+      const { status, body: out, headers, raw } = handler(entry);
       res.writeHead(status, { 'Content-Type': 'application/json', ...(headers ?? {}) });
-      res.end(out === undefined ? '' : JSON.stringify(out));
+      res.end(raw !== undefined ? raw : out === undefined ? '' : JSON.stringify(out));
     });
   });
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
@@ -868,5 +880,130 @@ describe('the OneRoster exchange over real HTTP', () => {
     });
     expect(stepOf(report, 'token').message).toMatch(/Could not reach/i);
     expect(stepOf(report, 'token').message).not.toMatch(/not the certificate/i);
+  });
+});
+
+describe('the SHAPE of a refusal is logged — its CONTENT never is (SPE-434)', () => {
+  // JSUSD's live failure: every token candidate answers 400 with no RFC 6749
+  // code, which the allow-list rightly discards — leaving the log unable to say
+  // WHY. The fix logs what KIND of thing answered, built entirely from our own
+  // fixed vocabulary. These tests pin both halves: the diagnosis arrives, and
+  // the no-content rule stays absolute even against a server crafted to smuggle
+  // the credential through a field name or a header.
+  let spy: jest.SpyInstance;
+  beforeEach(() => {
+    spy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => spy.mockRestore());
+  const logged = () => JSON.stringify(spy.mock.calls);
+
+  it('an ASP.NET-style refusal logs its field NAME and kind, never its message', async () => {
+    // The exact shape ASP.NET Web API uses for a framework-level rejection —
+    // the leading hypothesis for a 400 that names no OAuth code. Seeing
+    // fieldNames:["Message"] in production settles it without one byte of the
+    // message itself.
+    handler = (req) =>
+      req.url.includes('/token')
+        ? { status: 400, body: { Message: 'The request is invalid.' } }
+        : allGood(req);
+
+    await run();
+
+    expect(logged()).toContain('"bodyKind":"json"');
+    expect(logged()).toContain('"fieldNames":["Message"]');
+    expect(logged()).toContain('"contentType":"application/json"');
+    expect(logged()).not.toContain('The request is invalid');
+  });
+
+  it('logs known names ONLY — a value, an unknown code, even a field NAMED the secret stay out', async () => {
+    // The strongest form of the property. Field names are logged, and a server
+    // that echoes submitted credentials could put the secret IN a name — so
+    // names are matched against a fixed vocabulary, and anything else becomes
+    // arithmetic. If this test fails after a refactor, the refactor reopened
+    // the credential-echo channel that SPE-430 closed.
+    handler = (req) =>
+      req.url.includes('/token')
+        ? {
+            status: 400,
+            body: {
+              error: 'not_a_real_code',
+              error_description: `secret=${CLIENT_SECRET}`,
+              [CLIENT_SECRET]: 'a hostile server can put the credential in a KEY',
+            },
+          }
+        : allGood(req);
+
+    await run();
+
+    const out = logged();
+    expect(out).toContain('"fieldNames":["error","error_description","+1 unrecognised"]');
+    expect(out).not.toContain(CLIENT_SECRET);
+    expect(out).not.toContain('not_a_real_code');
+  });
+
+  it('an HTML error page logs as kind "html" with none of the page', async () => {
+    // Served RAW — through JSON.stringify this would be a JSON string and take
+    // the wrong code path entirely, which is how the Aeries suite once shipped
+    // a vacuous version of this exact test.
+    handler = (req) =>
+      req.url.includes('/token')
+        ? {
+            status: 400,
+            headers: { 'Content-Type': 'text/html' },
+            raw: `<!DOCTYPE html><html><body><h1>Server Error</h1><p>${CLIENT_SECRET}</p></body></html>`,
+          }
+        : allGood(req);
+
+    await run();
+
+    expect(logged()).toContain('"bodyKind":"html"');
+    expect(logged()).toContain('"contentType":"text/html"');
+    expect(logged()).not.toContain('DOCTYPE');
+    expect(logged()).not.toContain(CLIENT_SECRET);
+  });
+
+  it('an empty refusal logs as kind "empty"', async () => {
+    // The shape that would point at a switched-off API record: the server
+    // refuses and attaches nothing at all.
+    handler = (req) => (req.url.includes('/token') ? { status: 400, raw: '' } : allGood(req));
+
+    await run();
+
+    expect(logged()).toContain('"bodyKind":"empty"');
+  });
+
+  it('an unrecognised content-type logs as "other", never verbatim', async () => {
+    // The header is server-controlled text, same as the body — one more place
+    // a credential echo could hide, so it faces the same allow-list.
+    handler = (req) =>
+      req.url.includes('/token')
+        ? {
+            status: 400,
+            headers: { 'Content-Type': `application/x-${CLIENT_SECRET}` },
+            raw: 'no thanks',
+          }
+        : allGood(req);
+
+    await run();
+
+    expect(logged()).toContain('"contentType":"other"');
+    expect(logged()).toContain('"bodyKind":"text"');
+    expect(logged()).not.toContain(CLIENT_SECRET);
+  });
+
+  it('changes NOTHING about what the district is told', async () => {
+    // Pure observability: the report for a wordless 400 reads exactly as
+    // SPE-431 left it. A shape that leaked into district-facing advice would
+    // be a behaviour change wearing a logging patch.
+    handler = (req) =>
+      req.url.includes('/token')
+        ? { status: 400, body: { Message: 'The request is invalid.' } }
+        : allGood(req);
+
+    const report = await run();
+
+    expect(stepOf(report, 'token').message).toMatch(/behaved like a OneRoster sign-in endpoint/i);
+    expect(JSON.stringify(report)).not.toContain('Message');
+    expect(JSON.stringify(report)).not.toContain('bodyKind');
   });
 });

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -716,8 +716,8 @@ describe('the OneRoster exchange over real HTTP', () => {
   });
 
   it('DOES log a recognised code, so the allow-list is not just "log nothing"', async () => {
-    // The other half of the property above. A readOAuthErrorCode that always
-    // returned undefined would pass every safety assertion while making the
+    // The other half of the property above. A describeTokenRefusal that never
+    // surfaced a code would pass every safety assertion while making the
     // whole feature useless — this is the diagnostic we built it for.
     const spy = jest.spyOn(logger, 'error').mockImplementation(() => {});
     try {
@@ -918,9 +918,11 @@ describe('the SHAPE of a refusal is logged — its CONTENT never is (SPE-434)', 
   it('logs known names ONLY — a value, an unknown code, even a field NAMED the secret stay out', async () => {
     // The strongest form of the property. Field names are logged, and a server
     // that echoes submitted credentials could put the secret IN a name — so
-    // names are matched against a fixed vocabulary, and anything else becomes
-    // arithmetic. If this test fails after a refactor, the refactor reopened
-    // the credential-echo channel that SPE-430 closed.
+    // names are matched EXACTLY against a fixed vocabulary, and anything else
+    // becomes arithmetic. Exact, not case-insensitive: per-character casing of
+    // a matched word is itself a channel for server-chosen bytes, which is
+    // what the MeSsAgE key checks. If this test fails after a refactor, the
+    // refactor reopened the credential-echo channel that SPE-430 closed.
     handler = (req) =>
       req.url.includes('/token')
         ? {
@@ -929,6 +931,7 @@ describe('the SHAPE of a refusal is logged — its CONTENT never is (SPE-434)', 
               error: 'not_a_real_code',
               error_description: `secret=${CLIENT_SECRET}`,
               [CLIENT_SECRET]: 'a hostile server can put the credential in a KEY',
+              MeSsAgE: 'or spell bytes with the CASING of a recognised name',
             },
           }
         : allGood(req);
@@ -936,9 +939,10 @@ describe('the SHAPE of a refusal is logged — its CONTENT never is (SPE-434)', 
     await run();
 
     const out = logged();
-    expect(out).toContain('"fieldNames":["error","error_description","+1 unrecognised"]');
+    expect(out).toContain('"fieldNames":["error","error_description","+2 unrecognised"]');
     expect(out).not.toContain(CLIENT_SECRET);
     expect(out).not.toContain('not_a_real_code');
+    expect(out).not.toContain('MeSsAgE');
   });
 
   it('an HTML error page logs as kind "html" with none of the page', async () => {

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -966,6 +966,48 @@ describe('the SHAPE of a refusal is logged — its CONTENT never is (SPE-434)', 
     expect(logged()).not.toContain(CLIENT_SECRET);
   });
 
+  it('an XML error document logs as "xml", not as "html" — with none of the document', async () => {
+    // Raised by Codex on PR #826, and it matters because the two kinds carry
+    // OPPOSITE diagnoses: html reads as "a gateway or wrong address", while an
+    // XML error document is a framework speaking to us. Lumping them would
+    // misread every XML-speaking SIS the same way this incident's 400s were
+    // misread.
+    handler = (req) =>
+      req.url.includes('/token')
+        ? {
+            status: 400,
+            headers: { 'Content-Type': 'application/xml' },
+            raw: `<Error><Message>denied</Message><Detail>${CLIENT_SECRET}</Detail></Error>`,
+          }
+        : allGood(req);
+
+    await run();
+
+    expect(logged()).toContain('"bodyKind":"xml"');
+    expect(logged()).toContain('"contentType":"application/xml"');
+    expect(logged()).not.toContain('"bodyKind":"html"');
+    expect(logged()).not.toContain('<Error>');
+    expect(logged()).not.toContain(CLIENT_SECRET);
+  });
+
+  it('a mislabeled XML body is still "xml", via the prolog', async () => {
+    // The other signal: a server sending XML under a generic content type. The
+    // prolog is a fixed string, so this adds no server-chosen bytes to the log.
+    handler = (req) =>
+      req.url.includes('/token')
+        ? {
+            status: 400,
+            headers: { 'Content-Type': 'text/plain' },
+            raw: `<?xml version="1.0"?><Error>denied</Error>`,
+          }
+        : allGood(req);
+
+    await run();
+
+    expect(logged()).toContain('"bodyKind":"xml"');
+    expect(logged()).toContain('"contentType":"text/plain"');
+  });
+
   it('an empty refusal logs as kind "empty"', async () => {
     // The shape that would point at a switched-off API record: the server
     // refuses and attaches nothing at all.

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -555,11 +555,13 @@ export class OneRosterClient {
         // thrown, never returned to a caller.
         const refusal = phase === 'token' ? await describeTokenRefusal(res) : undefined;
         const oauthError = refusal?.oauthError;
-        // Diagnostics ride in the META slot, where the logger stringifies them
-        // into the formatted line and — per SPE-167 — never forwards them to
-        // Sentry. The previous shape passed this object as the `error`
-        // argument, which reached the console only as a loose positional value
-        // and pinged Sentry's non-Error branch on every failed candidate.
+        // Diagnostics ride in the META slot, where the logger stringifies
+        // them into the formatted line and — per SPE-167 — never forwards
+        // them to Sentry. (Sentry still records one captureMessage per failed
+        // candidate, exactly as before; what changed is that the payload
+        // stays out of it.) The previous shape passed this object as the
+        // `error` argument — a loose positional value that a line-capturing
+        // pipeline would drop entirely.
         logger.error('OneRoster API request failed', undefined, {
           status: res.status,
           path,

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -15,14 +15,16 @@
  * client secret, the bearer token, and any response body (OneRoster error
  * bodies can echo the request).
  *
- * There is exactly ONE thing read out of a response body, and it is worth
- * stating precisely because it is the only hole in the rule above: on a failed
- * TOKEN request, the RFC 6749 `error` code — and only when its value is one of
- * the six constants in `OAUTH_ERROR_CODES`. An allow-list of six known strings
- * cannot carry a secret, however hostile or malformed the body. Nothing else
- * from any body is read, logged or surfaced; `error_description`, which is free
- * text from the district's server, deliberately is not. Every log call is
- * status + path + phase, plus that one allow-listed code.
+ * Exactly TWO things are derived from a response body, and both are worth
+ * stating precisely because they are the only holes in the rule above — and
+ * both are allow-lists, which is why they are safe. On a failed TOKEN request:
+ * the RFC 6749 `error` code, only when its value is one of the six constants
+ * in `OAUTH_ERROR_CODES` (SPE-430); and the body's STRUCTURE — kind, length,
+ * and field names matched against `KNOWN_ERROR_FIELD_NAMES` (SPE-434). A fixed
+ * vocabulary cannot carry a secret, however hostile or malformed the body.
+ * Nothing else from any body is read, logged or surfaced; `error_description`,
+ * which is free text from the district's server, deliberately is not. Every
+ * log call is status + path + phase, plus those allow-listed derivations.
  *
  * Auth layering note (SPE-397 asks for this explicitly): the token request is
  * isolated in `fetchToken` so that OneRoster 1.2's scoped client-credentials
@@ -90,26 +92,138 @@ const OAUTH_ERROR_CODES = new Set([
 ]);
 
 /**
- * Pull the RFC 6749 error code out of a failed token response, or nothing.
+ * The structure of a refused token response — categories and counts only.
  *
- * Why this exists: a 400 from a token endpoint is ambiguous in the one way that
- * matters. `invalid_client` means the district's Consumer ID and Secret are
- * wrong; `invalid_scope` or `unsupported_grant_type` means OUR request is wrong
- * and their credentials are fine. Without this, both produce "your credentials
- * were rejected" — and a live district was about to be asked to re-enter
- * credentials that may have been correct all along (SPE-430).
+ * Every string here is one of OUR OWN constants, matched against the response
+ * rather than copied out of it. That is the entire safety argument, and it is
+ * the same one `OAUTH_ERROR_CODES` makes: a fixed vocabulary cannot carry a
+ * secret, however hostile or echo-happy the server. Even a field NAME or a
+ * content-type header could be crafted from the submitted credential, so
+ * neither is ever logged verbatim — an unrecognised name becomes a count.
+ */
+interface TokenRefusalShape {
+  /** One of `KNOWN_CONTENT_TYPES`, or 'other' / 'none'. */
+  contentType: string;
+  bodyKind: 'json' | 'json-nonobject' | 'html' | 'text' | 'empty';
+  /** Length of the body text — enough to tell an empty refusal from an essay. */
+  bodyChars: number;
+  /**
+   * JSON objects only: the top-level names that match `KNOWN_ERROR_FIELD_NAMES`
+   * (original casing, which itself distinguishes ASP.NET's `Message` from
+   * everyone else's `message`), plus one `+N unrecognised` entry for the rest.
+   */
+  fieldNames?: string[];
+}
+
+/**
+ * Field names that identify WHICH error dialect the server speaks — RFC 6749,
+ * ASP.NET Web API, or RFC 7807 problem+json. Matched case-insensitively;
+ * that per-dialect casing survives because the logged string is the matched
+ * key only when it differs from a constant by case alone.
+ */
+const KNOWN_ERROR_FIELD_NAMES = new Set([
+  // RFC 6749 §5.2
+  'error',
+  'error_description',
+  'error_uri',
+  // ASP.NET Web API's default error envelope
+  'message',
+  'exceptionmessage',
+  'exceptiontype',
+  'modelstate',
+  'stacktrace',
+  // RFC 7807 problem+json
+  'type',
+  'title',
+  'status',
+  'detail',
+  'instance',
+  'errors',
+  // Common ad-hoc shapes
+  'code',
+  'description',
+]);
+
+const KNOWN_CONTENT_TYPES = new Set([
+  'application/json',
+  'application/problem+json',
+  'text/html',
+  'text/plain',
+  'application/xml',
+  'text/xml',
+]);
+
+/**
+ * Read a refused token response for its RFC 6749 error code AND its shape.
+ *
+ * The code half exists because a 400 from a token endpoint is ambiguous in the
+ * one way that matters: `invalid_client` means the district's Consumer ID and
+ * Secret are wrong; `invalid_scope` or `unsupported_grant_type` means OUR
+ * request is wrong and their credentials are fine (SPE-430).
+ *
+ * The shape half exists because the first live district answered with a 400
+ * carrying NO recognised code at all — which the spec forbids — and the
+ * allow-list correctly discarded everything else, leaving nothing to diagnose
+ * with (SPE-434). Structure fills that gap without touching content: an
+ * ASP.NET `{"Message": …}` points at our request format, an OAuth-shaped body
+ * speaking a non-standard vocabulary points at their configuration, an HTML
+ * page says this is not a token endpoint at all.
+ *
+ * The safety rule is unchanged and load-bearing: the body can echo the
+ * submitted credentials, so no VALUE from it is ever returned except `error`,
+ * allow-listed against six fixed constants, and no NAME except against the
+ * fixed vocabulary above. `error_description` — where servers most often echo
+ * the secret — is never read.
  *
  * Never throws: a diagnostic that can fail the request it is diagnosing is
  * worse than no diagnostic.
  */
-async function readOAuthErrorCode(res: Response): Promise<string | undefined> {
+async function describeTokenRefusal(
+  res: Response,
+): Promise<{ oauthError?: string; shape: TokenRefusalShape }> {
+  const rawContentType = res.headers.get('content-type');
+  const mediaType = rawContentType ? rawContentType.split(';')[0].trim().toLowerCase() : '';
+  const contentType = !mediaType ? 'none' : KNOWN_CONTENT_TYPES.has(mediaType) ? mediaType : 'other';
+
+  let text = '';
   try {
-    const body: unknown = await res.json();
-    const code = (body as { error?: unknown } | null)?.error;
-    return typeof code === 'string' && OAUTH_ERROR_CODES.has(code) ? code : undefined;
+    text = await res.text();
   } catch {
-    return undefined;
+    // An unreadable body reads as empty; the status still tells its story.
   }
+  const bodyChars = text.length;
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return { shape: { contentType, bodyKind: 'empty', bodyChars } };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return {
+      shape: { contentType, bodyKind: trimmed.startsWith('<') ? 'html' : 'text', bodyChars },
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return { shape: { contentType, bodyKind: 'json-nonobject', bodyChars } };
+  }
+
+  const fieldNames: string[] = [];
+  let unrecognised = 0;
+  for (const key of Object.keys(parsed)) {
+    if (KNOWN_ERROR_FIELD_NAMES.has(key.toLowerCase())) {
+      fieldNames.push(key);
+    } else {
+      unrecognised += 1;
+    }
+  }
+  if (unrecognised > 0) fieldNames.push(`+${unrecognised} unrecognised`);
+
+  const code = (parsed as { error?: unknown }).error;
+  const oauthError = typeof code === 'string' && OAUTH_ERROR_CODES.has(code) ? code : undefined;
+  return { oauthError, shape: { contentType, bodyKind: 'json', bodyChars, fieldNames } };
 }
 
 /** Raised on a non-2xx from either the token endpoint or a data endpoint. */
@@ -411,16 +525,20 @@ export class OneRosterClient {
 
       if (!res.ok) {
         // The body is still never logged or surfaced — it can echo the
-        // submitted credentials. The one exception is the token endpoint's
-        // RFC 6749 `error` code, and only when it matches the fixed six-value
-        // allow-list, which cannot carry a secret. Reading it here is safe
-        // because a failed response is thrown, never returned to a caller.
-        const oauthError = phase === 'token' ? await readOAuthErrorCode(res) : undefined;
+        // submitted credentials. Two derived exceptions, both bounded: the
+        // RFC 6749 `error` code when it matches the fixed six-value
+        // allow-list, and the body's STRUCTURE (kind, sanitized field names,
+        // length), which is metadata about the content rather than the
+        // content. Reading them here is safe because a failed response is
+        // thrown, never returned to a caller.
+        const refusal = phase === 'token' ? await describeTokenRefusal(res) : undefined;
+        const oauthError = refusal?.oauthError;
         logger.error('OneRoster API request failed', {
           status: res.status,
           path,
           phase,
           oauthError,
+          refusalShape: refusal?.shape,
         });
         throw new OneRosterApiError(
           `OneRoster responded ${res.status} for ${path}`,

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -108,30 +108,41 @@ interface TokenRefusalShape {
   /** Length of the body text — enough to tell an empty refusal from an essay. */
   bodyChars: number;
   /**
-   * JSON objects only: the top-level names that match `KNOWN_ERROR_FIELD_NAMES`
-   * (original casing, which itself distinguishes ASP.NET's `Message` from
-   * everyone else's `message`), plus one `+N unrecognised` entry for the rest.
+   * JSON objects only: the top-level names that EXACTLY match a member of
+   * `KNOWN_ERROR_FIELD_NAMES`, sorted, plus one `+N unrecognised` entry for
+   * the rest. Sorted because key order is server-chosen data too.
    */
   fieldNames?: string[];
 }
 
 /**
  * Field names that identify WHICH error dialect the server speaks — RFC 6749,
- * ASP.NET Web API, or RFC 7807 problem+json. Matched case-insensitively;
- * that per-dialect casing survives because the logged string is the matched
- * key only when it differs from a constant by case alone.
+ * ASP.NET Web API, or RFC 7807 problem+json.
+ *
+ * Matched EXACTLY, which is what lets the log claim to contain only our own
+ * constants: a case-insensitive match would log the server's verbatim casing,
+ * and per-character case choices (or a Unicode character that merely
+ * case-folds into a constant, like the Kelvin sign into 'k') are a channel for
+ * server-chosen bytes. The dialects that differ by case are enumerated in the
+ * casing they actually ship.
  */
 const KNOWN_ERROR_FIELD_NAMES = new Set([
   // RFC 6749 §5.2
   'error',
   'error_description',
   'error_uri',
-  // ASP.NET Web API's default error envelope
+  // ASP.NET Web API's default error envelope, in its shipped PascalCase
+  'Message',
+  'ExceptionMessage',
+  'ExceptionType',
+  'ModelState',
+  'StackTrace',
+  // the same names as ad-hoc servers usually write them
   'message',
-  'exceptionmessage',
-  'exceptiontype',
-  'modelstate',
-  'stacktrace',
+  'exceptionMessage',
+  'exceptionType',
+  'modelState',
+  'stackTrace',
   // RFC 7807 problem+json
   'type',
   'title',
@@ -213,12 +224,13 @@ async function describeTokenRefusal(
   const fieldNames: string[] = [];
   let unrecognised = 0;
   for (const key of Object.keys(parsed)) {
-    if (KNOWN_ERROR_FIELD_NAMES.has(key.toLowerCase())) {
+    if (KNOWN_ERROR_FIELD_NAMES.has(key)) {
       fieldNames.push(key);
     } else {
       unrecognised += 1;
     }
   }
+  fieldNames.sort();
   if (unrecognised > 0) fieldNames.push(`+${unrecognised} unrecognised`);
 
   const code = (parsed as { error?: unknown }).error;
@@ -533,7 +545,12 @@ export class OneRosterClient {
         // thrown, never returned to a caller.
         const refusal = phase === 'token' ? await describeTokenRefusal(res) : undefined;
         const oauthError = refusal?.oauthError;
-        logger.error('OneRoster API request failed', {
+        // Diagnostics ride in the META slot, where the logger stringifies them
+        // into the formatted line and — per SPE-167 — never forwards them to
+        // Sentry. The previous shape passed this object as the `error`
+        // argument, which reached the console only as a loose positional value
+        // and pinged Sentry's non-Error branch on every failed candidate.
+        logger.error('OneRoster API request failed', undefined, {
           status: res.status,
           path,
           phase,

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -104,7 +104,7 @@ const OAUTH_ERROR_CODES = new Set([
 interface TokenRefusalShape {
   /** One of `KNOWN_CONTENT_TYPES`, or 'other' / 'none'. */
   contentType: string;
-  bodyKind: 'json' | 'json-nonobject' | 'html' | 'text' | 'empty';
+  bodyKind: 'json' | 'json-nonobject' | 'xml' | 'html' | 'text' | 'empty';
   /** Length of the body text — enough to tell an empty refusal from an essay. */
   bodyChars: number;
   /**
@@ -212,9 +212,19 @@ async function describeTokenRefusal(
   try {
     parsed = JSON.parse(trimmed);
   } catch {
-    return {
-      shape: { contentType, bodyKind: trimmed.startsWith('<') ? 'html' : 'text', bodyChars },
-    };
+    // XML before HTML (Codex, PR #826): both start with '<', but they carry
+    // opposite diagnoses — an XML error document is a framework SPEAKING to
+    // us, an HTML page is a gateway or a wrong address. Decided from two
+    // signals that are already ours: the allow-listed media type constant and
+    // the fixed '<?xml' prolog. No content is copied either way.
+    const declaredXml = contentType === 'application/xml' || contentType === 'text/xml';
+    const bodyKind =
+      declaredXml || trimmed.startsWith('<?xml')
+        ? 'xml'
+        : trimmed.startsWith('<')
+          ? 'html'
+          : 'text';
+    return { shape: { contentType, bodyKind, bodyChars } };
   }
 
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {


### PR DESCRIPTION
## Why

JSUSD's OneRoster test now dials all three token candidates (SPE-432 deployed and verified live). The answers: `/admin/token` → 400, `/admin/oauth/token` → 404, `/admin/token/` → 400. Both 400s carry **no RFC 6749 error code**, which the spec forbids — and our log line cannot say one word more than that, by design. SPE-430's allow-list reads a single field and discards everything else, because a token endpoint's error body can echo the submitted credentials. Correct rule; blinding side effect. Every remaining hypothesis — ASP.NET framework rejection, non-standard OAuth vocabulary, HTML gateway page, empty body — produces the identical line: `status: 400, oauthError: undefined`.

This is Option A from the incident thread: read the **structure** of the refusal, never its content, so the next click on the staff test button tells us which hypothesis is true — for JSUSD and for every district after them.

## What

When the token endpoint refuses, the `OneRoster API request failed` log line gains a `refusalShape`:

- `contentType` — matched against a fixed set of known media types, else `other` / `none`
- `bodyKind` — `json` / `json-nonobject` / `html` / `text` / `empty`
- `bodyChars` — length only
- `fieldNames` — for JSON objects, the top-level names that **exactly** match a fixed vocabulary of known error dialects (RFC 6749, ASP.NET Web API in its shipped PascalCase, RFC 7807), sorted; everything else becomes a single `+N unrecognised` count

**Every string logged is one of our own constants.** Not sanitized server text — matched constants. A hostile or echo-happy server could put credential material in a field *name*, a content-type header, or the *casing* of a recognised word (or a Unicode character that case-folds into one), so names match exactly, order is discarded by sorting, and unknown anything becomes arithmetic. Same safety argument as `OAUTH_ERROR_CODES`, extended to the whole shape. `error_description` remains unread.

**No behavioural change.** Same statuses, same wrong-address/credential classification, same district-facing messages; the report never carries the shape. The diagnostics also moved into the logger's `meta` slot (self-review finding): the old call passed context as the `error` argument, where a line-capturing pipeline would drop it entirely, and where Sentry's non-Error branch fired on every failed candidate. `meta` is deliberately never forwarded to Sentry (SPE-167).

## What each shape will tell us

| shape | reading |
|---|---|
| `fieldNames: ["Message"]` | ASP.NET rejected the request at framework level — likely OUR request format |
| `fieldNames: ["error", …]`, no recognised code | OAuth-ish endpoint, non-standard vocabulary — likely their configuration |
| `bodyKind: "html"` | a gateway or error page — not a token endpoint at all |
| `bodyKind: "empty"` | wordless refusal — consistent with a switched-off API record |

## Verification

- Real-HTTP tests against a local server serving real bodies — including **raw** (non-JSON-encoded) HTML, since through `JSON.stringify` an "HTML body" is a JSON string and takes the wrong code path; the harness gained a `raw` option for exactly that reason.
- Asserted at the **logger spy**, the altitude where the property lives (SPE-430's lesson).
- Negative assertions plant the consumer secret in a value, a field name, a weird-cased `MeSsAgE` key, and the content-type header, and prove none of them reach the log.
- Mutation-checked in three directions: logging the body fails 2 tests; dropping the name allow-list fails 1; deleting the capture fails 5.
- Full suite: 1097 passed, 12 skipped; the 3 failures are the known pre-existing `tests/integration/{key-check,basic-workflows,minimal}` ones. Typecheck and lint clean.
- Deep self-review at high effort ran before this PR; all three findings are applied in the second commit.

Linear: SPE-434

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT

---
_Generated by [Claude Code](https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of authentication failures when services return JSON, XML, HTML, plain text, empty, malformed, or mislabeled responses.
  - Added safer diagnostic details to help identify refusal types without exposing response contents, credentials, or other sensitive values.
  - Preserved existing district-facing error messages while improving internal troubleshooting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->