### PR TITLE
SPE-436: district admin Directories — read-only SIS browser, view-first

### DIFF
--- a/__tests__/unit/app/api/district/sis-directory.test.ts
+++ b/__tests__/unit/app/api/district/sis-directory.test.ts
@@ -1,0 +1,178 @@
+/**
+ * SPE-436 · GET /api/district/sis-directory — the gate, and what a refused
+ * caller does NOT set in motion.
+ *
+ * Same posture as the internal test route's suite (SPE-427): the load-bearing
+ * assertion is never the status code alone — it is that **no request reaches
+ * the district's SIS** unless an entitled caller, in their own district, with
+ * a stored credential, asked for a directory page.
+ */
+import { NextRequest } from 'next/server';
+
+const ADMIN_ID = '44444444-4444-4444-8444-444444444444';
+const DISTRICT_ID = '0618990';
+
+let currentUserId: string | null = ADMIN_ID;
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: async () =>
+        currentUserId
+          ? { data: { user: { id: currentUserId } }, error: null }
+          : { data: { user: null }, error: { message: 'no session' } },
+    },
+  }),
+  createServiceClient: () => ({ from: () => ({}) }),
+}));
+
+jest.mock('@/lib/api/rate-limit-user', () => ({
+  checkUserRateLimit: jest.fn().mockResolvedValue({ allowed: true }),
+}));
+
+const mockResolveCaller = jest.fn();
+jest.mock('@/lib/api/district-sis-caller', () => ({
+  resolveDistrictSisCaller: (...a: unknown[]) => mockResolveCaller(...a),
+}));
+
+const mockListConnections = jest.fn();
+const mockGetCredential = jest.fn();
+jest.mock('@/lib/sis/connections', () => ({
+  ...jest.requireActual('@/lib/sis/connections'),
+  listConnections: (...a: unknown[]) => mockListConnections(...a),
+  getDecryptedCredential: (...a: unknown[]) => mockGetCredential(...a),
+}));
+
+const mockFetchPage = jest.fn();
+jest.mock('@/lib/sis/oneroster-directory', () => ({
+  ...jest.requireActual('@/lib/sis/oneroster-directory'),
+  fetchDirectoryPage: (...a: unknown[]) => mockFetchPage(...a),
+}));
+
+import { GET } from '@/app/api/district/sis-directory/route';
+
+const CONNECTION = {
+  id: 'conn-1',
+  district_id: DISTRICT_ID,
+  sis_type: 'oneroster',
+  base_url: 'https://district.aeries.net/admin',
+  token_url: 'https://district.aeries.net/admin/token',
+};
+
+const PAGE = {
+  area: 'teachers',
+  rows: [
+    {
+      sourcedId: 't-1',
+      name: 'Dana Alvarez',
+      email: 'd@example.org',
+      identifier: 'S1',
+      grades: [],
+      schools: [],
+    },
+  ],
+  offset: 0,
+  pageFull: false,
+  stats: [{ label: 'Teachers listed', value: '1' }],
+};
+
+const call = (qs = 'area=teachers') =>
+  GET(new NextRequest(`http://localhost/api/district/sis-directory?${qs}`), {
+    params: Promise.resolve({}),
+  });
+
+const sisWasDialled = () => mockFetchPage.mock.calls.length > 0;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  currentUserId = ADMIN_ID;
+  mockResolveCaller.mockResolvedValue({ ok: true, districtId: DISTRICT_ID, role: 'district_admin' });
+  mockListConnections.mockResolvedValue([CONNECTION]);
+  mockGetCredential.mockResolvedValue({
+    sisType: 'oneroster',
+    clientId: 'consumer-id',
+    clientSecret: 'consumer-secret',
+  });
+  mockFetchPage.mockResolvedValue(PAGE);
+});
+
+describe('the gate', () => {
+  it('401s an unauthenticated caller, and dials nothing', async () => {
+    currentUserId = null;
+    const res = await call();
+    expect(res.status).toBe(401);
+    expect(sisWasDialled()).toBe(false);
+  });
+
+  it('403s a caller with no district grant, and dials nothing', async () => {
+    mockResolveCaller.mockResolvedValue({ ok: false, denied: 'no grant' });
+    const res = await call();
+    expect(res.status).toBe(403);
+    expect(sisWasDialled()).toBe(false);
+    expect(mockGetCredential).not.toHaveBeenCalled();
+  });
+
+  it('the district comes from the caller grants — the request cannot name one', async () => {
+    // A hostile query string naming another district changes nothing: the
+    // route never reads a district from the request at all.
+    await call('area=teachers&districtId=9999999');
+    expect(mockListConnections).toHaveBeenCalledWith(DISTRICT_ID);
+  });
+
+  it('rejects an unknown area before doing anything', async () => {
+    const res = await call('area=enrollments');
+    expect(res.status).toBe(400);
+    expect(sisWasDialled()).toBe(false);
+  });
+});
+
+describe('setup states', () => {
+  it('409s with setup guidance when no OneRoster connection exists', async () => {
+    mockListConnections.mockResolvedValue([]);
+    const res = await call();
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toMatch(/tech portal/i);
+    expect(sisWasDialled()).toBe(false);
+  });
+
+  it('409s when no credential is stored', async () => {
+    mockGetCredential.mockResolvedValue(null);
+    const res = await call();
+    expect(res.status).toBe(409);
+    expect(sisWasDialled()).toBe(false);
+  });
+});
+
+describe('the page it serves', () => {
+  it('passes the picked page through, with the stored addresses and the query offset', async () => {
+    const res = await call('area=teachers&offset=200');
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual(PAGE);
+    expect(mockFetchPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: CONNECTION.base_url,
+        tokenUrl: CONNECTION.token_url,
+        area: 'teachers',
+        offset: 200,
+      }),
+    );
+  });
+
+  it('turns a fetch failure into "run the connection test", never a stack trace', async () => {
+    mockFetchPage.mockRejectedValue(new Error('ECONNREFUSED 10.0.0.5:443'));
+    const res = await call();
+    const text = await res.text();
+
+    expect(res.status).toBe(502);
+    expect(text).toMatch(/connection test/i);
+    expect(text).not.toContain('ECONNREFUSED');
+  });
+
+  it('never returns the credential, anywhere in the body', async () => {
+    const text = await (await call()).text();
+    expect(text).not.toContain('consumer-secret');
+    expect(text).not.toContain('consumer-id');
+  });
+});

--- a/__tests__/unit/app/api/district/sis-directory.test.ts
+++ b/__tests__/unit/app/api/district/sis-directory.test.ts
@@ -8,11 +8,14 @@
  * a stored credential, asked for a directory page.
  */
 import { NextRequest } from 'next/server';
+import type { DirectoryPage } from '@/lib/sis/oneroster-directory';
 
 const ADMIN_ID = '44444444-4444-4444-8444-444444444444';
 const DISTRICT_ID = '0618990';
 
 let currentUserId: string | null = ADMIN_ID;
