### PR TITLE
SPE-435: roster probe — measure teachers, classes and joinable enrollments behind a green staff test

### DIFF
--- a/__tests__/unit/app/api/internal/sis-connection-test.test.ts
+++ b/__tests__/unit/app/api/internal/sis-connection-test.test.ts
@@ -76,9 +76,11 @@ jest.mock('@/lib/sis/aeries-setup', () => ({
   runAeriesConnectionTest: (...a: unknown[]) => mockAeriesTest(...a),
 }));
 const mockOneRosterTest = jest.fn();
+const mockProbe = jest.fn();
 jest.mock('@/lib/sis/oneroster-setup', () => ({
   ...jest.requireActual('@/lib/sis/oneroster-setup'),
   runOneRosterConnectionTest: (...a: unknown[]) => mockOneRosterTest(...a),
+  probeOneRosterRosterData: (...a: unknown[]) => mockProbe(...a),
 }));
 
 import { POST } from '@/app/api/internal/sis-connections/[connectionId]/test/route';
@@ -113,7 +115,10 @@ const call = () =>
 
 /** Every path that reaches a district's server, in one place. */
 const sisWasDialled = () =>
-  mockAeriesTest.mock.calls.length + mockOneRosterTest.mock.calls.length > 0;
+  mockAeriesTest.mock.calls.length +
+    mockOneRosterTest.mock.calls.length +
+    mockProbe.mock.calls.length >
+  0;
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -123,6 +128,7 @@ beforeEach(() => {
   mockGetCredential.mockResolvedValue({ sisType: 'aeries', certificate: CERT });
   mockAeriesTest.mockResolvedValue(AERIES_REPORT);
   mockRecordTestResult.mockResolvedValue(undefined);
+  mockProbe.mockResolvedValue([]);
 });
 
 describe('the staff gate', () => {
@@ -197,6 +203,94 @@ describe('nothing to test', () => {
     const res = await call();
     expect(res.status).toBe(409);
     expect(sisWasDialled()).toBe(false);
+  });
+});
+
+describe('the roster probe rides behind a green OneRoster test (SPE-435)', () => {
+  const ONEROSTER_CONNECTION = {
+    ...AERIES_CONNECTION,
+    sis_type: 'oneroster',
+    base_url: 'https://district.aeries.net/admin',
+    token_url: 'https://district.aeries.net/admin/token',
+  };
+  const ONEROSTER_CREDENTIAL = {
+    sisType: 'oneroster',
+    clientId: 'consumer-id',
+    clientSecret: 'consumer-secret',
+  };
+  const GREEN_REPORT = {
+    ok: true,
+    summary: 'Connected. OneRoster is ready.',
+    steps: [{ key: 'token', label: 'Sign-in', status: 'ok', message: 'Working.' }],
+  };
+
+  beforeEach(() => {
+    mockGetConnection.mockResolvedValue(ONEROSTER_CONNECTION);
+    mockGetCredential.mockResolvedValue(ONEROSTER_CREDENTIAL);
+    mockOneRosterTest.mockResolvedValue(GREEN_REPORT);
+  });
+
+  it('appends the probe checks and dials the address the test resolved', async () => {
+    mockOneRosterTest.mockResolvedValue({
+      ...GREEN_REPORT,
+      usedTokenUrl: 'https://district.aeries.net/admin/token/',
+    });
+    mockProbe.mockResolvedValue([
+      { key: 'teachers', label: 'Teacher directory', status: 'ok', message: '47 teachers in the first page.' },
+    ]);
+
+    const body = await (await call()).json();
+
+    // The resolved address wins over the stored one — probing the address the
+    // test did NOT use would measure a different server than the one that
+    // answered.
+    expect(mockProbe).toHaveBeenCalledWith(
+      expect.objectContaining({ tokenUrl: 'https://district.aeries.net/admin/token/' }),
+    );
+    expect(body.checks).toEqual([...GREEN_REPORT.steps, expect.objectContaining({ key: 'teachers' })]);
+  });
+
+  it('falls back to the stored token address when resolution never moved', async () => {
+    await call();
+    expect(mockProbe).toHaveBeenCalledWith(
+      expect.objectContaining({ tokenUrl: 'https://district.aeries.net/admin/token' }),
+    );
+  });
+
+  it('does NOT probe when the connection test failed', async () => {
+    // A probe behind a red test would fire more credentialed requests at a
+    // server we just failed to sign in to — noise for them, nothing for us.
+    mockOneRosterTest.mockResolvedValue({ ok: false, summary: 'Rejected.', steps: [] });
+
+    const body = await (await call()).json();
+
+    expect(mockProbe).not.toHaveBeenCalled();
+    expect(body.ok).toBe(false);
+  });
+
+  it('a probe crash appends an error check and changes nothing else', async () => {
+    mockProbe.mockRejectedValue(new Error('boom'));
+
+    const res = await call();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.checks).toEqual([
+      ...GREEN_REPORT.steps,
+      expect.objectContaining({ key: 'roster-probe', status: 'error' }),
+    ]);
+    // The stored verdict is the district's own test, never the probe.
+    expect(mockRecordTestResult).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+  });
+
+  it('never probes an Aeries connection', async () => {
+    mockGetConnection.mockResolvedValue(AERIES_CONNECTION);
+    mockGetCredential.mockResolvedValue({ sisType: 'aeries', certificate: CERT });
+
+    await call();
+
+    expect(mockProbe).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/unit/app/api/internal/sis-connection-test.test.ts
+++ b/__tests__/unit/app/api/internal/sis-connection-test.test.ts
@@ -268,6 +268,20 @@ describe('the roster probe rides behind a green OneRoster test (SPE-435)', () =>
     expect(body.ok).toBe(false);
   });
 
+  it('records the verdict BEFORE the probe runs, so a dead probe cannot cost the green', async () => {
+    // The probe adds up to five upstream requests after the connection test.
+    // With persistence on the far side of that await, a platform timeout or
+    // panel abort mid-probe would throw away the verdict the district's server
+    // just gave us (Codex, PR #827).
+    await call();
+
+    expect(mockRecordTestResult).toHaveBeenCalledTimes(1);
+    expect(mockProbe).toHaveBeenCalledTimes(1);
+    expect(mockRecordTestResult.mock.invocationCallOrder[0]).toBeLessThan(
+      mockProbe.mock.invocationCallOrder[0],
+    );
+  });
+
   it('a probe crash appends an error check and changes nothing else', async () => {
     mockProbe.mockRejectedValue(new Error('boom'));
 

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -1212,6 +1212,31 @@ describe('the roster probe measures presence and joinability, never people (SPE-
     expect(stepIn(steps, 'linkage').status).toBe('untested');
   });
 
+  it('enrollments with no STUDENT-role entries is the mirrored no-go, said just as plainly', async () => {
+    // The mirror of the case above (CodeRabbit, PR #827): teacher entries
+    // without student entries also cannot join, and the message must blame the
+    // right absence.
+    handler = (req) => {
+      if (req.url.includes('/enrollments')) {
+        return {
+          status: 200,
+          body: {
+            enrollments: [
+              { sourcedId: 'e1', role: 'teacher', user: { sourcedId: 't1' }, class: { sourcedId: 'c1' } },
+            ],
+          },
+        };
+      }
+      return rosterHandler(req);
+    };
+
+    const steps = await probe();
+
+    expect(stepIn(steps, 'rosters').status).toBe('denied');
+    expect(stepIn(steps, 'rosters').message).toMatch(/NO student entries/);
+    expect(stepIn(steps, 'linkage').status).toBe('untested');
+  });
+
   it('a token endpoint that dies MID-PROBE reads as a sign-in problem, not four missing endpoints', async () => {
     // The probe signs in on its own, so a token blip after a green connection
     // test hits every check. Read as 404-on-the-collection it would record

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -1124,6 +1124,10 @@ describe('the roster probe measures presence and joinability, never people (SPE-
             { sourcedId: 'e2', role: 'student', user: { sourcedId: PII_STUDENT_ID }, class: { sourcedId: 'cls-1' } },
             { sourcedId: 'e3', role: 'student', user: { sourcedId: 'stu-PII-9002' }, class: { sourcedId: 'cls-1' } },
             { sourcedId: 'e4', role: 'teacher', user: { sourcedId: 'tea-2' }, class: { sourcedId: 'cls-2' } },
+            // Co-teacher in cls-1: pushes the sample's teacher counts to
+            // [0, 1, 2, 2], whose even-length median must average the middles
+            // to 1.5 — the lower-middle shortcut reported 1 (Codex, PR #827).
+            { sourcedId: 'e8', role: 'teacher', user: { sourcedId: 'tea-2' }, class: { sourcedId: 'cls-1' } },
             { sourcedId: 'e5', role: 'student', user: { sourcedId: 'stu-PII-9003' }, class: { sourcedId: 'cls-2' } },
             // The cross-class student: sits in BOTH classes, so their teacher
             // count must come out 2 — the join actually joining.
@@ -1159,11 +1163,14 @@ describe('the roster probe measures presence and joinability, never people (SPE-
     expect(stepIn(steps, 'students').message).toContain('3 students');
     expect(stepIn(steps, 'classes').message).toContain('2 classes');
     expect(stepIn(steps, 'rosters').status).toBe('ok');
-    expect(stepIn(steps, 'rosters').message).toContain('5 student and 2 teacher entries across 3 classes');
-    // One student sits in both classes → 2 teachers; two have 1; the stranded
-    // one has 0 — and 0 must appear as the floor, not vanish.
+    expect(stepIn(steps, 'rosters').message).toContain('5 student and 3 teacher entries across 3 classes');
+    // Teacher counts per student come out [0, 1, 2, 2]: the cross-class
+    // student and one classmate reach 2, one has 1, the stranded one has 0 —
+    // and 0 must appear as the floor, not vanish. The even-length median
+    // averages the middles: typical 1.5, not the lower-middle 1.
     expect(stepIn(steps, 'linkage').message).toContain('Sampled 4 students');
     expect(stepIn(steps, 'linkage').message).toContain('fewest 0');
+    expect(stepIn(steps, 'linkage').message).toContain('typical 1.5');
     expect(stepIn(steps, 'linkage').message).toContain('most 2');
     expect(stepIn(steps, 'linkage').message).toContain('1 of them had NO teacher entry');
 

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -1128,6 +1128,10 @@ describe('the roster probe measures presence and joinability, never people (SPE-
             // The cross-class student: sits in BOTH classes, so their teacher
             // count must come out 2 — the join actually joining.
             { sourcedId: 'e6', role: 'student', user: { sourcedId: PII_STUDENT_ID }, class: { sourcedId: 'cls-2' } },
+            // And the stranded one: a class with no teacher entry at all. Their
+            // zero must be COUNTED, not dropped — the rate of unjoinable
+            // students is the number SPE-414 decides with (self-review fix).
+            { sourcedId: 'e7', role: 'student', user: { sourcedId: 'stu-PII-9004' }, class: { sourcedId: 'cls-9' } },
           ],
         },
       };
@@ -1155,11 +1159,13 @@ describe('the roster probe measures presence and joinability, never people (SPE-
     expect(stepIn(steps, 'students').message).toContain('3 students');
     expect(stepIn(steps, 'classes').message).toContain('2 classes');
     expect(stepIn(steps, 'rosters').status).toBe('ok');
-    expect(stepIn(steps, 'rosters').message).toContain('4 student and 2 teacher entries across 2 classes');
-    // One student sits in both classes → 2 teachers; the other two have 1.
-    expect(stepIn(steps, 'linkage').message).toContain('Sampled 3 students');
-    expect(stepIn(steps, 'linkage').message).toContain('fewest 1');
+    expect(stepIn(steps, 'rosters').message).toContain('5 student and 2 teacher entries across 3 classes');
+    // One student sits in both classes → 2 teachers; two have 1; the stranded
+    // one has 0 — and 0 must appear as the floor, not vanish.
+    expect(stepIn(steps, 'linkage').message).toContain('Sampled 4 students');
+    expect(stepIn(steps, 'linkage').message).toContain('fewest 0');
     expect(stepIn(steps, 'linkage').message).toContain('most 2');
+    expect(stepIn(steps, 'linkage').message).toContain('1 of them had NO teacher entry');
 
     // The whole point: names and IDs from the sample never leave the probe.
     const serialized = JSON.stringify(steps);
@@ -1204,5 +1210,62 @@ describe('the roster probe measures presence and joinability, never people (SPE-
     expect(stepIn(steps, 'rosters').status).toBe('denied');
     expect(stepIn(steps, 'rosters').message).toMatch(/NO teacher entries/);
     expect(stepIn(steps, 'linkage').status).toBe('untested');
+  });
+
+  it('a token endpoint that dies MID-PROBE reads as a sign-in problem, not four missing endpoints', async () => {
+    // The probe signs in on its own, so a token blip after a green connection
+    // test hits every check. Read as 404-on-the-collection it would record
+    // "this district lacks /teachers, /students, /classes and /enrollments"
+    // about endpoints that were never dialled (self-review fix).
+    handler = (req) =>
+      req.url.includes('/token') ? { status: 404, body: {} } : rosterHandler(req);
+
+    const steps = await probe();
+
+    for (const key of ['teachers', 'students', 'classes', 'rosters'] as const) {
+      expect(stepIn(steps, key).status).toBe('error');
+      expect(stepIn(steps, key).message).toMatch(/sign in/i);
+      expect(stepIn(steps, key).message).not.toMatch(/not provided/i);
+    }
+    expect(stepIn(steps, 'linkage').status).toBe('untested');
+    expect(stepIn(steps, 'linkage').message).toMatch(/did not answer/i);
+  });
+
+  it('a server without /enrollments leaves linkage "not measured", not a claim about a sample', async () => {
+    handler = (req) =>
+      req.url.includes('/enrollments') ? { status: 404, body: {} } : rosterHandler(req);
+
+    const steps = await probe();
+
+    expect(stepIn(steps, 'rosters').status).toBe('denied');
+    expect(stepIn(steps, 'linkage').status).toBe('untested');
+    expect(stepIn(steps, 'linkage').message).toMatch(/did not answer/i);
+    expect(stepIn(steps, 'linkage').message).not.toMatch(/shares a class/i);
+  });
+
+  it('enrollments without joinable IDs are called an ID-shape problem, not a role problem', async () => {
+    // Some vendors nest the user/class references differently. 150 rows with
+    // no sourcedIds is not "no teacher entries" — saying so would send the
+    // SPE-414 investigation toward roles when the defect is the ID nesting.
+    handler = (req) => {
+      if (req.url.includes('/enrollments')) {
+        return {
+          status: 200,
+          body: {
+            enrollments: [
+              { sourcedId: 'e1', role: 'student' },
+              { sourcedId: 'e2', role: 'teacher' },
+            ],
+          },
+        };
+      }
+      return rosterHandler(req);
+    };
+
+    const steps = await probe();
+
+    expect(stepIn(steps, 'rosters').status).toBe('denied');
+    expect(stepIn(steps, 'rosters').message).toMatch(/none carry joinable user and class IDs/);
+    expect(stepIn(steps, 'rosters').message).toContain('2 entries');
   });
 });

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -26,7 +26,7 @@ jest.mock('@/lib/sis/ssrf-guard', () => ({
   assertSafeSisUrl: jest.fn().mockResolvedValue(undefined),
 }));
 
-import { runOneRosterConnectionTest } from '@/lib/sis/oneroster-setup';
+import { probeOneRosterRosterData, runOneRosterConnectionTest } from '@/lib/sis/oneroster-setup';
 import { logger } from '@/lib/logger';
 
 const CLIENT_ID = 'speddy-consumer-id';
@@ -1066,5 +1066,143 @@ describe('the SHAPE of a refusal is logged — its CONTENT never is (SPE-434)', 
     expect(stepOf(report, 'token').message).toMatch(/behaved like a OneRoster sign-in endpoint/i);
     expect(JSON.stringify(report)).not.toContain('Message');
     expect(JSON.stringify(report)).not.toContain('bodyKind');
+  });
+});
+
+describe('the roster probe measures presence and joinability, never people (SPE-435)', () => {
+  // SPE-414 builds against whatever these checks report from JSUSD's real
+  // server. The fixtures plant names and IDs precisely so the negative
+  // assertions mean something: a probe that leaked its sample would fail here
+  // before it ever saw a real student.
+  const PII_TEACHER = 'Zelda Probe-Teacher';
+  const PII_STUDENT_ID = 'stu-PII-9001';
+
+  const rosterHandler: Handler = (req) => {
+    if (req.url.includes('/token')) {
+      return { status: 200, body: { access_token: TOKEN, token_type: 'bearer' } };
+    }
+    if (req.url.includes('/teachers')) {
+      return {
+        status: 200,
+        body: {
+          users: [
+            { sourcedId: 'tea-1', givenName: PII_TEACHER },
+            { sourcedId: 'tea-2' },
+          ],
+        },
+      };
+    }
+    if (req.url.includes('/students')) {
+      return {
+        status: 200,
+        body: {
+          users: [
+            { sourcedId: PII_STUDENT_ID },
+            { sourcedId: 'stu-PII-9002' },
+            { sourcedId: 'stu-PII-9003' },
+          ],
+        },
+      };
+    }
+    if (req.url.includes('/classes')) {
+      return {
+        status: 200,
+        body: {
+          classes: [
+            { sourcedId: 'cls-1', title: 'Room 12', classType: 'homeroom' },
+            { sourcedId: 'cls-2', title: 'Period 3 English' },
+          ],
+        },
+      };
+    }
+    if (req.url.includes('/enrollments')) {
+      return {
+        status: 200,
+        body: {
+          enrollments: [
+            { sourcedId: 'e1', role: 'teacher', user: { sourcedId: 'tea-1' }, class: { sourcedId: 'cls-1' } },
+            { sourcedId: 'e2', role: 'student', user: { sourcedId: PII_STUDENT_ID }, class: { sourcedId: 'cls-1' } },
+            { sourcedId: 'e3', role: 'student', user: { sourcedId: 'stu-PII-9002' }, class: { sourcedId: 'cls-1' } },
+            { sourcedId: 'e4', role: 'teacher', user: { sourcedId: 'tea-2' }, class: { sourcedId: 'cls-2' } },
+            { sourcedId: 'e5', role: 'student', user: { sourcedId: 'stu-PII-9003' }, class: { sourcedId: 'cls-2' } },
+            // The cross-class student: sits in BOTH classes, so their teacher
+            // count must come out 2 — the join actually joining.
+            { sourcedId: 'e6', role: 'student', user: { sourcedId: PII_STUDENT_ID }, class: { sourcedId: 'cls-2' } },
+          ],
+        },
+      };
+    }
+    return { status: 404, body: {} };
+  };
+
+  const probe = () =>
+    probeOneRosterRosterData({
+      baseUrl: `${origin}/admin`,
+      tokenUrl: `${origin}/admin/token/`,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+  const stepIn = (steps: Awaited<ReturnType<typeof probe>>, key: string) =>
+    steps.find((s) => s.key === key)!;
+
+  it('reports counts, both roles, and the teachers-per-student spread — and no sample content', async () => {
+    handler = rosterHandler;
+
+    const steps = await probe();
+
+    expect(stepIn(steps, 'teachers').message).toContain('2 teachers');
+    expect(stepIn(steps, 'students').message).toContain('3 students');
+    expect(stepIn(steps, 'classes').message).toContain('2 classes');
+    expect(stepIn(steps, 'rosters').status).toBe('ok');
+    expect(stepIn(steps, 'rosters').message).toContain('4 student and 2 teacher entries across 2 classes');
+    // One student sits in both classes → 2 teachers; the other two have 1.
+    expect(stepIn(steps, 'linkage').message).toContain('Sampled 3 students');
+    expect(stepIn(steps, 'linkage').message).toContain('fewest 1');
+    expect(stepIn(steps, 'linkage').message).toContain('most 2');
+
+    // The whole point: names and IDs from the sample never leave the probe.
+    const serialized = JSON.stringify(steps);
+    expect(serialized).not.toContain(PII_TEACHER);
+    expect(serialized).not.toContain('Zelda');
+    expect(serialized).not.toContain(PII_STUDENT_ID);
+    expect(serialized).not.toContain('stu-PII');
+    expect(serialized).not.toContain('Room 12');
+  });
+
+  it('a server without /classes is a finding on that check, not a dead probe', async () => {
+    handler = (req) =>
+      req.url.includes('/classes') ? { status: 404, body: {} } : rosterHandler(req);
+
+    const steps = await probe();
+
+    expect(stepIn(steps, 'classes').status).toBe('denied');
+    expect(stepIn(steps, 'classes').message).toMatch(/not provided/i);
+    // Everything else still measured.
+    expect(stepIn(steps, 'teachers').status).toBe('ok');
+    expect(stepIn(steps, 'rosters').status).toBe('ok');
+    expect(stepIn(steps, 'linkage').status).toBe('ok');
+  });
+
+  it('enrollments with no teacher-role entries is the SPE-414 no-go verdict, said plainly', async () => {
+    handler = (req) => {
+      if (req.url.includes('/enrollments')) {
+        return {
+          status: 200,
+          body: {
+            enrollments: [
+              { sourcedId: 'e1', role: 'student', user: { sourcedId: 's1' }, class: { sourcedId: 'c1' } },
+            ],
+          },
+        };
+      }
+      return rosterHandler(req);
+    };
+
+    const steps = await probe();
+
+    expect(stepIn(steps, 'rosters').status).toBe('denied');
+    expect(stepIn(steps, 'rosters').message).toMatch(/NO teacher entries/);
+    expect(stepIn(steps, 'linkage').status).toBe('untested');
   });
 });

--- a/__tests__/unit/lib/sis/oneroster-setup.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.test.ts
@@ -37,6 +37,12 @@ jest.mock('@/lib/integrations/oneroster', () => {
       fetchToken = (...a: unknown[]) => mockFetchToken(...a);
       getOrgs = (...a: unknown[]) => mockGetOrgs(...a);
       getSchools = jest.fn().mockResolvedValue([{ sourcedId: 'school-1' }]);
+      // The roster probe's collections (SPE-435). Empty is fine: the guard
+      // tests below only care whether a client was EVER built and used.
+      getTeachers = jest.fn().mockResolvedValue([]);
+      getStudents = jest.fn().mockResolvedValue([]);
+      getClasses = jest.fn().mockResolvedValue([]);
+      getEnrollments = jest.fn().mockResolvedValue([]);
     },
   };
 });
