### PR TITLE
SPE-435: request both read-only scopes — the owner-approved enrollments experiment

### DIFF
--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -594,18 +594,44 @@ describe('the OneRoster exchange over real HTTP', () => {
     expect(decoded).toBe(`${CLIENT_ID}:${CLIENT_SECRET}`);
   });
 
-  it('asks for client_credentials and only the roster-core scope', async () => {
+  it('asks for client_credentials and BOTH read-only scopes — never demographics', async () => {
+    // Dual request per the SPE-435 experiment: Aeries granted full
+    // roster-core.readonly and still refused /enrollments, so the umbrella
+    // read-only scope rides along. The line that must never change: no
+    // demographics, under any experiment.
     handler = allGood;
     await run();
 
     const body = seen.find((r) => r.url.includes('/token'))!.body;
     expect(body).toContain('grant_type=client_credentials');
-    expect(decodeURIComponent(body)).toContain(
-      'https://purl.imsglobal.org/spec/or/v1p1/scope/roster-core.readonly',
-    );
+    const decoded = decodeURIComponent(body.replace(/\+/g, ' '));
+    expect(decoded).toContain('https://purl.imsglobal.org/spec/or/v1p1/scope/roster-core.readonly');
+    expect(decoded).toContain('https://purl.imsglobal.org/spec/or/v1p1/scope/roster.readonly');
     // Demographics carries birthdate, sex and race. This flow has no use for
     // any of it, and a district reviewing the grant should see that.
-    expect(decodeURIComponent(body)).not.toContain('demographics');
+    expect(decoded).not.toContain('demographics');
+  });
+
+  it('falls back to the core scope alone when the dual request is refused', async () => {
+    // RFC 6749 lets a server refuse an unrecognised scope rather than narrow
+    // it. The experiment must never cost a district a sign-in that worked
+    // yesterday: one retry, core scope only, and the test still goes green.
+    handler = (req) => {
+      if (!req.url.includes('/token')) return allGood(req);
+      const scopes = decodeURIComponent(req.body.replace(/\+/g, ' '));
+      return scopes.includes('scope/roster.readonly')
+        ? { status: 400, body: { error: 'invalid_scope' } }
+        : { status: 200, body: { access_token: TOKEN, token_type: 'bearer' } };
+    };
+
+    const report = await run();
+
+    expect(report.ok).toBe(true);
+    const tokenBodies = seen.filter((r) => r.url.includes('/token')).map((r) => r.body);
+    expect(tokenBodies).toHaveLength(2);
+    expect(decodeURIComponent(tokenBodies[1].replace(/\+/g, ' '))).not.toContain(
+      'scope/roster.readonly',
+    );
   });
 
   it('fetches the token once and reuses it across both collections', async () => {

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -636,6 +636,22 @@ describe('the OneRoster exchange over real HTTP', () => {
     expect(fallbackBody).not.toContain('scope/roster.readonly');
   });
 
+  it('does NOT retry the fallback at an address that 404s wearing an OAuth body', async () => {
+    // The SPE-431 lesson applied to the fallback: the invalid_scope code only
+    // means "scope refused" on a 400. A wrong address answering 404 with an
+    // OAuth-shaped body must get ONE credentialed POST, not two (Codex,
+    // PR #829).
+    handler = (req) =>
+      req.url.includes('/token')
+        ? { status: 404, body: { error: 'invalid_scope' } }
+        : allGood(req);
+
+    await run();
+
+    const tokenUrls = seen.filter((r) => r.url.includes('/token')).map((r) => r.url);
+    expect(new Set(tokenUrls).size).toBe(tokenUrls.length);
+  });
+
   it('fetches the token once and reuses it across both collections', async () => {
     handler = allGood;
     await run();

--- a/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-setup.http.test.ts
@@ -629,9 +629,11 @@ describe('the OneRoster exchange over real HTTP', () => {
     expect(report.ok).toBe(true);
     const tokenBodies = seen.filter((r) => r.url.includes('/token')).map((r) => r.body);
     expect(tokenBodies).toHaveLength(2);
-    expect(decodeURIComponent(tokenBodies[1].replace(/\+/g, ' '))).not.toContain(
-      'scope/roster.readonly',
-    );
+    // Present AND absent, both asserted: an empty scope on the retry would
+    // also "not contain" the umbrella (CodeRabbit, PR #829).
+    const fallbackBody = decodeURIComponent(tokenBodies[1].replace(/\+/g, ' '));
+    expect(fallbackBody).toContain('scope/roster-core.readonly');
+    expect(fallbackBody).not.toContain('scope/roster.readonly');
   });
 
   it('fetches the token once and reuses it across both collections', async () => {

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -35,6 +35,7 @@
 import { logger } from '@/lib/logger';
 import {
   ONEROSTER_API_PATH,
+  ONEROSTER_CORE_SCOPE,
   ONEROSTER_SCOPE,
   type OneRosterConnectionConfig,
 } from './config';
@@ -324,14 +325,37 @@ export class OneRosterClient {
   /**
    * Exchange the consumer ID and secret for a bearer token.
    *
+   * Requests the dual read-only scope, and if the server rejects that outright
+   * with `invalid_scope` — RFC 6749 lets a server refuse rather than narrow —
+   * retries ONCE with the core scope alone. The experiment the dual request
+   * exists for (SPE-435) must never cost a district a sign-in that worked
+   * yesterday.
+   */
+  async fetchToken(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<string> {
+    if (this.token) return this.token;
+    try {
+      this.token = await this.exchange(ONEROSTER_SCOPE, timeoutMs);
+    } catch (err) {
+      const dualRefused =
+        err instanceof OneRosterApiError &&
+        err.phase === 'token' &&
+        err.oauthError === 'invalid_scope';
+      if (!dualRefused) throw err;
+      logger.info('OneRoster dual-scope request refused; retrying with the core scope alone');
+      this.token = await this.exchange(ONEROSTER_CORE_SCOPE, timeoutMs);
+    }
+    return this.token;
+  }
+
+  /**
+   * One token request for one scope string.
+   *
    * Credentials go in the Authorization header via HTTP Basic, not in the body.
    * Both are permitted by RFC 6749, but a body parameter is far more likely to
    * be captured by an intermediary's request logging, and this is a district's
    * long-lived SIS credential rather than a short-lived token.
    */
-  async fetchToken(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<string> {
-    if (this.token) return this.token;
-
+  private async exchange(scope: string, timeoutMs: number): Promise<string> {
     // Each component is form-urlencoded BEFORE being joined and base64'd, per
     // RFC 6749 §2.3.1. For the ordinary alphanumeric credential this is a
     // no-op, so it costs nothing in the common case — but Basic auth splits on
@@ -345,7 +369,7 @@ export class OneRosterClient {
 
     const body = new URLSearchParams({
       grant_type: 'client_credentials',
-      scope: ONEROSTER_SCOPE,
+      scope,
     });
 
     const res = await this.dial(
@@ -428,8 +452,7 @@ export class OneRosterClient {
       logger.info('OneRoster token granted', { tokenEndpoint, grantedScopes: 'not stated' });
     }
 
-    this.token = parsed.access_token;
-    return this.token;
+    return parsed.access_token;
   }
 
   /** GET a OneRoster collection, fetching a token first if needed. */

--- a/lib/integrations/oneroster/client.ts
+++ b/lib/integrations/oneroster/client.ts
@@ -336,9 +336,15 @@ export class OneRosterClient {
     try {
       this.token = await this.exchange(ONEROSTER_SCOPE, timeoutMs);
     } catch (err) {
+      // Status 400 required, not just the code: describeTokenRefusal reads
+      // the `error` field off ANY failed token response, so a wrong address
+      // 404ing with an OAuth-shaped body would otherwise trigger a second
+      // credentialed POST at a non-endpoint (Codex, PR #829 — the SPE-431
+      // status-gating lesson, one layer down).
       const dualRefused =
         err instanceof OneRosterApiError &&
         err.phase === 'token' &&
+        err.status === 400 &&
         err.oauthError === 'invalid_scope';
       if (!dualRefused) throw err;
       logger.info('OneRoster dual-scope request refused; retrying with the core scope alone');

--- a/lib/integrations/oneroster/config.ts
+++ b/lib/integrations/oneroster/config.ts
@@ -18,16 +18,31 @@
 export const ONEROSTER_API_PATH = '/ims/oneroster/v1p1';
 
 /**
- * The single OAuth2 scope we request.
- *
- * `roster-core.readonly` covers getAllOrgs and getAllSchools — exactly the two
- * calls the connection test makes, and nothing else. It deliberately excludes
+ * The core read-only rostering scope — orgs, schools, users, classes,
+ * enrollments per the IMS v1.1 table. Deliberately excludes
  * `roster-demographics.readonly`: demographics is the one OneRoster scope that
- * carries birthdate, sex and race, and this flow has no use for any of it. Ask
- * for the smallest scope that answers the question, so a district reviewing
- * what they granted sees a request that matches what we actually do.
+ * carries birthdate, sex and race, and this flow has no use for any of it.
  */
-export const ONEROSTER_SCOPE = 'https://purl.imsglobal.org/spec/or/v1p1/scope/roster-core.readonly';
+export const ONEROSTER_CORE_SCOPE =
+  'https://purl.imsglobal.org/spec/or/v1p1/scope/roster-core.readonly';
+
+/**
+ * What we actually request: the core scope PLUS the umbrella read-only scope,
+ * space-separated per RFC 6749 §3.3.
+ *
+ * The dual request exists because Aeries' enforcement does not follow the
+ * spec's scope table: JSUSD's server granted full `roster-core.readonly` and
+ * still refused `/enrollments`, an endpoint that scope covers on paper
+ * (SPE-435, owner-approved experiment 2026-08-08). `roster.readonly` is the
+ * standard's superset WITHOUT demographics, so the request stays free of
+ * birthdate, sex and race either way — a district reviewing the grant still
+ * sees read-only rostering and nothing more.
+ *
+ * A server that refuses the unfamiliar pair with `invalid_scope` gets one
+ * retry with the core scope alone (see `fetchToken`), so a district that was
+ * signing in yesterday still signs in today.
+ */
+export const ONEROSTER_SCOPE = `${ONEROSTER_CORE_SCOPE} https://purl.imsglobal.org/spec/or/v1p1/scope/roster.readonly`;
 
 export interface OneRosterConnectionConfig {
   /** Base URL up to but NOT including `/ims/oneroster/v1p1`. */

--- a/lib/integrations/oneroster/index.ts
+++ b/lib/integrations/oneroster/index.ts
@@ -14,6 +14,7 @@ export {
 
 export {
   ONEROSTER_API_PATH,
+  ONEROSTER_CORE_SCOPE,
   ONEROSTER_SCOPE,
   type OneRosterConnectionConfig,
 } from './config';


### PR DESCRIPTION
## Why

The granted-scope evidence (PR #828, live at 21:39 UTC) settled half the question: JSUSD's server grants our **full `roster-core.readonly`** — no narrowing — and still 403s `/enrollments`, an endpoint that scope covers per the IMS v1.1 table. Aeries' enforcement does not follow the spec's mapping. The remaining fork: does Aeries file enrollments under the umbrella `roster.readonly`, or is it a per-consumer console switch? This is the experiment that separates them, approved by the owner ("run the experiment").

## What

`ONEROSTER_SCOPE` now carries **both** read-only scopes, space-separated per RFC 6749 §3.3: `roster-core.readonly` + `roster.readonly`. Neither includes demographics — the request a district reviews still says read-only rostering and nothing more, and the never-demographics test assertion is unchanged.

**The safety rail:** RFC 6749 lets a server refuse an unfamiliar scope pair outright rather than narrow it. `fetchToken` now retries **once** with the core scope alone on a token-phase `invalid_scope`, so the experiment can never cost a district a sign-in that worked yesterday. The token exchange is factored into a private `exchange(scope)` helper; the granted-scope logging (#828) reports whatever the server actually honors, which is how the next staff click reads the verdict.

## Verification

- Real-HTTP tests: the dual request pinned by request-body inspection on a real server; the fallback pinned by a server that refuses `roster.readonly` pairs — exactly two token POSTs, second one core-only, test still green. Mutation-checked: removing the fallback fails its test.
- Full suite 1120 passed / 12 skipped (3 known pre-existing `tests/integration/*` failures). Typecheck and lint clean.
- Outcome reading, next staff click: class-rosters row green ⇒ Aeries' non-spec mapping, solved with zero district involvement. Still refused ⇒ definitively the console permission; the ask to the district is one sentence.

Linear: SPE-435

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT

---
_Generated by [Claude Code](https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OneRoster authentication compatibility by requesting the required read-only scopes without demographics.
  * Added automatic fallback to the core read-only scope when a provider rejects the broader scope.
  * Ensured fallback authentication retries only once before establishing a connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->