### PR TITLE
SPE-435: granted-scope visibility + honest permission verdicts in the roster probe

### DIFF
--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -1244,6 +1244,27 @@ describe('the roster probe measures presence and joinability, never people (SPE-
     expect(stepIn(steps, 'linkage').status).toBe('untested');
   });
 
+  it('a request-phase 401 is an authentication verdict, and ONE strike ends the probe', async () => {
+    // 401 rejects the bearer token itself, not a sharing setting — and the
+    // client reuses that token, so without the bail every later collection
+    // would be misreported as its own independent denial (Codex, PR #828).
+    handler = (req) => {
+      if (req.url.includes('/token')) return rosterHandler(req);
+      return { status: 401, body: {} };
+    };
+
+    const steps = await probe();
+
+    expect(stepIn(steps, 'teachers').status).toBe('error');
+    expect(stepIn(steps, 'teachers').message).toMatch(/authentication problem/i);
+    expect(stepIn(steps, 'teachers').message).not.toMatch(/refused permission/i);
+    for (const key of ['students', 'classes', 'rosters'] as const) {
+      expect(stepIn(steps, key).status).toBe('untested');
+    }
+    // One token fetch, one data request — then it stopped dialling.
+    expect(seen.filter((r) => !r.url.includes('/token')).length).toBe(1);
+  });
+
   it("a 403 on ONE collection reads as 'refused permission' — the live JSUSD misreport", async () => {
     // The first production run of this probe hit exactly this: /enrollments
     // answered 403 with everything else green, and the panel said the server
@@ -1360,7 +1381,7 @@ describe('the GRANTED scope is logged from our own vocabulary — never verbatim
     await run();
 
     expect(logged()).toContain('"grantedScopes":["roster-core.readonly","roster.readonly"]');
-    expect(logged()).toContain('"tokenHost":"127.0.0.1"');
+    expect(logged()).toContain('"tokenEndpoint":"127.0.0.1/admin/token/"');
     expect(logged()).toContain('"unrecognisedScopes":1');
     expect(logged()).not.toContain(CLIENT_SECRET);
     expect(logged()).not.toContain('evil.example');

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -1371,6 +1371,10 @@ describe('the GRANTED scope is logged from our own vocabulary — never verbatim
               token_type: 'bearer',
               scope: [
                 'https://purl.imsglobal.org/spec/or/v1p1/scope/roster-core.readonly',
+                // Repeated deliberately: a duplicated value must not produce a
+                // duplicated log entry, or the same grant reads differently
+                // run to run.
+                'https://purl.imsglobal.org/spec/or/v1p1/scope/roster-core.readonly',
                 'https://purl.imsglobal.org/spec/or/v1p1/scope/roster.readonly',
                 `https://evil.example/echo/${CLIENT_SECRET}`,
               ].join(' '),

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -1301,3 +1301,50 @@ describe('the roster probe measures presence and joinability, never people (SPE-
     expect(stepIn(steps, 'rosters').message).toContain('2 entries');
   });
 });
+
+describe('the GRANTED scope is logged from our own vocabulary — never verbatim (SPE-435)', () => {
+  // The 403 on /enrollments made "what did the server actually grant us"
+  // the deciding fact between our-request-too-narrow and their-console-says-no.
+  // The scope field is server text, so it faces the same allow-list as every
+  // other derivation: known IMS constants are logged in short form, anything
+  // else becomes arithmetic.
+  let spy: jest.SpyInstance;
+  beforeEach(() => {
+    spy = jest.spyOn(logger, 'info').mockImplementation(() => {});
+  });
+  afterEach(() => spy.mockRestore());
+  const logged = () => JSON.stringify(spy.mock.calls);
+
+  it('logs known granted scopes in short form, counts the rest, leaks nothing', async () => {
+    handler = (req) =>
+      req.url.includes('/token')
+        ? {
+            status: 200,
+            body: {
+              access_token: TOKEN,
+              token_type: 'bearer',
+              scope: [
+                'https://purl.imsglobal.org/spec/or/v1p1/scope/roster-core.readonly',
+                'https://purl.imsglobal.org/spec/or/v1p1/scope/roster.readonly',
+                `https://evil.example/echo/${CLIENT_SECRET}`,
+              ].join(' '),
+            },
+          }
+        : allGood(req);
+
+    await run();
+
+    expect(logged()).toContain('"grantedScopes":["roster-core.readonly","roster.readonly"]');
+    expect(logged()).toContain('"unrecognisedScopes":1');
+    expect(logged()).not.toContain(CLIENT_SECRET);
+    expect(logged()).not.toContain('evil.example');
+  });
+
+  it('says "not stated" when the server omits the scope field', async () => {
+    handler = allGood;
+
+    await run();
+
+    expect(logged()).toContain('"grantedScopes":"not stated"');
+  });
+});

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -1244,6 +1244,25 @@ describe('the roster probe measures presence and joinability, never people (SPE-
     expect(stepIn(steps, 'linkage').status).toBe('untested');
   });
 