@@ -44,6 +50,7 @@ jest.mock('@/lib/integrations/oneroster', () => {
 import {
   normalizeOneRosterBaseUrl,
   normalizeOneRosterTokenUrl,
+  probeOneRosterRosterData,
   runOneRosterConnectionTest,
   toStoredOneRosterTestResult,
 } from '@/lib/sis/oneroster-setup';
@@ -214,6 +221,42 @@ describe('runOneRosterConnectionTest guards both URLs before sending a credentia
 
     expect(mockFetchToken).toHaveBeenCalled();
     expect(report.ok).toBe(true);
+  });
+});
+
+describe('probeOneRosterRosterData guards both URLs before building a client (SPE-435)', () => {
+  const PARAMS = {
+    baseUrl: 'https://data.example.com/admin',
+    tokenUrl: 'https://data.example.com/admin/token',
+    ...CREDS,
+  };
+
+  it('refuses a privately-resolving address and never constructs a client', async () => {
+    // The probe reuses the district's stored credential against addresses read
+    // from the connection row. Rows can predate the guard, and DNS answers
+    // change — so the probe re-checks at dial time like every other caller.
+    // Delete the guard calls and this test fails while every http-level test
+    // stays green (they stub the guard).
+    mockLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+
+    const steps = await probeOneRosterRosterData(PARAMS);
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0].status).toBe('error');
+    expect(steps[0].message).toMatch(/refused/i);
+    expect(mockClientTokenUrls).toHaveLength(0);
+    expect(mockFetchToken).not.toHaveBeenCalled();
+  });
+
+  it('builds exactly ONE client, for exactly the token URL it was given', async () => {
+    // No candidate resolution in the probe — the connection test already did
+    // that, and a probe that hunted for endpoints would multiply requests
+    // against a district's production server.
+    mockLookup.mockResolvedValue([{ address: '104.16.0.1', family: 4 }]);
+
+    await probeOneRosterRosterData(PARAMS);
+
+    expect(mockClientTokenUrls).toEqual(['https://data.example.com/admin/token']);
   });
 });
 

