### PR TITLE
SPE-437: OneRoster teacher-directory sync — TCH-only auto-create behind a staff dry-run

### DIFF
--- a/__tests__/unit/app/api/internal/teacher-sync.test.ts
+++ b/__tests__/unit/app/api/internal/teacher-sync.test.ts
@@ -1,0 +1,230 @@
+/**
+ * SPE-437 · POST /api/internal/sis-connections/[connectionId]/teacher-sync —
+ * the staff gate, and what a refused caller does NOT set in motion.
+ *
+ * Same reasoning as the connection-test handler suite (SPE-427/421): no sim
+ * persona is ever `is_speddy_admin`, so the allowed branch is only coverable
+ * here. And the load-bearing assertion is not the 403 — it is that NOTHING
+ * dials the district's SIS and NOTHING writes when the caller is refused,
+ * the body is malformed, or the mode is dry-run.
+ */
+import { NextRequest } from 'next/server';
+
+const STAFF_ID = '11111111-1111-4111-8111-111111111111';
+const NON_STAFF_ID = '22222222-2222-4222-8222-222222222222';
+const CONNECTION_ID = '33333333-3333-4333-8333-333333333333';
+
+let currentUserId: string | null = STAFF_ID;
+let profileRow: { data: unknown; error: unknown } = {
+  data: { is_speddy_admin: true },
+  error: null,
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: async () =>
+        currentUserId
+          ? { data: { user: { id: currentUserId } }, error: null }
+          : { data: { user: null }, error: { message: 'no session' } },
+    },
+  }),
+  createServiceClient: () => ({
+    from: () => {
+      const q: Record<string, unknown> = {};
+      q.select = () => q;
+      q.eq = () => q;
+      q.maybeSingle = () => Promise.resolve(profileRow);
+      return q;
+    },
+  }),
+}));
+
+// Rate limiting writes to the database; it is not what this file is about.
+jest.mock('@/lib/api/rate-limit-user', () => ({
+  checkUserRateLimit: jest.fn().mockResolvedValue({ allowed: true }),
+}));
+
+const logCalls: unknown[][] = [];
+jest.mock('@/lib/logger', () => {
+  const record = (...args: unknown[]) => {
+    logCalls.push(args);
+  };
+  const fake = { info: record, warn: record, error: record, debug: record, child: () => fake };
+  return { logger: fake };
+});
+
+const mockGetConnection = jest.fn();
+const mockGetCredential = jest.fn();
+jest.mock('@/lib/sis/connections', () => ({
+  ...jest.requireActual('@/lib/sis/connections'),
+  getConnection: (...a: unknown[]) => mockGetConnection(...a),
+  getDecryptedCredential: (...a: unknown[]) => mockGetCredential(...a),
+}));
+
+// The two functions that reach beyond this process: one dials the SIS, one
+// writes the database. Counting their calls is the whole point of this suite.
+const mockLoad = jest.fn();
+const mockApply = jest.fn();
+jest.mock('@/lib/sis/teacher-directory-sync', () => ({
+  ...jest.requireActual('@/lib/sis/teacher-directory-sync'),
+  loadTeacherSyncInput: (...a: unknown[]) => mockLoad(...a),
+  applyTeacherSyncPlan: (...a: unknown[]) => mockApply(...a),
+}));
+
+import { POST } from '@/app/api/internal/sis-connections/[connectionId]/teacher-sync/route';
+import type { PlannerInput } from '@/lib/sis/teacher-directory-sync';
+
+const CONNECTION = {
+  id: CONNECTION_ID,
+  district_id: 'district-1',
+  sis_type: 'oneroster',
+  base_url: 'https://district.example.org/admin',
+  token_url: 'https://district.example.org/admin/token',
+  credential_hint: '••••44f2',
+  status: 'connected',
+};
+
+const CREDENTIAL = {
+  sisType: 'oneroster',
+  clientId: 'consumer-id',
+  clientSecret: 'consumer-secret',
+};
+
+/** A one-school input whose plan creates exactly one teacher. */
+const INPUT: PlannerInput = {
+  feedSchools: [{ sourcedId: 'org-1', name: 'Rodeo Vista Elementary School' }],
+  feedTeachers: [
+    {
+      sourcedId: 't-1',
+      firstName: 'DANA',
+      lastName: 'WHITFIELD',
+      email: 'dwhitfield@example.org',
+      identifier: '11_TCH_1',
+      grades: ['KG'],
+      orgIds: ['org-1'],
+      isTeacher: true,
+    },
+  ],
+  speddySchools: [{ id: 'sch-1', name: 'Rodeo Vista Elementary' }],
+  existingTeachers: [],
+  studentCounts: { 'sch-1': 4 },
+};
+
+const call = (body: unknown) =>
+  POST(
+    new NextRequest(`http://localhost/api/internal/sis-connections/${CONNECTION_ID}/teacher-sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ connectionId: CONNECTION_ID }) },
+  );
+
+/** Every path that reaches beyond this process, in one place. */
+const nothingHappened = () => {
+  expect(mockLoad).not.toHaveBeenCalled();
+  expect(mockApply).not.toHaveBeenCalled();
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  logCalls.length = 0;
+  currentUserId = STAFF_ID;
+  profileRow = { data: { is_speddy_admin: true }, error: null };
+  mockGetConnection.mockResolvedValue(CONNECTION);
+  mockGetCredential.mockResolvedValue(CREDENTIAL);
+  mockLoad.mockResolvedValue(INPUT);
+  mockApply.mockResolvedValue([
+    { schoolId: 'sch-1', schoolName: 'Rodeo Vista Elementary', created: 1, adopted: 0, updated: 0 },
+  ]);
+});
+
+describe('the staff gate', () => {
+  it('refuses a signed-in non-staff caller and dials NOTHING', async () => {
+    currentUserId = NON_STAFF_ID;
+    profileRow = { data: { is_speddy_admin: false }, error: null };
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(403);
+    nothingHappened();
+  });
+
+  it('refuses an unauthenticated caller and dials NOTHING', async () => {
+    currentUserId = null;
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(401);
+    nothingHappened();
+  });
+
+  it('refuses an unreadable staff verdict (fail closed) and dials NOTHING', async () => {
+    profileRow = { data: null, error: { message: 'boom' } };
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(403);
+    nothingHappened();
+  });
+});
+
+describe('input gates', () => {
+  it('400s a body without a valid mode, dialling nothing', async () => {
+    const res = await call({ mode: 'destroy-everything' });
+    expect(res.status).toBe(400);
+    nothingHappened();
+  });
+
+  it('404s an unknown connection, dialling nothing', async () => {
+    mockGetConnection.mockResolvedValue(null);
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(404);
+    nothingHappened();
+  });
+
+  it('409s an Aeries connection — teacher sync is OneRoster-fed', async () => {
+    mockGetConnection.mockResolvedValue({ ...CONNECTION, sis_type: 'aeries' });
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(409);
+    nothingHappened();
+  });
+
+  it('409s when no credential is stored, dialling nothing', async () => {
+    mockGetCredential.mockResolvedValue(null);
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(409);
+    nothingHappened();
+  });
+});
+
+describe('dry-run vs apply', () => {
+  it('dry-run plans from a live read and WRITES NOTHING', async () => {
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.mode).toBe('dry-run');
+    expect(body.plan.schools[0].creates).toHaveLength(1);
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+    expect(mockApply).not.toHaveBeenCalled();
+  });
+
+  it('apply recomputes the plan server-side and passes THAT to the writer', async () => {
+    const res = await call({ mode: 'apply' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.mode).toBe('apply');
+    expect(body.written).toEqual([
+      expect.objectContaining({ schoolId: 'sch-1', created: 1 }),
+    ]);
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+    expect(mockApply).toHaveBeenCalledTimes(1);
+    // The plan the writer received came from the fresh load, not the request.
+    const applied = mockApply.mock.calls[0][0] as { plan: { schools: unknown[] } };
+    expect(applied.plan.schools).toHaveLength(1);
+  });
+
+  it('logs counts only — the feed names and emails never reach a log line', async () => {
+    await call({ mode: 'dry-run' });
+    const logged = JSON.stringify(logCalls);
+    expect(logged).toContain('Teacher directory sync planned');
+    for (const value of ['DANA', 'WHITFIELD', 'dwhitfield@example.org']) {
+      expect(logged).not.toContain(value);
+    }
+  });
+});

--- a/__tests__/unit/app/api/internal/teacher-sync.test.ts
+++ b/__tests__/unit/app/api/internal/teacher-sync.test.ts
@@ -191,6 +191,37 @@ describe('input gates', () => {
     expect(res.status).toBe(409);
     nothingHappened();
   });
+
+  it('409s a connection with no saved address, dialling nothing', async () => {
+    mockGetConnection.mockResolvedValue({ ...CONNECTION, base_url: null });
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(409);
+    nothingHappened();
+  });
+
+  it('409s an Aeries credential on the OneRoster path, dialling nothing', async () => {
+    mockGetCredential.mockResolvedValue({ ...CREDENTIAL, sisType: 'aeries' });
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(409);
+    nothingHappened();
+  });
+
+  it('500s a credential that exists but cannot be decrypted — a key fault, not setup guidance', async () => {
+    mockGetCredential.mockRejectedValue(new Error('decrypt failed'));
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/could not be decrypted/i);
+    nothingHappened();
+  });
+
+  it('refuses a non-staff APPLY before anything dials or writes', async () => {
+    currentUserId = NON_STAFF_ID;
+    profileRow = { data: { is_speddy_admin: false }, error: null };
+    const res = await call({ mode: 'apply', expectedChanges: 1 });
+    expect(res.status).toBe(403);
+    nothingHappened();
+  });
 });
 
 describe('dry-run vs apply', () => {
@@ -204,8 +235,25 @@ describe('dry-run vs apply', () => {
     expect(mockApply).not.toHaveBeenCalled();
   });
 
-  it('apply recomputes the plan server-side and passes THAT to the writer', async () => {
+  it('apply without the reviewed count is refused at validation, dialling nothing', async () => {
     const res = await call({ mode: 'apply' });
+    expect(res.status).toBe(400);
+    nothingHappened();
+  });
+
+  it('apply refuses with 409 when the recomputed plan differs from the approved count', async () => {
+    // The operator approved 3 changes; the fresh plan writes 1 — the feed
+    // moved between preview and apply, so nothing may be written.
+    const res = await call({ mode: 'apply', expectedChanges: 3 });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/changed since your preview/i);
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+    expect(mockApply).not.toHaveBeenCalled();
+  });
+
+  it('apply recomputes the plan server-side and passes THAT to the writer', async () => {
+    const res = await call({ mode: 'apply', expectedChanges: 1 });
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.mode).toBe('apply');

--- a/__tests__/unit/lib/sis/teacher-directory-sync.apply.test.ts
+++ b/__tests__/unit/lib/sis/teacher-directory-sync.apply.test.ts
@@ -229,7 +229,10 @@ describe('applyTeacherSyncPlan', () => {
   it('audits and logs COUNTS only — no names or emails anywhere', async () => {
     await run();
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ action: 'sis_teacher_sync_applied' }),
+      expect.objectContaining({
+        action: 'sis_teacher_sync_applied',
+        metadata: expect.objectContaining({ partial: false }),
+      }),
     );
     const everything = JSON.stringify([mockAudit.mock.calls, logCalls]);
     for (const value of ['CHARLI', 'OMALLEY', 'comalley@example.org', 'Hand Entered']) {
@@ -237,14 +240,26 @@ describe('applyTeacherSyncPlan', () => {
     }
   });
 
-  it('a failed insert throws with the school named, and stops', async () => {
+  it('a failed insert throws with the school named — and the partial outcome is STILL audited', async () => {
+    // Writes that landed before the failure are real; a staff-gated
+    // service-role write path must never leave them unrecorded
+    // (CodeRabbit, PR #831).
     nextResult = (q) => {
       const insert = q.calls.find((c) => c.method === 'insert');
       if (insert) return { data: null, error: { message: 'unique violation' } };
       return { data: [{ id: 'touched' }], error: null };
     };
     await expect(run()).rejects.toThrow(/Rodeo Vista Elementary failed: unique violation/);
-    // Nothing was audited about a run that did not complete.
-    expect(mockAudit).not.toHaveBeenCalled();
+    expect(mockAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'sis_teacher_sync_applied',
+        metadata: expect.objectContaining({ partial: true }),
+      }),
+    );
+    // Still counts only, even on the failure path.
+    const everything = JSON.stringify([mockAudit.mock.calls, logCalls]);
+    for (const value of ['CHARLI', 'OMALLEY', 'comalley@example.org']) {
+      expect(everything).not.toContain(value);
+    }
   });
 });

--- a/__tests__/unit/lib/sis/teacher-directory-sync.apply.test.ts
+++ b/__tests__/unit/lib/sis/teacher-directory-sync.apply.test.ts
@@ -1,0 +1,250 @@
+/**
+ * SPE-437 · `applyTeacherSyncPlan` — what the writes actually carry, and what
+ * is never written at all.
+ *
+ * The supabase stub records every query-builder call, so the assertions are
+ * about the WRITE SHAPE: creates carry the SIS key and school placement,
+ * adoption re-checks `sis_id IS NULL` in its WHERE, keyed updates filter on
+ * the full key, refused schools see no writes, and counts come from what the
+ * database says happened rather than what the plan hoped.
+ */
+
+const logCalls: unknown[][] = [];
+jest.mock('@/lib/logger', () => {
+  const record = (...args: unknown[]) => {
+    logCalls.push(args);
+  };
+  const fake = { info: record, warn: record, error: record, debug: record, child: () => fake };
+  return { logger: fake };
+});
+
+const mockAudit = jest.fn().mockResolvedValue(undefined);
+jest.mock('@/lib/supabase/audit-log-server', () => ({
+  logServerAuditEvent: (...args: unknown[]) => mockAudit(...(args as [])),
+}));
+
+/** One recorded builder chain: the table, the method calls, their arguments. */
+interface RecordedQuery {
+  table: string;
+  calls: { method: string; args: unknown[] }[];
+  result: { data: unknown; error: unknown };
+}
+
+const recorded: RecordedQuery[] = [];
+/** Set per-test to control what a chain resolves to. */
+let nextResult: (q: RecordedQuery) => { data: unknown; error: unknown };
+
+jest.mock('@/lib/supabase/server', () => ({
+  createServiceClient: () => ({
+    from: (table: string) => {
+      const record: RecordedQuery = { table, calls: [], result: { data: [], error: null } };
+      recorded.push(record);
+      const chain: Record<string, unknown> = {};
+      for (const method of ['insert', 'update', 'select', 'eq', 'is', 'in']) {
+        chain[method] = (...args: unknown[]) => {
+          record.calls.push({ method, args });
+          return chain;
+        };
+      }
+      // Thenable, like the real builder: awaiting the chain resolves it.
+      chain.then = (resolve: (v: unknown) => unknown) => {
+        record.result = nextResult(record);
+        return Promise.resolve(record.result).then(resolve);
+      };
+      return chain;
+    },
+  }),
+}));
+
+import {
+  applyTeacherSyncPlan,
+  type SchoolPlan,
+  type TeacherSyncPlan,
+} from '@/lib/sis/teacher-directory-sync';
+
+const emptySchool: Omit<
+  SchoolPlan,
+  'schoolId' | 'schoolName' | 'sisSchoolName' | 'refusal'
+> = {
+  creates: [],
+  adopts: [],
+  updates: [],
+  unchanged: 0,
+  reviews: [],
+  missingFromSis: [],
+  excludedNonTeaching: 0,
+  studentCount: 5,
+};
+
+const plan: TeacherSyncPlan = {
+  schools: [
+    {
+      ...emptySchool,
+      schoolId: 'sch-elem',
+      schoolName: 'Rodeo Vista Elementary',
+      sisSchoolName: 'Rodeo Vista Elementary School',
+      refusal: null,
+      creates: [
+        {
+          sisId: 'sid-1',
+          firstName: 'CHARLI',
+          lastName: 'OMALLEY',
+          email: 'comalley@example.org',
+          staffId: '11_TCH_1',
+          gradeLevel: 'KG',
+        },
+      ],
+      adopts: [
+        { teacherId: 'row-adopt', sisId: 'sid-2', name: 'Hand Entered', email: 'he@example.org' },
+      ],
+      updates: [
+        {
+          teacherId: 'row-upd',
+          sisId: 'sid-3',
+          name: 'Keyed Row',
+          changes: { email: 'new@example.org' },
+        },
+      ],
+    },
+    {
+      ...emptySchool,
+      schoolId: 'sch-refused',
+      schoolName: 'Carquinez Stand-in Middle',
+      sisSchoolName: 'Carquinez Stand-in Middle School',
+      refusal: 'nothing here can be created accurately',
+      // Even if a bug ever left rows on a refused school's plan, apply must
+      // not write them; the planted create pins that.
+      creates: [
+        {
+          sisId: 'sid-refused',
+          firstName: 'NEVER',
+          lastName: 'WRITTEN',
+          email: 'nw@example.org',
+          staffId: 'x',
+          gradeLevel: null,
+        },
+      ],
+    },
+  ],
+  unmappedSisSchools: [],
+  shadowDuplicates: 0,
+  duplicateEmailAnomalies: 0,
+  feedTeacherRows: 3,
+  feedTotalRows: 3,
+};
+
+const run = () =>
+  applyTeacherSyncPlan({
+    plan,
+    actorId: 'staff-1',
+    connectionId: 'conn-1',
+    districtId: 'district-1',
+  });
+
+beforeEach(() => {
+  recorded.length = 0;
+  logCalls.length = 0;
+  mockAudit.mockClear();
+  // Default: every write succeeds and reports as many rows as were sent.
+  nextResult = (q) => {
+    const insert = q.calls.find((c) => c.method === 'insert');
+    if (insert) {
+      const rows = insert.args[0] as unknown[];
+      return { data: rows.map((_, i) => ({ id: `new-${i}` })), error: null };
+    }
+    return { data: [{ id: 'touched' }], error: null };
+  };
+});
+
+describe('applyTeacherSyncPlan', () => {
+  it('writes creates with the SIS key, school placement, and verbatim names', async () => {
+    const results = await run();
+
+    const insert = recorded.find((q) => q.calls.some((c) => c.method === 'insert'));
+    expect(insert).toBeDefined();
+    const rows = insert!.calls.find((c) => c.method === 'insert')!.args[0] as Record<
+      string,
+      unknown
+    >[];
+    expect(rows).toEqual([
+      {
+        first_name: 'CHARLI',
+        last_name: 'OMALLEY',
+        email: 'comalley@example.org',
+        school_id: 'sch-elem',
+        school_site: 'Rodeo Vista Elementary',
+        grade_level: 'KG',
+        created_by_admin: false,
+        sis_source: 'oneroster',
+        sis_id: 'sid-1',
+      },
+    ]);
+    expect(results).toEqual([
+      { schoolId: 'sch-elem', schoolName: 'Rodeo Vista Elementary', created: 1, adopted: 1, updated: 1 },
+    ]);
+  });
+
+  it('never writes anything for a refused school', async () => {
+    await run();
+    const serialized = JSON.stringify(recorded.map((q) => q.calls));
+    expect(serialized).not.toContain('sid-refused');
+    expect(serialized).not.toContain('NEVER');
+  });
+
+  it('adoption re-checks sis_id IS NULL, and reports an honest zero when the row moved on', async () => {
+    nextResult = (q) => {
+      const insert = q.calls.find((c) => c.method === 'insert');
+      if (insert) {
+        const rows = insert.args[0] as unknown[];
+        return { data: rows.map((_, i) => ({ id: `new-${i}` })), error: null };
+      }
+      // The adoption UPDATE matches nothing (someone stamped the row first).
+      const isNullGuard = q.calls.find((c) => c.method === 'is');
+      if (isNullGuard) return { data: [], error: null };
+      return { data: [{ id: 'touched' }], error: null };
+    };
+
+    const results = await run();
+
+    const adoption = recorded.find((q) => q.calls.some((c) => c.method === 'is'));
+    expect(adoption).toBeDefined();
+    expect(adoption!.calls).toContainEqual({ method: 'is', args: ['sis_id', null] });
+    expect(adoption!.calls).toContainEqual({
+      method: 'update',
+      args: [{ sis_source: 'oneroster', sis_id: 'sid-2' }],
+    });
+    expect(results[0].adopted).toBe(0);
+  });
+
+  it('keyed updates filter on the full SIS key, not just the row id', async () => {
+    await run();
+    const update = recorded.find((q) =>
+      q.calls.some((c) => c.method === 'update' && 'email' in ((c.args[0] ?? {}) as object)),
+    );
+    expect(update).toBeDefined();
+    expect(update!.calls).toContainEqual({ method: 'eq', args: ['sis_source', 'oneroster'] });
+    expect(update!.calls).toContainEqual({ method: 'eq', args: ['sis_id', 'sid-3'] });
+  });
+
+  it('audits and logs COUNTS only — no names or emails anywhere', async () => {
+    await run();
+    expect(mockAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'sis_teacher_sync_applied' }),
+    );
+    const everything = JSON.stringify([mockAudit.mock.calls, logCalls]);
+    for (const value of ['CHARLI', 'OMALLEY', 'comalley@example.org', 'Hand Entered']) {
+      expect(everything).not.toContain(value);
+    }
+  });
+
+  it('a failed insert throws with the school named, and stops', async () => {
+    nextResult = (q) => {
+      const insert = q.calls.find((c) => c.method === 'insert');
+      if (insert) return { data: null, error: { message: 'unique violation' } };
+      return { data: [{ id: 'touched' }], error: null };
+    };
+    await expect(run()).rejects.toThrow(/Rodeo Vista Elementary failed: unique violation/);
+    // Nothing was audited about a run that did not complete.
+    expect(mockAudit).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/lib/sis/teacher-directory-sync.http.test.ts
+++ b/__tests__/unit/lib/sis/teacher-directory-sync.http.test.ts
@@ -1,0 +1,254 @@
+/**
+ * SPE-437 · `loadTeacherSyncInput` against a REAL HTTP server.
+ *
+ * Three properties earn the suite:
+ *
+ * 1. FULL PAGINATION. The probe sampled first pages; a sync that missed page
+ *    two would report those teachers "missing from SIS" on the next run. The
+ *    fixture serves 1000 + 3 rows and the test counts 1003 landed.
+ * 2. THE PICK IS THE CONTRACT. Planted credential- and demographics-looking
+ *    fields on feed rows must not survive into the planner input.
+ * 3. LOGS ARE COUNTS ONLY. Nothing a fixture row carries — names, emails,
+ *    planted values — may appear in anything the module logs.
+ *
+ * The SSRF guard is stubbed (127.0.0.1 over http is exactly what it refuses);
+ * a separate case pins that the module CALLS it and stops when it throws.
+ */
+import { createServer, type Server } from 'http';
+import type { AddressInfo } from 'net';
+
+const logCalls: unknown[][] = [];
+jest.mock('@/lib/logger', () => {
+  const record = (...args: unknown[]) => {
+    logCalls.push(args);
+  };
+  const fake = { info: record, warn: record, error: record, debug: record, child: () => fake };
+  return { logger: fake };
+});
+
+const mockAssertSafe = jest.fn().mockResolvedValue(undefined);
+jest.mock('@/lib/sis/ssrf-guard', () => ({
+  ...jest.requireActual('@/lib/sis/ssrf-guard'),
+  assertSafeSisUrl: (...args: unknown[]) => mockAssertSafe(...(args as [string, unknown])),
+}));
+
+// The database half of the input: schools, existing teachers, student counts.
+const mockDb = {
+  schools: [
+    { id: 'sch-elem', name: 'Rodeo Vista Elementary' },
+    { id: 'sch-high', name: 'Crockett Point High' },
+  ],
+  teachers: [] as unknown[],
+  studentCounts: { 'sch-elem': 3, 'sch-high': 2 } as Record<string, number>,
+};
+jest.mock('@/lib/supabase/server', () => ({
+  createServiceClient: () => ({
+    from: (table: string) => {
+      if (table === 'schools') {
+        return {
+          select: () => ({ eq: async () => ({ data: mockDb.schools, error: null }) }),
+        };
+      }
+      if (table === 'teachers') {
+        return {
+          select: () => ({ in: async () => ({ data: mockDb.teachers, error: null }) }),
+        };
+      }
+      if (table === 'students') {
+        return {
+          select: () => ({
+            eq: async (_col: string, id: string) => ({
+              count: mockDb.studentCounts[id] ?? 0,
+              error: null,
+            }),
+          }),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  }),
+}));
+
+import {
+  loadTeacherSyncInput,
+  planTeacherDirectorySync,
+} from '@/lib/sis/teacher-directory-sync';
+
+const CLIENT_ID = 'sync-consumer-id';
+const CLIENT_SECRET = 'sync-consumer-secret';
+
+const PLANTED = {
+  password: 'planted-password-hash',
+  birthDate: 'planted-birth-date',
+  sex: 'planted-sex-value',
+  vendorExtra: 'planted-vendor-blob',
+};
+
+/** Page one of /teachers: a full page of anonymous filler rows. */
+function fillerTeachers(n: number): unknown[] {
+  return Array.from({ length: n }, (_, i) => ({
+    sourcedId: `fill-${String(i).padStart(4, '0')}`,
+    givenName: 'FILLER',
+    familyName: `ROW${i}`,
+    email: `filler${i}@example.org`,
+    identifier: `11_TCH_${9000 + i}`,
+    grades: ['03'],
+    orgs: [{ sourcedId: 'org-elem' }],
+    // Vendor extras and demographics the pick must drop, planted on row 0.
+    ...(i === 0 ? PLANTED : {}),
+  }));
+}
+
+let server: Server;
+let origin: string;
+let requests: string[] = [];
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const url = req.url ?? '';
+    requests.push(url);
+    const respond = (body: unknown) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(body));
+    };
+
+    if (url.includes('/token')) return respond({ access_token: 'sync-bearer' });
+    if (url.includes('/schools')) {
+      return respond({
+        orgs: [
+          { sourcedId: 'org-elem', name: 'Rodeo Vista Elementary School' },
+          { sourcedId: 'org-high', name: 'Crockett Point High School' },
+          { sourcedId: 'org-closed', name: 'Closed Annex', status: 'tobedeleted' },
+        ],
+      });
+    }
+    if (url.includes('/teachers')) {
+      const offset = Number(new URL(url, origin).searchParams.get('offset') ?? '0');
+      if (offset === 0) return respond({ users: fillerTeachers(1000) });
+      return respond({
+        users: [
+          {
+            sourcedId: 'real-1',
+            givenName: 'DANA',
+            familyName: 'WHITFIELD',
+            email: 'dwhitfield@example.org',
+            identifier: '22_TCH_777',
+            grades: ['09', '10'],
+            orgs: [{ sourcedId: 'org-high' }],
+          },
+          {
+            sourcedId: 'aide-1',
+            givenName: 'ROBIN',
+            familyName: 'OFFICESTAFF',
+            email: 'rofficestaff@example.org',
+            identifier: 'non-teaching staff',
+            grades: ['KG'],
+            orgs: [{ sourcedId: 'org-elem' }],
+          },
+          {
+            sourcedId: 'gone-1',
+            givenName: 'GONE',
+            familyName: 'TEACHER',
+            identifier: '22_TCH_778',
+            status: 'tobedeleted',
+            orgs: [{ sourcedId: 'org-high' }],
+          },
+        ],
+      });
+    }
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({}));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  requests = [];
+  logCalls.length = 0;
+  mockAssertSafe.mockClear().mockResolvedValue(undefined);
+});
+
+const load = () =>
+  loadTeacherSyncInput({
+    districtId: 'district-1',
+    baseUrl: origin,
+    tokenUrl: `${origin}/token`,
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+  });
+
+describe('loadTeacherSyncInput', () => {
+  it('walks /teachers to completion — 1003 rows across two pages, minus the dropped', async () => {
+    const input = await load();
+
+    // 1000 filler + real + sentinel; the tobedeleted row is dropped.
+    expect(input.feedTeachers).toHaveLength(1002);
+    const teacherPages = requests.filter((u) => u.includes('/teachers'));
+    expect(teacherPages.length).toBe(2);
+
+    // The pick carried what the planner needs…
+    const real = input.feedTeachers.find((t) => t.sourcedId === 'real-1');
+    expect(real).toMatchObject({
+      firstName: 'DANA',
+      lastName: 'WHITFIELD',
+      identifier: '22_TCH_777',
+      isTeacher: true,
+      orgIds: ['org-high'],
+    });
+    const aide = input.feedTeachers.find((t) => t.sourcedId === 'aide-1');
+    expect(aide?.isTeacher).toBe(false);
+
+    // …schools dropped the tobedeleted org…
+    expect(input.feedSchools.map((s) => s.sourcedId).sort()).toEqual(['org-elem', 'org-high']);
+
+    // …and the database half arrived keyed by school id.
+    expect(input.studentCounts).toEqual({ 'sch-elem': 3, 'sch-high': 2 });
+  });
+
+  it('drops planted vendor/demographic fields — and the whole pipeline stays clean of them', async () => {
+    const input = await load();
+    const serialized = JSON.stringify(input);
+    for (const value of Object.values(PLANTED)) {
+      expect(serialized).not.toContain(value);
+    }
+
+    // End-to-end: the plan built from this input is equally clean.
+    const plan = planTeacherDirectorySync(input);
+    const planSerialized = JSON.stringify(plan);
+    for (const value of Object.values(PLANTED)) {
+      expect(planSerialized).not.toContain(value);
+    }
+  });
+
+  it('logs nothing a fixture row carries — no names, emails, or planted values', async () => {
+    await load();
+    const logged = JSON.stringify(logCalls);
+    for (const value of [
+      'WHITFIELD',
+      'OFFICESTAFF',
+      'dwhitfield@example.org',
+      CLIENT_SECRET,
+      ...Object.values(PLANTED),
+    ]) {
+      expect(logged).not.toContain(value);
+    }
+  });
+
+  it('checks both URLs with the SSRF guard and dials NOTHING when it refuses', async () => {
+    mockAssertSafe.mockRejectedValue(new Error('refused'));
+    await expect(load()).rejects.toThrow('refused');
+    expect(requests).toHaveLength(0);
+  });
+
+  it('calls the guard on the base and token addresses', async () => {
+    await load();
+    const checked = mockAssertSafe.mock.calls.map((c) => c[0]);
+    expect(checked).toContain(origin);
+    expect(checked).toContain(`${origin}/token`);
+  });
+});

--- a/__tests__/unit/lib/sis/teacher-directory-sync.http.test.ts
+++ b/__tests__/unit/lib/sis/teacher-directory-sync.http.test.ts
@@ -50,8 +50,19 @@ jest.mock('@/lib/supabase/server', () => ({
         };
       }
       if (table === 'teachers') {
+        // Mimics PostgREST paging: .range(from, to) slices the fixture, so
+        // the loader's page-to-completion loop is exercised for real.
         return {
-          select: () => ({ in: async () => ({ data: mockDb.teachers, error: null }) }),
+          select: () => ({
+            in: () => ({
+              order: () => ({
+                range: async (from: number, to: number) => ({
+                  data: mockDb.teachers.slice(from, to + 1),
+                  error: null,
+                }),
+              }),
+            }),
+          }),
         };
       }
       if (table === 'students') {
@@ -73,6 +84,7 @@ import {
   loadTeacherSyncInput,
   planTeacherDirectorySync,
 } from '@/lib/sis/teacher-directory-sync';
+import { ONEROSTER_DEFAULT_PAGE_SIZE } from '@/lib/integrations/oneroster';
 
 const CLIENT_ID = 'sync-consumer-id';
 const CLIENT_SECRET = 'sync-consumer-secret';
@@ -123,8 +135,12 @@ beforeAll(async () => {
       });
     }
     if (url.includes('/teachers')) {
-      const offset = Number(new URL(url, origin).searchParams.get('offset') ?? '0');
-      if (offset === 0) return respond({ users: fillerTeachers(1000) });
+      const params = new URL(url, origin).searchParams;
+      const offset = Number(params.get('offset') ?? '0');
+      // A full first page at whatever limit the client asked for — so the
+      // fixture keeps proving pagination even if the client's page size moves.
+      const limit = Number(params.get('limit') ?? '1000');
+      if (offset === 0) return respond({ users: fillerTeachers(limit) });
       return respond({
         users: [
           {
@@ -183,11 +199,11 @@ const load = () =>
   });
 
 describe('loadTeacherSyncInput', () => {
-  it('walks /teachers to completion — 1003 rows across two pages, minus the dropped', async () => {
+  it('walks /teachers to completion — a full page plus the tail, minus the dropped', async () => {
     const input = await load();
 
-    // 1000 filler + real + sentinel; the tobedeleted row is dropped.
-    expect(input.feedTeachers).toHaveLength(1002);
+    // One full page of filler + real + sentinel; the tobedeleted row is dropped.
+    expect(input.feedTeachers).toHaveLength(ONEROSTER_DEFAULT_PAGE_SIZE + 2);
     const teacherPages = requests.filter((u) => u.includes('/teachers'));
     expect(teacherPages.length).toBe(2);
 
@@ -225,9 +241,34 @@ describe('loadTeacherSyncInput', () => {
     }
   });
 
+  it('reads the existing-teachers table past the 1000-row PostgREST cap', async () => {
+    // 1500 DB rows: an unpaginated read would return 1000 and the planner
+    // would re-create teachers 1001–1500 (the max_rows trap, PR #831 review).
+    mockDb.teachers = Array.from({ length: 1500 }, (_, i) => ({
+      id: `db-${String(i).padStart(4, '0')}`,
+      school_id: 'sch-elem',
+      first_name: 'Db',
+      last_name: `Row${i}`,
+      email: null,
+      grade_level: null,
+      sis_source: null,
+      sis_id: null,
+    }));
+    try {
+      const input = await load();
+      expect(input.existingTeachers).toHaveLength(1500);
+    } finally {
+      mockDb.teachers = [];
+    }
+  });
+
   it('logs nothing a fixture row carries — no names, emails, or planted values', async () => {
     await load();
     const logged = JSON.stringify(logCalls);
+    // Non-vacuous: the load path DOES log (the client's token-granted line),
+    // so an empty capture would mean the capture broke, not that logs are
+    // clean (CodeRabbit, PR #831).
+    expect(logCalls.length).toBeGreaterThan(0);
     for (const value of [
       'WHITFIELD',
       'OFFICESTAFF',

--- a/__tests__/unit/lib/sis/teacher-directory-sync.test.ts
+++ b/__tests__/unit/lib/sis/teacher-directory-sync.test.ts
@@ -133,11 +133,24 @@ describe('toFeedTeacher (the feed-row pick)', () => {
     expect(row?.isTeacher).toBe(false);
   });
 
-  it('drops tobedeleted and nameless rows entirely', () => {
+  it('drops tobedeleted, nameless, and unkeyable rows entirely', () => {
     expect(
       toFeedTeacher({ sourcedId: 'x', givenName: 'A', familyName: 'B', status: 'tobedeleted' }),
     ).toBeNull();
     expect(toFeedTeacher({ sourcedId: 'x', identifier: '11_TCH_1' })).toBeNull();
+    // A blank sourcedId can never become a teachers.sis_id.
+    expect(toFeedTeacher({ sourcedId: '   ', givenName: 'A', familyName: 'B' })).toBeNull();
+  });
+
+  it('degrades a non-array orgs value to no schools instead of throwing', () => {
+    const row = toFeedTeacher({
+      sourcedId: 'x',
+      givenName: 'A',
+      familyName: 'B',
+      identifier: '11_TCH_1',
+      orgs: { href: 'not-an-array' } as never,
+    });
+    expect(row?.orgIds).toEqual([]);
   });
 
   it('keeps only the fields the pick names — vendor extras cannot ride along', () => {
@@ -374,10 +387,46 @@ describe('the reconcile ladder', () => {
     );
     const elem = schoolPlan(plan, SCHOOL_ELEM.id);
     expect(elem.reviews).toEqual([
-      expect.objectContaining({ existingTeacherId: 'row-1', feedName: 'JORDAN RIVERA' }),
+      expect.objectContaining({
+        existingTeacherId: 'row-1',
+        feedName: 'JORDAN RIVERA',
+        reason: 'name-match',
+      }),
     ]);
     expect(elem.adopts).toHaveLength(0);
     expect(elem.creates).toHaveLength(0);
+  });
+
+  it('an email carried by SEVERAL unkeyed rows goes to review — adopting one would be a guess', () => {
+    const t = teacher({ email: 'shared@example.org' });
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [t],
+        existingTeachers: [
+          {
+            ...EXISTING_BASE,
+            id: 'row-1',
+            first_name: 'First',
+            last_name: 'Holder',
+            email: 'shared@example.org',
+          },
+          {
+            ...EXISTING_BASE,
+            id: 'row-2',
+            first_name: 'Second',
+            last_name: 'Holder',
+            email: 'SHARED@example.org',
+          },
+        ],
+      }),
+    );
+    const elem = schoolPlan(plan, SCHOOL_ELEM.id);
+    expect(elem.adopts).toHaveLength(0);
+    expect(elem.creates).toHaveLength(0);
+    expect(elem.reviews).toEqual([
+      expect.objectContaining({ existingTeacherId: 'row-1', reason: 'ambiguous-email' }),
+      expect.objectContaining({ existingTeacherId: 'row-2', reason: 'ambiguous-email' }),
+    ]);
   });
 
   it('no match → create', () => {
@@ -463,6 +512,51 @@ describe('feed anomalies', () => {
     expect(schoolPlan(plan, SCHOOL_ELEM.id).creates).toHaveLength(1);
     expect(plan.duplicateEmailAnomalies).toBe(1);
   });
+
+  it('the dedup tie goes to the row an existing teacher is KEYED to, never orphaning the key', () => {
+    // 'aaa' sorts first, but the existing row is keyed to 'bbb': dropping
+    // 'bbb' would create a duplicate and report the real teacher as missing
+    // (Codex P1, PR #831).
+    const a = teacher({ sourcedId: 'aaa', email: 'twin@example.org', grades: [] });
+    const b = teacher({ sourcedId: 'bbb', email: 'twin@example.org', grades: [] });
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [a, b],
+        existingTeachers: [
+          {
+            ...EXISTING_BASE,
+            id: 'row-keyed',
+            first_name: b.firstName,
+            last_name: b.lastName,
+            email: b.email,
+            sis_source: 'oneroster',
+            sis_id: 'bbb',
+          },
+        ],
+      }),
+    );
+    const elem = schoolPlan(plan, SCHOOL_ELEM.id);
+    expect(elem.unchanged).toBe(1);
+    expect(elem.creates).toHaveLength(0);
+    expect(elem.missingFromSis).toHaveLength(0);
+    expect(plan.duplicateEmailAnomalies).toBe(1);
+  });
+
+  it('a feed school whose name normalizes to nothing matches NO school', () => {
+    const plan = planTeacherDirectorySync(
+      input({
+        feedSchools: [FEED_ELEM, FEED_HIGH, { sourcedId: 'org-junk', name: '—***—' }],
+        feedTeachers: [teacher()],
+        // Students only where the feed has teachers, so the only refusal this
+        // fixture could produce is the ambiguity one under test.
+        studentCounts: { [SCHOOL_ELEM.id]: 10, [SCHOOL_HIGH.id]: 0 },
+      }),
+    );
+    // Neither poisoned into ambiguity nor matched: both real schools map.
+    expect(schoolPlan(plan, SCHOOL_ELEM.id).refusal).toBeNull();
+    expect(schoolPlan(plan, SCHOOL_HIGH.id).refusal).toBeNull();
+    expect(plan.unmappedSisSchools).toEqual([{ name: '—***—', teacherRows: 0 }]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -483,6 +577,30 @@ describe('the zero-teachers guard', () => {
     expect(elem.refusal).toMatch(/2 staff row\(s\)/);
     expect(elem.refusal).toMatch(/none with a real staff ID/);
     expect(elem.creates).toHaveLength(0);
+  });
+
+  it('does NOT refuse a school whose qualifying rows all await review — and shows them', () => {
+    // The false-refusal bug both review bots flagged on PR #831: review rows
+    // ARE qualifying rows, and a refusal here would claim "none with a real
+    // staff ID" about rows that have one — while hiding the review list.
+    const t = teacher({ firstName: 'JORDAN', lastName: 'RIVERA', email: 'jr-new@example.org' });
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [t],
+        existingTeachers: [
+          {
+            ...EXISTING_BASE,
+            id: 'row-1',
+            first_name: 'Jordan',
+            last_name: 'Rivera',
+            email: 'jr-old@example.org',
+          },
+        ],
+      }),
+    );
+    const elem = schoolPlan(plan, SCHOOL_ELEM.id);
+    expect(elem.refusal).toBeNull();
+    expect(elem.reviews).toHaveLength(1);
   });
 
   it('does NOT refuse an empty school with no students — nothing to protect', () => {

--- a/__tests__/unit/lib/sis/teacher-directory-sync.test.ts
+++ b/__tests__/unit/lib/sis/teacher-directory-sync.test.ts
@@ -1,0 +1,518 @@
+/**
+ * SPE-437 · the teacher-sync planner, rung by rung.
+ *
+ * Everything here is the PURE half — plain data in, a plan out — so each rule
+ * the owner decided from JSUSD's live feed is pinned without a server:
+ * the staff-ID population rule, the KG-is-filler grade rule, the school-name
+ * mapping that refuses ambiguity, and a ladder where a name match NEVER
+ * writes anything on its own.
+ *
+ * Fixture names are invented. The real feed's shapes (sentinel identifiers,
+ * ALL-CAPS names, shadow duplicate rows) are reproduced; its people are not.
+ */
+import {
+  planTeacherDirectorySync,
+  toFeedTeacher,
+  type FeedTeacher,
+  type PlannerInput,
+} from '@/lib/sis/teacher-directory-sync';
+
+jest.mock('@/lib/logger', () => {
+  const fake: Record<string, unknown> = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+  fake.child = () => fake;
+  return { logger: fake };
+});
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+const SCHOOL_ELEM = { id: 'sch-elem', name: 'Rodeo Vista Elementary' };
+const SCHOOL_HIGH = { id: 'sch-high', name: 'Crockett Point High' };
+
+const FEED_ELEM = { sourcedId: 'org-elem', name: 'Rodeo Vista Elementary School' };
+const FEED_HIGH = { sourcedId: 'org-high', name: 'Crockett Point High School' };
+
+let nextId = 0;
+function teacher(overrides: Partial<FeedTeacher> = {}): FeedTeacher {
+  nextId += 1;
+  return {
+    sourcedId: `t-${String(nextId).padStart(3, '0')}`,
+    firstName: 'PAT',
+    lastName: `TEACHER${nextId}`,
+    email: `pat${nextId}@example.org`,
+    identifier: `11_TCH_${1000 + nextId}`,
+    grades: ['03'],
+    orgIds: [FEED_ELEM.sourcedId],
+    isTeacher: true,
+    ...overrides,
+  };
+}
+
+function input(overrides: Partial<PlannerInput> = {}): PlannerInput {
+  return {
+    feedSchools: [FEED_ELEM, FEED_HIGH],
+    feedTeachers: [],
+    speddySchools: [SCHOOL_ELEM, SCHOOL_HIGH],
+    existingTeachers: [],
+    studentCounts: { [SCHOOL_ELEM.id]: 10, [SCHOOL_HIGH.id]: 10 },
+    ...overrides,
+  };
+}
+
+const schoolPlan = (plan: ReturnType<typeof planTeacherDirectorySync>, id: string) => {
+  const found = plan.schools.find((s) => s.schoolId === id);
+  if (!found) throw new Error(`no plan for ${id}`);
+  return found;
+};
+
+beforeEach(() => {
+  nextId = 0;
+});
+
+// ---------------------------------------------------------------------------
+// The population rule (owner decision 1)
+// ---------------------------------------------------------------------------
+
+describe('the staff-ID population rule', () => {
+  it('creates real-teacher rows and excludes sentinel rows, per school', () => {
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [
+          teacher(),
+          teacher({ isTeacher: false, identifier: 'non-teaching staff', email: 'aide@example.org' }),
+        ],
+      }),
+    );
+    const elem = schoolPlan(plan, SCHOOL_ELEM.id);
+    expect(elem.creates).toHaveLength(1);
+    expect(elem.excludedNonTeaching).toBe(1);
+    expect(plan.feedTeacherRows).toBe(1);
+    expect(plan.feedTotalRows).toBe(2);
+  });
+
+  it('stores names VERBATIM — no case prettifying', () => {
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [teacher({ firstName: 'CHARLI', lastName: 'OMALLEY' })],
+      }),
+    );
+    const [create] = schoolPlan(plan, SCHOOL_ELEM.id).creates;
+    expect(create.firstName).toBe('CHARLI');
+    expect(create.lastName).toBe('OMALLEY');
+  });
+
+  it('carries the display staff ID onto the planned create', () => {
+    const plan = planTeacherDirectorySync(
+      input({ feedTeachers: [teacher({ identifier: '11_TCH_1174' })] }),
+    );
+    expect(schoolPlan(plan, SCHOOL_ELEM.id).creates[0].staffId).toBe('11_TCH_1174');
+  });
+});
+
+describe('toFeedTeacher (the feed-row pick)', () => {
+  it('flags the sentinel identifier as non-teaching, case- and space-insensitively', () => {
+    for (const value of ['non-teaching staff', 'Non-Teaching Staff', ' NON-TEACHING   STAFF ']) {
+      const row = toFeedTeacher({
+        sourcedId: 'x',
+        givenName: 'A',
+        familyName: 'B',
+        identifier: value,
+      });
+      expect(row?.isTeacher).toBe(false);
+    }
+  });
+
+  it('treats a missing identifier as non-teaching (no ID, no auto-create)', () => {
+    const row = toFeedTeacher({ sourcedId: 'x', givenName: 'A', familyName: 'B' });
+    expect(row?.isTeacher).toBe(false);
+  });
+
+  it('drops tobedeleted and nameless rows entirely', () => {
+    expect(
+      toFeedTeacher({ sourcedId: 'x', givenName: 'A', familyName: 'B', status: 'tobedeleted' }),
+    ).toBeNull();
+    expect(toFeedTeacher({ sourcedId: 'x', identifier: '11_TCH_1' })).toBeNull();
+  });
+
+  it('keeps only the fields the pick names — vendor extras cannot ride along', () => {
+    const row = toFeedTeacher({
+      sourcedId: 'x',
+      givenName: 'A',
+      familyName: 'B',
+      identifier: '11_TCH_1',
+      password: 'planted-password',
+      birthDate: 'planted-birthdate',
+    });
+    expect(JSON.stringify(row)).not.toContain('planted-');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The grade rule
+// ---------------------------------------------------------------------------
+
+describe('the KG-is-filler grade rule', () => {
+  it('keeps KG at an elementary school', () => {
+    const plan = planTeacherDirectorySync(input({ feedTeachers: [teacher({ grades: ['KG'] })] }));
+    expect(schoolPlan(plan, SCHOOL_ELEM.id).creates[0].gradeLevel).toBe('KG');
+  });
+
+  it('treats a lone KG as unknown at a non-elementary school', () => {
+    const plan = planTeacherDirectorySync(
+      input({ feedTeachers: [teacher({ grades: ['KG'], orgIds: [FEED_HIGH.sourcedId] })] }),
+    );
+    expect(schoolPlan(plan, SCHOOL_HIGH.id).creates[0].gradeLevel).toBeNull();
+  });
+
+  it('keeps real grade lists anywhere', () => {
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [teacher({ grades: ['09', '10', '11', '12'], orgIds: [FEED_HIGH.sourcedId] })],
+      }),
+    );
+    expect(schoolPlan(plan, SCHOOL_HIGH.id).creates[0].gradeLevel).toBe('09, 10, 11, 12');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// School mapping
+// ---------------------------------------------------------------------------
+
+describe('school mapping', () => {
+  it('matches by normalized name prefix — “X Elementary” ↔ “X Elementary School”', () => {
+    const plan = planTeacherDirectorySync(input({ feedTeachers: [teacher()] }));
+    expect(schoolPlan(plan, SCHOOL_ELEM.id).sisSchoolName).toBe(FEED_ELEM.name);
+    expect(schoolPlan(plan, SCHOOL_ELEM.id).refusal).toBeNull();
+  });
+
+  it('REFUSES a school whose name matches two SIS schools, and says so', () => {
+    const plan = planTeacherDirectorySync(
+      input({
+        feedSchools: [
+          FEED_ELEM,
+          { sourcedId: 'org-elem-2', name: 'Rodeo Vista Elementary Annex' },
+        ],
+        feedTeachers: [teacher()],
+      }),
+    );
+    const elem = schoolPlan(plan, SCHOOL_ELEM.id);
+    expect(elem.refusal).toMatch(/2 SIS schools match/);
+    expect(elem.creates).toHaveLength(0);
+  });
+
+  it('REFUSES both schools when they claim the same SIS school', () => {
+    const plan = planTeacherDirectorySync(
+      input({
+        speddySchools: [
+          { id: 'a', name: 'Crockett Point High' },
+          { id: 'b', name: 'Crockett Point' },
+        ],
+        feedSchools: [FEED_HIGH],
+        studentCounts: { a: 1, b: 1 },
+      }),
+    );
+    expect(schoolPlan(plan, 'a').refusal).toMatch(/same SIS school/);
+    expect(schoolPlan(plan, 'b').refusal).toMatch(/same SIS school/);
+  });
+
+  it('REFUSES a school with no SIS counterpart rather than guessing', () => {
+    const plan = planTeacherDirectorySync(
+      input({ speddySchools: [{ id: 'x', name: 'Willowbrook K8' }], studentCounts: { x: 5 } }),
+    );
+    expect(schoolPlan(plan, 'x').refusal).toMatch(/No school in the SIS feed matches/);
+  });
+
+  it('reports SIS schools nobody claims, with their teacher-row counts', () => {
+    const plan = planTeacherDirectorySync(
+      input({
+        feedSchools: [FEED_ELEM, FEED_HIGH, { sourcedId: 'org-willow', name: 'Willow High 501' }],
+        feedTeachers: [teacher({ orgIds: ['org-willow'] })],
+      }),
+    );
+    expect(plan.unmappedSisSchools).toEqual([{ name: 'Willow High 501', teacherRows: 1 }]);
+    // And nothing was created anywhere for it.
+    expect(plan.schools.flatMap((s) => s.creates)).toHaveLength(0);
+  });
+
+  it('creates a multi-school teacher once per mapped school', () => {
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [teacher({ orgIds: [FEED_ELEM.sourcedId, FEED_HIGH.sourcedId] })],
+      }),
+    );
+    expect(schoolPlan(plan, SCHOOL_ELEM.id).creates).toHaveLength(1);
+    expect(schoolPlan(plan, SCHOOL_HIGH.id).creates).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The ladder
+// ---------------------------------------------------------------------------
+
+const EXISTING_BASE = {
+  school_id: SCHOOL_ELEM.id,
+  grade_level: null,
+  sis_source: null,
+  sis_id: null,
+};
+
+describe('the reconcile ladder', () => {
+  it('keyed + identical → unchanged; nothing written', () => {
+    const t = teacher({ grades: [] });
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [t],
+        existingTeachers: [
+          {
+            ...EXISTING_BASE,
+            id: 'row-1',
+            first_name: t.firstName,
+            last_name: t.lastName,
+            email: t.email,
+            sis_source: 'oneroster',
+            sis_id: t.sourcedId,
+          },
+        ],
+      }),
+    );
+    const elem = schoolPlan(plan, SCHOOL_ELEM.id);
+    expect(elem.unchanged).toBe(1);
+    expect(elem.creates).toHaveLength(0);
+    expect(elem.updates).toHaveLength(0);
+  });
+
+  it('keyed + drifted → update carrying ONLY the changed fields (SIS-owned row)', () => {
+    const t = teacher({ email: 'new-address@example.org', grades: [] });
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [t],
+        existingTeachers: [
+          {
+            ...EXISTING_BASE,
+            id: 'row-1',
+            first_name: t.firstName,
+            last_name: t.lastName,
+            email: 'old-address@example.org',
+            sis_source: 'oneroster',
+            sis_id: t.sourcedId,
+          },
+        ],
+      }),
+    );
+    const [update] = schoolPlan(plan, SCHOOL_ELEM.id).updates;
+    expect(update.teacherId).toBe('row-1');
+    expect(update.changes).toEqual({ email: 'new-address@example.org' });
+  });
+
+  it('a case-only email difference is NOT a change', () => {
+    const t = teacher({ email: 'Same@Example.org', grades: [] });
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [t],
+        existingTeachers: [
+          {
+            ...EXISTING_BASE,
+            id: 'row-1',
+            first_name: t.firstName,
+            last_name: t.lastName,
+            email: 'same@example.org',
+            sis_source: 'oneroster',
+            sis_id: t.sourcedId,
+          },
+        ],
+      }),
+    );
+    expect(schoolPlan(plan, SCHOOL_ELEM.id).unchanged).toBe(1);
+  });
+
+  it('email match on an unkeyed row → ADOPT, never create', () => {
+    const t = teacher({ email: 'shared@example.org' });
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [t],
+        existingTeachers: [
+          {
+            ...EXISTING_BASE,
+            id: 'row-1',
+            first_name: 'Hand',
+            last_name: 'Entered',
+            email: 'SHARED@example.org',
+          },
+        ],
+      }),
+    );
+    const elem = schoolPlan(plan, SCHOOL_ELEM.id);
+    expect(elem.adopts).toEqual([
+      expect.objectContaining({ teacherId: 'row-1', sisId: t.sourcedId }),
+    ]);
+    expect(elem.creates).toHaveLength(0);
+  });
+
+  it('a NAME match alone goes to review — never adopted, never created', () => {
+    // The mutation-style pin for the ladder's most important property: if
+    // someone "simplifies" the name rung into an adopt, this fails.
+    const t = teacher({ firstName: 'JORDAN', lastName: 'RIVERA', email: 'jr-new@example.org' });
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [t],
+        existingTeachers: [
+          {
+            ...EXISTING_BASE,
+            id: 'row-1',
+            first_name: 'Jordan',
+            last_name: 'Rivera',
+            email: 'jr-old@example.org',
+          },
+        ],
+      }),
+    );
+    const elem = schoolPlan(plan, SCHOOL_ELEM.id);
+    expect(elem.reviews).toEqual([
+      expect.objectContaining({ existingTeacherId: 'row-1', feedName: 'JORDAN RIVERA' }),
+    ]);
+    expect(elem.adopts).toHaveLength(0);
+    expect(elem.creates).toHaveLength(0);
+  });
+
+  it('no match → create', () => {
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [teacher()],
+        existingTeachers: [
+          {
+            ...EXISTING_BASE,
+            id: 'row-1',
+            first_name: 'Someone',
+            last_name: 'Else',
+            email: 'else@example.org',
+          },
+        ],
+      }),
+    );
+    expect(schoolPlan(plan, SCHOOL_ELEM.id).creates).toHaveLength(1);
+  });
+
+  it('a sync-keyed row the feed no longer carries is REPORTED, in no write bucket', () => {
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [],
+        studentCounts: { [SCHOOL_ELEM.id]: 0, [SCHOOL_HIGH.id]: 0 },
+        existingTeachers: [
+          {
+            ...EXISTING_BASE,
+            id: 'row-gone',
+            first_name: 'Gone',
+            last_name: 'Fromfeed',
+            email: 'gone@example.org',
+            sis_source: 'oneroster',
+            sis_id: 'no-longer-there',
+          },
+        ],
+      }),
+    );
+    const elem = schoolPlan(plan, SCHOOL_ELEM.id);
+    expect(elem.missingFromSis).toEqual([
+      expect.objectContaining({ teacherId: 'row-gone', name: 'Gone Fromfeed' }),
+    ]);
+    expect(elem.creates).toHaveLength(0);
+    expect(elem.adopts).toHaveLength(0);
+    expect(elem.updates).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Feed anomalies
+// ---------------------------------------------------------------------------
+
+describe('feed anomalies', () => {
+  it('counts a sentinel row whose email matches a real teacher as a shadow duplicate', () => {
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [
+          teacher({ email: 'both@example.org', orgIds: [FEED_HIGH.sourcedId] }),
+          teacher({
+            isTeacher: false,
+            identifier: 'non-teaching staff',
+            email: 'both@example.org',
+            orgIds: [FEED_ELEM.sourcedId],
+          }),
+        ],
+      }),
+    );
+    expect(plan.shadowDuplicates).toBe(1);
+    // The person exists once, at the school where they are a teacher.
+    expect(schoolPlan(plan, SCHOOL_HIGH.id).creates).toHaveLength(1);
+    expect(schoolPlan(plan, SCHOOL_ELEM.id).creates).toHaveLength(0);
+  });
+
+  it('keeps one row and counts the rest when two teacher rows share an email at one school', () => {
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [
+          teacher({ sourcedId: 'aaa', email: 'twin@example.org' }),
+          teacher({ sourcedId: 'bbb', email: 'twin@example.org' }),
+        ],
+      }),
+    );
+    expect(schoolPlan(plan, SCHOOL_ELEM.id).creates).toHaveLength(1);
+    expect(plan.duplicateEmailAnomalies).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The loud per-school refusal (Carquinez's state)
+// ---------------------------------------------------------------------------
+
+describe('the zero-teachers guard', () => {
+  it('refuses a school with students whose feed rows all fail the population rule', () => {
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [
+          teacher({ isTeacher: false, identifier: 'non-teaching staff' }),
+          teacher({ isTeacher: false, identifier: 'non-teaching staff' }),
+        ],
+      }),
+    );
+    const elem = schoolPlan(plan, SCHOOL_ELEM.id);
+    expect(elem.refusal).toMatch(/2 staff row\(s\)/);
+    expect(elem.refusal).toMatch(/none with a real staff ID/);
+    expect(elem.creates).toHaveLength(0);
+  });
+
+  it('does NOT refuse an empty school with no students — nothing to protect', () => {
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [],
+        studentCounts: { [SCHOOL_ELEM.id]: 0, [SCHOOL_HIGH.id]: 0 },
+      }),
+    );
+    expect(schoolPlan(plan, SCHOOL_ELEM.id).refusal).toBeNull();
+  });
+
+  it('does NOT refuse when the school is already fully synced (unchanged counts as sync)', () => {
+    const t = teacher({ grades: [] });
+    const plan = planTeacherDirectorySync(
+      input({
+        feedTeachers: [t],
+        existingTeachers: [
+          {
+            ...EXISTING_BASE,
+            id: 'row-1',
+            first_name: t.firstName,
+            last_name: t.lastName,
+            email: t.email,
+            sis_source: 'oneroster',
+            sis_id: t.sourcedId,
+          },
+        ],
+      }),
+    );
+    expect(schoolPlan(plan, SCHOOL_ELEM.id).refusal).toBeNull();
+  });
+});

--- a/app/api/internal/sis-connections/[connectionId]/teacher-sync/route.ts
+++ b/app/api/internal/sis-connections/[connectionId]/teacher-sync/route.ts
@@ -13,7 +13,22 @@ import {
 
 const log = logger.child({ module: 'internal-teacher-sync' });
 
-const bodySchema = z.object({ mode: z.enum(['dry-run', 'apply']) });
+const bodySchema = z
+  .object({
+    mode: z.enum(['dry-run', 'apply']),
+    /**
+     * Apply only: the writable-change count from the dry-run the operator
+     * reviewed. Apply recomputes the plan from a fresh feed read; if the
+     * recomputed plan would write a DIFFERENT number of changes than the one
+     * approved, the route refuses with 409 and the operator re-previews.
+     * Count-level rather than a full plan digest — proportionate for a
+     * staff-clicked concierge surface (Codex/CodeRabbit, PR #831).
+     */
+    expectedChanges: z.number().int().min(0).optional(),
+  })
+  .refine((b) => b.mode !== 'apply' || b.expectedChanges !== undefined, {
+    message: 'apply requires expectedChanges from the reviewed preview',
+  });
 
 /**
  * POST /api/internal/sis-connections/[connectionId]/teacher-sync — plan (and,
@@ -86,9 +101,20 @@ export const POST = withRoute<{ connectionId: string }, z.infer<typeof bodySchem
     try {
       credential = await getDecryptedCredential(connection.id);
     } catch (err) {
+      // Distinct from "not stored yet": telling an operator to have the
+      // district re-enter credentials that exist hides an operational fault
+      // (likely a key rotation) behind setup guidance — same split the
+      // SPE-436 directory route makes.
       log.error('Could not decrypt the stored SIS credential', err, {
         connectionId: connection.id,
       });
+      return NextResponse.json(
+        {
+          error:
+            'The stored OneRoster credential could not be decrypted. Check the encryption key — re-entering credentials is not the fix.',
+        },
+        { status: 500 },
+      );
     }
     if (!credential || credential.sisType !== 'oneroster') {
       return NextResponse.json(
@@ -117,6 +143,29 @@ export const POST = withRoute<{ connectionId: string }, z.infer<typeof bodySchem
 
     if (body.mode === 'dry-run') {
       return NextResponse.json({ mode: 'dry-run', plan });
+    }
+
+    // The approval boundary: what the operator confirmed was the PREVIEW's
+    // writable count. The feed may have moved since; writing a different
+    // change set under a confirmation for the old one is the one thing apply
+    // must not do. Count mismatch → nothing written, re-preview.
+    const writable = plan.schools
+      .filter((s) => !s.refusal)
+      .reduce((sum, s) => sum + s.creates.length + s.adopts.length + s.updates.length, 0);
+    if (writable !== body.expectedChanges) {
+      log.info('Teacher sync apply refused: the plan moved since the preview', {
+        connectionId: connection.id,
+        expected: body.expectedChanges,
+        recomputed: writable,
+      });
+      return NextResponse.json(
+        {
+          error:
+            `The district's data changed since your preview (${body.expectedChanges} ` +
+            `change(s) approved, ${writable} now planned). Nothing was written — run the preview again.`,
+        },
+        { status: 409 },
+      );
     }
 
     const written = await applyTeacherSyncPlan({

--- a/app/api/internal/sis-connections/[connectionId]/teacher-sync/route.ts
+++ b/app/api/internal/sis-connections/[connectionId]/teacher-sync/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withRoute } from '@/lib/api/with-route';
+import { speddyAdminDenialReason } from '@/lib/api/speddy-admin-denial-reason';
+import { logger } from '@/lib/logger';
+import { getConnection, getDecryptedCredential } from '@/lib/sis/connections';
+import {
+  applyTeacherSyncPlan,
+  loadTeacherSyncInput,
+  planCounts,
+  planTeacherDirectorySync,
+} from '@/lib/sis/teacher-directory-sync';
+
+const log = logger.child({ module: 'internal-teacher-sync' });
+
+const bodySchema = z.object({ mode: z.enum(['dry-run', 'apply']) });
+
+/**
+ * POST /api/internal/sis-connections/[connectionId]/teacher-sync — plan (and,
+ * on `mode: 'apply'`, execute) the OneRoster teacher-directory sync (SPE-437).
+ *
+ * Staff-gated like the connection test (SPE-427): this dials a district's SIS
+ * with their stored credential, so the gate must refuse BEFORE anything is
+ * dialled — the handler tests pin that, not just the 403.
+ *
+ * `apply` recomputes the plan server-side from a fresh feed read. The client
+ * never posts a plan back; a stale or tampered browser payload therefore
+ * cannot write anything the current feed does not support. The cost is one
+ * extra fetch pass, which for a staff-clicked concierge flow is the right
+ * trade.
+ *
+ * The response carries teacher directory rows (names, work emails, staff
+ * IDs) for the reviewing human — the same fields the district admin already
+ * sees in the SPE-436 Directories view. Logs stay counts-only. No student
+ * data is read from the SIS at all.
+ */
+export const POST = withRoute<{ connectionId: string }, z.infer<typeof bodySchema>>(
+  {
+    body: bodySchema,
+    // Each run walks full pagination against a school district's production
+    // server, and apply runs the walk again — keep the ceiling low.
+    rateLimit: { requests: 4, windowSeconds: 60, name: 'internal-teacher-sync' },
+  },
+  async ({ userId, params, body }) => {
+    const denied = await speddyAdminDenialReason(userId);
+    if (denied) {
+      log.warn('Non-speddy-admin tried to run the teacher sync', {
+        userId,
+        connectionId: params.connectionId,
+        denied,
+      });
+      return NextResponse.json(
+        { error: 'Forbidden: Speddy admin access required' },
+        { status: 403 },
+      );
+    }
+
+    // Wrapped: withRoute's catch echoes error.message to the client in
+    // development, and a Supabase error names tables and constraints.
+    let connection;
+    try {
+      connection = await getConnection(params.connectionId);
+    } catch (err) {
+      log.error('Failed to load the SIS connection', err, {
+        connectionId: params.connectionId,
+      });
+      return NextResponse.json({ error: 'Could not load that connection.' }, { status: 500 });
+    }
+    if (!connection) {
+      return NextResponse.json({ error: 'No such SIS connection.' }, { status: 404 });
+    }
+    if (connection.sis_type !== 'oneroster') {
+      return NextResponse.json(
+        { error: 'Teacher sync reads the OneRoster connection; this one is not it.' },
+        { status: 409 },
+      );
+    }
+    if (!connection.base_url) {
+      return NextResponse.json(
+        { error: 'This connection has no address saved, so there is nothing to sync from.' },
+        { status: 409 },
+      );
+    }
+
+    let credential: Awaited<ReturnType<typeof getDecryptedCredential>> = null;
+    try {
+      credential = await getDecryptedCredential(connection.id);
+    } catch (err) {
+      log.error('Could not decrypt the stored SIS credential', err, {
+        connectionId: connection.id,
+      });
+    }
+    if (!credential || credential.sisType !== 'oneroster') {
+      return NextResponse.json(
+        { error: 'This district has no OneRoster credentials stored, so there is nothing to sync.' },
+        { status: 409 },
+      );
+    }
+
+    const input = await loadTeacherSyncInput({
+      districtId: connection.district_id,
+      baseUrl: connection.base_url,
+      tokenUrl: connection.token_url,
+      clientId: credential.clientId,
+      clientSecret: credential.clientSecret,
+    });
+    const plan = planTeacherDirectorySync(input);
+
+    // Counts only — this line, not the panel, is what outlives the session.
+    log.info('Teacher directory sync planned', {
+      connectionId: connection.id,
+      districtId: connection.district_id,
+      actorId: userId,
+      mode: body.mode,
+      plan: planCounts(plan),
+    });
+
+    if (body.mode === 'dry-run') {
+      return NextResponse.json({ mode: 'dry-run', plan });
+    }
+
+    const written = await applyTeacherSyncPlan({
+      plan,
+      actorId: userId,
+      connectionId: connection.id,
+      districtId: connection.district_id,
+    });
+    return NextResponse.json({ mode: 'apply', plan, written });
+  },
+);

--- a/app/components/internal/sis-connections-panel.tsx
+++ b/app/components/internal/sis-connections-panel.tsx
@@ -11,6 +11,8 @@ import { useCallback, useEffect, useState } from 'react';
  */
 import type { SisKeySelfTest } from '@/lib/sis/credential-crypto';
 
+import TeacherSyncCard from './teacher-sync-card';
+
 /**
  * The verdict plus which build produced it. Extends the shared union rather
  * than restating it, so the ok/problem contract still has exactly one owner.
@@ -616,6 +618,16 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
                     </div>
                   )}
                 </div>
+
+                {/* SPE-437: the concierge teacher sync. Only where it can run —
+                    an OneRoster connection with a recorded DPA and a stored
+                    credential; anything else would be a button whose only
+                    outcome is a 409. */}
+                {connection.sis_type === 'oneroster' &&
+                  dpaCleared &&
+                  connection.credential_hint && (
+                    <TeacherSyncCard connectionId={connection.id} />
+                  )}
               </li>
             );
           })}