+  it("a 403 on ONE collection reads as 'refused permission' — the live JSUSD misreport", async () => {
+    // The first production run of this probe hit exactly this: /enrollments
+    // answered 403 with everything else green, and the panel said the server
+    // 'did not answer'. It answered. It refused. Those send the investigation
+    // to different people, and the misreport survived the whole test suite —
+    // caught by the self-review reading the live logs against the screenshot.
+    handler = (req) =>
+      req.url.includes('/enrollments') ? { status: 403, body: {} } : rosterHandler(req);
+
+    const steps = await probe();
+
+    expect(stepIn(steps, 'rosters').status).toBe('denied');
+    expect(stepIn(steps, 'rosters').message).toMatch(/refused permission/i);
+    expect(stepIn(steps, 'rosters').message).not.toMatch(/did not answer/i);
+    // Everything the server DID grant still reports normally.
+    expect(stepIn(steps, 'teachers').status).toBe('ok');
+    expect(stepIn(steps, 'linkage').status).toBe('untested');
+  });
+
   it('a token endpoint that dies MID-PROBE reads as a sign-in problem, not four missing endpoints', async () => {
     // The probe signs in on its own, so a token blip after a green connection
     // test hits every check. Read as 404-on-the-collection it would record
@@ -1254,13 +1273,19 @@ describe('the roster probe measures presence and joinability, never people (SPE-
 
     const steps = await probe();
 
-    for (const key of ['teachers', 'students', 'classes', 'rosters'] as const) {
-      expect(stepIn(steps, key).status).toBe('error');
-      expect(stepIn(steps, key).message).toMatch(/sign in/i);
-      expect(stepIn(steps, key).message).not.toMatch(/not provided/i);
+    expect(stepIn(steps, 'teachers').status).toBe('error');
+    expect(stepIn(steps, 'teachers').message).toMatch(/sign in/i);
+    expect(stepIn(steps, 'teachers').message).not.toMatch(/not provided/i);
+    // The rest bail rather than re-POSTing the district's credentials at a
+    // dead token endpoint three more times (self-review, PR #827): exactly
+    // one token request left this probe.
+    for (const key of ['students', 'classes', 'rosters'] as const) {
+      expect(stepIn(steps, key).status).toBe('untested');
+      expect(stepIn(steps, key).message).toMatch(/not attempted/i);
     }
+    expect(seen.filter((r) => r.url.includes('/token')).length).toBe(1);
     expect(stepIn(steps, 'linkage').status).toBe('untested');
-    expect(stepIn(steps, 'linkage').message).toMatch(/did not answer/i);
+    expect(stepIn(steps, 'linkage').message).toMatch(/no class-roster sample/i);
   });
 
   it('a server without /enrollments leaves linkage "not measured", not a claim about a sample', async () => {
@@ -1271,7 +1296,7 @@ describe('the roster probe measures presence and joinability, never people (SPE-
 
     expect(stepIn(steps, 'rosters').status).toBe('denied');
     expect(stepIn(steps, 'linkage').status).toBe('untested');
-    expect(stepIn(steps, 'linkage').message).toMatch(/did not answer/i);
+    expect(stepIn(steps, 'linkage').message).toMatch(/no class-roster sample/i);
     expect(stepIn(steps, 'linkage').message).not.toMatch(/shares a class/i);
   });
 
@@ -1335,6 +1360,7 @@ describe('the GRANTED scope is logged from our own vocabulary — never verbatim
     await run();
 
     expect(logged()).toContain('"grantedScopes":["roster-core.readonly","roster.readonly"]');
+    expect(logged()).toContain('"tokenHost":"127.0.0.1"');
     expect(logged()).toContain('"unrecognisedScopes":1');
     expect(logged()).not.toContain(CLIENT_SECRET);
     expect(logged()).not.toContain('evil.example');

--- a/app/api/internal/sis-connections/[connectionId]/test/route.ts
+++ b/app/api/internal/sis-connections/[connectionId]/test/route.ts
@@ -191,14 +191,17 @@ export const POST = withRoute<{ connectionId: string }>(
     // report, and never touch what recordTestResult persists.
     if (oneRosterProbeArgs) {
       try {
+        const probeStartedAt = Date.now();
         const probeSteps = await probeOneRosterRosterData(oneRosterProbeArgs);
         checks = [...checks, ...probeSteps];
         // Aggregates only, by the probe's construction — this line is how the
         // result outlives the panel (SPE-435's record is written from these
-        // logs, not from a screenshot).
+        // logs, not from a screenshot). Duration included so a district whose
+        // server crawls is visible before it becomes a timeout mystery.
         log.info('OneRoster roster probe', {
           connectionId: connection.id,
           districtId: connection.district_id,
+          durationMs: Date.now() - probeStartedAt,
           probe: probeSteps.map(({ key, status, message }) => ({ key, status, message })),
         });
       } catch (err) {

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -165,6 +165,26 @@ const KNOWN_CONTENT_TYPES = new Set([
   'text/xml',
 ]);
 
+const IMS_SCOPE_PREFIX = 'https://purl.imsglobal.org/spec/or/v1p1/scope/';
+
+/**
+ * Every scope OneRoster v1.1 defines. The token response's `scope` field
+ * states what the server actually granted; entries are logged only when they
+ * match one of these constants (shortened by the shared prefix), so the log
+ * stays inside our own vocabulary even against a server that echoes.
+ */
+const KNOWN_ONEROSTER_SCOPES = new Set(
+  [
+    'roster-core.readonly',
+    'roster.readonly',
+    'roster-demographics.readonly',
+    'resource.readonly',
+    'gradebook.readonly',
+    'gradebook.createput',
+    'gradebook.delete',
+  ].map((s) => `${IMS_SCOPE_PREFIX}${s}`),
+);
+
 /**
  * Read a refused token response for its RFC 6749 error code AND its shape.
  *
@@ -367,6 +387,31 @@ export class OneRosterClient {
         'token',
         true,
       );
+    }
+
+    // What the server GRANTED, versus what we asked for. JSUSD's first live
+    // probe hit a 403 on /enrollments with everything else green (SPE-435),
+    // and this is the field that says whether the grant itself was narrower
+    // than our request — or the refusal lives in the district's console.
+    // Same allow-list rule as every derivation in this file: the logged names
+    // are matched against our own constants, and anything else is a count.
+    if (typeof parsed.scope === 'string') {
+      const granted: string[] = [];
+      let unrecognised = 0;
+      for (const entry of parsed.scope.split(/\s+/).filter(Boolean)) {
+        if (KNOWN_ONEROSTER_SCOPES.has(entry)) {
+          granted.push(entry.slice(IMS_SCOPE_PREFIX.length));
+        } else {
+          unrecognised += 1;
+        }
+      }
+      granted.sort();
+      logger.info('OneRoster token granted', {
+        grantedScopes: granted,
+        unrecognisedScopes: unrecognised,
+      });
+    } else {
+      logger.info('OneRoster token granted', { grantedScopes: 'not stated' });
     }
 
     this.token = parsed.access_token;

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -395,6 +395,15 @@ export class OneRosterClient {
     // than our request — or the refusal lives in the district's console.
     // Same allow-list rule as every derivation in this file: the logged names
     // are matched against our own constants, and anything else is a count.
+    // Attributed by token host — two districts' tests can fetch tokens in the
+    // same minute, and an unattributable grant line answers nothing. The host
+    // is operator-entered configuration, not response text and not a secret.
+    let tokenHost = 'unparseable';
+    try {
+      tokenHost = new URL(this.config.tokenUrl).hostname;
+    } catch {
+      // Never let attribution break the exchange itself.
+    }
     if (typeof parsed.scope === 'string') {
       const granted: string[] = [];
       let unrecognised = 0;
@@ -407,11 +416,12 @@ export class OneRosterClient {
       }
       granted.sort();
       logger.info('OneRoster token granted', {
+        tokenHost,
         grantedScopes: granted,
         unrecognisedScopes: unrecognised,
       });
     } else {
-      logger.info('OneRoster token granted', { grantedScopes: 'not stated' });
+      logger.info('OneRoster token granted', { tokenHost, grantedScopes: 'not stated' });
     }
 
     this.token = parsed.access_token;

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -395,12 +395,15 @@ export class OneRosterClient {
     // than our request — or the refusal lives in the district's console.
     // Same allow-list rule as every derivation in this file: the logged names
     // are matched against our own constants, and anything else is a count.
-    // Attributed by token host — two districts' tests can fetch tokens in the
-    // same minute, and an unattributable grant line answers nothing. The host
-    // is operator-entered configuration, not response text and not a secret.
-    let tokenHost = 'unparseable';
+    // Attributed by token endpoint (host + path) — two districts' tests can
+    // fetch tokens in the same minute, and an unattributable grant line
+    // answers nothing. Host ALONE is not enough: a multi-tenant SIS serves
+    // districts from one host, separated by path (Codex, PR #828). Both parts
+    // are operator-entered configuration, not response text and not a secret.
+    let tokenEndpoint = 'unparseable';
     try {
-      tokenHost = new URL(this.config.tokenUrl).hostname;
+      const u = new URL(this.config.tokenUrl);
+      tokenEndpoint = `${u.hostname}${u.pathname}`;
     } catch {
       // Never let attribution break the exchange itself.
     }
@@ -416,12 +419,12 @@ export class OneRosterClient {
       }
       granted.sort();
       logger.info('OneRoster token granted', {
-        tokenHost,
+        tokenEndpoint,
         grantedScopes: granted,
         unrecognisedScopes: unrecognised,
       });
     } else {
-      logger.info('OneRoster token granted', { tokenHost, grantedScopes: 'not stated' });
+      logger.info('OneRoster token granted', { tokenEndpoint, grantedScopes: 'not stated' });
     }
 
     this.token = parsed.access_token;

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -408,19 +408,20 @@ export class OneRosterClient {
       // Never let attribution break the exchange itself.
     }
     if (typeof parsed.scope === 'string') {
-      const granted: string[] = [];
+      // A Set: servers can repeat a scope value, and a duplicated grant line
+      // reads as a different grant than yesterday's (CodeRabbit, PR #828).
+      const granted = new Set<string>();
       let unrecognised = 0;
       for (const entry of parsed.scope.split(/\s+/).filter(Boolean)) {
         if (KNOWN_ONEROSTER_SCOPES.has(entry)) {
-          granted.push(entry.slice(IMS_SCOPE_PREFIX.length));
+          granted.add(entry.slice(IMS_SCOPE_PREFIX.length));
         } else {
           unrecognised += 1;
         }
       }
-      granted.sort();
       logger.info('OneRoster token granted', {
         tokenEndpoint,
-        grantedScopes: granted,
+        grantedScopes: [...granted].sort(),
         unrecognisedScopes: unrecognised,
       });
     } else {

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -743,11 +743,20 @@ export async function probeOneRosterRosterData(params: {
           message:
             'Could not sign in for this check — the sign-in that just passed stopped answering mid-probe. Run the test again.',
         });
-      } else if (
-        err instanceof OneRosterApiError &&
-        err.phase === 'request' &&
-        (err.status === 401 || err.status === 403)
-      ) {
+      } else if (err instanceof OneRosterApiError && err.phase === 'request' && err.status === 401) {
+        // 401 rejects the BEARER TOKEN, not this resource's sharing — and the
+        // client reuses that token, so every later sample would be misreported
+        // as its own denial. One strike, same as a dead token endpoint
+        // (Codex, PR #828). 403 stays a per-resource permission verdict.
+        tokenDead = true;
+        steps.push({
+          key,
+          label,
+          status: 'error',
+          message:
+            'The sign-in pass was not accepted for this data request — an authentication problem, not a sharing setting. Run the test again.',
+        });
+      } else if (err instanceof OneRosterApiError && err.phase === 'request' && err.status === 403) {
         steps.push({
           key,
           label,

--- a/lib/sis/oneroster-setup.ts
+++ b/lib/sis/oneroster-setup.ts
@@ -698,11 +698,17 @@ export async function probeOneRosterRosterData(params: {
   });
 
   const steps: OneRosterRosterProbeStep[] = [];
+  // Once the probe's own sign-in has failed, every later sample would re-POST
+  // the district's credentials at the same dead token endpoint to learn what
+  // the first failure already established (self-review, PR #827). One strike.
+  let tokenDead = false;
 
   /**
-   * Fetch one collection, folding every failure into a step. 404/405 read as
-   * "this server does not provide the endpoint" — a per-collection verdict the
-   * probe exists to report — while anything else reads as an error.
+   * Fetch one collection, folding every failure into a step. The refusals a
+   * probe exists to tell apart: 404/405 is "this server does not provide the
+   * endpoint"; 401/403 on the DATA request is "the server refused permission
+   * for it" — JSUSD's live case on /enrollments, and reading it as a network
+   * failure was exactly the misreport this ticket was filed to end.
    */
   const sample = async <T>(
     key: OneRosterRosterProbeStep['key'],
@@ -710,6 +716,15 @@ export async function probeOneRosterRosterData(params: {
     fetchPage: () => Promise<T[]>,
     describe: (rows: T[]) => { status: OneRosterRosterProbeStep['status']; message: string },
   ): Promise<T[] | null> => {
+    if (tokenDead) {
+      steps.push({
+        key,
+        label,
+        status: 'untested',
+        message: 'Not attempted — the probe could not sign in.',
+      });
+      return null;
+    }
     try {
       const rows = await fetchPage();
       steps.push({ key, label, ...describe(rows) });
@@ -717,15 +732,27 @@ export async function probeOneRosterRosterData(params: {
     } catch (err) {
       if (err instanceof OneRosterApiError && err.phase === 'token') {
         // The probe fetches its own token, so a token-endpoint blip surfaces
-        // on every check. Without this branch it would read as the COLLECTION
+        // here first. Without this branch it would read as the COLLECTION
         // being absent — recording "this district lacks /teachers, /students,
         // /classes and /enrollments" about endpoints that were never dialled.
+        tokenDead = true;
         steps.push({
           key,
           label,
           status: 'error',
           message:
             'Could not sign in for this check — the sign-in that just passed stopped answering mid-probe. Run the test again.',
+        });
+      } else if (
+        err instanceof OneRosterApiError &&
+        err.phase === 'request' &&
+        (err.status === 401 || err.status === 403)
+      ) {
+        steps.push({
+          key,
+          label,
+          status: 'denied',
+          message: 'The server refused permission for this data.',
         });
       } else if (err instanceof OneRosterApiError && (err.status === 404 || err.status === 405)) {
         steps.push({ key, label, status: 'denied', message: 'Not provided by this server.' });
@@ -809,12 +836,14 @@ export async function probeOneRosterRosterData(params: {
     if (enrollments === null) {
       // A statement about a sample requires a sample. Without this branch the
       // step would assert "no student shares a class with a teacher" about
-      // enrollments that were never fetched.
+      // enrollments that were never fetched. Worded for every way the sample
+      // can be missing — refused, absent, unanswered — because this step
+      // cannot see which; the rosters row above carries the specific verdict.
       steps.push({
         key,
         label,
         status: 'untested',
-        message: 'Not measured — the class-roster request did not answer.',
+        message: 'Not measured — no class-roster sample was available.',
       });
     } else {
       const joinable = enrollments.filter((r) => r.user?.sourcedId && r.class?.sourcedId);


### PR DESCRIPTION
## Why

The probe's first production run (PR #827, JSUSD, 18:24 UTC) answered most of SPE-435 and sharpened the last question: `/teachers` (84), `/students` (200+), `/classes` (163) are all granted — and `/enrollments` returns **403**. Whether that 403 means *our requested scope is too narrow on Aeries' mapping* or *the permission is off in the district's console* turns on one fact we never read: **what the token grant actually carries**.

The same run also exposed a misreport in the probe itself: the panel said the server "did not answer" the enrollments request. The logs show it answered — with a refusal. Those two sentences send the investigation to different people.

## What

**Granted-scope logging** (`lib/integrations/oneroster/client.ts`): on every token success, the response's `scope` field is read under the file's standing allow-list rule — entries matching the seven IMS v1.1 scope constants are logged in short form (`grantedScopes: ["roster-core.readonly", …]`), anything else becomes a count. Attributed by token **host** (operator-entered config, never response text) so grants stay attributable when two districts fetch tokens in the same minute. A server that echoes credential material through the scope field cannot reach the log — the test plants exactly that and the mutation check (log it verbatim) fails.

**Honest probe verdicts** (`lib/sis/oneroster-setup.ts`), from the second deep self-review:
- A request-phase **401/403 reads "The server refused permission for this data"** (`denied`), not "did not answer" (`error`) — pinned by a fixture of the exact live JSUSD case, mutation-checked by deleting the branch.
- After the probe's own sign-in fails once, remaining samples **bail as "Not attempted"** instead of re-POSTing the district's credentials at a dead token endpoint three more times — the test counts exactly one token request.
- The linkage step no longer claims the class-roster request "did not answer" when the row above says it answered with a 404 — reworded to "no class-roster sample was available", true in every branch.

No behavioural change to any district-facing flow; internal staff route and logs only.

## Verification

- 63 tests green in the real-HTTP file, including the new 403 fixture, the one-token-POST count, and the scope-echo negative assertions.
- Mutation-checked: verbatim scope logging fails its test; deleting the 401/403 branch fails the live-case fixture.
- Full suite 1118 passed / 12 skipped; 3 failures are the known pre-existing `tests/integration/*` ones. Typecheck and lint clean.
- Two deep self-review rounds ran (the second caught the misreport against live evidence); CodeRabbit and Codex rounds on the prior PR are folded in.

Linear: SPE-435

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT

---
_Generated by [Claude Code](https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OneRoster connection tests now include read-only roster validation for teachers, students, classes, enrollments, and relationship quality.
  * Results report roster availability, joinability, and teacher-to-student linkage.
  * Connection diagnostics now include clearer outcomes for authentication, permissions, missing endpoints, and server errors.
  * OAuth scope reporting highlights recognized permissions while protecting sensitive details.

* **Bug Fixes**
  * Failed connection tests no longer trigger roster probing.
  * Probe failures are reported separately without incorrectly marking the primary connection test as failed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->