--- a/app/api/internal/sis-connections/[connectionId]/test/route.ts
+++ b/app/api/internal/sis-connections/[connectionId]/test/route.ts
@@ -121,6 +121,9 @@ export const POST = withRoute<{ connectionId: string }>(
     // and for OneRoster — where the token address is normally blank — it would
     // guess wrong on every healthy test.
     let storedAddress: string | null;
+    // Set inside the OneRoster branch, consumed only after the verdict is
+    // recorded — see the ordering note below.
+    let oneRosterProbeArgs: Parameters<typeof probeOneRosterRosterData>[0] | null = null;
 
     if (credential.sisType === 'aeries') {
       const report = await runAeriesConnectionTest({
@@ -145,52 +148,25 @@ export const POST = withRoute<{ connectionId: string }>(
       usedAddress = report.usedTokenUrl;
       storedAddress = connection.token_url;
 
-      // SPE-435: with the connection green, keep going and measure whether
-      // this server carries the data SPE-414 would sync — teachers, classes,
-      // and enrollments joinable in both directions. Appended AFTER `stored`
-      // and `ok` are fixed, deliberately: the probe is exploratory, so its
-      // findings must never change the connection verdict the district's own
-      // button would report, and never touch what recordTestResult persists.
-      //
       // `usedTokenUrl` is only set when resolution moved off the stored
       // address, so the fallback chain covers both green cases; a report
       // green with NEITHER address cannot happen, and skipping is safer than
       // guessing one.
-      if (ok) {
-        const probeTokenUrl = report.usedTokenUrl ?? connection.token_url;
-        if (probeTokenUrl) {
-          try {
-            const probeSteps = await probeOneRosterRosterData({
-              baseUrl: connection.base_url,
-              tokenUrl: probeTokenUrl,
-              clientId: credential.clientId,
-              clientSecret: credential.clientSecret,
-            });
-            checks = [...checks, ...probeSteps];
-            // Aggregates only, by the probe's construction — this line is how
-            // the result outlives the panel (SPE-435's record is written from
-            // these logs, not from a screenshot).
-            log.info('OneRoster roster probe', {
-              connectionId: connection.id,
-              districtId: connection.district_id,
-              probe: probeSteps.map(({ key, status, message }) => ({ key, status, message })),
-            });
-          } catch (err) {
-            log.error('OneRoster roster probe failed', err, { connectionId: connection.id });
-            checks = [
-              ...checks,
-              {
-                key: 'roster-probe',
-                label: 'Roster data',
-                status: 'error',
-                message: 'The roster probe itself failed — the connection result above is unaffected.',
-              },
-            ];
-          }
-        }
+      const probeTokenUrl = report.usedTokenUrl ?? connection.token_url;
+      if (ok && probeTokenUrl) {
+        oneRosterProbeArgs = {
+          baseUrl: connection.base_url,
+          tokenUrl: probeTokenUrl,
+          clientId: credential.clientId,
+          clientSecret: credential.clientSecret,
+        };
       }
     }
 
+    // The verdict is persisted BEFORE the roster probe runs (Codex, PR #827):
+    // the probe adds up to five more upstream requests, and a platform timeout
+    // or client abort during them must not cost the district their recorded
+    // green. The probe is exploratory; the record is not.
     try {
       await recordTestResult({
         connectionId: connection.id,
@@ -205,6 +181,38 @@ export const POST = withRoute<{ connectionId: string }>(
       log.error('Failed to record the SIS test result', err, {
         connectionId: connection.id,
       });
+    }
+
+    // SPE-435: with the connection green and recorded, keep going and measure
+    // whether this server carries the data SPE-414 would sync — teachers,
+    // classes, and enrollments joinable in both directions. Appended after
+    // `stored` and `ok` are fixed AND persisted: the probe's findings must
+    // never change the connection verdict the district's own button would
+    // report, and never touch what recordTestResult persists.
+    if (oneRosterProbeArgs) {
+      try {
+        const probeSteps = await probeOneRosterRosterData(oneRosterProbeArgs);
+        checks = [...checks, ...probeSteps];
+        // Aggregates only, by the probe's construction — this line is how the
+        // result outlives the panel (SPE-435's record is written from these
+        // logs, not from a screenshot).
+        log.info('OneRoster roster probe', {
+          connectionId: connection.id,
+          districtId: connection.district_id,
+          probe: probeSteps.map(({ key, status, message }) => ({ key, status, message })),
+        });
+      } catch (err) {
+        log.error('OneRoster roster probe failed', err, { connectionId: connection.id });
+        checks = [
+          ...checks,
+          {
+            key: 'roster-probe',
+            label: 'Roster data',
+            status: 'error',
+            message: 'The roster probe itself failed — the connection result above is unaffected.',
+          },
+        ];
+      }
     }
 
     log.info('SIS connection tested by Speddy staff', {

--- a/app/api/internal/sis-connections/[connectionId]/test/route.ts
+++ b/app/api/internal/sis-connections/[connectionId]/test/route.ts
@@ -5,6 +5,7 @@ import { logger } from '@/lib/logger';
 import { getConnection, getDecryptedCredential, recordTestResult } from '@/lib/sis/connections';
 import { runAeriesConnectionTest, toStoredTestResult } from '@/lib/sis/aeries-setup';
 import {
+  probeOneRosterRosterData,
   runOneRosterConnectionTest,
   toStoredOneRosterTestResult,
 } from '@/lib/sis/oneroster-setup';
@@ -143,6 +144,51 @@ export const POST = withRoute<{ connectionId: string }>(
       stored = toStoredOneRosterTestResult(report);
       usedAddress = report.usedTokenUrl;
       storedAddress = connection.token_url;
+
+      // SPE-435: with the connection green, keep going and measure whether
+      // this server carries the data SPE-414 would sync — teachers, classes,
+      // and enrollments joinable in both directions. Appended AFTER `stored`
+      // and `ok` are fixed, deliberately: the probe is exploratory, so its
+      // findings must never change the connection verdict the district's own
+      // button would report, and never touch what recordTestResult persists.
+      //
+      // `usedTokenUrl` is only set when resolution moved off the stored
+      // address, so the fallback chain covers both green cases; a report
+      // green with NEITHER address cannot happen, and skipping is safer than
+      // guessing one.
+      if (ok) {
+        const probeTokenUrl = report.usedTokenUrl ?? connection.token_url;
+        if (probeTokenUrl) {
+          try {
+            const probeSteps = await probeOneRosterRosterData({
+              baseUrl: connection.base_url,
+              tokenUrl: probeTokenUrl,
+              clientId: credential.clientId,
+              clientSecret: credential.clientSecret,
+            });
+            checks = [...checks, ...probeSteps];
+            // Aggregates only, by the probe's construction — this line is how
+            // the result outlives the panel (SPE-435's record is written from
+            // these logs, not from a screenshot).
+            log.info('OneRoster roster probe', {
+              connectionId: connection.id,
+              districtId: connection.district_id,
+              probe: probeSteps.map(({ key, status, message }) => ({ key, status, message })),
+            });
+          } catch (err) {
+            log.error('OneRoster roster probe failed', err, { connectionId: connection.id });
+            checks = [
+              ...checks,
+              {
+                key: 'roster-probe',
+                label: 'Roster data',
+                status: 'error',
+                message: 'The roster probe itself failed — the connection result above is unaffected.',
+              },
+            ];
+          }
+        }
+      }
     }
 
     try {

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -40,6 +40,7 @@ import {
 } from './config';
 import type {
   OneRosterTokenResponse,
+  RawOneRosterClass,
   RawOneRosterEnrollment,
   RawOneRosterOrg,
   RawOneRosterSchool,
@@ -425,6 +426,11 @@ export class OneRosterClient {
   /** `GET /enrollments` — the student↔class↔teacher edges (SPE-398 report 3). */
   async getEnrollments(options?: OneRosterRequestOptions): Promise<RawOneRosterEnrollment[]> {
     return this.namedCollection<RawOneRosterEnrollment>('enrollments', 'enrollments', options);
+  }
+
+  /** `GET /classes` — titles, types and periods for future link labels (SPE-435). */
+  async getClasses(options?: OneRosterRequestOptions): Promise<RawOneRosterClass[]> {
+    return this.namedCollection<RawOneRosterClass>('classes', 'classes', options);
   }
 
   /**

--- a/lib/integrations/oneroster/index.ts
+++ b/lib/integrations/oneroster/index.ts
@@ -23,5 +23,6 @@ export type {
   RawOneRosterSchool,
   RawOneRosterUser,
   RawOneRosterEnrollment,
+  RawOneRosterClass,
   OneRosterTokenResponse,
 } from './types';

--- a/lib/integrations/oneroster/types.ts
+++ b/lib/integrations/oneroster/types.ts
@@ -56,6 +56,16 @@ export interface RawOneRosterEnrollment {
   [key: string]: unknown;
 }
 
+/** A class record — the node that joins a student's enrollment to a teacher's. */
+export interface RawOneRosterClass {
+  sourcedId: string;
+  title?: string | null;
+  /** 'homeroom' | 'scheduled' in v1.1 — the elementary/secondary discriminator. */
+  classType?: string | null;
+  periods?: string[];
+  [key: string]: unknown;
+}
+
 /**
  * The OAuth2 token response.
  *

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -706,7 +706,19 @@ export async function probeOneRosterRosterData(params: {
       steps.push({ key, label, ...describe(rows) });
       return rows;
     } catch (err) {
-      if (err instanceof OneRosterApiError && (err.status === 404 || err.status === 405)) {
+      if (err instanceof OneRosterApiError && err.phase === 'token') {
+        // The probe fetches its own token, so a token-endpoint blip surfaces
+        // on every check. Without this branch it would read as the COLLECTION
+        // being absent — recording "this district lacks /teachers, /students,
+        // /classes and /enrollments" about endpoints that were never dialled.
+        steps.push({
+          key,
+          label,
+          status: 'error',
+          message:
+            'Could not sign in for this check — the sign-in that just passed stopped answering mid-probe. Run the test again.',
+        });
+      } else if (err instanceof OneRosterApiError && (err.status === 404 || err.status === 405)) {
         steps.push({ key, label, status: 'denied', message: 'Not provided by this server.' });
       } else {
         steps.push({
@@ -720,12 +732,12 @@ export async function probeOneRosterRosterData(params: {
     }
   };
 
+  // "In the first page", never a total: servers cap `limit` silently (the
+  // client's getAllPages docstring exists because of it), so a full page at
+  // ANY size may be truncation. The wording claims exactly what was seen.
   const countMessage = (n: number, noun: string): { status: 'ok' | 'denied'; message: string } =>
     n > 0
-      ? {
-          status: 'ok',
-          message: `${n} ${noun} in the first page${n === PROBE_PAGE_LIMIT ? ' (page full — more exist)' : ''}.`,
-        }
+      ? { status: 'ok', message: `${n} ${noun} in the first page.` }
       : { status: 'denied', message: `The server answered, with zero ${noun}.` };
 
   await sample('teachers', 'Teacher directory', () => client.getTeachers({ limit: PROBE_PAGE_LIMIT }), (rows) =>
@@ -750,6 +762,15 @@ export async function probeOneRosterRosterData(params: {
       const teachers = joinable.filter((r) => r.role === 'teacher').length;
       const classCount = new Set(joinable.map((r) => r.class!.sourcedId)).size;
       if (rows.length === 0) return { status: 'denied', message: 'The server answered, with zero roster entries.' };
+      if (joinable.length === 0) {
+        // Entries exist but none carry both IDs — a shape problem, not a role
+        // problem. Reported as such so the SPE-414 investigation starts at the
+        // ID nesting, not at roles that were never the issue.
+        return {
+          status: 'denied',
+          message: `${rows.length} entries in the first page, but none carry joinable user and class IDs.`,
+        };
+      }
       if (teachers === 0) {
         return {
           status: 'denied',
@@ -776,42 +797,59 @@ export async function probeOneRosterRosterData(params: {
   {
     const key = 'linkage' as const;
     const label = 'Teachers per student';
-    const joinable = (enrollments ?? []).filter((r) => r.user?.sourcedId && r.class?.sourcedId);
-    const teachersByClass = new Map<string, Set<string>>();
-    for (const row of joinable) {
-      if (row.role !== 'teacher') continue;
-      const classId = row.class!.sourcedId;
-      if (!teachersByClass.has(classId)) teachersByClass.set(classId, new Set());
-      teachersByClass.get(classId)!.add(row.user!.sourcedId);
-    }
-    const teachersByStudent = new Map<string, Set<string>>();
-    for (const row of joinable) {
-      if (row.role !== 'student') continue;
-      const studentId = row.user!.sourcedId;
-      if (!teachersByStudent.has(studentId)) teachersByStudent.set(studentId, new Set());
-      for (const teacher of teachersByClass.get(row.class!.sourcedId) ?? []) {
-        teachersByStudent.get(studentId)!.add(teacher);
-      }
-    }
-    const counts = [...teachersByStudent.values()].map((set) => set.size).filter((n) => n > 0);
-    if (counts.length === 0) {
+    if (enrollments === null) {
+      // A statement about a sample requires a sample. Without this branch the
+      // step would assert "no student shares a class with a teacher" about
+      // enrollments that were never fetched.
       steps.push({
         key,
         label,
         status: 'untested',
-        message: 'Not computable — no student in the sample shares a class with a teacher entry.',
+        message: 'Not measured — the class-roster request did not answer.',
       });
     } else {
-      counts.sort((a, b) => a - b);
-      const min = counts[0];
-      const max = counts[counts.length - 1];
-      const median = counts[Math.floor((counts.length - 1) / 2)];
-      steps.push({
-        key,
-        label,
-        status: 'ok',
-        message: `Sampled ${counts.length} students: fewest ${min}, typical ${median}, most ${max} teachers each (first-page sample).`,
-      });
+      const joinable = enrollments.filter((r) => r.user?.sourcedId && r.class?.sourcedId);
+      const teachersByClass = new Map<string, Set<string>>();
+      for (const row of joinable) {
+        if (row.role !== 'teacher') continue;
+        const classId = row.class!.sourcedId;
+        if (!teachersByClass.has(classId)) teachersByClass.set(classId, new Set());
+        teachersByClass.get(classId)!.add(row.user!.sourcedId);
+      }
+      const teachersByStudent = new Map<string, Set<string>>();
+      for (const row of joinable) {
+        if (row.role !== 'student') continue;
+        const studentId = row.user!.sourcedId;
+        if (!teachersByStudent.has(studentId)) teachersByStudent.set(studentId, new Set());
+        for (const teacher of teachersByClass.get(row.class!.sourcedId) ?? []) {
+          teachersByStudent.get(studentId)!.add(teacher);
+        }
+      }
+      // Zeroes stay in. A student with no reachable teacher is the finding
+      // SPE-414 most needs to know the rate of — dropping them would let a
+      // sample where joining mostly FAILS read as one where it worked.
+      const counts = [...teachersByStudent.values()].map((set) => set.size);
+      const unlinked = counts.filter((n) => n === 0).length;
+      if (counts.length === 0 || counts.every((n) => n === 0)) {
+        steps.push({
+          key,
+          label,
+          status: 'untested',
+          message: 'Not computable — no student in the sample shares a class with a teacher entry.',
+        });
+      } else {
+        counts.sort((a, b) => a - b);
+        const min = counts[0];
+        const max = counts[counts.length - 1];
+        const median = counts[Math.floor((counts.length - 1) / 2)];
+        const gap = unlinked > 0 ? ` ${unlinked} of them had NO teacher entry.` : '';
+        steps.push({
+          key,
+          label,
+          status: 'ok',
+          message: `Sampled ${counts.length} students: fewest ${min}, typical ${median}, most ${max} teachers each (first-page sample).${gap}`,
+        });
+      }
     }
   }
 

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -647,6 +647,15 @@ export interface OneRosterRosterProbeStep {
 
 /** First page only — a probe measures presence and shape, not the district. */
 const PROBE_PAGE_LIMIT = 200;
+/**
+ * Per-request ceiling, well under the client's 30s default. Five sequential
+ * requests at the default could hold the route open for minutes on a slow
+ * server; a healthy OneRoster answers these in a couple of seconds, and a
+ * server that cannot answer in ten is itself a finding. Keeps the completed
+ * CONNECTION verdict deliverable even when the probe crawls (CodeRabbit,
+ * PR #827).
+ */
+const PROBE_REQUEST_TIMEOUT_MS = 10_000;
 
 /**
  * Measure whether a OneRoster server carries the data SPE-414 would sync:
@@ -740,20 +749,20 @@ export async function probeOneRosterRosterData(params: {
       ? { status: 'ok', message: `${n} ${noun} in the first page.` }
       : { status: 'denied', message: `The server answered, with zero ${noun}.` };
 
-  await sample('teachers', 'Teacher directory', () => client.getTeachers({ limit: PROBE_PAGE_LIMIT }), (rows) =>
+  await sample('teachers', 'Teacher directory', () => client.getTeachers({ limit: PROBE_PAGE_LIMIT, timeoutMs: PROBE_REQUEST_TIMEOUT_MS }), (rows) =>
     countMessage(rows.length, 'teachers'),
   );
-  await sample('students', 'Student roster', () => client.getStudents({ limit: PROBE_PAGE_LIMIT }), (rows) =>
+  await sample('students', 'Student roster', () => client.getStudents({ limit: PROBE_PAGE_LIMIT, timeoutMs: PROBE_REQUEST_TIMEOUT_MS }), (rows) =>
     countMessage(rows.length, 'students'),
   );
-  await sample('classes', 'Class records', () => client.getClasses({ limit: PROBE_PAGE_LIMIT }), (rows) =>
+  await sample('classes', 'Class records', () => client.getClasses({ limit: PROBE_PAGE_LIMIT, timeoutMs: PROBE_REQUEST_TIMEOUT_MS }), (rows) =>
     countMessage(rows.length, 'classes'),
   );
 
   const enrollments = await sample(
     'rosters',
     'Class rosters',
-    () => client.getEnrollments({ limit: PROBE_PAGE_LIMIT }),
+    () => client.getEnrollments({ limit: PROBE_PAGE_LIMIT, timeoutMs: PROBE_REQUEST_TIMEOUT_MS }),
     (rows) => {
       // Joinability is the whole question: a row missing either key cannot
       // connect a person to a class, whatever else it says.

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -850,7 +850,13 @@ export async function probeOneRosterRosterData(params: {
         counts.sort((a, b) => a - b);
         const min = counts[0];
         const max = counts[counts.length - 1];
-        const median = counts[Math.floor((counts.length - 1) / 2)];
+        // True median: even-length samples average the two middle values. The
+        // lower-middle shortcut reported [1, 1, 5, 5] as "typical 1" — a
+        // systematic understatement in the one number the elementary-vs-
+        // secondary default gets decided on (Codex, PR #827).
+        const mid =
+          (counts[Math.floor((counts.length - 1) / 2)] + counts[Math.ceil((counts.length - 1) / 2)]) / 2;
+        const median = Number.isInteger(mid) ? mid : mid.toFixed(1);
         const gap = unlinked > 0 ? ` ${unlinked} of them had NO teacher entry.` : '';
         steps.push({
           key,

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -631,3 +631,189 @@ export function toStoredOneRosterTestResult(report: OneRosterTestReport): SisTes
     message: report.summary,
   };
 }
+
+/**
+ * One roster-probe finding. Same display contract as a test step — the
+ * internal panel renders both through one list — but its own key space, so
+ * the connection test's steps and the probe's can never collide.
+ */
+export interface OneRosterRosterProbeStep {
+  key: 'teachers' | 'students' | 'classes' | 'rosters' | 'linkage';
+  label: string;
+  status: 'ok' | 'denied' | 'error' | 'untested';
+  /** Plain English, numbers and fixed words only. Never a name or an ID. */
+  message: string;
+}
+
+/** First page only — a probe measures presence and shape, not the district. */
+const PROBE_PAGE_LIMIT = 200;
+
+/**
+ * Measure whether a OneRoster server carries the data SPE-414 would sync:
+ * teachers, classes, and enrollments joinable in BOTH directions (SPE-435).
+ *
+ * Read-only, first-page samples, aggregate-only messages. Runs AFTER a green
+ * connection test, against the token endpoint that test resolved — it never
+ * re-resolves candidates, because a probe that hunted for endpoints would turn
+ * one staff click into a scatter of requests the connection test already made.
+ *
+ * Never throws for server-side reasons: a district whose server omits
+ * `/classes` is a FINDING (labels unavailable), not an error — each check
+ * degrades independently, because "which parts are missing" is exactly what
+ * this probe exists to learn. The one hard refusal is the SSRF guard: both
+ * URLs are checked before any request, same as every other caller (SPE-396's
+ * lesson — a guard nothing calls is not a control).
+ */
+export async function probeOneRosterRosterData(params: {
+  baseUrl: string;
+  /** The token endpoint the connection test signed in at. */
+  tokenUrl: string;
+  clientId: string;
+  clientSecret: string;
+}): Promise<OneRosterRosterProbeStep[]> {
+  try {
+    await assertSafeSisUrl(params.baseUrl, ONEROSTER_URL_LABELS);
+    await assertSafeSisUrl(params.tokenUrl, ONEROSTER_URL_LABELS);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'That address cannot be used.';
+    return [
+      { key: 'rosters', label: 'Roster data', status: 'error', message: `Roster probe refused: ${message}` },
+    ];
+  }
+
+  const client = new OneRosterClient({
+    baseUrl: params.baseUrl,
+    tokenUrl: params.tokenUrl,
+    clientId: params.clientId,
+    clientSecret: params.clientSecret,
+  });
+
+  const steps: OneRosterRosterProbeStep[] = [];
+
+  /**
+   * Fetch one collection, folding every failure into a step. 404/405 read as
+   * "this server does not provide the endpoint" — a per-collection verdict the
+   * probe exists to report — while anything else reads as an error.
+   */
+  const sample = async <T>(
+    key: OneRosterRosterProbeStep['key'],
+    label: string,
+    fetchPage: () => Promise<T[]>,
+    describe: (rows: T[]) => { status: OneRosterRosterProbeStep['status']; message: string },
+  ): Promise<T[] | null> => {
+    try {
+      const rows = await fetchPage();
+      steps.push({ key, label, ...describe(rows) });
+      return rows;
+    } catch (err) {
+      if (err instanceof OneRosterApiError && (err.status === 404 || err.status === 405)) {
+        steps.push({ key, label, status: 'denied', message: 'Not provided by this server.' });
+      } else {
+        steps.push({
+          key,
+          label,
+          status: 'error',
+          message: 'The server did not answer this request. The connection result above is unaffected.',
+        });
+      }
+      return null;
+    }
+  };
+
+  const countMessage = (n: number, noun: string): { status: 'ok' | 'denied'; message: string } =>
+    n > 0
+      ? {
+          status: 'ok',
+          message: `${n} ${noun} in the first page${n === PROBE_PAGE_LIMIT ? ' (page full — more exist)' : ''}.`,
+        }
+      : { status: 'denied', message: `The server answered, with zero ${noun}.` };
+
+  await sample('teachers', 'Teacher directory', () => client.getTeachers({ limit: PROBE_PAGE_LIMIT }), (rows) =>
+    countMessage(rows.length, 'teachers'),
+  );
+  await sample('students', 'Student roster', () => client.getStudents({ limit: PROBE_PAGE_LIMIT }), (rows) =>
+    countMessage(rows.length, 'students'),
+  );
+  await sample('classes', 'Class records', () => client.getClasses({ limit: PROBE_PAGE_LIMIT }), (rows) =>
+    countMessage(rows.length, 'classes'),
+  );
+
+  const enrollments = await sample(
+    'rosters',
+    'Class rosters',
+    () => client.getEnrollments({ limit: PROBE_PAGE_LIMIT }),
+    (rows) => {
+      // Joinability is the whole question: a row missing either key cannot
+      // connect a person to a class, whatever else it says.
+      const joinable = rows.filter((r) => r.user?.sourcedId && r.class?.sourcedId);
+      const students = joinable.filter((r) => r.role === 'student').length;
+      const teachers = joinable.filter((r) => r.role === 'teacher').length;
+      const classCount = new Set(joinable.map((r) => r.class!.sourcedId)).size;
+      if (rows.length === 0) return { status: 'denied', message: 'The server answered, with zero roster entries.' };
+      if (teachers === 0) {
+        return {
+          status: 'denied',
+          message: `${students} student entries but NO teacher entries in the first page — students cannot be joined to teachers from this data.`,
+        };
+      }
+      if (students === 0) {
+        return {
+          status: 'denied',
+          message: `${teachers} teacher entries but NO student entries in the first page — students cannot be joined to teachers from this data.`,
+        };
+      }
+      return {
+        status: 'ok',
+        message: `${students} student and ${teachers} teacher entries across ${classCount} classes in the first page.`,
+      };
+    },
+  );
+
+  // Teachers-per-student, from the same sample: student → their classes →
+  // every teacher-role entry sharing a class. First-page arithmetic, so it can
+  // undercount a student whose classes fall outside the page — stated in the
+  // message rather than silently presented as the whole truth.
+  {
+    const key = 'linkage' as const;
+    const label = 'Teachers per student';
+    const joinable = (enrollments ?? []).filter((r) => r.user?.sourcedId && r.class?.sourcedId);
+    const teachersByClass = new Map<string, Set<string>>();
+    for (const row of joinable) {
+      if (row.role !== 'teacher') continue;
+      const classId = row.class!.sourcedId;
+      if (!teachersByClass.has(classId)) teachersByClass.set(classId, new Set());
+      teachersByClass.get(classId)!.add(row.user!.sourcedId);
+    }
+    const teachersByStudent = new Map<string, Set<string>>();
+    for (const row of joinable) {
+      if (row.role !== 'student') continue;
+      const studentId = row.user!.sourcedId;
+      if (!teachersByStudent.has(studentId)) teachersByStudent.set(studentId, new Set());
+      for (const teacher of teachersByClass.get(row.class!.sourcedId) ?? []) {
+        teachersByStudent.get(studentId)!.add(teacher);
+      }
+    }
+    const counts = [...teachersByStudent.values()].map((set) => set.size).filter((n) => n > 0);
+    if (counts.length === 0) {
+      steps.push({
+        key,
+        label,
+        status: 'untested',
+        message: 'Not computable — no student in the sample shares a class with a teacher entry.',
+      });
+    } else {
+      counts.sort((a, b) => a - b);
+      const min = counts[0];
+      const max = counts[counts.length - 1];
+      const median = counts[Math.floor((counts.length - 1) / 2)];
+      steps.push({
+        key,
+        label,
+        status: 'ok',
+        message: `Sampled ${counts.length} students: fewest ${min}, typical ${median}, most ${max} teachers each (first-page sample).`,
+      });
+    }
+  }
+
+  return steps;
+}


### PR DESCRIPTION
## Why

SPE-414 (teacher directory + student↔teacher links from OneRoster — the owner-approved roster plan) builds against whatever a district's server actually carries. The OneRoster *standard* promises `/teachers`, `/classes`, and both-role `/enrollments`; whether **JSUSD's Aeries-hosted endpoint populates them** is an empirical question. This is the owner's verification-before-construction gate (SPE-435): one staff click answers it, before six weeks of product get built on an assumption — this week's lesson, four times over.

Why not the SPE-398 exploration scripts: they dial the district's SIS from wherever they run, and the dev environment's egress policy blocks district hosts. The internal staff test route (SPE-427) already runs server-side with working egress, staff-gated, rate-limited, SSRF-guarded — so the probe extends it.

## What

After the district's own OneRoster connection test comes back **green**, the internal staff route keeps going and appends five read-only checks, first-page samples, aggregate-only:

| check | question it answers |
|---|---|
| Teacher directory | does `/teachers` answer, with how many in the first page |
| Student roster | same for `/students` |
| Class records | same for `/classes` (new client method — later the source of homeroom/`classType` and subject/period labels) |
| Class rosters | do `/enrollments` carry **both** roles with joinable user+class IDs — the go/no-go fact for SPE-414 Part 2 |
| Teachers per student | fewest/typical/most from the sample, **zeros included and counted** — the elementary-vs-secondary default decides on this number |

Probe results are appended to the panel's `checks` (the panel renders them with zero component changes) and logged as aggregates — the SPE-435 record is written from those logs. The stored verdict, `ok` flag, and `recordTestResult` remain exactly the district's own test: an exploratory probe can never flip a connection's recorded status. The district-facing test route and report are untouched.

## Honest-verdict edges (self-review round)

- A token endpoint that dies **mid-probe** reads as a sign-in problem on each check — not `Not provided by this server` four times, which would have recorded that the district lacks all four endpoints when none were ever dialled.
- Students with no reachable teacher stay in the linkage arithmetic as zeros with their count called out — dropping them would let a sample where joining mostly *fails* read as one where it worked.
- Linkage after a failed enrollments fetch says "not measured", never a claim about a sample that didn't exist.
- Enrollment rows with no joinable IDs are named an **ID-shape** problem, not zero-students-zero-teachers.
- No "(page full — more exist)" caveat: servers cap `limit` silently, so the message claims exactly what was seen.

**Deferred with reason:** the probe fetches its own token (one extra credentialed POST per staff click). Reusing the connection test's client means changing the district-facing test's return contract — not worth it for a staff-clicked, rate-limited route. Noted on the ticket.

## Privacy

Messages are numbers and fixed words. The test fixtures plant a teacher name and student IDs, and negative assertions prove they never appear in steps or logs (SPE-434 pattern). SSRF guard runs on both URLs before any request, pinned by a DNS-mocked wiring test that fails if the guard calls are deleted.

## Verification

- Real-HTTP suite: full fixture (counts, both roles, cross-class student → spread with a zero floor), missing `/classes`, missing `/enrollments`, token-death mid-probe, no-teacher-role enrollments, unjoinable-ID enrollments — 59 green in the file.
- DNS-mocked guard wiring: private address → no client ever constructed, secret never sent; public → exactly ONE client for exactly the given token URL (no candidate hunting).
- Handler tests: probe only behind a green test, resolved-address-wins fallback chain, probe crash appends an error check without touching `ok`/stored, Aeries never probes, refused callers dial nothing.
- Mutation-checked: a probe that names a sampled teacher fails the PII test; deleting the guard fails the wiring test; probing behind a red test fails the handler test.
- Full suite 1113 passed / 12 skipped; the 3 failures are the known pre-existing `tests/integration/{key-check,basic-workflows,minimal}` ones. Typecheck and lint clean.

Linear: SPE-435 (child of SPE-414)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT

---
_Generated by [Claude Code](https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OneRoster connection tests now verify access to teachers, students, classes, enrollments, and roster relationships.
  * Results include aggregate roster counts, role coverage, class availability, and teacher-student linkage insights.
  * Connection tests use the resolved authentication endpoint when available, with a fallback to the configured endpoint.
* **Bug Fixes**
  * Probe failures are reported separately without changing the primary connection verdict.
  * Unsupported Aeries connections no longer trigger OneRoster roster checks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->