--- a/app/components/internal/sis-connections-panel.tsx
+++ b/app/components/internal/sis-connections-panel.tsx
@@ -620,12 +620,13 @@ export default function SisConnectionsPanel({ districtId }: { districtId: string
                 </div>
 
                 {/* SPE-437: the concierge teacher sync. Only where it can run —
-                    an OneRoster connection with a recorded DPA and a stored
-                    credential; anything else would be a button whose only
-                    outcome is a 409. */}
+                    an OneRoster connection with a recorded DPA, a stored
+                    credential AND a saved address; anything else would be a
+                    button whose only outcome is a 409. */}
                 {connection.sis_type === 'oneroster' &&
                   dpaCleared &&
-                  connection.credential_hint && (
+                  connection.credential_hint &&
+                  connection.base_url && (
                     <TeacherSyncCard connectionId={connection.id} />
                   )}
               </li>

--- a/app/components/internal/teacher-sync-card.tsx
+++ b/app/components/internal/teacher-sync-card.tsx
@@ -158,13 +158,17 @@ function SchoolSection({ school }: { school: SchoolPlan }) {
           {school.reviews.length > 0 && (
             <details className="mt-1" open>
               <summary className="cursor-pointer text-xs text-amber-300">
-                Needs a human ({school.reviews.length}) — name matches, email does not
+                Needs a human ({school.reviews.length}) — never auto-linked
               </summary>
               <ul className="mt-1 space-y-0.5 pl-4 text-xs text-amber-200/80">
                 {school.reviews.map((r) => (
-                  <li key={r.sisId}>
+                  <li key={`${r.sisId}:${r.existingTeacherId}`}>
                     SIS “{r.feedName}” ({r.feedEmail ?? 'no email'}) vs existing “{r.existingName}”
-                    ({r.existingEmail ?? 'no email'}) — nothing written either way.
+                    ({r.existingEmail ?? 'no email'}) —{' '}
+                    {r.reason === 'ambiguous-email'
+                      ? 'several existing rows share this email; picking one automatically could stamp the wrong row.'
+                      : 'the name matches but the email does not.'}{' '}
+                    Nothing written either way.
                   </li>
                 ))}
               </ul>
@@ -203,11 +207,15 @@ export default function TeacherSyncCard({ connectionId }: { connectionId: string
   const [error, setError] = useState<string | null>(null);
 
   const run = async (mode: 'dry-run' | 'apply') => {
+    // Apply carries the previewed count; the server refuses if the freshly
+    // recomputed plan would write a different number than was confirmed.
+    let expectedChanges: number | undefined;
     if (mode === 'apply') {
       const plan = result?.plan;
       if (!plan) return;
+      expectedChanges = writableCount(plan);
       const confirmed = window.confirm(
-        `Apply the teacher sync?\n\nThis writes ${writableCount(plan)} change(s) to the live ` +
+        `Apply the teacher sync?\n\nThis writes ${expectedChanges} change(s) to the live ` +
           'teacher directory (creates, adoptions, and updates shown in the preview). ' +
           'Review rows and refused schools are not touched.',
       );
@@ -229,7 +237,9 @@ export default function TeacherSyncCard({ connectionId }: { connectionId: string
         headers: { 'Content-Type': 'application/json' },
         cache: 'no-store',
         signal: abort.signal,
-        body: JSON.stringify({ mode }),
+        body: JSON.stringify(
+          mode === 'apply' ? { mode, expectedChanges } : { mode },
+        ),
       });
       const json: unknown = await res.json().catch(() => null);
       if (!res.ok) {

--- a/app/components/internal/teacher-sync-card.tsx
+++ b/app/components/internal/teacher-sync-card.tsx
@@ -1,0 +1,355 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * Types imported from the sync module, never re-declared — a hand-copy would
+ * let the panel and the planner drift with nothing failing the build. `import
+ * type` is erased at compile time, so no server-only code reaches the bundle
+ * (same pattern as the key-health card in sis-connections-panel.tsx).
+ */
+import type {
+  SchoolPlan,
+  SchoolWriteResult,
+  TeacherSyncPlan,
+} from '@/lib/sis/teacher-directory-sync';
+
+interface TeacherSyncResponse {
+  mode: 'dry-run' | 'apply';
+  plan: TeacherSyncPlan;
+  written?: SchoolWriteResult[];
+}
+
+/**
+ * Validated rather than asserted: an off-shape 200 would otherwise render an
+ * empty plan as "nothing to create", which reads as a verdict and is not one.
+ */
+function isTeacherSyncResponse(value: unknown): value is TeacherSyncResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const body = value as { mode?: unknown; plan?: unknown };
+  if (body.mode !== 'dry-run' && body.mode !== 'apply') return false;
+  if (typeof body.plan !== 'object' || body.plan === null) return false;
+  return Array.isArray((body.plan as { schools?: unknown }).schools);
+}
+
+function writableCount(plan: TeacherSyncPlan): number {
+  return plan.schools
+    .filter((s) => !s.refusal)
+    .reduce((sum, s) => sum + s.creates.length + s.adopts.length + s.updates.length, 0);
+}
+
+function CountChip({ label, n, tone }: { label: string; n: number; tone: string }) {
+  if (n === 0) return null;
+  return (
+    <span className={`rounded-full border px-2 py-0.5 text-xs ${tone}`}>
+      {n} {label}
+    </span>
+  );
+}
+
+function SchoolSection({ school }: { school: SchoolPlan }) {
+  return (
+    <div className="rounded-md border border-slate-700 bg-slate-900/40 px-3 py-2">
+      <p className="text-sm font-medium text-white">
+        {school.schoolName}
+        {school.sisSchoolName && (
+          <span className="ml-2 text-xs font-normal text-slate-400">
+            ← SIS “{school.sisSchoolName}”
+          </span>
+        )}
+      </p>
+
+      {school.refusal ? (
+        <p className="mt-1 rounded border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-200">
+          Not synced — {school.refusal}
+        </p>
+      ) : (
+        <>
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            <CountChip
+              label="to create"
+              n={school.creates.length}
+              tone="bg-emerald-500/10 text-emerald-300 border-emerald-500/30"
+            />
+            <CountChip
+              label="to adopt (stamp SIS key on an existing row)"
+              n={school.adopts.length}
+              tone="bg-sky-500/10 text-sky-300 border-sky-500/30"
+            />
+            <CountChip
+              label="to update"
+              n={school.updates.length}
+              tone="bg-sky-500/10 text-sky-300 border-sky-500/30"
+            />
+            <CountChip
+              label="unchanged"
+              n={school.unchanged}
+              tone="bg-slate-500/10 text-slate-300 border-slate-500/30"
+            />
+            <CountChip
+              label="need review — never auto-matched"
+              n={school.reviews.length}
+              tone="bg-amber-500/10 text-amber-300 border-amber-500/30"
+            />
+            <CountChip
+              label="in Speddy but gone from the SIS (never deleted)"
+              n={school.missingFromSis.length}
+              tone="bg-slate-500/10 text-slate-300 border-slate-500/30"
+            />
+            <CountChip
+              label="excluded: non-teaching staff"
+              n={school.excludedNonTeaching}
+              tone="bg-slate-600/10 text-slate-400 border-slate-600/30"
+            />
+          </div>
+
+          {school.creates.length > 0 && (
+            <details className="mt-2">
+              <summary className="cursor-pointer text-xs text-slate-300">
+                Teachers to create ({school.creates.length})
+              </summary>
+              <ul className="mt-1 space-y-0.5 pl-4 text-xs text-slate-400">
+                {school.creates.map((c) => (
+                  <li key={c.sisId}>
+                    <span className="text-slate-200">
+                      {c.firstName} {c.lastName}
+                    </span>
+                    {c.email && <> · {c.email}</>}
+                    {c.staffId && <> · {c.staffId}</>}
+                    {c.gradeLevel && <> · grades {c.gradeLevel}</>}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+
+          {school.adopts.length > 0 && (
+            <details className="mt-1">
+              <summary className="cursor-pointer text-xs text-slate-300">
+                Existing rows to adopt ({school.adopts.length})
+              </summary>
+              <ul className="mt-1 space-y-0.5 pl-4 text-xs text-slate-400">
+                {school.adopts.map((a) => (
+                  <li key={a.sisId}>
+                    <span className="text-slate-200">{a.name}</span> · {a.email} — same email
+                    already in Speddy; only the SIS key is stamped.
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+
+          {school.updates.length > 0 && (
+            <details className="mt-1">
+              <summary className="cursor-pointer text-xs text-slate-300">
+                SIS-owned rows to update ({school.updates.length})
+              </summary>
+              <ul className="mt-1 space-y-0.5 pl-4 text-xs text-slate-400">
+                {school.updates.map((u) => (
+                  <li key={u.sisId}>
+                    <span className="text-slate-200">{u.name}</span> ·{' '}
+                    {Object.keys(u.changes).join(', ')} changed
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+
+          {school.reviews.length > 0 && (
+            <details className="mt-1" open>
+              <summary className="cursor-pointer text-xs text-amber-300">
+                Needs a human ({school.reviews.length}) — name matches, email does not
+              </summary>
+              <ul className="mt-1 space-y-0.5 pl-4 text-xs text-amber-200/80">
+                {school.reviews.map((r) => (
+                  <li key={r.sisId}>
+                    SIS “{r.feedName}” ({r.feedEmail ?? 'no email'}) vs existing “{r.existingName}”
+                    ({r.existingEmail ?? 'no email'}) — nothing written either way.
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+
+          {school.missingFromSis.length > 0 && (
+            <details className="mt-1">
+              <summary className="cursor-pointer text-xs text-slate-300">
+                In Speddy, gone from the SIS ({school.missingFromSis.length})
+              </summary>
+              <ul className="mt-1 space-y-0.5 pl-4 text-xs text-slate-400">
+                {school.missingFromSis.map((m) => (
+                  <li key={m.teacherId}>{m.name} — left in place; deleting is a human call.</li>
+                ))}
+              </ul>
+            </details>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Teacher-directory sync for an OneRoster connection (SPE-437).
+ *
+ * Two deliberate clicks: PREVIEW fetches the live feed and shows the exact
+ * per-school diff without writing anything; APPLY re-plans server-side and
+ * writes creates + adopts + keyed updates only. The plan shown is the review
+ * artifact — the concierge model's "owner sees it before it lands".
+ */
+export default function TeacherSyncCard({ connectionId }: { connectionId: string }) {
+  const [running, setRunning] = useState<'dry-run' | 'apply' | null>(null);
+  const [result, setResult] = useState<TeacherSyncResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async (mode: 'dry-run' | 'apply') => {
+    if (mode === 'apply') {
+      const plan = result?.plan;
+      if (!plan) return;
+      const confirmed = window.confirm(
+        `Apply the teacher sync?\n\nThis writes ${writableCount(plan)} change(s) to the live ` +
+          'teacher directory (creates, adoptions, and updates shown in the preview). ' +
+          'Review rows and refused schools are not touched.',
+      );
+      if (!confirmed) return;
+    }
+
+    setRunning(mode);
+    setError(null);
+    if (mode === 'dry-run') setResult(null);
+
+    // Bounded above the server's worst case (full pagination against a
+    // district SIS), for the same reason the connection test is: a shorter
+    // deadline reports "nothing happened" about a run the server completes.
+    const abort = new AbortController();
+    const timer = setTimeout(() => abort.abort(), 180_000);
+    try {
+      const res = await fetch(`/api/internal/sis-connections/${connectionId}/teacher-sync`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        cache: 'no-store',
+        signal: abort.signal,
+        body: JSON.stringify({ mode }),
+      });
+      const json: unknown = await res.json().catch(() => null);
+      if (!res.ok) {
+        const message =
+          typeof (json as { error?: unknown })?.error === 'string'
+            ? (json as { error: string }).error
+            : `The sync could not run (HTTP ${res.status}).`;
+        setError(message);
+        return;
+      }
+      if (!isTeacherSyncResponse(json)) {
+        setError('The sync returned an unreadable response. Nothing was written.');
+        return;
+      }
+      setResult(json);
+    } catch (err) {
+      const timedOut = err instanceof DOMException && err.name === 'AbortError';
+      setError(
+        timedOut
+          ? mode === 'apply'
+            ? 'Gave up waiting for the district’s SIS. The apply may still be running — re-run the preview before trying again.'
+            : 'Gave up waiting for the district’s SIS. Try the preview again in a moment.'
+          : 'Could not reach the sync. Nothing was written.',
+      );
+    } finally {
+      clearTimeout(timer);
+      setRunning(null);
+    }
+  };
+
+  const plan = result?.plan ?? null;
+  const canApply = plan !== null && result?.mode === 'dry-run' && writableCount(plan) > 0;
+
+  return (
+    <div className="mt-4 rounded-md border border-slate-700 bg-slate-900/40 px-4 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium text-white">Teacher directory sync</p>
+          <p className="mt-0.5 text-xs text-slate-400">
+            Fills each school’s teacher list from the OneRoster feed — real teacher rows only
+            (staff-ID rule, SPE-437). Preview shows the exact diff and writes nothing.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => run('dry-run')}
+            disabled={running !== null}
+            className="px-3 py-2 text-sm bg-slate-600 hover:bg-slate-500 disabled:opacity-50 text-white rounded-md transition-colors"
+          >
+            {running === 'dry-run' ? 'Previewing…' : 'Preview sync (no writes)'}
+          </button>
+          {canApply && (
+            <button
+              type="button"
+              onClick={() => run('apply')}
+              disabled={running !== null}
+              className="px-3 py-2 text-sm bg-purple-600 hover:bg-purple-700 disabled:opacity-50 text-white rounded-md transition-colors"
+            >
+              {running === 'apply' ? 'Applying…' : `Apply ${writableCount(plan)} change(s)`}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="mt-3 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-300"
+        >
+          {error}
+        </div>
+      )}
+
+      {/* Mounted unconditionally with only its CONTENT conditional — the
+          aria-live rule the rest of this panel follows. */}
+      <div role="status" aria-live="polite" className="contents">
+        {result && (
+          <div className="mt-3 space-y-2">
+            {result.mode === 'apply' && result.written && (
+              <div className="rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-200">
+                Applied.{' '}
+                {result.written
+                  .map((w) => `${w.schoolName}: ${w.created} created, ${w.adopted} adopted, ${w.updated} updated`)
+                  .join(' · ') || 'Nothing was writable.'}
+              </div>
+            )}
+
+            {plan?.schools.map((school) => (
+              <SchoolSection key={school.schoolId} school={school} />
+            ))}
+
+            <p className="text-xs text-slate-500">
+              Feed: {plan?.feedTeacherRows} teacher row(s) of {plan?.feedTotalRows} staff row(s).
+              {plan && plan.unmappedSisSchools.length > 0 && (
+                <>
+                  {' '}
+                  Skipped SIS schools with no Speddy counterpart:{' '}
+                  {plan.unmappedSisSchools
+                    .map((s) => `${s.name} (${s.teacherRows} teacher rows)`)
+                    .join(', ')}
+                  .
+                </>
+              )}
+              {plan && plan.shadowDuplicates > 0 && (
+                <>
+                  {' '}
+                  {plan.shadowDuplicates} duplicate staff listing(s) resolved to their teacher row.
+                </>
+              )}
+              {plan && plan.duplicateEmailAnomalies > 0 && (
+                <>
+                  {' '}
+                  {plan.duplicateEmailAnomalies} row(s) skipped for a repeated email at one school.
+                </>
+              )}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/sis/teacher-directory-sync.ts
+++ b/lib/sis/teacher-directory-sync.ts
@@ -1,0 +1,750 @@
+/**
+ * OneRoster → Speddy teacher-directory sync (SPE-437, SPE-414 Part 1).
+ *
+ * Auto-creates gen ed teachers per school from the district's OneRoster feed —
+ * the concierge path that spares site admins hand-typing a directory. Runs as
+ * a PLAN first (dry-run: the full per-school diff, zero writes), and APPLY
+ * recomputes the plan server-side rather than trusting anything a client
+ * posts back.
+ *
+ * The population rule, decided by the owner (2026-08-10) from JSUSD's live
+ * feed: a feed row becomes a teacher at school S only when it is org'd to S
+ * AND carries a real staff identifier. JSUSD's export marks everyone else
+ * with the literal identifier "non-teaching staff" — counselors, office
+ * staff, and (at Carquinez Middle) teachers whose SIS records lack the
+ * teacher linkage. Those rows are never created: planting office staff in
+ * teacher pickers is the inaccuracy this feature exists to avoid, and a
+ * school where NO row qualifies refuses loudly rather than syncing nobody.
+ *
+ * The reconcile ladder (v1 posture, per SPE-412's whose-data-wins decision):
+ *   keyed row (sis_source+sis_id)  -> SIS-owned: update changed fields
+ *   email match on an unkeyed row  -> ADOPT: stamp the SIS key, touch nothing
+ *   name match on an unkeyed row   -> REVIEW bucket; never auto-stamped
+ *   no match                       -> CREATE
+ * Sync-keyed rows missing from the feed are reported, never deleted.
+ *
+ * Names are stored VERBATIM as the feed sends them (owner decision):
+ * title-casing breaks O'MALLEY and MCKISSOCK, and a human can edit a row a
+ * machine got ugly, but nobody notices a name a machine silently mangled.
+ *
+ * PRIVACY. This module handles teacher directory data (names, work emails,
+ * staff IDs) — the same fields the district admin already sees in the SPE-436
+ * Directories view. Plans carry them so the reviewing human can review; LOGS
+ * carry counts only, and students are never read from the SIS at all.
+ *
+ * Server-only: dials an external SIS with a decrypted credential.
+ */
+import { logger } from '@/lib/logger';
+import { createServiceClient } from '@/lib/supabase/server';
+import { logServerAuditEvent } from '@/lib/supabase/audit-log-server';
+import { OneRosterClient, type RawOneRosterUser } from '@/lib/integrations/oneroster';
+import { ONEROSTER_URL_LABELS, assertSafeSisUrl } from './ssrf-guard';
+import { oneRosterTokenUrlCandidates } from './oneroster-setup';
+
+const log = logger.child({ module: 'teacher-directory-sync' });
+
+/** The value `teachers.sis_source` carries for rows this sync owns. */
+export const TEACHER_SIS_SOURCE = 'oneroster';
+
+/**
+ * JSUSD's feed marks non-teaching staff with this literal in the identifier
+ * field. Compared normalized (case/whitespace) so a vendor's casing change
+ * cannot silently turn office staff into teachers.
+ */
+const NON_TEACHING_SENTINEL = 'non-teaching staff';
+
+// ---------------------------------------------------------------------------
+// Planner input shapes — plain data, so the planner is testable without HTTP.
+// ---------------------------------------------------------------------------
+
+export interface FeedSchool {
+  sourcedId: string;
+  name: string;
+}
+
+export interface FeedTeacher {
+  sourcedId: string;
+  firstName: string;
+  lastName: string;
+  email: string | null;
+  /** The staff ID as the district shows it (e.g. `11_TCH_1174`) — display. */
+  identifier: string | null;
+  grades: string[];
+  orgIds: string[];
+  /** True when the identifier is present and not the non-teaching sentinel. */
+  isTeacher: boolean;
+}
+
+export interface SpeddySchool {
+  id: string;
+  name: string;
+}
+
+export interface ExistingTeacher {
+  id: string;
+  school_id: string;
+  first_name: string | null;
+  last_name: string | null;
+  email: string | null;
+  grade_level: string | null;
+  sis_source: string | null;
+  sis_id: string | null;
+}
+
+export interface PlannerInput {
+  feedSchools: FeedSchool[];
+  feedTeachers: FeedTeacher[];
+  speddySchools: SpeddySchool[];
+  existingTeachers: ExistingTeacher[];
+  /** Caseload rows per Speddy school id — the "school has students" gate. */
+  studentCounts: Record<string, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Plan shapes — what the staff panel renders and what apply executes.
+// ---------------------------------------------------------------------------
+
+export interface PlannedCreate {
+  sisId: string;
+  firstName: string;
+  lastName: string;
+  email: string | null;
+  staffId: string | null;
+  gradeLevel: string | null;
+}
+
+export interface PlannedAdopt {
+  teacherId: string;
+  sisId: string;
+  name: string;
+  email: string;
+}
+
+export interface PlannedUpdate {
+  teacherId: string;
+  sisId: string;
+  name: string;
+  changes: Partial<
+    Pick<ExistingTeacher, 'first_name' | 'last_name' | 'email' | 'grade_level'>
+  >;
+}
+
+export interface ReviewCandidate {
+  sisId: string;
+  feedName: string;
+  feedEmail: string | null;
+  existingTeacherId: string;
+  existingName: string;
+  existingEmail: string | null;
+}
+
+export interface SchoolPlan {
+  schoolId: string;
+  schoolName: string;
+  /** The SIS school this Speddy school mapped to, when it mapped. */
+  sisSchoolName: string | null;
+  creates: PlannedCreate[];
+  adopts: PlannedAdopt[];
+  updates: PlannedUpdate[];
+  unchanged: number;
+  reviews: ReviewCandidate[];
+  /** Sync-keyed rows the feed no longer carries — reported, never deleted. */
+  missingFromSis: { teacherId: string; name: string }[];
+  /** Feed rows org'd here that the population rule excluded. */
+  excludedNonTeaching: number;
+  studentCount: number;
+  /**
+   * The loud per-school no. Set when this school cannot be synced — no SIS
+   * school matched, the name-match was ambiguous, or every row the feed has
+   * for it failed the population rule while the school has students
+   * (Carquinez's state). A refused school is never written to.
+   */
+  refusal: string | null;
+}
+
+export interface TeacherSyncPlan {
+  schools: SchoolPlan[];
+  /** SIS schools no Speddy school claims (e.g. non-pilot schools) — skipped. */
+  unmappedSisSchools: { name: string; teacherRows: number }[];
+  /**
+   * Excluded rows whose email also appears on an included teacher — the same
+   * human carried twice by the feed (JSUSD: a sentinel row at one school and
+   * a real teacher row at another). Informational; the teacher row wins.
+   */
+  shadowDuplicates: number;
+  /** Included rows dropped because another row already claimed their email at that school. */
+  duplicateEmailAnomalies: number;
+  feedTeacherRows: number;
+  feedTotalRows: number;
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+const trimOrNull = (v: unknown): string | null =>
+  typeof v === 'string' && v.trim() ? v.trim() : null;
+
+/** Lowercased alphanumerics only — the school-name matching alphabet. */
+const normName = (v: string): string => v.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+const normEmail = (v: string | null): string | null => (v ? v.trim().toLowerCase() : null);
+
+/** Case/whitespace-insensitive person-name key for the review rung. */
+const personKey = (first: string | null, last: string | null): string =>
+  `${(first ?? '').trim().toLowerCase()} ${(last ?? '').trim().toLowerCase()}`
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const isNonTeachingSentinel = (identifier: string | null): boolean =>
+  identifier !== null && identifier.replace(/\s+/g, ' ').trim().toLowerCase() === NON_TEACHING_SENTINEL;
+
+/**
+ * The grade rule from the owner's JSUSD review: `KG` alone is the feed's
+ * filler value (it appears on every sentinel row and on obvious non-K staff),
+ * so it is stored only where the school context corroborates it — an
+ * elementary school. Multi-grade lists and non-KG values are stored verbatim.
+ */
+function gradeLevelFor(grades: string[], speddySchoolName: string): string | null {
+  if (grades.length === 0) return null;
+  const kgOnly = grades.length === 1 && grades[0].trim().toUpperCase() === 'KG';
+  if (kgOnly && !/elementary/i.test(speddySchoolName)) return null;
+  return grades.join(', ');
+}
+
+// ---------------------------------------------------------------------------
+// School mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Match Speddy schools to SIS schools by normalized name, prefix in either
+ * direction — "Rodeo Hills Elementary" ↔ "Rodeo Hills Elementary School".
+ *
+ * Ambiguity REFUSES the school rather than guessing: a wrong school mapping
+ * would file every teacher under the wrong roof, which is worse than filing
+ * none. JSUSD has 2 usable schools; if name-matching proves brittle at a
+ * bigger district, persisting a confirmed mapping is the follow-up (SPE-414).
+ */
+function mapSchools(
+  speddySchools: SpeddySchool[],
+  feedSchools: FeedSchool[],
+): {
+  bySchoolId: Map<string, { feed: FeedSchool } | { refusal: string }>;
+  claimedFeedIds: Set<string>;
+} {
+  const bySchoolId = new Map<string, { feed: FeedSchool } | { refusal: string }>();
+  const claims = new Map<string, string[]>(); // feed sourcedId -> speddy school ids
+
+  for (const school of speddySchools) {
+    const target = normName(school.name);
+    if (!target) {
+      bySchoolId.set(school.id, { refusal: 'This school has no name to match on.' });
+      continue;
+    }
+    const candidates = feedSchools.filter((f) => {
+      const n = normName(f.name);
+      return n.startsWith(target) || target.startsWith(n);
+    });
+    if (candidates.length === 0) {
+      bySchoolId.set(school.id, {
+        refusal: `No school in the SIS feed matches “${school.name}”.`,
+      });
+    } else if (candidates.length > 1) {
+      bySchoolId.set(school.id, {
+        refusal: `${candidates.length} SIS schools match “${school.name}” by name — refusing to guess which.`,
+      });
+    } else {
+      bySchoolId.set(school.id, { feed: candidates[0] });
+      const list = claims.get(candidates[0].sourcedId) ?? [];
+      list.push(school.id);
+      claims.set(candidates[0].sourcedId, list);
+    }
+  }
+
+  // A feed school claimed by two Speddy schools is the same ambiguity from the
+  // other side; refuse both claimants.
+  for (const [, schoolIds] of claims) {
+    if (schoolIds.length > 1) {
+      for (const id of schoolIds) {
+        bySchoolId.set(id, {
+          refusal: 'Two schools here match the same SIS school by name — refusing to guess.',
+        });
+      }
+    }
+  }
+
+  const claimedFeedIds = new Set<string>();
+  for (const value of bySchoolId.values()) {
+    if ('feed' in value) claimedFeedIds.add(value.feed.sourcedId);
+  }
+  return { bySchoolId, claimedFeedIds };
+}
+
+// ---------------------------------------------------------------------------
+// The planner — pure, so tests can pin every rung without a server.
+// ---------------------------------------------------------------------------
+
+export function planTeacherDirectorySync(input: PlannerInput): TeacherSyncPlan {
+  const { bySchoolId, claimedFeedIds } = mapSchools(input.speddySchools, input.feedSchools);
+
+  const teacherRows = input.feedTeachers.filter((t) => t.isTeacher);
+
+  // Emails carried by included teacher rows — the shadow-duplicate detector.
+  const teacherEmails = new Set<string>();
+  for (const t of teacherRows) {
+    const e = normEmail(t.email);
+    if (e) teacherEmails.add(e);
+  }
+  let shadowDuplicates = 0;
+  for (const t of input.feedTeachers) {
+    if (t.isTeacher) continue;
+    const e = normEmail(t.email);
+    if (e && teacherEmails.has(e)) shadowDuplicates += 1;
+  }
+
+  let duplicateEmailAnomalies = 0;
+  const schools: SchoolPlan[] = [];
+
+  for (const school of input.speddySchools) {
+    const mapping = bySchoolId.get(school.id);
+    const studentCount = input.studentCounts[school.id] ?? 0;
+    const existingAtSchool = input.existingTeachers.filter((t) => t.school_id === school.id);
+
+    if (!mapping || 'refusal' in mapping) {
+      schools.push({
+        schoolId: school.id,
+        schoolName: school.name,
+        sisSchoolName: null,
+        creates: [],
+        adopts: [],
+        updates: [],
+        unchanged: 0,
+        reviews: [],
+        missingFromSis: [],
+        excludedNonTeaching: 0,
+        studentCount,
+        refusal: mapping?.refusal ?? 'This school could not be mapped.',
+      });
+      continue;
+    }
+
+    const feedSchool = mapping.feed;
+    const atSchool = teacherRows.filter((t) => t.orgIds.includes(feedSchool.sourcedId));
+    const excludedNonTeaching = input.feedTeachers.filter(
+      (t) => !t.isTeacher && t.orgIds.includes(feedSchool.sourcedId),
+    ).length;
+
+    // One row per person per school: sourcedId is the key; a second included
+    // row carrying the same email at the same school is a feed anomaly — keep
+    // the deterministic first, count the rest rather than creating twins.
+    const seenIds = new Set<string>();
+    const seenEmails = new Set<string>();
+    const candidates: FeedTeacher[] = [];
+    for (const t of [...atSchool].sort((a, b) => a.sourcedId.localeCompare(b.sourcedId))) {
+      if (seenIds.has(t.sourcedId)) continue;
+      seenIds.add(t.sourcedId);
+      const e = normEmail(t.email);
+      if (e) {
+        if (seenEmails.has(e)) {
+          duplicateEmailAnomalies += 1;
+          continue;
+        }
+        seenEmails.add(e);
+      }
+      candidates.push(t);
+    }
+
+    // Index the existing rows once per school, by each ladder key.
+    const keyed = new Map<string, ExistingTeacher>();
+    const unkeyedByEmail = new Map<string, ExistingTeacher>();
+    const unkeyedByName = new Map<string, ExistingTeacher>();
+    for (const row of existingAtSchool) {
+      if (row.sis_source === TEACHER_SIS_SOURCE && row.sis_id) {
+        keyed.set(row.sis_id, row);
+        continue;
+      }
+      if (row.sis_id) continue; // keyed to some other SIS — not ours to match
+      const e = normEmail(row.email);
+      if (e && !unkeyedByEmail.has(e)) unkeyedByEmail.set(e, row);
+      const n = personKey(row.first_name, row.last_name);
+      if (n && !unkeyedByName.has(n)) unkeyedByName.set(n, row);
+    }
+
+    const creates: PlannedCreate[] = [];
+    const adopts: PlannedAdopt[] = [];
+    const updates: PlannedUpdate[] = [];
+    const reviews: ReviewCandidate[] = [];
+    let unchanged = 0;
+    const feedIdsAtSchool = new Set(candidates.map((c) => c.sourcedId));
+
+    for (const t of candidates) {
+      const gradeLevel = gradeLevelFor(t.grades, school.name);
+      const feedName = `${t.firstName} ${t.lastName}`.trim();
+
+      const keyedRow = keyed.get(t.sourcedId);
+      if (keyedRow) {
+        // SIS-owned row: bring the directory fields up to date. Email is
+        // compared normalized (a case-only change is not a change), stored
+        // verbatim.
+        const changes: PlannedUpdate['changes'] = {};
+        if ((keyedRow.first_name ?? '') !== t.firstName) changes.first_name = t.firstName;
+        if ((keyedRow.last_name ?? '') !== t.lastName) changes.last_name = t.lastName;
+        if (normEmail(keyedRow.email) !== normEmail(t.email)) changes.email = t.email;
+        if ((keyedRow.grade_level ?? null) !== gradeLevel) changes.grade_level = gradeLevel;
+        if (Object.keys(changes).length === 0) {
+          unchanged += 1;
+        } else {
+          updates.push({ teacherId: keyedRow.id, sisId: t.sourcedId, name: feedName, changes });
+        }
+        continue;
+      }
+
+      const email = normEmail(t.email);
+      const emailMatch = email ? unkeyedByEmail.get(email) : undefined;
+      if (emailMatch) {
+        // Email equality is strong identity: stamp the key, touch nothing
+        // else. The row stays human-owned.
+        adopts.push({
+          teacherId: emailMatch.id,
+          sisId: t.sourcedId,
+          name: feedName,
+          email: t.email as string,
+        });
+        continue;
+      }
+
+      const nameMatch = unkeyedByName.get(personKey(t.firstName, t.lastName));
+      if (nameMatch) {
+        // A name alone NEVER stamps a key — same-named humans exist, and the
+        // feed itself shows names drifting from emails. A human confirms.
+        reviews.push({
+          sisId: t.sourcedId,
+          feedName,
+          feedEmail: t.email,
+          existingTeacherId: nameMatch.id,
+          existingName: `${nameMatch.first_name ?? ''} ${nameMatch.last_name ?? ''}`.trim(),
+          existingEmail: nameMatch.email,
+        });
+        continue;
+      }
+
+      creates.push({
+        sisId: t.sourcedId,
+        firstName: t.firstName,
+        lastName: t.lastName,
+        email: t.email,
+        staffId: t.identifier,
+        gradeLevel,
+      });
+    }
+
+    const missingFromSis = existingAtSchool
+      .filter(
+        (row) =>
+          row.sis_source === TEACHER_SIS_SOURCE && row.sis_id && !feedIdsAtSchool.has(row.sis_id),
+      )
+      .map((row) => ({
+        teacherId: row.id,
+        name: `${row.first_name ?? ''} ${row.last_name ?? ''}`.trim(),
+      }));
+
+    // The Carquinez guard: students but not one qualifying teacher row. Say
+    // exactly what the feed had, so the fix (district-side) is nameable.
+    const touchable = creates.length + adopts.length + updates.length + unchanged;
+    const refusal =
+      studentCount > 0 && touchable === 0
+        ? `“${feedSchool.name}” has ${excludedNonTeaching} staff row(s) in the feed, ` +
+          'none with a real staff ID — nothing here can be created accurately. ' +
+          'This is district-side data (teacher records missing their staff linkage), not a Speddy failure.'
+        : null;
+
+    schools.push({
+      schoolId: school.id,
+      schoolName: school.name,
+      sisSchoolName: feedSchool.name,
+      creates,
+      adopts,
+      updates,
+      unchanged,
+      reviews,
+      missingFromSis,
+      excludedNonTeaching,
+      studentCount,
+      refusal,
+    });
+  }
+
+  const unmappedSisSchools = input.feedSchools
+    .filter((f) => !claimedFeedIds.has(f.sourcedId))
+    .map((f) => ({
+      name: f.name,
+      teacherRows: teacherRows.filter((t) => t.orgIds.includes(f.sourcedId)).length,
+    }));
+
+  return {
+    schools,
+    unmappedSisSchools,
+    shadowDuplicates,
+    duplicateEmailAnomalies,
+    feedTeacherRows: teacherRows.length,
+    feedTotalRows: input.feedTeachers.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// IO: fetch the inputs (SIS + database), run the planner, optionally write.
+// ---------------------------------------------------------------------------
+
+export interface TeacherSyncConnectionParams {
+  districtId: string;
+  baseUrl: string;
+  tokenUrl?: string | null;
+  clientId: string;
+  clientSecret: string;
+}
+
+/** Exported for tests: the feed-row pick, sentinel rule included. */
+export function toFeedTeacher(raw: RawOneRosterUser): FeedTeacher | null {
+  if (raw.status === 'tobedeleted') return null;
+  const firstName = trimOrNull(raw.givenName) ?? '';
+  const lastName = trimOrNull(raw.familyName) ?? '';
+  // A row with no name at all cannot become a picker entry anyone recognizes.
+  if (!firstName && !lastName) return null;
+  const identifier = trimOrNull(raw.identifier);
+  return {
+    sourcedId: raw.sourcedId,
+    firstName,
+    lastName,
+    email: trimOrNull(raw.email),
+    identifier,
+    grades: Array.isArray(raw.grades)
+      ? raw.grades.filter((g): g is string => typeof g === 'string' && g.trim() !== '')
+      : [],
+    orgIds: (raw.orgs ?? []).map((o) => o.sourcedId),
+    isTeacher: identifier !== null && !isNonTeachingSentinel(identifier),
+  };
+}
+
+/**
+ * Fetch everything the planner needs. SIS reads are FULL pagination — a
+ * first-page sample was fine for the probe, but a sync that missed page two
+ * would report the missing teachers as "missing from SIS" on the next run.
+ *
+ * Uses the stored token address (or the first derived candidate), never the
+ * candidate hunt — same posture as the SPE-436 directory: resolution belongs
+ * to the connection test, and an unhealthy connection should fail here and
+ * point at the tech portal, not probe a production SIS.
+ */
+export async function loadTeacherSyncInput(
+  params: TeacherSyncConnectionParams,
+): Promise<PlannerInput> {
+  const tokenUrl =
+    (params.tokenUrl ?? '').trim() || oneRosterTokenUrlCandidates(params.baseUrl)[0];
+  if (!tokenUrl) throw new Error('This connection has no usable token address.');
+
+  await assertSafeSisUrl(params.baseUrl, ONEROSTER_URL_LABELS);
+  await assertSafeSisUrl(tokenUrl, ONEROSTER_URL_LABELS);
+
+  const client = new OneRosterClient({
+    baseUrl: params.baseUrl,
+    tokenUrl,
+    clientId: params.clientId,
+    clientSecret: params.clientSecret,
+  });
+
+  const rawSchools = await client.getAllPages<Record<string, unknown>>('schools', 'orgs');
+  const feedSchools: FeedSchool[] = rawSchools.flatMap((s) => {
+    const sourcedId = trimOrNull(s.sourcedId);
+    const name = trimOrNull(s.name);
+    return sourcedId && name && s.status !== 'tobedeleted' ? [{ sourcedId, name }] : [];
+  });
+
+  const rawTeachers = await client.getAllPages<RawOneRosterUser>('teachers', 'users');
+  const feedTeachers = rawTeachers
+    .map(toFeedTeacher)
+    .filter((t): t is FeedTeacher => t !== null);
+
+  const supabase = createServiceClient();
+  const { data: schoolRows, error: schoolsError } = await supabase
+    .from('schools')
+    .select('id, name')
+    .eq('district_id', params.districtId);
+  if (schoolsError) throw new Error(`Could not load this district's schools: ${schoolsError.message}`);
+  const speddySchools: SpeddySchool[] = (schoolRows ?? []).map((s) => ({
+    id: String(s.id),
+    name: String(s.name ?? ''),
+  }));
+  const schoolIds = speddySchools.map((s) => s.id);
+
+  let existingTeachers: ExistingTeacher[] = [];
+  const studentCounts: Record<string, number> = {};
+  if (schoolIds.length > 0) {
+    const { data: teacherRows, error: teachersError } = await supabase
+      .from('teachers')
+      .select('id, school_id, first_name, last_name, email, grade_level, sis_source, sis_id')
+      .in('school_id', schoolIds);
+    if (teachersError) {
+      throw new Error(`Could not load existing teachers: ${teachersError.message}`);
+    }
+    existingTeachers = (teacherRows ?? []) as ExistingTeacher[];
+
+    // Caseload rows per school — the "has students" side of the loud-refusal
+    // gate. Head-count per school id; the exact number is display-only.
+    for (const id of schoolIds) {
+      const { count, error: countError } = await supabase
+        .from('students')
+        .select('id', { count: 'exact', head: true })
+        .eq('school_id', id);
+      if (countError) {
+        throw new Error(`Could not count students: ${countError.message}`);
+      }
+      studentCounts[id] = count ?? 0;
+    }
+  }
+
+  return { feedSchools, feedTeachers, speddySchools, existingTeachers, studentCounts };
+}
+
+/** Counts-only view of a plan — the ONLY shape this module ever logs. */
+export function planCounts(plan: TeacherSyncPlan) {
+  return {
+    schools: plan.schools.map((s) => ({
+      schoolId: s.schoolId,
+      creates: s.creates.length,
+      adopts: s.adopts.length,
+      updates: s.updates.length,
+      unchanged: s.unchanged,
+      reviews: s.reviews.length,
+      missingFromSis: s.missingFromSis.length,
+      excludedNonTeaching: s.excludedNonTeaching,
+      refused: s.refusal !== null,
+    })),
+    unmappedSisSchools: plan.unmappedSisSchools.length,
+    shadowDuplicates: plan.shadowDuplicates,
+    duplicateEmailAnomalies: plan.duplicateEmailAnomalies,
+    feedTeacherRows: plan.feedTeacherRows,
+    feedTotalRows: plan.feedTotalRows,
+  };
+}
+
+export interface SchoolWriteResult {
+  schoolId: string;
+  schoolName: string;
+  created: number;
+  adopted: number;
+  updated: number;
+}
+
+/**
+ * Apply a freshly computed plan: creates + adopts + keyed updates only.
+ * Review candidates and missing-from-SIS rows are never written — the first
+ * needs a human's "same person", the second is a delete this sync does not do.
+ *
+ * Writes run through the service role: this is the staff-gated concierge
+ * path (SPE-427 pattern), not a district session. Adoption re-checks
+ * `sis_id IS NULL` in the WHERE so a concurrent apply cannot double-stamp.
+ */
+export async function applyTeacherSyncPlan(params: {
+  plan: TeacherSyncPlan;
+  actorId: string;
+  connectionId: string;
+  districtId: string;
+}): Promise<SchoolWriteResult[]> {
+  const supabase = createServiceClient();
+  const results: SchoolWriteResult[] = [];
+
+  for (const school of params.plan.schools) {
+    if (school.refusal) continue;
+    const result: SchoolWriteResult = {
+      schoolId: school.schoolId,
+      schoolName: school.schoolName,
+      created: 0,
+      adopted: 0,
+      updated: 0,
+    };
+
+    if (school.creates.length > 0) {
+      const rows = school.creates.map((c) => ({
+        first_name: c.firstName,
+        last_name: c.lastName,
+        email: c.email,
+        school_id: school.schoolId,
+        school_site: school.schoolName,
+        grade_level: c.gradeLevel,
+        created_by_admin: false,
+        sis_source: TEACHER_SIS_SOURCE,
+        sis_id: c.sisId,
+      }));
+      const { data, error } = await supabase
+        .from('teachers')
+        .insert(rows)
+        .select('id');
+      if (error) {
+        // Stop rather than continue past a failed school: a partial apply that
+        // keeps going reports success about a state it does not know.
+        throw new Error(`Creating teachers for ${school.schoolName} failed: ${error.message}`);
+      }
+      result.created = (data ?? []).length;
+    }
+
+    for (const adopt of school.adopts) {
+      const { data, error } = await supabase
+        .from('teachers')
+        .update({ sis_source: TEACHER_SIS_SOURCE, sis_id: adopt.sisId })
+        .eq('id', adopt.teacherId)
+        .is('sis_id', null)
+        .select('id');
+      if (error) {
+        throw new Error(`Adopting a teacher at ${school.schoolName} failed: ${error.message}`);
+      }
+      // RLS is bypassed here (service role), so an empty result means the row
+      // changed since the plan was computed — count honestly, don't guess.
+      result.adopted += (data ?? []).length;
+    }
+
+    for (const update of school.updates) {
+      const { data, error } = await supabase
+        .from('teachers')
+        .update(update.changes)
+        .eq('id', update.teacherId)
+        .eq('sis_source', TEACHER_SIS_SOURCE)
+        .eq('sis_id', update.sisId)
+        .select('id');
+      if (error) {
+        throw new Error(`Updating a teacher at ${school.schoolName} failed: ${error.message}`);
+      }
+      result.updated += (data ?? []).length;
+    }
+
+    results.push(result);
+  }
+
+  await logServerAuditEvent({
+    user_id: params.actorId,
+    action: 'sis_teacher_sync_applied',
+    resource_type: 'district_sis_connection',
+    resource_id: params.connectionId,
+    metadata: {
+      districtId: params.districtId,
+      written: results.map((r) => ({
+        schoolId: r.schoolId,
+        created: r.created,
+        adopted: r.adopted,
+        updated: r.updated,
+      })),
+    },
+  });
+
+  log.info('Teacher directory sync applied', {
+    connectionId: params.connectionId,
+    districtId: params.districtId,
+    written: results.map(({ schoolId, created, adopted, updated }) => ({
+      schoolId,
+      created,
+      adopted,
+      updated,
+    })),
+  });
+
+  return results;
+}

--- a/lib/sis/teacher-directory-sync.ts
+++ b/lib/sis/teacher-directory-sync.ts
@@ -136,6 +136,13 @@ export interface ReviewCandidate {
   existingTeacherId: string;
   existingName: string;
   existingEmail: string | null;
+  /**
+   * Why a human is needed: a bare name match (never auto-stamped), or an
+   * email carried by MORE THAN ONE unkeyed row — adopting one of those
+   * nondeterministically would make the wrong row SIS-owned forever
+   * (Codex P1, PR #831).
+   */
+  reason: 'name-match' | 'ambiguous-email';
 }
 
 export interface SchoolPlan {
@@ -243,7 +250,10 @@ function mapSchools(
     }
     const candidates = feedSchools.filter((f) => {
       const n = normName(f.name);
-      return n.startsWith(target) || target.startsWith(n);
+      // An empty normalized feed name would prefix-match EVERYTHING
+      // (`target.startsWith('')` is always true) — a junk-named SIS org must
+      // match nothing, not poison every school into ambiguity.
+      return n !== '' && (n.startsWith(target) || target.startsWith(n));
     });
     if (candidates.length === 0) {
       bySchoolId.set(school.id, {
@@ -334,13 +344,43 @@ export function planTeacherDirectorySync(input: PlannerInput): TeacherSyncPlan {
       (t) => !t.isTeacher && t.orgIds.includes(feedSchool.sourcedId),
     ).length;
 
+    // Index the existing rows once per school, by each ladder key. Indexed
+    // BEFORE feed dedup because the dedup preference below needs `keyed`.
+    const keyed = new Map<string, ExistingTeacher>();
+    const unkeyedByEmail = new Map<string, ExistingTeacher[]>();
+    const unkeyedByName = new Map<string, ExistingTeacher>();
+    for (const row of existingAtSchool) {
+      if (row.sis_source === TEACHER_SIS_SOURCE && row.sis_id) {
+        keyed.set(row.sis_id, row);
+        continue;
+      }
+      if (row.sis_id) continue; // keyed to some other SIS — not ours to match
+      const e = normEmail(row.email);
+      if (e) {
+        const list = unkeyedByEmail.get(e) ?? [];
+        list.push(row);
+        unkeyedByEmail.set(e, list);
+      }
+      const n = personKey(row.first_name, row.last_name);
+      if (n && !unkeyedByName.has(n)) unkeyedByName.set(n, row);
+    }
+
     // One row per person per school: sourcedId is the key; a second included
     // row carrying the same email at the same school is a feed anomaly — keep
-    // the deterministic first, count the rest rather than creating twins.
+    // one, count the rest rather than creating twins. The row an existing
+    // teacher is ALREADY KEYED to wins the tie: dropping it would orphan a
+    // stable key, create a duplicate, and report the real teacher as missing
+    // (Codex P1, PR #831). Ties among unkeyed rows fall back to sourcedId
+    // order for determinism.
     const seenIds = new Set<string>();
     const seenEmails = new Set<string>();
     const candidates: FeedTeacher[] = [];
-    for (const t of [...atSchool].sort((a, b) => a.sourcedId.localeCompare(b.sourcedId))) {
+    const deduped = [...atSchool].sort((a, b) => {
+      const aKeyed = keyed.has(a.sourcedId) ? 0 : 1;
+      const bKeyed = keyed.has(b.sourcedId) ? 0 : 1;
+      return aKeyed - bKeyed || a.sourcedId.localeCompare(b.sourcedId);
+    });
+    for (const t of deduped) {
       if (seenIds.has(t.sourcedId)) continue;
       seenIds.add(t.sourcedId);
       const e = normEmail(t.email);
@@ -354,28 +394,15 @@ export function planTeacherDirectorySync(input: PlannerInput): TeacherSyncPlan {
       candidates.push(t);
     }
 
-    // Index the existing rows once per school, by each ladder key.
-    const keyed = new Map<string, ExistingTeacher>();
-    const unkeyedByEmail = new Map<string, ExistingTeacher>();
-    const unkeyedByName = new Map<string, ExistingTeacher>();
-    for (const row of existingAtSchool) {
-      if (row.sis_source === TEACHER_SIS_SOURCE && row.sis_id) {
-        keyed.set(row.sis_id, row);
-        continue;
-      }
-      if (row.sis_id) continue; // keyed to some other SIS — not ours to match
-      const e = normEmail(row.email);
-      if (e && !unkeyedByEmail.has(e)) unkeyedByEmail.set(e, row);
-      const n = personKey(row.first_name, row.last_name);
-      if (n && !unkeyedByName.has(n)) unkeyedByName.set(n, row);
-    }
-
     const creates: PlannedCreate[] = [];
     const adopts: PlannedAdopt[] = [];
     const updates: PlannedUpdate[] = [];
     const reviews: ReviewCandidate[] = [];
     let unchanged = 0;
-    const feedIdsAtSchool = new Set(candidates.map((c) => c.sourcedId));
+    // ALL teacher-row ids at the school, pre-dedup: a keyed row whose feed
+    // twin lost the dedup tie must not be reported "gone from the SIS" —
+    // the feed still carries it (Codex P1, PR #831).
+    const feedIdsAtSchool = new Set(atSchool.map((c) => c.sourcedId));
 
     for (const t of candidates) {
       const gradeLevel = gradeLevelFor(t.grades, school.name);
@@ -400,16 +427,33 @@ export function planTeacherDirectorySync(input: PlannerInput): TeacherSyncPlan {
       }
 
       const email = normEmail(t.email);
-      const emailMatch = email ? unkeyedByEmail.get(email) : undefined;
-      if (emailMatch) {
-        // Email equality is strong identity: stamp the key, touch nothing
-        // else. The row stays human-owned.
+      const emailMatches = email ? (unkeyedByEmail.get(email) ?? []) : [];
+      if (emailMatches.length === 1) {
+        // Email equality against exactly ONE row is strong identity: stamp
+        // the key, touch nothing else. The row stays human-owned.
         adopts.push({
-          teacherId: emailMatch.id,
+          teacherId: emailMatches[0].id,
           sisId: t.sourcedId,
           name: feedName,
           email: t.email as string,
         });
+        continue;
+      }
+      if (emailMatches.length > 1) {
+        // The same email on SEVERAL unkeyed rows (the schema permits it):
+        // adopting one nondeterministically would make the wrong row
+        // SIS-owned forever. A human picks (Codex P1, PR #831).
+        for (const row of emailMatches) {
+          reviews.push({
+            sisId: t.sourcedId,
+            feedName,
+            feedEmail: t.email,
+            existingTeacherId: row.id,
+            existingName: `${row.first_name ?? ''} ${row.last_name ?? ''}`.trim(),
+            existingEmail: row.email,
+            reason: 'ambiguous-email',
+          });
+        }
         continue;
       }
 
@@ -424,6 +468,7 @@ export function planTeacherDirectorySync(input: PlannerInput): TeacherSyncPlan {
           existingTeacherId: nameMatch.id,
           existingName: `${nameMatch.first_name ?? ''} ${nameMatch.last_name ?? ''}`.trim(),
           existingEmail: nameMatch.email,
+          reason: 'name-match',
         });
         continue;
       }
@@ -448,11 +493,14 @@ export function planTeacherDirectorySync(input: PlannerInput): TeacherSyncPlan {
         name: `${row.first_name ?? ''} ${row.last_name ?? ''}`.trim(),
       }));
 
-    // The Carquinez guard: students but not one qualifying teacher row. Say
-    // exactly what the feed had, so the fix (district-side) is nameable.
-    const touchable = creates.length + adopts.length + updates.length + unchanged;
+    // The Carquinez guard: students but not one QUALIFYING teacher row in
+    // the feed. Gated on candidates, not on writable buckets — a school
+    // whose rows all await human review has qualifying rows and must render
+    // them, not a refusal claiming it has none (Codex P2 / CodeRabbit,
+    // PR #831). Say exactly what the feed had, so the district-side fix is
+    // nameable.
     const refusal =
-      studentCount > 0 && touchable === 0
+      studentCount > 0 && candidates.length === 0
         ? `“${feedSchool.name}” has ${excludedNonTeaching} staff row(s) in the feed, ` +
           'none with a real staff ID — nothing here can be created accurately. ' +
           'This is district-side data (teacher records missing their staff linkage), not a Speddy failure.'
@@ -506,13 +554,17 @@ export interface TeacherSyncConnectionParams {
 /** Exported for tests: the feed-row pick, sentinel rule included. */
 export function toFeedTeacher(raw: RawOneRosterUser): FeedTeacher | null {
   if (raw.status === 'tobedeleted') return null;
+  // A blank sourcedId cannot key anything — writing it to `teachers.sis_id`
+  // would collide every such row into one "identity".
+  const sourcedId = trimOrNull(raw.sourcedId);
+  if (!sourcedId) return null;
   const firstName = trimOrNull(raw.givenName) ?? '';
   const lastName = trimOrNull(raw.familyName) ?? '';
   // A row with no name at all cannot become a picker entry anyone recognizes.
   if (!firstName && !lastName) return null;
   const identifier = trimOrNull(raw.identifier);
   return {
-    sourcedId: raw.sourcedId,
+    sourcedId,
     firstName,
     lastName,
     email: trimOrNull(raw.email),
@@ -520,7 +572,15 @@ export function toFeedTeacher(raw: RawOneRosterUser): FeedTeacher | null {
     grades: Array.isArray(raw.grades)
       ? raw.grades.filter((g): g is string => typeof g === 'string' && g.trim() !== '')
       : [],
-    orgIds: (raw.orgs ?? []).map((o) => o.sourcedId),
+    // Guarded like `grades`: the shape comes from an external SIS, and a
+    // vendor sending `orgs` as an object must degrade to "no schools", not
+    // throw away the whole run.
+    orgIds: Array.isArray(raw.orgs)
+      ? raw.orgs.flatMap((o) => {
+          const id = trimOrNull(o?.sourcedId);
+          return id ? [id] : [];
+        })
+      : [],
     isTeacher: identifier !== null && !isNonTeachingSentinel(identifier),
   };
 }
@@ -576,30 +636,43 @@ export async function loadTeacherSyncInput(
   }));
   const schoolIds = speddySchools.map((s) => s.id);
 
-  let existingTeachers: ExistingTeacher[] = [];
+  const existingTeachers: ExistingTeacher[] = [];
   const studentCounts: Record<string, number> = {};
   if (schoolIds.length > 0) {
-    const { data: teacherRows, error: teachersError } = await supabase
-      .from('teachers')
-      .select('id, school_id, first_name, last_name, email, grade_level, sis_source, sis_id')
-      .in('school_id', schoolIds);
-    if (teachersError) {
-      throw new Error(`Could not load existing teachers: ${teachersError.message}`);
+    // Paged to completion: PostgREST caps a select at max_rows (1000 on this
+    // project), and a truncated read here has the same failure mode the SIS
+    // side avoids with getAllPages — keyed rows past the cap look absent, so
+    // the planner re-creates teachers that already exist and the apply then
+    // trips the unique index mid-school. Ordered so pages cannot shear.
+    const DB_PAGE = 1000;
+    for (let from = 0; ; from += DB_PAGE) {
+      const { data: teacherRows, error: teachersError } = await supabase
+        .from('teachers')
+        .select('id, school_id, first_name, last_name, email, grade_level, sis_source, sis_id')
+        .in('school_id', schoolIds)
+        .order('id')
+        .range(from, from + DB_PAGE - 1);
+      if (teachersError) {
+        throw new Error(`Could not load existing teachers: ${teachersError.message}`);
+      }
+      existingTeachers.push(...((teacherRows ?? []) as ExistingTeacher[]));
+      if (!teacherRows || teacherRows.length < DB_PAGE) break;
     }
-    existingTeachers = (teacherRows ?? []) as ExistingTeacher[];
 
     // Caseload rows per school — the "has students" side of the loud-refusal
-    // gate. Head-count per school id; the exact number is display-only.
-    for (const id of schoolIds) {
-      const { count, error: countError } = await supabase
-        .from('students')
-        .select('id', { count: 'exact', head: true })
-        .eq('school_id', id);
-      if (countError) {
-        throw new Error(`Could not count students: ${countError.message}`);
-      }
-      studentCounts[id] = count ?? 0;
-    }
+    // gate. Head-counts run concurrently; the exact number is display-only.
+    await Promise.all(
+      schoolIds.map(async (id) => {
+        const { count, error: countError } = await supabase
+          .from('students')
+          .select('id', { count: 'exact', head: true })
+          .eq('school_id', id);
+        if (countError) {
+          throw new Error(`Could not count students: ${countError.message}`);
+        }
+        studentCounts[id] = count ?? 0;
+      }),
+    );
   }
 
   return { feedSchools, feedTeachers, speddySchools, existingTeachers, studentCounts };
@@ -653,7 +726,49 @@ export async function applyTeacherSyncPlan(params: {
   const supabase = createServiceClient();
   const results: SchoolWriteResult[] = [];
 
-  for (const school of params.plan.schools) {
+  // Written in BOTH outcomes. Stop-on-failure means a school can fail after
+  // earlier schools committed, and service-role writes that happened must
+  // never go unrecorded because a later school threw (CodeRabbit, PR #831).
+  // Counts only, per the module's logging rule.
+  const recordOutcome = async (partial: boolean) => {
+    const written = results.map(({ schoolId, created, adopted, updated }) => ({
+      schoolId,
+      created,
+      adopted,
+      updated,
+    }));
+    await logServerAuditEvent({
+      user_id: params.actorId,
+      action: 'sis_teacher_sync_applied',
+      resource_type: 'district_sis_connection',
+      resource_id: params.connectionId,
+      metadata: { districtId: params.districtId, partial, written },
+    });
+    log.info('Teacher directory sync applied', {
+      connectionId: params.connectionId,
+      districtId: params.districtId,
+      partial,
+      written,
+    });
+  };
+
+  try {
+    await applySchools(supabase, params.plan, results);
+  } catch (err) {
+    await recordOutcome(true);
+    throw err;
+  }
+
+  await recordOutcome(false);
+  return results;
+}
+
+async function applySchools(
+  supabase: ReturnType<typeof createServiceClient>,
+  plan: TeacherSyncPlan,
+  results: SchoolWriteResult[],
+): Promise<void> {
+  for (const school of plan.schools) {
     if (school.refusal) continue;
     const result: SchoolWriteResult = {
       schoolId: school.schoolId,
@@ -662,6 +777,10 @@ export async function applyTeacherSyncPlan(params: {
       adopted: 0,
       updated: 0,
     };
+    // Pushed BEFORE the writes, counts accumulating on the shared reference:
+    // a school that fails halfway must still contribute what it DID write to
+    // the partial-outcome audit record, not vanish from it.
+    results.push(result);
 
     if (school.creates.length > 0) {
       const rows = school.creates.map((c) => ({
@@ -716,35 +835,5 @@ export async function applyTeacherSyncPlan(params: {
       result.updated += (data ?? []).length;
     }
 
-    results.push(result);
   }
-
-  await logServerAuditEvent({
-    user_id: params.actorId,
-    action: 'sis_teacher_sync_applied',
-    resource_type: 'district_sis_connection',
-    resource_id: params.connectionId,
-    metadata: {
-      districtId: params.districtId,
-      written: results.map((r) => ({
-        schoolId: r.schoolId,
-        created: r.created,
-        adopted: r.adopted,
-        updated: r.updated,
-      })),
-    },
-  });
-
-  log.info('Teacher directory sync applied', {
-    connectionId: params.connectionId,
-    districtId: params.districtId,
-    written: results.map(({ schoolId, created, adopted, updated }) => ({
-      schoolId,
-      created,
-      adopted,
-      updated,
-    })),
-  });
-
-  return results;
 }

--- a/supabase/migrations/20260810_spe437_teachers_sis_key.sql
+++ b/supabase/migrations/20260810_spe437_teachers_sis_key.sql
@@ -22,8 +22,25 @@ ALTER TABLE public.teachers
 
 -- The pair travels together: a source without an id identifies nothing, and an
 -- id without a source is unkeyable the moment a second SIS exists.
-ALTER TABLE public.teachers
-  ADD CONSTRAINT teachers_sis_pair_chk CHECK ((sis_source IS NULL) = (sis_id IS NULL));
+--
+-- Guarded (Postgres has no ADD CONSTRAINT IF NOT EXISTS) so a partial or
+-- repeated run of this file cannot fail on the one unguarded statement, and
+-- NOT VALID + VALIDATE so adding it never takes the write-blocking scan —
+-- every existing row has both columns NULL, so validation is trivially true.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.teachers'::regclass
+      AND conname = 'teachers_sis_pair_chk'
+  ) THEN
+    ALTER TABLE public.teachers
+      ADD CONSTRAINT teachers_sis_pair_chk
+      CHECK ((sis_source IS NULL) = (sis_id IS NULL)) NOT VALID;
+  END IF;
+END $$;
+
+ALTER TABLE public.teachers VALIDATE CONSTRAINT teachers_sis_pair_chk;
 
 -- One row per SIS identity per school. Partial: the NULL (human-entered) rows
 -- stay unconstrained — a school can hand-enter as many teachers as it likes.

--- a/supabase/migrations/20260810_spe437_teachers_sis_key.sql
+++ b/supabase/migrations/20260810_spe437_teachers_sis_key.sql
@@ -1,0 +1,39 @@
+-- SPE-437: SIS identity on `teachers` — the generalized (source, id) pair.
+--
+-- The teacher-directory sync (SPE-414 Part 1) needs re-syncs to be KEYED, not
+-- fuzzy: a teacher created from OneRoster today must be findable tomorrow by
+-- the same stable key, or every re-sync re-matches by name/email and the
+-- failure mode is duplicates — exactly what auto-create exists to prevent.
+--
+-- One generalized pair rather than per-source columns (`oneroster_sourced_id`,
+-- `aeries_teacher_number`, …), decided once for SPE-437 and SPE-123 jointly
+-- (see SPE-414 "decide ONCE"): the same two columns serve OneRoster's
+-- `sourcedId` now and Aeries' `TeacherNumber` later, and adding a third SIS
+-- never needs a migration again.
+--
+-- NULL means "human-entered, no SIS identity" — every existing row. The sync's
+-- ladder (SPE-437) treats NULL rows as human-owned: it may ADOPT one by
+-- stamping these columns when the email matches, but never edits its other
+-- fields without a human confirming.
+
+ALTER TABLE public.teachers
+  ADD COLUMN IF NOT EXISTS sis_source text,
+  ADD COLUMN IF NOT EXISTS sis_id text;
+
+-- The pair travels together: a source without an id identifies nothing, and an
+-- id without a source is unkeyable the moment a second SIS exists.
+ALTER TABLE public.teachers
+  ADD CONSTRAINT teachers_sis_pair_chk CHECK ((sis_source IS NULL) = (sis_id IS NULL));
+
+-- One row per SIS identity per school. Partial: the NULL (human-entered) rows
+-- stay unconstrained — a school can hand-enter as many teachers as it likes.
+-- Per school rather than global because a multi-school teacher is one row per
+-- school (teachers.school_id is single-valued), each carrying the same SIS key.
+CREATE UNIQUE INDEX IF NOT EXISTS teachers_school_sis_key
+  ON public.teachers (school_id, sis_source, sis_id)
+  WHERE sis_id IS NOT NULL;
+
+-- No grant or RLS changes: `teachers` keeps its table-level grants, and the new
+-- columns carry no secrets — a staff id is directory data the district already
+-- shows in the SIS-fed Directories view (SPE-436). Row-level policies are
+-- unchanged; the sync writes through the service role on a staff-gated route.


### PR DESCRIPTION
SPE-414 Part 1, scoped to the owner's 2026-08-10 decisions after reviewing JSUSD's live teacher directory: auto-create gen ed teachers per school from the OneRoster feed, accurately, with a staff-only dry-run as the review artifact before anything writes.

## The population rule (owner decision, from live JSUSD data)

A feed row becomes a Speddy teacher at school S only when it is **org'd to S and carries a real staff identifier**. JSUSD's export marks everyone else — counselors, office staff, and (at Carquinez Middle) teachers whose SIS records lack the teacher linkage — with the literal identifier `non-teaching staff`; those rows are never created. A school **with students** where no row qualifies (Carquinez's current state) **refuses loudly with the named reason** instead of syncing nobody. Names are stored **verbatim** (no title-casing — it breaks O'MALLEY/MCKISSOCK). A lone `KG` grade is the feed's filler value and is stored only at elementary schools.

## What's in the diff

- **Migration (file only, NOT applied)**: `teachers.sis_source` + `teachers.sis_id`, paired `CHECK`, partial unique index per school. The generalized pair decided once for SPE-437/SPE-123 jointly — OneRoster `sourcedId` now, Aeries `TeacherNumber` later. Applied separately after owner sign-off per the standing rule.
- **`lib/sis/teacher-directory-sync.ts`**: a pure planner (school mapping by normalized name that refuses ambiguity in either direction; the reconcile ladder) plus IO (full pagination via `getAllPages`, SSRF-guarded, stored token address only — no candidate hunting) and apply (recomputes the plan server-side; a client can never post a plan back).
- **The ladder**: keyed row → SIS-owned update of changed fields · email match on an unkeyed row → adopt (stamp keys, touch nothing else) · **name match → review bucket, never auto-stamped** · no match → create. Sync-keyed rows missing from the feed are reported, never deleted. Adoption re-checks `sis_id IS NULL` in the WHERE so a concurrent apply cannot double-stamp; counts come from what the database says happened.
- **Route** `POST /api/internal/sis-connections/[connectionId]/teacher-sync` (`dry-run`/`apply`): staff-gated (SPE-427 pattern), rate-limited 4/min, 409s for non-OneRoster/credential-less connections.
- **Panel card** on `/internal`: Preview (zero writes) renders the per-school diff — creates, adopts, updates, review rows, missing-from-SIS, exclusions, refusals — then Apply behind a confirm.

## Privacy posture

Plans carry teacher directory fields (names, work emails, staff IDs) for the reviewing human — the same fields the district admin already sees in the SPE-436 Directories view. **Logs and audit rows carry counts only**, pinned by tests. No student data is read from the SIS at all.

## Verification

- 49 new tests across 4 suites, all green; typecheck and lint clean (remaining lint warnings pre-date this diff).
- Planner rungs pinned individually, including the mutation-style "a name match alone never writes" case and the zero-teachers refusal both ways.
- Real-HTTP fixture server: pagination walked to completion (1000+3 rows over two pages); planted credential/demographic fields and planted PII asserted absent from the planner input, the plan, and every captured log line.
- Handler suite: non-staff/unauthenticated/fail-closed refusals dial nothing; malformed body dials nothing; dry-run never reaches the writer; apply's plan comes from the fresh server-side load.
- `tests/integration/*` failures are pre-existing on `main` (environment-dependent; verified identical on a clean checkout).
- Live acceptance is deliberately manual: staff dry-run against JSUSD once deployed — expected shape: Rodeo Hills ~28 creates, John Swett High ~23, Carquinez refused with the named reason, Willow schools reported as unmapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcxL3WefHrAjGStyvVJrAo

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcxL3WefHrAjGStyvVJrAo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OneRoster teacher-directory synchronization for approved connections.
  - Preview planned creates, adoptions, updates, reviews, missing records, and data issues before applying changes.
  - Apply approved synchronization plans with confirmation and live status feedback.
  - Added safeguards for authorization, credentials, invalid connections, ambiguous school matches, and incomplete data.
  - Added SIS identity tracking to prevent duplicate teacher records and support reliable updates.
- **Privacy & Safety**
  - Operational logs show counts and outcomes without exposing teacher names or email addresses.
  - Added protections against unsafe connection URLs and unauthorized changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->