+/** Whether the grant lookup finds a district_admin row for a tech-role caller. */
+let holdsAdminGrant = false;
 
 jest.mock('@/lib/supabase/server', () => ({
   createClient: async () => ({
@@ -23,7 +26,17 @@ jest.mock('@/lib/supabase/server', () => ({
           : { data: { user: null }, error: { message: 'no session' } },
     },
   }),
-  createServiceClient: () => ({ from: () => ({}) }),
+  createServiceClient: () => ({
+    from: () => {
+      const q: Record<string, unknown> = {};
+      q.select = () => q;
+      q.eq = () => q;
+      q.limit = () => q;
+      q.maybeSingle = () =>
+        Promise.resolve({ data: holdsAdminGrant ? { id: 'grant-1' } : null, error: null });
+      return q;
+    },
+  }),
 }));
 
 jest.mock('@/lib/api/rate-limit-user', () => ({
@@ -59,7 +72,7 @@ const CONNECTION = {
   token_url: 'https://district.aeries.net/admin/token',
 };
 
-const PAGE = {
+const PAGE: DirectoryPage = {
   area: 'teachers',
   rows: [
     {
@@ -73,7 +86,7 @@ const PAGE = {
   ],
   offset: 0,
   pageFull: false,
-  stats: [{ label: 'Teachers listed', value: '1' }],
+  stats: [{ label: 'Teachers listed', n: 1 }],
 };
 
 const call = (qs = 'area=teachers') =>
@@ -86,6 +99,7 @@ const sisWasDialled = () => mockFetchPage.mock.calls.length > 0;
 beforeEach(() => {
   jest.clearAllMocks();
   currentUserId = ADMIN_ID;
+  holdsAdminGrant = false;
   mockResolveCaller.mockResolvedValue({ ok: true, districtId: DISTRICT_ID, role: 'district_admin' });
   mockListConnections.mockResolvedValue([CONNECTION]);
   mockGetCredential.mockResolvedValue({
@@ -110,6 +124,38 @@ describe('the gate', () => {
     expect(res.status).toBe(403);
     expect(sisWasDialled()).toBe(false);
     expect(mockGetCredential).not.toHaveBeenCalled();
+  });
+
+  it('403s a district_tech caller — SPE-393: tech has no right to student data', async () => {
+    // The shared seam admits tech for connection MANAGEMENT. Reused unchecked
+    // here it would have served student names, IDs and grades to the role the
+    // permission model explicitly keeps out of them (Codex, PR #830).
+    mockResolveCaller.mockResolvedValue({
+      ok: true,
+      districtId: DISTRICT_ID,
+      role: 'district_tech',
+    });
+
+    const res = await call();
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toMatch(/district admins/i);
+    expect(sisWasDialled()).toBe(false);
+    expect(mockGetCredential).not.toHaveBeenCalled();
+  });
+
+  it('admits a caller the seam REPORTS as tech who also holds the admin grant', async () => {
+    // resolveDistrictSisCaller prefers the tech role when both are held; the
+    // extra grant lookup keeps that person from being wrongly refused.
+    mockResolveCaller.mockResolvedValue({
+      ok: true,
+      districtId: DISTRICT_ID,
+      role: 'district_tech',
+    });
+    holdsAdminGrant = true;
+
+    const res = await call();
+    expect(res.status).toBe(200);
   });
 
   it('the district comes from the caller grants — the request cannot name one', async () => {
@@ -139,6 +185,16 @@ describe('setup states', () => {
     mockGetCredential.mockResolvedValue(null);
     const res = await call();
     expect(res.status).toBe(409);
+    expect(sisWasDialled()).toBe(false);
+  });
+
+  it('a credential that cannot be DECRYPTED is a 500 with re-save guidance, not setup advice', async () => {
+    // "No credentials stored yet" about credentials that exist would send the
+    // admin to re-enter what a key rotation broke (CodeRabbit, PR #830).
+    mockGetCredential.mockRejectedValue(new Error('bad ciphertext'));
+    const res = await call();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/re-save/i);
     expect(sisWasDialled()).toBe(false);
   });
 });

--- a/__tests__/unit/lib/sis/oneroster-directory.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-directory.http.test.ts
@@ -76,6 +76,8 @@ const baseHandler = (url: string): { status: number; body: unknown } => {
             vendorExtra: PLANTED.vendorExtra,
           },
           { sourcedId: 't-2', familyName: 'Okafor', orgs: [{ sourcedId: 'sch-2' }] },
+          // Neither name field — the placeholder branch (CodeRabbit, PR #830).
+          { sourcedId: 't-3', orgs: [] },
         ],
       },
     };
@@ -141,7 +143,7 @@ describe('the pick is the contract', () => {
   it('teachers: picked fields arrive, planted vendor fields cannot', async () => {
     const page = await fetchArea('teachers');
 
-    expect(page.rows).toHaveLength(2);
+    expect(page.rows).toHaveLength(3);
     expect(page.rows[0]).toEqual({
       sourcedId: 't-1',
       name: 'Dana Alvarez',
@@ -174,6 +176,7 @@ describe('the pick is the contract', () => {
     const second = page.rows[1] as { name: string; schools: string[] };
     expect(second.name).toBe('Okafor');
     expect(second.schools).toEqual(['Crockett Middle']);
+    expect((page.rows[2] as { name: string }).name).toBe('(no name given)');
   });
 });
 
@@ -185,10 +188,10 @@ describe('the owner check numbers', () => {
     const page = await fetchArea('teachers');
     const byLabel = Object.fromEntries(page.stats.map((s) => [s.label, s]));
 
-    expect(byLabel['Teachers listed']).toMatchObject({ n: 2 });
-    expect(byLabel['with an email']).toMatchObject({ n: 1, of: 2 });
-    expect(byLabel['with a staff ID']).toMatchObject({ n: 1, of: 2 });
-    expect(byLabel['with a grade level']).toMatchObject({ n: 1, of: 2 });
+    expect(byLabel['Teachers listed']).toMatchObject({ n: 3 });
+    expect(byLabel['with an email']).toMatchObject({ n: 1, of: 3 });
+    expect(byLabel['with a staff ID']).toMatchObject({ n: 1, of: 3 });
+    expect(byLabel['with a grade level']).toMatchObject({ n: 1, of: 3 });
   });
 
   it('classes: the homeroom/scheduled split is the elementary detector', async () => {
@@ -269,7 +272,7 @@ describe('degradation', () => {
     };
 
     const page = await fetchArea('teachers');
-    expect(page.rows).toHaveLength(2);
+    expect(page.rows).toHaveLength(3);
     expect((page.rows[0] as { schools: string[] }).schools).toEqual([]);
   });
 

--- a/__tests__/unit/lib/sis/oneroster-directory.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-directory.http.test.ts
@@ -1,0 +1,243 @@
+/**
+ * SPE-436 · the directory fetch against a REAL HTTP server, and the property
+ * that earns the suite: THE PICK IS THE CONTRACT. The fixtures deliberately
+ * carry fields a district admin must never see in this surface — demographics,
+ * credential-looking strings, vendor extras — and the tests assert they cannot
+ * survive into a page, however the vendor payload is shaped.
+ *
+ * The SSRF guard is stubbed (127.0.0.1 over http is exactly what it refuses);
+ * oneroster-directory.test.ts covers that the module CALLS the real one.
+ */
+import { createServer, type Server } from 'http';
+import type { AddressInfo } from 'net';
+
+jest.mock('@/lib/sis/ssrf-guard', () => ({
+  ...jest.requireActual('@/lib/sis/ssrf-guard'),
+  assertSafeSisUrl: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { fetchDirectoryPage, DIRECTORY_PAGE_SIZE } from '@/lib/sis/oneroster-directory';
+
+const CLIENT_ID = 'dir-consumer-id';
+const CLIENT_SECRET = 'dir-consumer-secret';
+const TOKEN = 'dir-bearer-token';
+
+// Planted values that must never appear in any page this module returns.
+const PLANTED = {
+  birthDate: '2015-03-14',
+  sex: 'female',
+  race: 'planted-race-value',
+  password: 'planted-password-hash',
+  vendorExtra: 'planted-vendor-blob',
+};
+
+let server: Server;
+let origin: string;
+let handler: (url: string) => { status: number; body: unknown };
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const { status, body } = handler(req.url ?? '');
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(body));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+const SCHOOLS = {
+  orgs: [
+    { sourcedId: 'sch-1', name: 'Rodeo Hills Elementary', identifier: '0001', type: 'school' },
+    { sourcedId: 'sch-2', name: 'Crockett Middle', identifier: '0002', type: 'school' },
+  ],
+};
+
+const baseHandler = (url: string): { status: number; body: unknown } => {
+  if (url.includes('/token')) return { status: 200, body: { access_token: TOKEN } };
+  if (url.includes('/schools')) return { status: 200, body: SCHOOLS };
+  if (url.includes('/teachers')) {
+    return {
+      status: 200,
+      body: {
+        users: [
+          {
+            sourcedId: 't-1',
+            givenName: 'Dana',
+            familyName: 'Alvarez',
+            email: 'dalvarez@example.org',
+            identifier: 'STAFF-9',
+            grades: ['03'],
+            orgs: [{ sourcedId: 'sch-1' }],
+            password: PLANTED.password,
+            vendorExtra: PLANTED.vendorExtra,
+          },
+          { sourcedId: 't-2', familyName: 'Okafor', orgs: [{ sourcedId: 'sch-2' }] },
+        ],
+      },
+    };
+  }
+  if (url.includes('/students')) {
+    return {
+      status: 200,
+      body: {
+        users: [
+          {
+            sourcedId: 's-1',
+            givenName: 'Sam',
+            familyName: 'Nguyen',
+            identifier: '123456',
+            grades: ['05'],
+            orgs: [{ sourcedId: 'sch-1' }],
+            // The line this surface must never cross, even if a server
+            // volunteers it despite the no-demographics scope.
+            birthDate: PLANTED.birthDate,
+            sex: PLANTED.sex,
+            race: PLANTED.race,
+          },
+        ],
+      },
+    };
+  }
+  if (url.includes('/classes')) {
+    return {
+      status: 200,
+      body: {
+        classes: [
+          {
+            sourcedId: 'c-1',
+            title: 'Room 12',
+            classType: 'homeroom',
+            subjects: ['ELA'],
+            periods: ['1'],
+            grades: ['03'],
+          },
+          { sourcedId: 'c-2', title: 'Period 3 English', classType: 'scheduled', subjects: [] },
+        ],
+      },
+    };
+  }
+  return { status: 404, body: {} };
+};
+
+beforeEach(() => {
+  handler = baseHandler;
+});
+
+const fetchArea = (area: 'teachers' | 'students' | 'classes' | 'schools', offset = 0) =>
+  fetchDirectoryPage({
+    baseUrl: `${origin}/admin`,
+    tokenUrl: `${origin}/admin/token`,
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    area,
+    offset,
+  });
+
+describe('the pick is the contract', () => {
+  it('teachers: picked fields arrive, planted vendor fields cannot', async () => {
+    const page = await fetchArea('teachers');
+
+    expect(page.rows).toHaveLength(2);
+    expect(page.rows[0]).toEqual({
+      sourcedId: 't-1',
+      name: 'Dana Alvarez',
+      email: 'dalvarez@example.org',
+      identifier: 'STAFF-9',
+      grades: ['03'],
+      schools: ['Rodeo Hills Elementary'],
+    });
+
+    const serialized = JSON.stringify(page);
+    expect(serialized).not.toContain(PLANTED.password);
+    expect(serialized).not.toContain(PLANTED.vendorExtra);
+  });
+
+  it('students: demographics a server volunteers are structurally unrepresentable', async () => {
+    // The scope never asks for demographics, but the pick is what GUARANTEES
+    // they cannot reach a browser even from a server that sends them anyway.
+    const page = await fetchArea('students');
+
+    const serialized = JSON.stringify(page);
+    expect(serialized).not.toContain(PLANTED.birthDate);
+    expect(serialized).not.toContain(PLANTED.sex);
+    expect(serialized).not.toContain(PLANTED.race);
+    expect(serialized).toContain('123456');
+    expect(serialized).toContain('Sam Nguyen');
+  });
+
+  it('a teacher with no name renders a placeholder, not undefined-undefined', async () => {
+    const page = await fetchArea('teachers');
+    const second = page.rows[1] as { name: string; schools: string[] };
+    expect(second.name).toBe('Okafor');
+    expect(second.schools).toEqual(['Crockett Middle']);
+  });
+});
+
+describe('the owner check numbers', () => {
+  it('teachers: coverage stats count what the page shows', async () => {
+    const page = await fetchArea('teachers');
+    const byLabel = Object.fromEntries(page.stats.map((s) => [s.label, s.value]));
+
+    expect(byLabel['Teachers listed']).toBe('2');
+    expect(byLabel['with an email']).toBe('1 of 2');
+    expect(byLabel['with a staff ID']).toBe('1 of 2');
+    expect(byLabel['with a grade level']).toBe('1 of 2');
+  });
+
+  it('classes: the homeroom/scheduled split is the elementary detector', async () => {
+    const page = await fetchArea('classes');
+    const byLabel = Object.fromEntries(page.stats.map((s) => [s.label, s.value]));
+
+    expect(byLabel['Classes listed']).toBe('2');
+    expect(byLabel['homeroom / scheduled']).toBe('1 / 1');
+    expect(byLabel['with a subject']).toBe('1 of 2');
+  });
+
+  it('a full page is flagged so counts read as page counts, not district counts', async () => {
+    handler = (url) => {
+      if (url.includes('/token')) return { status: 200, body: { access_token: TOKEN } };
+      if (url.includes('/schools')) {
+        return {
+          status: 200,
+          body: {
+            orgs: Array.from({ length: DIRECTORY_PAGE_SIZE }, (_, i) => ({
+              sourcedId: `sch-${i}`,
+              name: `School ${i}`,
+            })),
+          },
+        };
+      }
+      return { status: 404, body: {} };
+    };
+
+    const page = await fetchArea('schools');
+    expect(page.rows).toHaveLength(DIRECTORY_PAGE_SIZE);
+    expect(page.pageFull).toBe(true);
+  });
+});
+
+describe('degradation', () => {
+  it('a broken /schools read leaves teachers rendered with an empty school column', async () => {
+    handler = (url) => {
+      if (url.includes('/schools')) return { status: 500, body: {} };
+      return baseHandler(url);
+    };
+
+    const page = await fetchArea('teachers');
+    expect(page.rows).toHaveLength(2);
+    expect((page.rows[0] as { schools: string[] }).schools).toEqual([]);
+  });
+
+  it('an unreachable area throws — the route turns that into "run the test"', async () => {
+    handler = (url) => {
+      if (url.includes('/teachers')) return { status: 500, body: {} };
+      return baseHandler(url);
+    };
+
+    await expect(fetchArea('teachers')).rejects.toThrow();
+  });
+});

--- a/__tests__/unit/lib/sis/oneroster-directory.http.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-directory.http.test.ts
@@ -178,23 +178,28 @@ describe('the pick is the contract', () => {
 });
 
 describe('the owner check numbers', () => {
-  it('teachers: coverage stats count what the page shows', async () => {
+  it('teachers: coverage stats count what the page shows, numerically', async () => {
+    // Numeric (n / of) rather than pre-formatted strings, so the client can
+    // sum stats across appended pages instead of showing the last page's
+    // counts over an accumulated table (self-review, PR: stats drift).
     const page = await fetchArea('teachers');
-    const byLabel = Object.fromEntries(page.stats.map((s) => [s.label, s.value]));
+    const byLabel = Object.fromEntries(page.stats.map((s) => [s.label, s]));
 
-    expect(byLabel['Teachers listed']).toBe('2');
-    expect(byLabel['with an email']).toBe('1 of 2');
-    expect(byLabel['with a staff ID']).toBe('1 of 2');
-    expect(byLabel['with a grade level']).toBe('1 of 2');
+    expect(byLabel['Teachers listed']).toMatchObject({ n: 2 });
+    expect(byLabel['with an email']).toMatchObject({ n: 1, of: 2 });
+    expect(byLabel['with a staff ID']).toMatchObject({ n: 1, of: 2 });
+    expect(byLabel['with a grade level']).toMatchObject({ n: 1, of: 2 });
   });
 
   it('classes: the homeroom/scheduled split is the elementary detector', async () => {
     const page = await fetchArea('classes');
-    const byLabel = Object.fromEntries(page.stats.map((s) => [s.label, s.value]));
+    const byLabel = Object.fromEntries(page.stats.map((s) => [s.label, s]));
 
-    expect(byLabel['Classes listed']).toBe('2');
-    expect(byLabel['homeroom / scheduled']).toBe('1 / 1');
-    expect(byLabel['with a subject']).toBe('1 of 2');
+    expect(byLabel['Classes listed']).toMatchObject({ n: 2 });
+    expect(byLabel['homeroom']).toMatchObject({ n: 1 });
+    expect(byLabel['scheduled']).toMatchObject({ n: 1 });
+    expect(byLabel['untyped']).toMatchObject({ n: 0 });
+    expect(byLabel['with a subject']).toMatchObject({ n: 1, of: 2 });
   });
 
   it('a full page is flagged so counts read as page counts, not district counts', async () => {
@@ -217,6 +222,42 @@ describe('the owner check numbers', () => {
     const page = await fetchArea('schools');
     expect(page.rows).toHaveLength(DIRECTORY_PAGE_SIZE);
     expect(page.pageFull).toBe(true);
+  });
+});
+
+describe('the school-name map', () => {
+  it('follows a FULL schools page so big districts keep their names', async () => {
+    // A first page that comes back full may be truncation. A person whose
+    // school fell off the map would render an empty School column —
+    // indistinguishable from the SIS not linking them (self-review).
+    handler = (url) => {
+      if (url.includes('/token')) return { status: 200, body: { access_token: TOKEN } };
+      if (url.includes('/schools')) {
+        const offset = Number(new URL(`http://x${url}`).searchParams.get('offset') ?? '0');
+        if (offset === 0) {
+          return {
+            status: 200,
+            body: {
+              orgs: Array.from({ length: DIRECTORY_PAGE_SIZE }, (_, i) => ({
+                sourcedId: `sch-${i}`,
+                name: `School ${i}`,
+              })),
+            },
+          };
+        }
+        return { status: 200, body: { orgs: [{ sourcedId: 'sch-tail', name: 'Tail School' }] } };
+      }
+      if (url.includes('/teachers')) {
+        return {
+          status: 200,
+          body: { users: [{ sourcedId: 't-1', familyName: 'Tail', orgs: [{ sourcedId: 'sch-tail' }] }] },
+        };
+      }
+      return { status: 404, body: {} };
+    };
+
+    const page = await fetchArea('teachers');
+    expect((page.rows[0] as { schools: string[] }).schools).toEqual(['Tail School']);
   });
 });
 

--- a/__tests__/unit/lib/sis/oneroster-directory.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-directory.test.ts
@@ -1,0 +1,62 @@
+/**
+ * SPE-436 · the directory module CALLS the real SSRF guard (the SPE-396
+ * lesson: a guard with tests of its internals and no test that anything calls
+ * it is deletable with a green suite). DNS is mocked under the real guard;
+ * the observable consequence is that no client is ever constructed.
+ */
+const mockLookup = jest.fn();
+jest.mock('dns/promises', () => ({ lookup: (...a: unknown[]) => mockLookup(...a) }));
+
+const constructed: string[] = [];
+jest.mock('@/lib/integrations/oneroster', () => {
+  const actual = jest.requireActual('@/lib/integrations/oneroster');
+  return {
+    ...actual,
+    OneRosterClient: class {
+      constructor(config: { tokenUrl: string }) {
+        constructed.push(config.tokenUrl);
+      }
+      getSchools = jest.fn().mockResolvedValue([]);
+      getTeachers = jest.fn().mockResolvedValue([]);
+      getStudents = jest.fn().mockResolvedValue([]);
+      getClasses = jest.fn().mockResolvedValue([]);
+    },
+  };
+});
+
+import { fetchDirectoryPage } from '@/lib/sis/oneroster-directory';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  constructed.length = 0;
+});
+
+const PARAMS = {
+  baseUrl: 'https://data.example.com/admin',
+  tokenUrl: 'https://data.example.com/admin/token',
+  clientId: 'id',
+  clientSecret: 'secret',
+  area: 'teachers' as const,
+};
+
+it('refuses a privately-resolving address before any client exists', async () => {
+  mockLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+
+  await expect(fetchDirectoryPage(PARAMS)).rejects.toThrow();
+  expect(constructed).toHaveLength(0);
+});
+
+it('proceeds on public resolution, using the stored token address verbatim', async () => {
+  mockLookup.mockResolvedValue([{ address: '104.16.0.1', family: 4 }]);
+
+  const page = await fetchDirectoryPage(PARAMS);
+  expect(constructed).toEqual(['https://data.example.com/admin/token']);
+  expect(page.rows).toEqual([]);
+});
+
+it('derives the first candidate when no token address is stored — and still guards it', async () => {
+  mockLookup.mockResolvedValue([{ address: '104.16.0.1', family: 4 }]);
+
+  await fetchDirectoryPage({ ...PARAMS, tokenUrl: null });
+  expect(constructed).toEqual(['https://data.example.com/admin/token']);
+});

--- a/__tests__/unit/lib/sis/oneroster-directory.test.ts
+++ b/__tests__/unit/lib/sis/oneroster-directory.test.ts
@@ -59,4 +59,7 @@ it('derives the first candidate when no token address is stored — and still gu
 
   await fetchDirectoryPage({ ...PARAMS, tokenUrl: null });
   expect(constructed).toEqual(['https://data.example.com/admin/token']);
+  // "Still guards it" means the derived address went through DNS resolution
+  // too — one lookup per URL (CodeRabbit, PR #830).
+  expect(mockLookup).toHaveBeenCalledTimes(2);
 });

--- a/app/(dashboard)/dashboard/admin/directories/page.tsx
+++ b/app/(dashboard)/dashboard/admin/directories/page.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+/**
+ * District admin → Directories (SPE-436). Read-only browser over the
+ * district's own SIS data, live per request — the owner's Phase 0: see the
+ * data populate cleanly BEFORE any of it flows into Speddy records.
+ *
+ * Everything shown here came through the server route's picked shapes; this
+ * page adds no fields, stores nothing, and offers no actions but "look".
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Card } from '@/app/components/ui/card';
+
+type Area = 'teachers' | 'students' | 'classes' | 'schools';
+
+interface Stat {
+  label: string;
+  value: string;
+}
+
+interface PersonRow {
+  sourcedId: string;
+  name: string;
+  email: string | null;
+  identifier: string | null;
+  grades: string[];
+  schools: string[];
+}
+
+interface ClassRow {
+  sourcedId: string;
+  title: string;
+  classType: string | null;
+  subjects: string[];
+  periods: string[];
+  grades: string[];
+}
+
+interface SchoolRow {
+  sourcedId: string;
+  name: string;
+  identifier: string | null;
+  type: string | null;
+}
+
+interface Page {
+  area: Area;
+  rows: (PersonRow | ClassRow | SchoolRow)[];
+  offset: number;
+  pageFull: boolean;
+  stats: Stat[];
+}
+
+const AREA_LABELS: Record<Area, string> = {
+  teachers: 'Teachers',
+  students: 'Students',
+  classes: 'Classes',
+  schools: 'Schools',
+};
+
+const AREAS: Area[] = ['teachers', 'students', 'classes', 'schools'];
+
+const join = (values: string[]) => (values.length ? values.join(', ') : '—');
+const dash = (value: string | null) => value ?? '—';
+
+export default function DirectoriesPage() {
+  const [area, setArea] = useState<Area>('teachers');
+  const [rows, setRows] = useState<Page['rows']>([]);
+  const [stats, setStats] = useState<Stat[]>([]);
+  const [pageFull, setPageFull] = useState(false);
+  const [nextOffset, setNextOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const load = useCallback(async (target: Area, offset: number, append: boolean) => {
+    if (append) {
+      setLoadingMore(true);
+    } else {
+      setLoading(true);
+      setNotice(null);
+      setRows([]);
+      setStats([]);
+    }
+    try {
+      const res = await fetch(`/api/district/sis-directory?area=${target}&offset=${offset}`);
+      const body = (await res.json()) as Page & { error?: string };
+      if (!res.ok) {
+        setNotice(body.error ?? 'Something went wrong loading this directory.');
+        return;
+      }
+      setRows((prev) => (append ? [...prev, ...body.rows] : body.rows));
+      setStats(body.stats);
+      setPageFull(body.pageFull);
+      setNextOffset(body.offset + body.rows.length);
+    } catch {
+      setNotice('Something went wrong loading this directory. Try again in a moment.');
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load(area, 0, false);
+  }, [area, load]);
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto space-y-4">
+      <div>
+        <h1 className="text-2xl font-semibold text-slate-900">Directories</h1>
+        <p className="text-sm text-slate-500 mt-1">
+          What your district&apos;s SIS shares with Speddy, read live — nothing here is saved into
+          Speddy yet.
+        </p>
+      </div>
+
+      <div className="flex gap-2" role="tablist" aria-label="Directory areas">
+        {AREAS.map((a) => (
+          <button
+            key={a}
+            role="tab"
+            aria-selected={area === a}
+            onClick={() => setArea(a)}
+            className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+              area === a
+                ? 'bg-slate-900 text-white'
+                : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+            }`}
+          >
+            {AREA_LABELS[a]}
+          </button>
+        ))}
+      </div>
+
+      <Card className="p-4">
+        {loading ? (
+          <p className="text-sm text-slate-500 py-8 text-center">
+            Reading {AREA_LABELS[area].toLowerCase()} from your SIS…
+          </p>
+        ) : notice ? (
+          <p className="text-sm text-slate-600 py-8 text-center">{notice}</p>
+        ) : (
+          <>
+            <div className="flex flex-wrap gap-2 mb-4">
+              {stats.map((s) => (
+                <span
+                  key={s.label}
+                  className="inline-flex items-baseline gap-1.5 rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-600"
+                >
+                  <span className="font-semibold text-slate-900">{s.value}</span>
+                  {s.label}
+                </span>
+              ))}
+              {pageFull && (
+                <span className="inline-flex items-center rounded-full bg-amber-50 px-3 py-1 text-xs text-amber-700">
+                  Showing the first {rows.length} — counts describe what&apos;s loaded
+                </span>
+              )}
+            </div>
+
+            {rows.length === 0 ? (
+              <p className="text-sm text-slate-500 py-6 text-center">
+                Your SIS answered, with nothing in this area.
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-xs uppercase tracking-wide text-slate-400 border-b border-slate-200">
+                      {(area === 'teachers' || area === 'students') && (
+                        <>
+                          <th className="py-2 pr-4">Name</th>
+                          <th className="py-2 pr-4">Email</th>
+                          <th className="py-2 pr-4">{area === 'teachers' ? 'Staff ID' : 'District ID'}</th>
+                          <th className="py-2 pr-4">Grades</th>
+                          <th className="py-2">School</th>
+                        </>
+                      )}
+                      {area === 'classes' && (
+                        <>
+                          <th className="py-2 pr-4">Class</th>
+                          <th className="py-2 pr-4">Type</th>
+                          <th className="py-2 pr-4">Subjects</th>
+                          <th className="py-2 pr-4">Periods</th>
+                          <th className="py-2">Grades</th>
+                        </>
+                      )}
+                      {area === 'schools' && (
+                        <>
+                          <th className="py-2 pr-4">School</th>
+                          <th className="py-2 pr-4">Code</th>
+                          <th className="py-2">Type</th>
+                        </>
+                      )}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100">
+                    {rows.map((row) => (
+                      <tr key={row.sourcedId} className="text-slate-700">
+                        {(area === 'teachers' || area === 'students') && (
+                          <>
+                            <td className="py-2 pr-4 font-medium text-slate-900">
+                              {(row as PersonRow).name}
+                            </td>
+                            <td className="py-2 pr-4">{dash((row as PersonRow).email)}</td>
+                            <td className="py-2 pr-4 font-mono text-xs">
+                              {dash((row as PersonRow).identifier)}
+                            </td>
+                            <td className="py-2 pr-4">{join((row as PersonRow).grades)}</td>
+                            <td className="py-2">{join((row as PersonRow).schools)}</td>
+                          </>
+                        )}
+                        {area === 'classes' && (
+                          <>
+                            <td className="py-2 pr-4 font-medium text-slate-900">
+                              {(row as ClassRow).title}
+                            </td>
+                            <td className="py-2 pr-4">{dash((row as ClassRow).classType)}</td>
+                            <td className="py-2 pr-4">{join((row as ClassRow).subjects)}</td>
+                            <td className="py-2 pr-4">{join((row as ClassRow).periods)}</td>
+                            <td className="py-2">{join((row as ClassRow).grades)}</td>
+                          </>
+                        )}
+                        {area === 'schools' && (
+                          <>
+                            <td className="py-2 pr-4 font-medium text-slate-900">
+                              {(row as SchoolRow).name}
+                            </td>
+                            <td className="py-2 pr-4 font-mono text-xs">
+                              {dash((row as SchoolRow).identifier)}
+                            </td>
+                            <td className="py-2">{dash((row as SchoolRow).type)}</td>
+                          </>
+                        )}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            {pageFull && (
+              <div className="mt-4 text-center">
+                <button
+                  onClick={() => void load(area, nextOffset, true)}
+                  disabled={loadingMore}
+                  className="px-4 py-2 rounded-md bg-slate-100 text-sm font-medium text-slate-700 hover:bg-slate-200 disabled:opacity-50"
+                >
+                  {loadingMore ? 'Loading…' : 'Load more'}
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/admin/directories/page.tsx
+++ b/app/(dashboard)/dashboard/admin/directories/page.tsx
@@ -32,7 +32,7 @@ const AREA_LABELS: Record<DirectoryArea, string> = {
 
 const AREAS: DirectoryArea[] = ['teachers', 'students', 'classes', 'schools'];
 
-const join = (values: string[]) => (values.length ? values.join(', ') : '—');
+const join = (values: string[] | undefined) => (values?.length ? values.join(', ') : '—');
 const dash = (value: string | null) => value ?? '—';
 const formatStat = (s: DirectoryStat) => (s.of === undefined ? String(s.n) : `${s.n} of ${s.of}`);
 
@@ -123,6 +123,28 @@ export default function DirectoriesPage() {
     void load(area, 0, false);
   }, [area, load]);
 
+  /**
+   * Tab switches clear the table SYNCHRONOUSLY. The effect above also clears
+   * it, but only after a render in which the old area's rows would already
+   * have met the new area's columns — person rows under class headers is a
+   * crash, not a flicker (Codex, PR #830).
+   */
+  const switchArea = (target: DirectoryArea) => {
+    if (target === area) return;
+    // Kill any in-flight response NOW: until the effect's load() bumps the
+    // sequence, an old response would still pass the seq check and land its
+    // old-shape rows under the new columns (CodeRabbit, PR #830).
+    requestSeq.current += 1;
+    setRows([]);
+    setStats([]);
+    setNotice(null);
+    setAppendNotice(null);
+    setExhausted(false);
+    setMayHaveMore(false);
+    setLoading(true);
+    setArea(target);
+  };
+
   return (
     <div className="p-6 max-w-6xl mx-auto space-y-4">
       <div>
@@ -139,7 +161,7 @@ export default function DirectoriesPage() {
             key={a}
             role="tab"
             aria-selected={area === a}
-            onClick={() => setArea(a)}
+            onClick={() => switchArea(a)}
             className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
               area === a
                 ? 'bg-slate-900 text-white'

--- a/app/(dashboard)/dashboard/admin/directories/page.tsx
+++ b/app/(dashboard)/dashboard/admin/directories/page.tsx
@@ -7,98 +7,115 @@
  *
  * Everything shown here came through the server route's picked shapes; this
  * page adds no fields, stores nothing, and offers no actions but "look".
+ * Row/stat types are imported type-only from the server module — erased at
+ * build time, so the server-only code never enters the client bundle, and the
+ * shapes cannot drift from what the route actually returns.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Card } from '@/app/components/ui/card';
+import type {
+  DirectoryArea,
+  DirectoryClassRow,
+  DirectoryPage,
+  DirectoryPersonRow,
+  DirectorySchoolRow,
+  DirectoryStat,
+} from '@/lib/sis/oneroster-directory';
 
-type Area = 'teachers' | 'students' | 'classes' | 'schools';
-
-interface Stat {
-  label: string;
-  value: string;
-}
-
-interface PersonRow {
-  sourcedId: string;
-  name: string;
-  email: string | null;
-  identifier: string | null;
-  grades: string[];
-  schools: string[];
-}
-
-interface ClassRow {
-  sourcedId: string;
-  title: string;
-  classType: string | null;
-  subjects: string[];
-  periods: string[];
-  grades: string[];
-}
-
-interface SchoolRow {
-  sourcedId: string;
-  name: string;
-  identifier: string | null;
-  type: string | null;
-}
-
-interface Page {
-  area: Area;
-  rows: (PersonRow | ClassRow | SchoolRow)[];
-  offset: number;
-  pageFull: boolean;
-  stats: Stat[];
-}
-
-const AREA_LABELS: Record<Area, string> = {
+const AREA_LABELS: Record<DirectoryArea, string> = {
   teachers: 'Teachers',
   students: 'Students',
   classes: 'Classes',
   schools: 'Schools',
 };
 
-const AREAS: Area[] = ['teachers', 'students', 'classes', 'schools'];
+const AREAS: DirectoryArea[] = ['teachers', 'students', 'classes', 'schools'];
 
 const join = (values: string[]) => (values.length ? values.join(', ') : '—');
 const dash = (value: string | null) => value ?? '—';
+const formatStat = (s: DirectoryStat) => (s.of === undefined ? String(s.n) : `${s.n} of ${s.of}`);
+
+/** Sum page stats by label, so badges describe everything loaded, not the last page. */
+function sumStats(prev: DirectoryStat[], next: DirectoryStat[]): DirectoryStat[] {
+  const byLabel = new Map(prev.map((s) => [s.label, { ...s }]));
+  for (const stat of next) {
+    const existing = byLabel.get(stat.label);
+    if (!existing) {
+      byLabel.set(stat.label, { ...stat });
+    } else {
+      existing.n += stat.n;
+      if (existing.of !== undefined || stat.of !== undefined) {
+        existing.of = (existing.of ?? 0) + (stat.of ?? 0);
+      }
+    }
+  }
+  return [...byLabel.values()];
+}
 
 export default function DirectoriesPage() {
-  const [area, setArea] = useState<Area>('teachers');
-  const [rows, setRows] = useState<Page['rows']>([]);
-  const [stats, setStats] = useState<Stat[]>([]);
-  const [pageFull, setPageFull] = useState(false);
+  const [area, setArea] = useState<DirectoryArea>('teachers');
+  const [rows, setRows] = useState<DirectoryPage['rows']>([]);
+  const [stats, setStats] = useState<DirectoryStat[]>([]);
   const [nextOffset, setNextOffset] = useState(0);
+  /** Last page had rows — more MAY exist. Never trusts the requested limit. */
+  const [mayHaveMore, setMayHaveMore] = useState(false);
+  const [exhausted, setExhausted] = useState(false);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
+  const [appendNotice, setAppendNotice] = useState<string | null>(null);
+  /**
+   * Latest-request-wins: a slow response for a previous tab must not land in
+   * the current one — person rows rendered under class columns is a crash.
+   */
+  const requestSeq = useRef(0);
 
-  const load = useCallback(async (target: Area, offset: number, append: boolean) => {
+  const load = useCallback(async (target: DirectoryArea, offset: number, append: boolean) => {
+    const seq = ++requestSeq.current;
     if (append) {
       setLoadingMore(true);
+      setAppendNotice(null);
     } else {
       setLoading(true);
       setNotice(null);
+      setAppendNotice(null);
       setRows([]);
       setStats([]);
+      setExhausted(false);
+      setMayHaveMore(false);
     }
     try {
       const res = await fetch(`/api/district/sis-directory?area=${target}&offset=${offset}`);
-      const body = (await res.json()) as Page & { error?: string };
+      const body = (await res.json()) as DirectoryPage & { error?: string };
+      if (seq !== requestSeq.current) return; // a newer request owns the screen
       if (!res.ok) {
-        setNotice(body.error ?? 'Something went wrong loading this directory.');
+        const message = body.error ?? 'Something went wrong loading this directory.';
+        if (append) {
+          setAppendNotice(message);
+        } else {
+          setNotice(message);
+        }
         return;
       }
       setRows((prev) => (append ? [...prev, ...body.rows] : body.rows));
-      setStats(body.stats);
-      setPageFull(body.pageFull);
-      setNextOffset(body.offset + body.rows.length);
+      setStats((prev) => (append ? sumStats(prev, body.stats) : body.stats));
+      setNextOffset(offset + body.rows.length);
+      setMayHaveMore(body.rows.length > 0);
+      if (append && body.rows.length === 0) setExhausted(true);
     } catch {
-      setNotice('Something went wrong loading this directory. Try again in a moment.');
+      if (seq !== requestSeq.current) return;
+      const message = 'Something went wrong loading this directory. Try again in a moment.';
+      if (append) {
+        setAppendNotice(message);
+      } else {
+        setNotice(message);
+      }
     } finally {
-      setLoading(false);
-      setLoadingMore(false);
+      if (seq === requestSeq.current) {
+        setLoading(false);
+        setLoadingMore(false);
+      }
     }
   }, []);
 
@@ -149,13 +166,13 @@ export default function DirectoriesPage() {
                   key={s.label}
                   className="inline-flex items-baseline gap-1.5 rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-600"
                 >
-                  <span className="font-semibold text-slate-900">{s.value}</span>
+                  <span className="font-semibold text-slate-900">{formatStat(s)}</span>
                   {s.label}
                 </span>
               ))}
-              {pageFull && (
+              {mayHaveMore && !exhausted && (
                 <span className="inline-flex items-center rounded-full bg-amber-50 px-3 py-1 text-xs text-amber-700">
-                  Showing the first {rows.length} — counts describe what&apos;s loaded
+                  Counts describe the {rows.length} loaded so far
                 </span>
               )}
             </div>
@@ -173,7 +190,9 @@ export default function DirectoriesPage() {
                         <>
                           <th className="py-2 pr-4">Name</th>
                           <th className="py-2 pr-4">Email</th>
-                          <th className="py-2 pr-4">{area === 'teachers' ? 'Staff ID' : 'District ID'}</th>
+                          <th className="py-2 pr-4">
+                            {area === 'teachers' ? 'Staff ID' : 'District ID'}
+                          </th>
                           <th className="py-2 pr-4">Grades</th>
                           <th className="py-2">School</th>
                         </>
@@ -202,36 +221,36 @@ export default function DirectoriesPage() {
                         {(area === 'teachers' || area === 'students') && (
                           <>
                             <td className="py-2 pr-4 font-medium text-slate-900">
-                              {(row as PersonRow).name}
+                              {(row as DirectoryPersonRow).name}
                             </td>
-                            <td className="py-2 pr-4">{dash((row as PersonRow).email)}</td>
+                            <td className="py-2 pr-4">{dash((row as DirectoryPersonRow).email)}</td>
                             <td className="py-2 pr-4 font-mono text-xs">
-                              {dash((row as PersonRow).identifier)}
+                              {dash((row as DirectoryPersonRow).identifier)}
                             </td>
-                            <td className="py-2 pr-4">{join((row as PersonRow).grades)}</td>
-                            <td className="py-2">{join((row as PersonRow).schools)}</td>
+                            <td className="py-2 pr-4">{join((row as DirectoryPersonRow).grades)}</td>
+                            <td className="py-2">{join((row as DirectoryPersonRow).schools)}</td>
                           </>
                         )}
                         {area === 'classes' && (
                           <>
                             <td className="py-2 pr-4 font-medium text-slate-900">
-                              {(row as ClassRow).title}
+                              {(row as DirectoryClassRow).title}
                             </td>
-                            <td className="py-2 pr-4">{dash((row as ClassRow).classType)}</td>
-                            <td className="py-2 pr-4">{join((row as ClassRow).subjects)}</td>
-                            <td className="py-2 pr-4">{join((row as ClassRow).periods)}</td>
-                            <td className="py-2">{join((row as ClassRow).grades)}</td>
+                            <td className="py-2 pr-4">{dash((row as DirectoryClassRow).classType)}</td>
+                            <td className="py-2 pr-4">{join((row as DirectoryClassRow).subjects)}</td>
+                            <td className="py-2 pr-4">{join((row as DirectoryClassRow).periods)}</td>
+                            <td className="py-2">{join((row as DirectoryClassRow).grades)}</td>
                           </>
                         )}
                         {area === 'schools' && (
                           <>
                             <td className="py-2 pr-4 font-medium text-slate-900">
-                              {(row as SchoolRow).name}
+                              {(row as DirectorySchoolRow).name}
                             </td>
                             <td className="py-2 pr-4 font-mono text-xs">
-                              {dash((row as SchoolRow).identifier)}
+                              {dash((row as DirectorySchoolRow).identifier)}
                             </td>
-                            <td className="py-2">{dash((row as SchoolRow).type)}</td>
+                            <td className="py-2">{dash((row as DirectorySchoolRow).type)}</td>
                           </>
                         )}
                       </tr>
@@ -241,8 +260,8 @@ export default function DirectoriesPage() {
               </div>
             )}
 
-            {pageFull && (
-              <div className="mt-4 text-center">
+            {mayHaveMore && !exhausted && rows.length > 0 && (
+              <div className="mt-4 text-center space-y-2">
                 <button
                   onClick={() => void load(area, nextOffset, true)}
                   disabled={loadingMore}
@@ -250,7 +269,13 @@ export default function DirectoriesPage() {
                 >
                   {loadingMore ? 'Loading…' : 'Load more'}
                 </button>
+                {appendNotice && <p className="text-xs text-amber-700">{appendNotice}</p>}
               </div>
+            )}
+            {exhausted && rows.length > 0 && (
+              <p className="mt-4 text-center text-xs text-slate-400">
+                That&apos;s everything your SIS lists here.
+              </p>
             )}
           </>
         )}

--- a/app/api/district/sis-directory/route.ts
+++ b/app/api/district/sis-directory/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withRoute } from '@/lib/api/with-route';
+import { resolveDistrictSisCaller } from '@/lib/api/district-sis-caller';
+import { logger } from '@/lib/logger';
+import { getDecryptedCredential, listConnections } from '@/lib/sis/connections';
+import {
+  DIRECTORY_AREAS,
+  fetchDirectoryPage,
+  type DirectoryArea,
+} from '@/lib/sis/oneroster-directory';
+
+const log = logger.child({ module: 'district-sis-directory' });
+
+const querySchema = z.object({
+  area: z.enum(DIRECTORY_AREAS as [DirectoryArea, ...DirectoryArea[]]),
+  offset: z.coerce.number().int().min(0).max(100_000).default(0),
+});
+
+/**
+ * GET /api/district/sis-directory?area=teachers — one read-only directory
+ * page, live from the caller's own district's OneRoster server (SPE-436).
+ *
+ * Authorization is `resolveDistrictSisCaller` (SPE-396's seam): district_admin
+ * or district_tech, the district comes from the caller's own grants, and a
+ * request can never name one. The decrypted credential exists only inside this
+ * request; the response carries the picked rows and aggregate stats, nothing
+ * else — see `oneroster-directory.ts` for why the pick is the contract.
+ *
+ * Rate-limited like the SIS test routes: every call reaches a school
+ * district's production server (teachers/students cost two upstream reads —
+ * the area plus the school-name map).
+ */
+export const GET = withRoute(
+  {
+    query: querySchema,
+    rateLimit: { requests: 12, windowSeconds: 60, name: 'district-sis-directory' },
+  },
+  async ({ userId, query }) => {
+    const caller = await resolveDistrictSisCaller(userId);
+    if (!caller.ok) {
+      log.warn('Non-district-admin tried to read the SIS directory', {
+        userId,
+        denied: caller.denied,
+      });
+      return NextResponse.json(
+        { error: 'Forbidden: district admin access required' },
+        { status: 403 },
+      );
+    }
+
+    // Wrapped: withRoute's catch echoes error.message to the client in
+    // development, and a Supabase error names tables and constraints.
+    let connections;
+    try {
+      connections = await listConnections(caller.districtId);
+    } catch (err) {
+      log.error('Failed to load SIS connections for the directory', err, {
+        districtId: caller.districtId,
+      });
+      return NextResponse.json({ error: 'Could not load your connection.' }, { status: 500 });
+    }
+
+    const connection = connections.find((c) => c.sis_type === 'oneroster');
+    if (!connection || !connection.base_url) {
+      // Not an error state: directories simply need the OneRoster connection
+      // to exist first. The page words this as setup guidance.
+      return NextResponse.json(
+        { error: 'Directories need a OneRoster connection. Set one up in the tech portal first.' },
+        { status: 409 },
+      );
+    }
+
+    let credential: Awaited<ReturnType<typeof getDecryptedCredential>> = null;
+    try {
+      credential = await getDecryptedCredential(connection.id);
+    } catch (err) {
+      log.error('Could not decrypt the stored SIS credential for the directory', err, {
+        connectionId: connection.id,
+      });
+    }
+    if (!credential || credential.sisType !== 'oneroster') {
+      return NextResponse.json(
+        { error: 'No OneRoster credentials are stored yet, so there is nothing to show.' },
+        { status: 409 },
+      );
+    }
+
+    try {
+      const page = await fetchDirectoryPage({
+        baseUrl: connection.base_url,
+        tokenUrl: connection.token_url,
+        clientId: credential.clientId,
+        clientSecret: credential.clientSecret,
+        area: query.area,
+        offset: query.offset,
+      });
+
+      // Counts only — the established SIS logging discipline. Which area a
+      // district admin browsed is operational; what it contained is not ours
+      // to keep.
+      log.info('SIS directory page served', {
+        districtId: caller.districtId,
+        role: caller.role,
+        area: page.area,
+        offset: page.offset,
+        rows: page.rows.length,
+      });
+
+      return NextResponse.json(page);
+    } catch (err) {
+      // The lib throws for unreachable/refusing servers and guard refusals.
+      // The admin's fix is the same either way: run the connection test in
+      // the tech portal, where the step-by-step diagnostics live.
+      log.error('SIS directory fetch failed', err, {
+        districtId: caller.districtId,
+        area: query.area,
+      });
+      return NextResponse.json(
+        {
+          error:
+            'Could not reach your OneRoster server just now. Run the connection test in the tech portal to see exactly what is wrong.',
+        },
+        { status: 502 },
+      );
+    }
+  },
+);

--- a/app/api/district/sis-directory/route.ts
+++ b/app/api/district/sis-directory/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { withRoute } from '@/lib/api/with-route';
 import { resolveDistrictSisCaller } from '@/lib/api/district-sis-caller';
+import { createServiceClient } from '@/lib/supabase/server';
 import { logger } from '@/lib/logger';
 import { getDecryptedCredential, listConnections } from '@/lib/sis/connections';
 import {
@@ -13,7 +14,7 @@ import {
 const log = logger.child({ module: 'district-sis-directory' });
 
 const querySchema = z.object({
-  area: z.enum(DIRECTORY_AREAS as [DirectoryArea, ...DirectoryArea[]]),
+  area: z.enum(DIRECTORY_AREAS),
   offset: z.coerce.number().int().min(0).max(100_000).default(0),
 });
 
@@ -28,8 +29,9 @@ const querySchema = z.object({
  * else — see `oneroster-directory.ts` for why the pick is the contract.
  *
  * Rate-limited like the SIS test routes: every call reaches a school
- * district's production server (teachers/students cost two upstream reads —
- * the area plus the school-name map).
+ * district's production server (teachers/students cost the area read plus the
+ * school-name map — up to six upstream reads for a district with hundreds of
+ * schools).
  */
 export const GET = withRoute(
   {
@@ -47,6 +49,33 @@ export const GET = withRoute(
         { error: 'Forbidden: district admin access required' },
         { status: 403 },
       );
+    }
+
+    // DIRECTORIES ARE DISTRICT-ADMIN ONLY. The shared seam admits
+    // district_tech too — right for connection management, wrong here:
+    // `district_tech` has no right to student data (SPE-393), and this route
+    // serves student names, IDs and grades. The seam also REPORTS
+    // district_tech when a caller holds both grants, so a tech-role answer
+    // gets one more look at the grants before it is refused (Codex, PR #830).
+    if (caller.role !== 'district_admin') {
+      const { data: adminGrant } = await createServiceClient()
+        .from('admin_permissions')
+        .select('id')
+        .eq('admin_id', userId)
+        .eq('role', 'district_admin')
+        .eq('district_id', caller.districtId)
+        .limit(1)
+        .maybeSingle();
+      if (!adminGrant) {
+        log.warn('district_tech tried to read the SIS directory', {
+          userId,
+          districtId: caller.districtId,
+        });
+        return NextResponse.json(
+          { error: 'Forbidden: directories are for district admins.' },
+          { status: 403 },
+        );
+      }
     }
 
     // Wrapped: withRoute's catch echoes error.message to the client in
@@ -75,9 +104,16 @@ export const GET = withRoute(
     try {
       credential = await getDecryptedCredential(connection.id);
     } catch (err) {
+      // Distinct from "not stored yet": telling an admin to enter credentials
+      // that exist hides an operational fault (likely a key rotation) behind
+      // setup guidance (CodeRabbit, PR #830).
       log.error('Could not decrypt the stored SIS credential for the directory', err, {
         connectionId: connection.id,
       });
+      return NextResponse.json(
+        { error: 'Your stored OneRoster credential could not be read. Re-save it in the tech portal.' },
+        { status: 500 },
+      );
     }
     if (!credential || credential.sisType !== 'oneroster') {
       return NextResponse.json(

--- a/app/components/navigation/navbar.tsx
+++ b/app/components/navigation/navbar.tsx
@@ -95,10 +95,12 @@ export default function Navbar() {
     }
 
     if (role === 'district_admin') {
-      // District admins see schools overview, dashboard, curriculums, and CARE
+      // District admins see schools overview, dashboard, curriculums, CARE,
+      // and the SIS directories (SPE-436).
       return [
         { name: 'Dashboard', href: '/dashboard/admin' },
         { name: 'Schools', href: '/dashboard/admin/schools' },
+        { name: 'Directories', href: '/dashboard/admin/directories' },
         { name: 'Curriculums', href: '/dashboard/admin/curriculums' },
         { name: 'CARE', href: '/dashboard/admin/care' },
       ];

--- a/lib/sis/oneroster-directory.ts
+++ b/lib/sis/oneroster-directory.ts
@@ -16,6 +16,7 @@
  *
  * Server-only: dials an external SIS with a decrypted credential.
  */
+import { logger } from '@/lib/logger';
 import {
   OneRosterClient,
   type RawOneRosterClass,
@@ -25,9 +26,9 @@ import {
 import { ONEROSTER_URL_LABELS, assertSafeSisUrl } from './ssrf-guard';
 import { oneRosterTokenUrlCandidates } from './oneroster-setup';
 
-export type DirectoryArea = 'teachers' | 'students' | 'classes' | 'schools';
+export const DIRECTORY_AREAS = ['teachers', 'students', 'classes', 'schools'] as const;
 
-export const DIRECTORY_AREAS: DirectoryArea[] = ['teachers', 'students', 'classes', 'schools'];
+export type DirectoryArea = (typeof DIRECTORY_AREAS)[number];
 
 /** One page per request. JSUSD-sized areas fit in one; larger districts page. */
 export const DIRECTORY_PAGE_SIZE = 200;
@@ -234,9 +235,15 @@ export async function fetchDirectoryPage(params: {
       }
       if (batch.length < DIRECTORY_PAGE_SIZE) break;
     }
-  } catch {
+  } catch (err) {
     // A directory without school names is degraded, not dead — rows still
-    // render, the schools column is simply empty.
+    // render, the schools column is simply empty. Logged, because that state
+    // is otherwise indistinguishable from the SIS not linking anyone
+    // (CodeRabbit, PR #830). Our own error strings only, never response text.
+    logger.warn('Directory school-name map unavailable; school column will be empty', {
+      area: params.area,
+      error: err instanceof Error ? err.message : 'unknown',
+    });
   }
 
   const rawRows =

--- a/lib/sis/oneroster-directory.ts
+++ b/lib/sis/oneroster-directory.ts
@@ -64,10 +64,16 @@ export interface DirectorySchoolRow {
 
 export type DirectoryRow = DirectoryPersonRow | DirectoryClassRow | DirectorySchoolRow;
 
-/** A named number the panel shows above the table — the owner's "our check". */
+/**
+ * A named count the panel shows above the table — the owner's "our check".
+ * Numeric on purpose: the client sums stats across appended pages by label,
+ * so counting stays server-side and only formatting lives in the page.
+ */
 export interface DirectoryStat {
   label: string;
-  value: string;
+  n: number;
+  /** When present, renders as "n of of" — a coverage ratio. */
+  of?: number;
 }
 
 export interface DirectoryPage {
@@ -126,29 +132,29 @@ function pickSchool(raw: RawOneRosterSchool): DirectorySchoolRow {
   };
 }
 
-const pct = (n: number, of: number) => (of === 0 ? '0' : `${n} of ${of}`);
-
 function personStats(rows: DirectoryPersonRow[], noun: string): DirectoryStat[] {
   const withEmail = rows.filter((r) => r.email).length;
   const withId = rows.filter((r) => r.identifier).length;
   const withGrade = rows.filter((r) => r.grades.length > 0).length;
   return [
-    { label: `${noun} listed`, value: String(rows.length) },
-    { label: 'with an email', value: pct(withEmail, rows.length) },
-    { label: noun === 'Students' ? 'with a district ID' : 'with a staff ID', value: pct(withId, rows.length) },
-    { label: 'with a grade level', value: pct(withGrade, rows.length) },
+    { label: `${noun} listed`, n: rows.length },
+    { label: 'with an email', n: withEmail, of: rows.length },
+    { label: noun === 'Students' ? 'with a district ID' : 'with a staff ID', n: withId, of: rows.length },
+    { label: 'with a grade level', n: withGrade, of: rows.length },
   ];
 }
 
 function classStats(rows: DirectoryClassRow[]): DirectoryStat[] {
   const homeroom = rows.filter((r) => r.classType === 'homeroom').length;
   const scheduled = rows.filter((r) => r.classType === 'scheduled').length;
-  const other = rows.length - homeroom - scheduled;
+  const untyped = rows.length - homeroom - scheduled;
   const withSubject = rows.filter((r) => r.subjects.length > 0).length;
   return [
-    { label: 'Classes listed', value: String(rows.length) },
-    { label: 'homeroom / scheduled', value: `${homeroom} / ${scheduled}${other ? ` (+${other} untyped)` : ''}` },
-    { label: 'with a subject', value: pct(withSubject, rows.length) },
+    { label: 'Classes listed', n: rows.length },
+    { label: 'homeroom', n: homeroom },
+    { label: 'scheduled', n: scheduled },
+    { label: 'untyped', n: untyped },
+    { label: 'with a subject', n: withSubject, of: rows.length },
   ];
 }
 
@@ -194,7 +200,7 @@ export async function fetchDirectoryPage(params: {
       rows,
       offset,
       pageFull: rows.length === DIRECTORY_PAGE_SIZE,
-      stats: [{ label: 'Schools listed', value: String(rows.length) }],
+      stats: [{ label: 'Schools listed', n: rows.length }],
     };
   }
 
@@ -213,9 +219,20 @@ export async function fetchDirectoryPage(params: {
   // own /schools list is small and resolves them in one extra read.
   const schoolNames = new Map<string, string>();
   try {
-    for (const school of await client.getSchools({ limit: DIRECTORY_PAGE_SIZE })) {
-      const name = str(school.name);
-      if (name) schoolNames.set(school.sourcedId, name);
+    // Follow full pages a few deep: a first page that comes back full may be
+    // a truncation, and a person whose school fell off the map would render
+    // an empty School column — indistinguishable from the SIS not linking
+    // them, which is exactly the data-quality signal this surface displays.
+    for (let page = 0; page < 5; page += 1) {
+      const batch = await client.getSchools({
+        limit: DIRECTORY_PAGE_SIZE,
+        offset: page * DIRECTORY_PAGE_SIZE,
+      });
+      for (const school of batch) {
+        const name = str(school.name);
+        if (name) schoolNames.set(school.sourcedId, name);
+      }
+      if (batch.length < DIRECTORY_PAGE_SIZE) break;
     }
   } catch {
     // A directory without school names is degraded, not dead — rows still

--- a/lib/sis/oneroster-directory.ts
+++ b/lib/sis/oneroster-directory.ts
@@ -1,0 +1,235 @@
+/**
+ * Read-only SIS directories for the district admin view (SPE-436).
+ *
+ * Phase 0 of SPE-414, in the owner's sequencing: the district admin SEES the
+ * SIS data populate cleanly before any of it flows into Speddy's own records.
+ * So this module only READS — live from the district's OneRoster server, per
+ * request, nothing stored — and shapes each area into an explicitly picked
+ * row plus data-quality aggregates ("84 of 84 with an email").
+ *
+ * THE PICK IS THE CONTRACT. Raw SIS rows are never spread into a response: a
+ * field this module does not name cannot reach a browser, however much the
+ * vendor's payload carries. That is the same allow-list posture as every SIS
+ * derivation in this codebase (SPE-430/434/435), applied to row shaping — and
+ * it is what keeps this surface inside the no-demographics line even if a
+ * server volunteers more than the spec asks it to.
+ *
+ * Server-only: dials an external SIS with a decrypted credential.
+ */
+import {
+  OneRosterClient,
+  type RawOneRosterClass,
+  type RawOneRosterSchool,
+  type RawOneRosterUser,
+} from '@/lib/integrations/oneroster';
+import { ONEROSTER_URL_LABELS, assertSafeSisUrl } from './ssrf-guard';
+import { oneRosterTokenUrlCandidates } from './oneroster-setup';
+
+export type DirectoryArea = 'teachers' | 'students' | 'classes' | 'schools';
+
+export const DIRECTORY_AREAS: DirectoryArea[] = ['teachers', 'students', 'classes', 'schools'];
+
+/** One page per request. JSUSD-sized areas fit in one; larger districts page. */
+export const DIRECTORY_PAGE_SIZE = 200;
+
+/** A person row — teachers and students share the shape, not the fields' meaning. */
+export interface DirectoryPersonRow {
+  /** OneRoster's stable id — a react key, never displayed as identity. */
+  sourcedId: string;
+  name: string;
+  /** Teachers: work email. Students: student email when the district assigns one. */
+  email: string | null;
+  /** Teachers: staff ID. Students: the district student ID our imports match on. */
+  identifier: string | null;
+  grades: string[];
+  /** School names resolved from the district's own /schools list. */
+  schools: string[];
+}
+
+export interface DirectoryClassRow {
+  sourcedId: string;
+  title: string;
+  classType: string | null;
+  subjects: string[];
+  periods: string[];
+  grades: string[];
+}
+
+export interface DirectorySchoolRow {
+  sourcedId: string;
+  name: string;
+  identifier: string | null;
+  type: string | null;
+}
+
+export type DirectoryRow = DirectoryPersonRow | DirectoryClassRow | DirectorySchoolRow;
+
+/** A named number the panel shows above the table — the owner's "our check". */
+export interface DirectoryStat {
+  label: string;
+  value: string;
+}
+
+export interface DirectoryPage {
+  area: DirectoryArea;
+  rows: DirectoryRow[];
+  offset: number;
+  /**
+   * True when the page came back full — more rows may exist, and every stat
+   * below describes THIS page, not the district. The UI says so.
+   */
+  pageFull: boolean;
+  stats: DirectoryStat[];
+}
+
+const str = (v: unknown): string | null => (typeof v === 'string' && v.trim() ? v.trim() : null);
+const strArray = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string' && x.trim() !== '') : [];
+
+function personName(raw: RawOneRosterUser): string {
+  const given = str(raw.givenName) ?? '';
+  const family = str(raw.familyName) ?? '';
+  const joined = `${given} ${family}`.trim();
+  return joined || '(no name given)';
+}
+
+function pickPerson(raw: RawOneRosterUser, schoolNames: Map<string, string>): DirectoryPersonRow {
+  return {
+    sourcedId: raw.sourcedId,
+    name: personName(raw),
+    email: str(raw.email),
+    identifier: str(raw.identifier),
+    grades: strArray(raw.grades),
+    schools: (raw.orgs ?? [])
+      .map((o) => schoolNames.get(o.sourcedId))
+      .filter((n): n is string => Boolean(n)),
+  };
+}
+
+function pickClass(raw: RawOneRosterClass): DirectoryClassRow {
+  return {
+    sourcedId: raw.sourcedId,
+    title: str(raw.title) ?? '(untitled class)',
+    classType: str(raw.classType),
+    subjects: strArray(raw.subjects),
+    periods: strArray(raw.periods),
+    grades: strArray(raw.grades),
+  };
+}
+
+function pickSchool(raw: RawOneRosterSchool): DirectorySchoolRow {
+  return {
+    sourcedId: raw.sourcedId,
+    name: str(raw.name) ?? '(unnamed school)',
+    identifier: str(raw.identifier),
+    type: str(raw.type),
+  };
+}
+
+const pct = (n: number, of: number) => (of === 0 ? '0' : `${n} of ${of}`);
+
+function personStats(rows: DirectoryPersonRow[], noun: string): DirectoryStat[] {
+  const withEmail = rows.filter((r) => r.email).length;
+  const withId = rows.filter((r) => r.identifier).length;
+  const withGrade = rows.filter((r) => r.grades.length > 0).length;
+  return [
+    { label: `${noun} listed`, value: String(rows.length) },
+    { label: 'with an email', value: pct(withEmail, rows.length) },
+    { label: noun === 'Students' ? 'with a district ID' : 'with a staff ID', value: pct(withId, rows.length) },
+    { label: 'with a grade level', value: pct(withGrade, rows.length) },
+  ];
+}
+
+function classStats(rows: DirectoryClassRow[]): DirectoryStat[] {
+  const homeroom = rows.filter((r) => r.classType === 'homeroom').length;
+  const scheduled = rows.filter((r) => r.classType === 'scheduled').length;
+  const other = rows.length - homeroom - scheduled;
+  const withSubject = rows.filter((r) => r.subjects.length > 0).length;
+  return [
+    { label: 'Classes listed', value: String(rows.length) },
+    { label: 'homeroom / scheduled', value: `${homeroom} / ${scheduled}${other ? ` (+${other} untyped)` : ''}` },
+    { label: 'with a subject', value: pct(withSubject, rows.length) },
+  ];
+}
+
+/**
+ * Fetch one directory page, live from the district's OneRoster server.
+ *
+ * Uses the STORED token address, or the first derived candidate when none is
+ * stored — never the full candidate hunt. Resolution belongs to the connection
+ * test; a directory read against an unhealthy connection should fail fast and
+ * point the admin at the tech portal's test, not go probing a production SIS.
+ */
+export async function fetchDirectoryPage(params: {
+  baseUrl: string;
+  tokenUrl?: string | null;
+  clientId: string;
+  clientSecret: string;
+  area: DirectoryArea;
+  offset?: number;
+}): Promise<DirectoryPage> {
+  const tokenUrl =
+    (params.tokenUrl ?? '').trim() || oneRosterTokenUrlCandidates(params.baseUrl)[0];
+  if (!tokenUrl) throw new Error('This connection has no usable token address.');
+
+  // Re-guarded at dial time like every caller: stored rows can predate the
+  // guard, and DNS answers change (SPE-396's control, kept CALLED).
+  await assertSafeSisUrl(params.baseUrl, ONEROSTER_URL_LABELS);
+  await assertSafeSisUrl(tokenUrl, ONEROSTER_URL_LABELS);
+
+  const client = new OneRosterClient({
+    baseUrl: params.baseUrl,
+    tokenUrl,
+    clientId: params.clientId,
+    clientSecret: params.clientSecret,
+  });
+
+  const offset = Math.max(0, params.offset ?? 0);
+  const paging = { limit: DIRECTORY_PAGE_SIZE, offset };
+
+  if (params.area === 'schools') {
+    const rows = (await client.getSchools(paging)).map(pickSchool);
+    return {
+      area: params.area,
+      rows,
+      offset,
+      pageFull: rows.length === DIRECTORY_PAGE_SIZE,
+      stats: [{ label: 'Schools listed', value: String(rows.length) }],
+    };
+  }
+
+  if (params.area === 'classes') {
+    const rows = (await client.getClasses(paging)).map(pickClass);
+    return {
+      area: params.area,
+      rows,
+      offset,
+      pageFull: rows.length === DIRECTORY_PAGE_SIZE,
+      stats: classStats(rows),
+    };
+  }
+
+  // Teachers and students carry org links, not school names. The district's
+  // own /schools list is small and resolves them in one extra read.
+  const schoolNames = new Map<string, string>();
+  try {
+    for (const school of await client.getSchools({ limit: DIRECTORY_PAGE_SIZE })) {
+      const name = str(school.name);
+      if (name) schoolNames.set(school.sourcedId, name);
+    }
+  } catch {
+    // A directory without school names is degraded, not dead — rows still
+    // render, the schools column is simply empty.
+  }
+
+  const rawRows =
+    params.area === 'teachers' ? await client.getTeachers(paging) : await client.getStudents(paging);
+  const rows = rawRows.map((r) => pickPerson(r, schoolNames));
+  return {
+    area: params.area,
+    rows,
+    offset,
+    pageFull: rows.length === DIRECTORY_PAGE_SIZE,
+    stats: personStats(rows, params.area === 'teachers' ? 'Teachers' : 'Students'),
+  };
+}


### PR DESCRIPTION
## Why

The owner's Phase 0 for roster data (SPE-414 re-sequenced): *"build in directories to the district admin profile to start. Once everything populates in there cleanly (at least based on our check) then we can talk about how that data should flow through to site admins and providers."* The district admin **sees** the SIS data before any of it writes into Speddy records — so this PR reads and renders, and deliberately does nothing else.

## What

**`/dashboard/admin/directories`** (linked from the district admin nav): four tabs — Teachers, Students, Classes, Schools — read **live** from the district's OneRoster server per request. Nothing stored, no schema change, no writes, no site-admin/provider visibility. Each tab leads with the owner's check numbers: email/ID/grade coverage for people, the homeroom-vs-scheduled split for classes (the elementary detector). "Load more" paging that never trusts the requested page size; a district is only called complete after an empty page.

**The pick is the contract** (`lib/sis/oneroster-directory.ts`): raw SIS rows are never spread into a response. Each area maps to an explicitly picked shape, so a field the pick doesn't name cannot reach a browser — even from a server that volunteers demographics the scope never asked for. Pinned by planted-field fixtures (birthDate, sex, race, a password-looking string, a vendor blob) asserted absent from every page; mutation-checked by spreading the raw row (fails two tests).

**Authorization**: `resolveDistrictSisCaller` (SPE-396's seam) — district_admin or district_tech, own district only, scope from the caller's grants; a request naming a district changes nothing, pinned by a test that sends one. SSRF guard on both URLs at dial time (DNS-mocked wiring test; deleting the calls fails it). Stored token address or first derived candidate — no candidate hunting; unhealthy connections get "run the connection test in the tech portal". Rate-limited 12/60s; logs are counts only; the credential exists only inside the request.

## Verification

- Real-HTTP suite (9): pick-is-the-contract with planted fields, no-name placeholder, numeric coverage stats, full-page flag, school-name map following full pages, degraded-schools fallback, unreachable-area throw.
- Guard wiring (3): private resolution → no client ever constructed; stored address used verbatim; derived-when-blank still guarded.
- Handler suite (9): 401/403/400/409s with **nothing dialled on any refusal**, district-from-grants pin, page passthrough, no stack traces to the client, credential never in a body.
- Self-review at high effort ran twice (eight findings applied in the second commit: nav link, stale-response race guard, truncation-honest paging, summed stats, non-destructive append errors, paged school map, type-only imports, `0 of 0`).
- Full suite 1142 passed / 12 skipped; 3 known pre-existing `tests/integration/*` failures. Typecheck and lint clean.
- Sim-district gate walk planned post-deploy (sim has no live SIS; populated-state acceptance is the owner's JSUSD check, per the direction).

Linear: SPE-436 (child of SPE-414)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT

---
_Generated by [Claude Code](https://claude.ai/code/session_012ivaBpUsg8c6786nokAajT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only SIS Directories page for district administrators.
  * Browse teachers, students, classes, and schools with tabs, pagination, statistics, and clear loading or empty states.
  * Added secure directory retrieval with district authorization and protection of sensitive SIS fields.
  * Added a Directories link to the administrator navigation.

* **Bug Fixes**
  * Improved handling of unavailable SIS connections, upstream errors, and partial school data.
  * Prevented unauthorized requests and private network endpoints from being accessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->