### PR TITLE
SPE-445: accounts-on-apply + the district admin's own Preview → Apply

### DIFF
--- a/__tests__/unit/app/api/district/teacher-sync.test.ts
+++ b/__tests__/unit/app/api/district/teacher-sync.test.ts
@@ -1,0 +1,262 @@
+/**
+ * SPE-438 · POST /api/district/teacher-sync — the district admin's own
+ * Preview → Apply, and what a refused caller does NOT set in motion.
+ *
+ * Same posture as the sis-directory suite (SPE-436) plus the internal
+ * teacher-sync suite (SPE-437): the load-bearing assertions are that nothing
+ * dials the district's SIS and nothing writes — accounts included — unless a
+ * district admin, in their own district, with a stored credential, asked.
+ * `district_tech` is refused here on purpose: this surface serves teacher
+ * PII and provisions sign-in accounts, both outside that role's
+ * integrations-only line (SPE-393).
+ */
+import { NextRequest } from 'next/server';
+
+const ADMIN_ID = '55555555-5555-4555-8555-555555555555';
+const DISTRICT_ID = '0618990';
+
+let currentUserId: string | null = ADMIN_ID;
+/** Whether the grant re-check finds a district_admin row for a tech-role caller. */
+let holdsAdminGrant = false;
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: async () =>
+        currentUserId
+          ? { data: { user: { id: currentUserId } }, error: null }
+          : { data: { user: null }, error: { message: 'no session' } },
+    },
+  }),
+  createServiceClient: () => ({
+    from: () => {
+      const q: Record<string, unknown> = {};
+      q.select = () => q;
+      q.eq = () => q;
+      q.limit = () => q;
+      q.maybeSingle = () =>
+        Promise.resolve({ data: holdsAdminGrant ? { id: 'grant-1' } : null, error: null });
+      return q;
+    },
+  }),
+}));
+
+jest.mock('@/lib/api/rate-limit-user', () => ({
+  checkUserRateLimit: jest.fn().mockResolvedValue({ allowed: true }),
+}));
+
+const logCalls: unknown[][] = [];
+jest.mock('@/lib/logger', () => {
+  const record = (...args: unknown[]) => {
+    logCalls.push(args);
+  };
+  const fake = { info: record, warn: record, error: record, debug: record, child: () => fake };
+  return { logger: fake };
+});
+
+const mockResolveCaller = jest.fn();
+jest.mock('@/lib/api/district-sis-caller', () => ({
+  resolveDistrictSisCaller: (...a: unknown[]) => mockResolveCaller(...a),
+}));
+
+const mockListConnections = jest.fn();
+const mockGetCredential = jest.fn();
+jest.mock('@/lib/sis/connections', () => ({
+  ...jest.requireActual('@/lib/sis/connections'),
+  listConnections: (...a: unknown[]) => mockListConnections(...a),
+  getDecryptedCredential: (...a: unknown[]) => mockGetCredential(...a),
+}));
+
+// The two functions that reach beyond this process: one dials the SIS, one
+// writes the database and provisions accounts.
+const mockLoad = jest.fn();
+const mockApply = jest.fn();
+jest.mock('@/lib/sis/teacher-directory-sync', () => ({
+  ...jest.requireActual('@/lib/sis/teacher-directory-sync'),
+  loadTeacherSyncInput: (...a: unknown[]) => mockLoad(...a),
+  applyTeacherSyncPlan: (...a: unknown[]) => mockApply(...a),
+}));
+
+import { POST } from '@/app/api/district/teacher-sync/route';
+import type { PlannerInput } from '@/lib/sis/teacher-directory-sync';
+
+const CONNECTION = {
+  id: 'conn-1',
+  district_id: DISTRICT_ID,
+  sis_type: 'oneroster',
+  base_url: 'https://district.example.org/admin',
+  token_url: 'https://district.example.org/admin/token',
+};
+
+/** A one-school input whose plan creates exactly one teacher (with email). */
+const INPUT: PlannerInput = {
+  feedSchools: [{ sourcedId: 'org-1', name: 'Rodeo Vista Elementary School' }],
+  feedTeachers: [
+    {
+      sourcedId: 't-1',
+      firstName: 'DANA',
+      lastName: 'WHITFIELD',
+      email: 'dwhitfield@example.org',
+      identifier: '11_TCH_1',
+      grades: ['KG'],
+      orgIds: ['org-1'],
+      isTeacher: true,
+    },
+  ],
+  speddySchools: [{ id: 'sch-1', name: 'Rodeo Vista Elementary' }],
+  existingTeachers: [],
+  studentCounts: { 'sch-1': 4 },
+};
+
+const call = (body: unknown) =>
+  POST(
+    new NextRequest('http://localhost/api/district/teacher-sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({}) },
+  );
+
+const nothingHappened = () => {
+  expect(mockLoad).not.toHaveBeenCalled();
+  expect(mockApply).not.toHaveBeenCalled();
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  logCalls.length = 0;
+  currentUserId = ADMIN_ID;
+  holdsAdminGrant = false;
+  mockResolveCaller.mockResolvedValue({ ok: true, role: 'district_admin', districtId: DISTRICT_ID });
+  mockListConnections.mockResolvedValue([CONNECTION]);
+  mockGetCredential.mockResolvedValue({
+    sisType: 'oneroster',
+    clientId: 'consumer-id',
+    clientSecret: 'consumer-secret',
+  });
+  mockLoad.mockResolvedValue(INPUT);
+  mockApply.mockResolvedValue([
+    {
+      schoolId: 'sch-1',
+      schoolName: 'Rodeo Vista Elementary',
+      created: 1,
+      adopted: 0,
+      updated: 0,
+      accountsCreated: 1,
+      directoryOnly: 0,
+      accountConflicts: [],
+    },
+  ]);
+});
+
+describe('the gate', () => {
+  it('refuses an unauthenticated caller, dialling nothing', async () => {
+    currentUserId = null;
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(401);
+    nothingHappened();
+  });
+
+  it('refuses a caller with no district grant at all, dialling nothing', async () => {
+    mockResolveCaller.mockResolvedValue({ ok: false, denied: 'no-grant' });
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(403);
+    nothingHappened();
+  });
+
+  it('refuses district_tech — accounts and teacher PII are beyond its line', async () => {
+    mockResolveCaller.mockResolvedValue({
+      ok: true,
+      role: 'district_tech',
+      districtId: DISTRICT_ID,
+    });
+    holdsAdminGrant = false;
+    const res = await call({ mode: 'apply', expectedChanges: 1 });
+    expect(res.status).toBe(403);
+    nothingHappened();
+  });
+
+  it('admits a dual-role caller whose grants include district_admin', async () => {
+    mockResolveCaller.mockResolvedValue({
+      ok: true,
+      role: 'district_tech',
+      districtId: DISTRICT_ID,
+    });
+    holdsAdminGrant = true;
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(200);
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('connection gates', () => {
+  it('409s when the district has no OneRoster connection, dialling nothing', async () => {
+    mockListConnections.mockResolvedValue([{ ...CONNECTION, sis_type: 'aeries' }]);
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(409);
+    nothingHappened();
+  });
+
+  it('409s when no credential is stored, dialling nothing', async () => {
+    mockGetCredential.mockResolvedValue(null);
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(409);
+    nothingHappened();
+  });
+
+  it('500s a credential that cannot be decrypted, dialling nothing', async () => {
+    mockGetCredential.mockRejectedValue(new Error('decrypt failed'));
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(500);
+    nothingHappened();
+  });
+});
+
+describe('dry-run vs apply', () => {
+  it('dry-run plans from a live read and never reaches the writer', async () => {
+    const res = await call({ mode: 'dry-run' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.mode).toBe('dry-run');
+    expect(body.plan.schools[0].creates).toHaveLength(1);
+    expect(mockApply).not.toHaveBeenCalled();
+  });
+
+  it('apply without the reviewed count is refused at validation, dialling nothing', async () => {
+    const res = await call({ mode: 'apply' });
+    expect(res.status).toBe(400);
+    nothingHappened();
+  });
+
+  it('apply refuses with 409 when the plan moved since the preview — nothing written', async () => {
+    const res = await call({ mode: 'apply', expectedChanges: 3 });
+    expect(res.status).toBe(409);
+    expect(mockApply).not.toHaveBeenCalled();
+  });
+
+  it('apply passes the fresh plan to the writer and reports accounts created', async () => {
+    const res = await call({ mode: 'apply', expectedChanges: 1 });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.written).toEqual([
+      expect.objectContaining({ schoolId: 'sch-1', created: 1, accountsCreated: 1 }),
+    ]);
+    expect(mockApply).toHaveBeenCalledTimes(1);
+    // The connection came from the CALLER's grants, never from the request.
+    expect(mockApply.mock.calls[0][0]).toMatchObject({
+      actorId: ADMIN_ID,
+      connectionId: CONNECTION.id,
+      districtId: DISTRICT_ID,
+    });
+  });
+
+  it('logs counts only — feed names and emails never reach a log line', async () => {
+    await call({ mode: 'dry-run' });
+    const logged = JSON.stringify(logCalls);
+    expect(logged).toContain('Teacher directory sync planned by district admin');
+    for (const value of ['DANA', 'WHITFIELD', 'dwhitfield@example.org']) {
+      expect(logged).not.toContain(value);
+    }
+  });
+});

--- a/__tests__/unit/app/api/district/teacher-sync.test.ts
+++ b/__tests__/unit/app/api/district/teacher-sync.test.ts
@@ -18,6 +18,8 @@ const DISTRICT_ID = '0618990';
 let currentUserId: string | null = ADMIN_ID;
 /** Whether the grant re-check finds a district_admin row for a tech-role caller. */
 let holdsAdminGrant = false;
+/** Every filter the grant re-check applied — the cross-district scoping pin. */
+const mockGrantFilters: [string, unknown][] = [];
 
 jest.mock('@/lib/supabase/server', () => ({
   createClient: async () => ({
@@ -32,7 +34,10 @@ jest.mock('@/lib/supabase/server', () => ({
     from: () => {
       const q: Record<string, unknown> = {};
       q.select = () => q;
-      q.eq = () => q;
+      q.eq = (col: string, val: unknown) => {
+        mockGrantFilters.push([col, val]);
+        return q;
+      };
       q.limit = () => q;
       q.maybeSingle = () =>
         Promise.resolve({ data: holdsAdminGrant ? { id: 'grant-1' } : null, error: null });
@@ -177,16 +182,26 @@ describe('the gate', () => {
     nothingHappened();
   });
 
-  it('admits a dual-role caller whose grants include district_admin', async () => {
+  it('admits a dual-role caller whose grants include district_admin — scoped to CALLER and DISTRICT', async () => {
     mockResolveCaller.mockResolvedValue({
       ok: true,
       role: 'district_tech',
       districtId: DISTRICT_ID,
     });
     holdsAdminGrant = true;
+    mockGrantFilters.length = 0;
     const res = await call({ mode: 'dry-run' });
     expect(res.status).toBe(200);
     expect(mockLoad).toHaveBeenCalledTimes(1);
+    // The re-check must filter on this caller, this role, this district — a
+    // dropped filter would admit an admin of a DIFFERENT district.
+    expect(mockGrantFilters).toEqual(
+      expect.arrayContaining([
+        ['admin_id', ADMIN_ID],
+        ['role', 'district_admin'],
+        ['district_id', DISTRICT_ID],
+      ]),
+    );
   });
 });
 

--- a/__tests__/unit/lib/sis/teacher-directory-sync.apply.test.ts
+++ b/__tests__/unit/lib/sis/teacher-directory-sync.apply.test.ts
@@ -1,11 +1,14 @@
 /**
- * SPE-437 · `applyTeacherSyncPlan` — what the writes actually carry, and what
- * is never written at all.
+ * SPE-437/438 · `applyTeacherSyncPlan` — what the writes actually carry, and
+ * what is never written at all.
  *
  * The supabase stub records every query-builder call, so the assertions are
- * about the WRITE SHAPE: creates carry the SIS key and school placement,
- * adoption re-checks `sis_id IS NULL` in its WHERE, keyed updates filter on
- * the full key, refused schools see no writes, and counts come from what the
+ * about the WRITE SHAPE: creates carry the SIS key, school placement, and —
+ * when the feed has an email — a freshly provisioned sign-in account (auth
+ * user + profile RPC + linked row, mirroring the admin creation route);
+ * adoption re-checks `sis_id IS NULL`; keyed updates filter on the full key;
+ * refused schools see no writes; an already-registered email lands the row
+ * accountless in the conflicts bucket; and counts come from what the
  * database says happened rather than what the plan hoped.
  */
 
@@ -34,25 +37,43 @@ const recorded: RecordedQuery[] = [];
 /** Set per-test to control what a chain resolves to. */
 let nextResult: (q: RecordedQuery) => { data: unknown; error: unknown };
 
-jest.mock('@/lib/supabase/server', () => ({
-  createServiceClient: () => ({
-    from: (table: string) => {
-      const record: RecordedQuery = { table, calls: [], result: { data: [], error: null } };
-      recorded.push(record);
-      const chain: Record<string, unknown> = {};
-      for (const method of ['insert', 'update', 'select', 'eq', 'is', 'in']) {
-        chain[method] = (...args: unknown[]) => {
-          record.calls.push({ method, args });
-          return chain;
-        };
-      }
-      // Thenable, like the real builder: awaiting the chain resolves it.
-      chain.then = (resolve: (v: unknown) => unknown) => {
-        record.result = nextResult(record);
-        return Promise.resolve(record.result).then(resolve);
-      };
+function makeFrom(table: string): Record<string, unknown> {
+  const record: RecordedQuery = { table, calls: [], result: { data: [], error: null } };
+  recorded.push(record);
+  const chain: Record<string, unknown> = {};
+  for (const method of ['insert', 'update', 'select', 'eq', 'is', 'in']) {
+    chain[method] = (...args: unknown[]) => {
+      record.calls.push({ method, args });
       return chain;
+    };
+  }
+  // Thenable, like the real builder: awaiting the chain resolves it.
+  chain.then = (resolve: (v: unknown) => unknown) => {
+    record.result = nextResult(record);
+    return Promise.resolve(record.result).then(resolve);
+  };
+  return chain;
+}
+
+jest.mock('@/lib/supabase/server', () => ({
+  createServiceClient: () => ({ from: (table: string) => makeFrom(table) }),
+}));
+
+// The raw admin client the module builds for auth work — same recording
+// approach so "who got an account" is an assertion, not an assumption.
+const mockCreateUser = jest.fn();
+const mockDeleteUser = jest.fn();
+const mockRpc = jest.fn();
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    auth: {
+      admin: {
+        createUser: (...a: unknown[]) => mockCreateUser(...a),
+        deleteUser: (...a: unknown[]) => mockDeleteUser(...a),
+      },
     },
+    rpc: (...a: unknown[]) => mockRpc(...a),
+    from: (table: string) => makeFrom(`admin:${table}`),
   }),
 }));
 
@@ -61,6 +82,11 @@ import {
   type SchoolPlan,
   type TeacherSyncPlan,
 } from '@/lib/sis/teacher-directory-sync';
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://supabase.test';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key';
+});
 
 const emptySchool: Omit<
   SchoolPlan,
@@ -141,10 +167,18 @@ const run = () =>
     districtId: 'district-1',
   });
 
+let nextUserId = 0;
 beforeEach(() => {
   recorded.length = 0;
   logCalls.length = 0;
+  nextUserId = 0;
   mockAudit.mockClear();
+  mockCreateUser.mockReset().mockImplementation(async () => {
+    nextUserId += 1;
+    return { data: { user: { id: `auth-${nextUserId}`, email: 'x' } }, error: null };
+  });
+  mockDeleteUser.mockReset().mockResolvedValue({ data: null, error: null });
+  mockRpc.mockReset().mockResolvedValue({ error: null });
   // Default: every write succeeds and reports as many rows as were sent.
   nextResult = (q) => {
     const insert = q.calls.find((c) => c.method === 'insert');
@@ -157,7 +191,7 @@ beforeEach(() => {
 });
 
 describe('applyTeacherSyncPlan', () => {
-  it('writes creates with the SIS key, school placement, and verbatim names', async () => {
+  it('writes creates with the SIS key, school placement, verbatim names — and a linked account', async () => {
     const results = await run();
 
     const insert = recorded.find((q) => q.calls.some((c) => c.method === 'insert'));
@@ -177,18 +211,110 @@ describe('applyTeacherSyncPlan', () => {
         created_by_admin: false,
         sis_source: 'oneroster',
         sis_id: 'sid-1',
+        account_id: 'auth-1',
       },
     ]);
+    // The account mirrored the admin-creation route: pre-verified email, a
+    // random password that is never surfaced, teacher-role metadata, and the
+    // profile RPC + school stamp.
+    expect(mockCreateUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'comalley@example.org',
+        email_confirm: true,
+        user_metadata: expect.objectContaining({ role: 'teacher' }),
+      }),
+    );
+    expect(mockRpc).toHaveBeenCalledWith(
+      'create_profile_for_new_user',
+      expect.objectContaining({ user_id: 'auth-1' }),
+    );
     expect(results).toEqual([
-      { schoolId: 'sch-elem', schoolName: 'Rodeo Vista Elementary', created: 1, adopted: 1, updated: 1 },
+      {
+        schoolId: 'sch-elem',
+        schoolName: 'Rodeo Vista Elementary',
+        created: 1,
+        adopted: 1,
+        updated: 1,
+        accountsCreated: 1,
+        directoryOnly: 0,
+        accountConflicts: [],
+      },
     ]);
   });
 
-  it('never writes anything for a refused school', async () => {
+  it('an already-registered email lands the row ACCOUNTLESS in the conflicts bucket', async () => {
+    mockCreateUser.mockResolvedValue({
+      data: { user: null },
+      error: { message: 'A user with this email address has already been registered' },
+    });
+
+    const results = await run();
+
+    expect(results[0].accountsCreated).toBe(0);
+    expect(results[0].accountConflicts).toEqual([
+      { name: 'CHARLI OMALLEY', email: 'comalley@example.org' },
+    ]);
+    // The directory row still landed — accountless.
+    const insert = recorded.find((q) => q.calls.some((c) => c.method === 'insert'));
+    const rows = insert!.calls.find((c) => c.method === 'insert')!.args[0] as Record<
+      string,
+      unknown
+    >[];
+    expect(rows[0].account_id).toBeNull();
+    // And nothing was touched on the existing identity.
+    expect(mockRpc).not.toHaveBeenCalled();
+    expect(mockDeleteUser).not.toHaveBeenCalled();
+  });
+
+  it('a create without an email is directory-only — no account attempt at all', async () => {
+    const emaillessPlan: TeacherSyncPlan = {
+      ...plan,
+      schools: [
+        {
+          ...plan.schools[0],
+          adopts: [],
+          updates: [],
+          creates: [
+            {
+              sisId: 'sid-noemail',
+              firstName: 'NO',
+              lastName: 'EMAIL',
+              email: null,
+              staffId: '11_TCH_9',
+              gradeLevel: null,
+            },
+          ],
+        },
+      ],
+    };
+    const results = await applyTeacherSyncPlan({
+      plan: emaillessPlan,
+      actorId: 'staff-1',
+      connectionId: 'conn-1',
+      districtId: 'district-1',
+    });
+
+    expect(mockCreateUser).not.toHaveBeenCalled();
+    expect(results[0]).toMatchObject({ created: 1, accountsCreated: 0, directoryOnly: 1 });
+  });
+
+  it('a profile failure rolls back ITS auth user and stops', async () => {
+    mockRpc.mockResolvedValue({ error: { message: 'rpc exploded' } });
+    await expect(run()).rejects.toThrow(/Profile creation failed/);
+    expect(mockDeleteUser).toHaveBeenCalledWith('auth-1');
+    // Partial outcome still audited (nothing written yet for this school).
+    expect(mockAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: expect.objectContaining({ partial: true }) }),
+    );
+  });
+
+  it('never writes anything for a refused school — and provisions no account', async () => {
     await run();
     const serialized = JSON.stringify(recorded.map((q) => q.calls));
     expect(serialized).not.toContain('sid-refused');
     expect(serialized).not.toContain('NEVER');
+    const accountEmails = JSON.stringify(mockCreateUser.mock.calls);
+    expect(accountEmails).not.toContain('nw@example.org');
   });
 
   it('adoption re-checks sis_id IS NULL, and reports an honest zero when the row moved on', async () => {
@@ -240,16 +366,18 @@ describe('applyTeacherSyncPlan', () => {
     }
   });
 
-  it('a failed insert throws with the school named — and the partial outcome is STILL audited', async () => {
+  it('a failed insert throws with the school named — partial outcome audited, orphan account removed', async () => {
     // Writes that landed before the failure are real; a staff-gated
     // service-role write path must never leave them unrecorded
-    // (CodeRabbit, PR #831).
+    // (CodeRabbit, PR #831). And an account whose directory row never landed
+    // must not survive — a re-run only reads `teachers` and would try again.
     nextResult = (q) => {
       const insert = q.calls.find((c) => c.method === 'insert');
       if (insert) return { data: null, error: { message: 'unique violation' } };
       return { data: [{ id: 'touched' }], error: null };
     };
     await expect(run()).rejects.toThrow(/Rodeo Vista Elementary failed: unique violation/);
+    expect(mockDeleteUser).toHaveBeenCalledWith('auth-1');
     expect(mockAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: 'sis_teacher_sync_applied',

--- a/__tests__/unit/lib/sis/teacher-directory-sync.apply.test.ts
+++ b/__tests__/unit/lib/sis/teacher-directory-sync.apply.test.ts
@@ -41,7 +41,7 @@ function makeFrom(table: string): Record<string, unknown> {
   const record: RecordedQuery = { table, calls: [], result: { data: [], error: null } };
   recorded.push(record);
   const chain: Record<string, unknown> = {};
-  for (const method of ['insert', 'update', 'select', 'eq', 'is', 'in']) {
+  for (const method of ['insert', 'update', 'delete', 'select', 'eq', 'is', 'in']) {
     chain[method] = (...args: unknown[]) => {
       record.calls.push({ method, args });
       return chain;
@@ -83,9 +83,20 @@ import {
   type TeacherSyncPlan,
 } from '@/lib/sis/teacher-directory-sync';
 
+const savedEnv = {
+  url: process.env.NEXT_PUBLIC_SUPABASE_URL,
+  key: process.env.SUPABASE_SERVICE_ROLE_KEY,
+};
 beforeAll(() => {
   process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://supabase.test';
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key';
+});
+afterAll(() => {
+  // Jest shares a worker between files; leaked env values would follow it.
+  if (savedEnv.url === undefined) delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+  else process.env.NEXT_PUBLIC_SUPABASE_URL = savedEnv.url;
+  if (savedEnv.key === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  else process.env.SUPABASE_SERVICE_ROLE_KEY = savedEnv.key;
 });
 
 const emptySchool: Omit<
@@ -298,14 +309,138 @@ describe('applyTeacherSyncPlan', () => {
     expect(results[0]).toMatchObject({ created: 1, accountsCreated: 0, directoryOnly: 1 });
   });
 
-  it('a profile failure rolls back ITS auth user and stops', async () => {
+  it('a profile failure rolls back ITS auth user — profile row FIRST, then auth — and stops', async () => {
     mockRpc.mockResolvedValue({ error: { message: 'rpc exploded' } });
     await expect(run()).rejects.toThrow(/Profile creation failed/);
+    // Order is load-bearing: profiles.id → auth.users(id) has no cascade, so
+    // deleting the auth user first would fail on the FK (PR #833 review).
+    const profileDelete = recorded.find(
+      (q) => q.table === 'admin:profiles' && q.calls.some((c) => c.method === 'delete'),
+    );
+    expect(profileDelete).toBeDefined();
     expect(mockDeleteUser).toHaveBeenCalledWith('auth-1');
     // Partial outcome still audited (nothing written yet for this school).
     expect(mockAudit).toHaveBeenCalledWith(
       expect.objectContaining({ metadata: expect.objectContaining({ partial: true }) }),
     );
+  });
+
+  it('a FAILED rollback is logged loudly by account id — never swallowed', async () => {
+    mockRpc.mockResolvedValue({ error: { message: 'rpc exploded' } });
+    // The admin API RESOLVES with { error }, it does not reject — the exact
+    // shape the first version's empty .catch() could never observe.
+    mockDeleteUser.mockResolvedValue({ data: null, error: { message: 'FK still references' } });
+    await expect(run()).rejects.toThrow(/Profile creation failed/);
+    const logged = JSON.stringify(logCalls);
+    expect(logged).toContain('orphaned auth account');
+    expect(logged).toContain('auth-1');
+  });
+
+  it('conflict detection honors the stable email_exists code, without prose', async () => {
+    mockCreateUser.mockResolvedValue({
+      data: { user: null },
+      error: { message: 'Unprocessable Entity', code: 'email_exists' },
+    });
+    const results = await run();
+    expect(results[0].accountConflicts).toHaveLength(1);
+  });
+
+  it('a multi-school teacher gets ONE account, linked at every school', async () => {
+    const twoSchoolPlan: TeacherSyncPlan = {
+      ...plan,
+      schools: [
+        {
+          ...plan.schools[0],
+          adopts: [],
+          updates: [],
+          creates: [
+            {
+              sisId: 'sid-multi',
+              firstName: 'SAMUEL',
+              lastName: 'DAVIS',
+              email: 'sdavis@example.org',
+              staffId: '33_TCH_779',
+              gradeLevel: null,
+            },
+          ],
+        },
+        {
+          ...plan.schools[0],
+          schoolId: 'sch-high',
+          schoolName: 'Crockett Point High',
+          refusal: null,
+          adopts: [],
+          updates: [],
+          creates: [
+            {
+              sisId: 'sid-multi',
+              firstName: 'SAMUEL',
+              lastName: 'DAVIS',
+              email: 'sdavis@example.org',
+              staffId: '33_TCH_779',
+              gradeLevel: null,
+            },
+          ],
+        },
+      ],
+      shadowDuplicates: 0,
+      duplicateEmailAnomalies: 0,
+    };
+    const results = await applyTeacherSyncPlan({
+      plan: twoSchoolPlan,
+      actorId: 'staff-1',
+      connectionId: 'conn-1',
+      districtId: 'district-1',
+    });
+
+    // One human, one account — created once, never misread as a conflict.
+    expect(mockCreateUser).toHaveBeenCalledTimes(1);
+    expect(results.map((r) => r.accountsCreated)).toEqual([1, 0]);
+    expect(results.flatMap((r) => r.accountConflicts)).toHaveLength(0);
+    // Both directory rows link the same account.
+    const inserts = recorded
+      .filter((q) => q.table === 'teachers' && q.calls.some((c) => c.method === 'insert'))
+      .map((q) => (q.calls.find((c) => c.method === 'insert')!.args[0] as { account_id: unknown }[])[0]);
+    expect(inserts.map((r) => r.account_id)).toEqual(['auth-1', 'auth-1']);
+  });
+
+  it('outcome counters move only AFTER the row lands — a failed insert reports nothing', async () => {
+    const emaillessPlan: TeacherSyncPlan = {
+      ...plan,
+      schools: [
+        {
+          ...plan.schools[0],
+          adopts: [],
+          updates: [],
+          creates: [
+            {
+              sisId: 'sid-noemail',
+              firstName: 'NO',
+              lastName: 'EMAIL',
+              email: null,
+              staffId: '11_TCH_9',
+              gradeLevel: null,
+            },
+          ],
+        },
+      ],
+    };
+    nextResult = (q) => {
+      const insert = q.calls.find((c) => c.method === 'insert');
+      if (insert) return { data: null, error: { message: 'insert refused' } };
+      return { data: [{ id: 'touched' }], error: null };
+    };
+    await expect(
+      applyTeacherSyncPlan({
+        plan: emaillessPlan,
+        actorId: 'staff-1',
+        connectionId: 'conn-1',
+        districtId: 'district-1',
+      }),
+    ).rejects.toThrow(/insert refused/);
+    // The partial audit must not claim a directory-only row that never landed.
+    const auditWritten = JSON.stringify(mockAudit.mock.calls);
+    expect(auditWritten).toContain('"directoryOnly":0');
   });
 
   it('never writes anything for a refused school — and provisions no account', async () => {

--- a/__tests__/unit/lib/sis/teacher-directory-sync.test.ts
+++ b/__tests__/unit/lib/sis/teacher-directory-sync.test.ts
@@ -142,6 +142,29 @@ describe('toFeedTeacher (the feed-row pick)', () => {
     expect(toFeedTeacher({ sourcedId: '   ', givenName: 'A', familyName: 'B' })).toBeNull();
   });
 
+  it('nulls an implausible email so it behaves as absent everywhere at once', () => {
+    // GoTrue would reject it mid-apply otherwise, wedging the run on the same
+    // row forever (PR #833 review). Same shape check as the admin route.
+    for (const bad of ['j smith@district.org', 'none', 'x@y', 'trailingdot@x.', '@x.org']) {
+      const row = toFeedTeacher({
+        sourcedId: 'x',
+        givenName: 'A',
+        familyName: 'B',
+        identifier: '11_TCH_1',
+        email: bad,
+      });
+      expect(row?.email).toBeNull();
+    }
+    const good = toFeedTeacher({
+      sourcedId: 'x',
+      givenName: 'A',
+      familyName: 'B',
+      identifier: '11_TCH_1',
+      email: 'a.b@district.org',
+    });
+    expect(good?.email).toBe('a.b@district.org');
+  });
+
   it('degrades a non-array orgs value to no schools instead of throwing', () => {
     const row = toFeedTeacher({
       sourcedId: 'x',

--- a/app/(dashboard)/dashboard/admin/directories/page.tsx
+++ b/app/(dashboard)/dashboard/admin/directories/page.tsx
@@ -14,6 +14,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Card } from '@/app/components/ui/card';
+import DistrictTeacherSyncPanel from '@/app/components/admin/district-teacher-sync-panel';
 import type {
   DirectoryArea,
   DirectoryClassRow,
@@ -150,10 +151,15 @@ export default function DirectoriesPage() {
       <div>
         <h1 className="text-2xl font-semibold text-slate-900">Directories</h1>
         <p className="text-sm text-slate-500 mt-1">
-          What your district&apos;s SIS shares with Speddy, read live — nothing here is saved into
-          Speddy yet.
+          What your district&apos;s SIS shares with Speddy, read live. The tabs below save
+          nothing; the teacher sync writes only when you apply a preview.
         </p>
       </div>
+
+      {/* SPE-438: the action counterpart to the read-only tabs — the district
+          admin's own Preview → Apply, moved here from /internal per the
+          owner's direction. */}
+      <DistrictTeacherSyncPanel />
 
       <div className="flex gap-2" role="tablist" aria-label="Directory areas">
         {AREAS.map((a) => (

--- a/app/api/district/teacher-sync/route.ts
+++ b/app/api/district/teacher-sync/route.ts
@@ -1,0 +1,171 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withRoute } from '@/lib/api/with-route';
+import { resolveDistrictSisCaller } from '@/lib/api/district-sis-caller';
+import { createServiceClient } from '@/lib/supabase/server';
+import { logger } from '@/lib/logger';
+import { getDecryptedCredential, listConnections } from '@/lib/sis/connections';
+import {
+  applyTeacherSyncPlan,
+  loadTeacherSyncInput,
+  planCounts,
+  planTeacherDirectorySync,
+} from '@/lib/sis/teacher-directory-sync';
+
+const log = logger.child({ module: 'district-teacher-sync' });
+
+const bodySchema = z
+  .object({
+    mode: z.enum(['dry-run', 'apply']),
+    /** Apply only: the writable count from the preview the admin reviewed. */
+    expectedChanges: z.number().int().min(0).optional(),
+  })
+  .refine((b) => b.mode !== 'apply' || b.expectedChanges !== undefined, {
+    message: 'apply requires expectedChanges from the reviewed preview',
+  });
+
+/**
+ * POST /api/district/teacher-sync — the district admin's own Preview → Apply
+ * for the teacher-directory sync (SPE-438; moved out of /internal per the
+ * owner's 2026-08-10 direction — "a district admin making this call", with
+ * site-admin delegation as the eventual shape).
+ *
+ * Same engine as the internal route, different authorization: the caller's
+ * OWN district only, resolved from their grants — a request can never name a
+ * district or a connection. DISTRICT ADMINS ONLY: the shared seam admits
+ * `district_tech` too, which is right for connection management and wrong
+ * here twice over — this surface serves teacher PII and, on apply, PROVISIONS
+ * SIGN-IN ACCOUNTS. Same one-more-look grant re-check as the sis-directory
+ * route (SPE-436).
+ *
+ * Apply recomputes the plan server-side and is count-bound to the reviewed
+ * preview (409 on drift). Logs stay counts-only; row detail exists only in
+ * the response for the reviewing admin.
+ */
+export const POST = withRoute<Record<string, string>, z.infer<typeof bodySchema>>(
+  {
+    body: bodySchema,
+    // Every run walks full pagination against the district's production SIS,
+    // and apply provisions accounts on top — keep the ceiling low.
+    rateLimit: { requests: 4, windowSeconds: 60, name: 'district-teacher-sync' },
+  },
+  async ({ userId, body }) => {
+    const caller = await resolveDistrictSisCaller(userId);
+    if (!caller.ok) {
+      log.warn('Non-district-admin tried the teacher sync', { userId, denied: caller.denied });
+      return NextResponse.json(
+        { error: 'Forbidden: district admin access required' },
+        { status: 403 },
+      );
+    }
+    if (caller.role !== 'district_admin') {
+      const { data: adminGrant } = await createServiceClient()
+        .from('admin_permissions')
+        .select('id')
+        .eq('admin_id', userId)
+        .eq('role', 'district_admin')
+        .eq('district_id', caller.districtId)
+        .limit(1)
+        .maybeSingle();
+      if (!adminGrant) {
+        log.warn('district_tech tried the teacher sync', {
+          userId,
+          districtId: caller.districtId,
+        });
+        return NextResponse.json(
+          { error: 'Forbidden: the teacher sync is for district admins.' },
+          { status: 403 },
+        );
+      }
+    }
+
+    // Wrapped: withRoute's catch echoes error.message to the client in
+    // development, and a Supabase error names tables and constraints.
+    let connections;
+    try {
+      connections = await listConnections(caller.districtId);
+    } catch (err) {
+      log.error('Failed to load SIS connections for the teacher sync', err, {
+        districtId: caller.districtId,
+      });
+      return NextResponse.json({ error: 'Could not load your connection.' }, { status: 500 });
+    }
+
+    const connection = connections.find((c) => c.sis_type === 'oneroster');
+    if (!connection || !connection.base_url) {
+      return NextResponse.json(
+        { error: 'Teacher sync needs a OneRoster connection. Set one up in the tech portal first.' },
+        { status: 409 },
+      );
+    }
+
+    let credential: Awaited<ReturnType<typeof getDecryptedCredential>> = null;
+    try {
+      credential = await getDecryptedCredential(connection.id);
+    } catch (err) {
+      log.error('Could not decrypt the stored SIS credential', err, {
+        connectionId: connection.id,
+      });
+      return NextResponse.json(
+        { error: 'Your stored OneRoster credential could not be read. Re-save it in the tech portal.' },
+        { status: 500 },
+      );
+    }
+    if (!credential || credential.sisType !== 'oneroster') {
+      return NextResponse.json(
+        { error: 'No OneRoster credentials are stored yet, so there is nothing to sync.' },
+        { status: 409 },
+      );
+    }
+
+    const input = await loadTeacherSyncInput({
+      districtId: connection.district_id,
+      baseUrl: connection.base_url,
+      tokenUrl: connection.token_url,
+      clientId: credential.clientId,
+      clientSecret: credential.clientSecret,
+    });
+    const plan = planTeacherDirectorySync(input);
+
+    log.info('Teacher directory sync planned by district admin', {
+      connectionId: connection.id,
+      districtId: connection.district_id,
+      actorId: userId,
+      mode: body.mode,
+      plan: planCounts(plan),
+    });
+
+    if (body.mode === 'dry-run') {
+      return NextResponse.json({ mode: 'dry-run', plan });
+    }
+
+    // The approval boundary, same as the internal route: apply is bound to
+    // the count the admin confirmed; drift refuses and asks for a re-preview.
+    const writable = plan.schools
+      .filter((s) => !s.refusal)
+      .reduce((sum, s) => sum + s.creates.length + s.adopts.length + s.updates.length, 0);
+    if (writable !== body.expectedChanges) {
+      log.info('Teacher sync apply refused: the plan moved since the preview', {
+        connectionId: connection.id,
+        expected: body.expectedChanges,
+        recomputed: writable,
+      });
+      return NextResponse.json(
+        {
+          error:
+            `Your district's data changed since the preview (${body.expectedChanges} ` +
+            `change(s) approved, ${writable} now planned). Nothing was written — run the preview again.`,
+        },
+        { status: 409 },
+      );
+    }
+
+    const written = await applyTeacherSyncPlan({
+      plan,
+      actorId: userId,
+      connectionId: connection.id,
+      districtId: connection.district_id,
+    });
+    return NextResponse.json({ mode: 'apply', plan, written });
+  },
+);

--- a/app/api/district/teacher-sync/route.ts
+++ b/app/api/district/teacher-sync/route.ts
@@ -10,7 +10,13 @@ import {
   loadTeacherSyncInput,
   planCounts,
   planTeacherDirectorySync,
+  writableChangeCount,
 } from '@/lib/sis/teacher-directory-sync';
+
+// Full SIS pagination twice on apply, plus one-at-a-time account provisioning:
+// well past the platform's default function window. Matches the ceiling the
+// other long-running SIS routes use.
+export const maxDuration = 300;
 
 const log = logger.child({ module: 'district-teacher-sync' });
 
@@ -59,7 +65,7 @@ export const POST = withRoute<Record<string, string>, z.infer<typeof bodySchema>
       );
     }
     if (caller.role !== 'district_admin') {
-      const { data: adminGrant } = await createServiceClient()
+      const { data: adminGrant, error: grantError } = await createServiceClient()
         .from('admin_permissions')
         .select('id')
         .eq('admin_id', userId)
@@ -67,6 +73,14 @@ export const POST = withRoute<Record<string, string>, z.infer<typeof bodySchema>
         .eq('district_id', caller.districtId)
         .limit(1)
         .maybeSingle();
+      if (grantError) {
+        // Fail-closed either way, but a database fault must not read as a
+        // missing grant in the logs.
+        log.error('The district_admin grant re-check failed; refusing', grantError, {
+          userId,
+          districtId: caller.districtId,
+        });
+      }
       if (!adminGrant) {
         log.warn('district_tech tried the teacher sync', {
           userId,
@@ -118,13 +132,28 @@ export const POST = withRoute<Record<string, string>, z.infer<typeof bodySchema>
       );
     }
 
-    const input = await loadTeacherSyncInput({
-      districtId: connection.district_id,
-      baseUrl: connection.base_url,
-      tokenUrl: connection.token_url,
-      clientId: credential.clientId,
-      clientSecret: credential.clientSecret,
-    });
+    // Wrapped like the other outbound calls: withRoute's dev-mode catch
+    // echoes error.message, and a SIS failure's text can carry the base URL
+    // or upstream response fragments a district admin should not see.
+    let input;
+    try {
+      input = await loadTeacherSyncInput({
+        districtId: connection.district_id,
+        baseUrl: connection.base_url,
+        tokenUrl: connection.token_url,
+        clientId: credential.clientId,
+        clientSecret: credential.clientSecret,
+      });
+    } catch (err) {
+      log.error('Reading the district SIS for the teacher sync failed', err, {
+        connectionId: connection.id,
+        districtId: connection.district_id,
+      });
+      return NextResponse.json(
+        { error: 'Your SIS did not answer completely. Nothing was written — try again in a moment.' },
+        { status: 502 },
+      );
+    }
     const plan = planTeacherDirectorySync(input);
 
     log.info('Teacher directory sync planned by district admin', {
@@ -141,9 +170,7 @@ export const POST = withRoute<Record<string, string>, z.infer<typeof bodySchema>
 
     // The approval boundary, same as the internal route: apply is bound to
     // the count the admin confirmed; drift refuses and asks for a re-preview.
-    const writable = plan.schools
-      .filter((s) => !s.refusal)
-      .reduce((sum, s) => sum + s.creates.length + s.adopts.length + s.updates.length, 0);
+    const writable = writableChangeCount(plan);
     if (writable !== body.expectedChanges) {
       log.info('Teacher sync apply refused: the plan moved since the preview', {
         connectionId: connection.id,

--- a/app/api/internal/sis-connections/[connectionId]/teacher-sync/route.ts
+++ b/app/api/internal/sis-connections/[connectionId]/teacher-sync/route.ts
@@ -9,7 +9,11 @@ import {
   loadTeacherSyncInput,
   planCounts,
   planTeacherDirectorySync,
+  writableChangeCount,
 } from '@/lib/sis/teacher-directory-sync';
+
+// Full SIS pagination twice on apply, plus one-at-a-time account provisioning.
+export const maxDuration = 300;
 
 const log = logger.child({ module: 'internal-teacher-sync' });
 
@@ -149,9 +153,7 @@ export const POST = withRoute<{ connectionId: string }, z.infer<typeof bodySchem
     // writable count. The feed may have moved since; writing a different
     // change set under a confirmation for the old one is the one thing apply
     // must not do. Count mismatch → nothing written, re-preview.
-    const writable = plan.schools
-      .filter((s) => !s.refusal)
-      .reduce((sum, s) => sum + s.creates.length + s.adopts.length + s.updates.length, 0);
+    const writable = writableChangeCount(plan);
     if (writable !== body.expectedChanges) {
       log.info('Teacher sync apply refused: the plan moved since the preview', {
         connectionId: connection.id,

--- a/app/components/admin/district-teacher-sync-panel.tsx
+++ b/app/components/admin/district-teacher-sync-panel.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * Types imported from the sync module, never re-declared (same rule as the
+ * internal card and the directories page): `import type` is erased at compile
+ * time, so no server-only code reaches the bundle.
+ */
+import type {
+  SchoolPlan,
+  SchoolWriteResult,
+  TeacherSyncPlan,
+} from '@/lib/sis/teacher-directory-sync';
+
+interface TeacherSyncResponse {
+  mode: 'dry-run' | 'apply';
+  plan: TeacherSyncPlan;
+  written?: SchoolWriteResult[];
+}
+
+function isTeacherSyncResponse(value: unknown): value is TeacherSyncResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const body = value as { mode?: unknown; plan?: unknown };
+  if (body.mode !== 'dry-run' && body.mode !== 'apply') return false;
+  if (typeof body.plan !== 'object' || body.plan === null) return false;
+  return Array.isArray((body.plan as { schools?: unknown }).schools);
+}
+
+const writableCount = (plan: TeacherSyncPlan): number =>
+  plan.schools
+    .filter((s) => !s.refusal)
+    .reduce((sum, s) => sum + s.creates.length + s.adopts.length + s.updates.length, 0);
+
+const accountCount = (plan: TeacherSyncPlan): number =>
+  plan.schools
+    .filter((s) => !s.refusal)
+    .reduce((sum, s) => sum + s.creates.filter((c) => c.email).length, 0);
+
+function Chip({ label, n, tone }: { label: string; n: number; tone: string }) {
+  if (n === 0) return null;
+  return (
+    <span className={`rounded-full border px-2 py-0.5 text-xs ${tone}`}>
+      {n} {label}
+    </span>
+  );
+}
+
+function SchoolSection({ school }: { school: SchoolPlan }) {
+  return (
+    <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5">
+      <p className="text-sm font-medium text-slate-900">
+        {school.schoolName}
+        {school.sisSchoolName && (
+          <span className="ml-2 text-xs font-normal text-slate-400">
+            from SIS “{school.sisSchoolName}”
+          </span>
+        )}
+      </p>
+
+      {school.refusal ? (
+        <p className="mt-1.5 rounded border border-amber-200 bg-amber-50 px-2.5 py-1.5 text-xs text-amber-800">
+          Not synced — {school.refusal}
+        </p>
+      ) : (
+        <>
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            <Chip
+              label="teachers to add"
+              n={school.creates.length}
+              tone="bg-emerald-50 text-emerald-700 border-emerald-200"
+            />
+            <Chip
+              label="with sign-in access"
+              n={school.creates.filter((c) => c.email).length}
+              tone="bg-emerald-50 text-emerald-700 border-emerald-200"
+            />
+            <Chip
+              label="existing entries to link"
+              n={school.adopts.length}
+              tone="bg-sky-50 text-sky-700 border-sky-200"
+            />
+            <Chip
+              label="to update"
+              n={school.updates.length}
+              tone="bg-sky-50 text-sky-700 border-sky-200"
+            />
+            <Chip
+              label="already up to date"
+              n={school.unchanged}
+              tone="bg-slate-50 text-slate-600 border-slate-200"
+            />
+            <Chip
+              label="need your review"
+              n={school.reviews.length}
+              tone="bg-amber-50 text-amber-700 border-amber-200"
+            />
+            <Chip
+              label="in Speddy but not in your SIS (kept)"
+              n={school.missingFromSis.length}
+              tone="bg-slate-50 text-slate-600 border-slate-200"
+            />
+            <Chip
+              label="non-teaching staff skipped"
+              n={school.excludedNonTeaching}
+              tone="bg-slate-50 text-slate-500 border-slate-200"
+            />
+          </div>
+
+          {school.creates.length > 0 && (
+            <details className="mt-2">
+              <summary className="cursor-pointer text-xs font-medium text-slate-700">
+                Teachers to add ({school.creates.length})
+              </summary>
+              <ul className="mt-1 space-y-0.5 pl-4 text-xs text-slate-500">
+                {school.creates.map((c) => (
+                  <li key={c.sisId}>
+                    <span className="text-slate-800">
+                      {c.firstName} {c.lastName}
+                    </span>
+                    {c.email ? <> · {c.email}</> : <> · no email — directory entry only</>}
+                    {c.staffId && <> · {c.staffId}</>}
+                    {c.gradeLevel && <> · grade {c.gradeLevel}</>}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+
+          {school.reviews.length > 0 && (
+            <details className="mt-1" open>
+              <summary className="cursor-pointer text-xs font-medium text-amber-700">
+                Needs your review ({school.reviews.length}) — nothing written for these
+              </summary>
+              <ul className="mt-1 space-y-0.5 pl-4 text-xs text-amber-800/80">
+                {school.reviews.map((r) => (
+                  <li key={`${r.sisId}:${r.existingTeacherId}`}>
+                    SIS “{r.feedName}” ({r.feedEmail ?? 'no email'}) vs existing “{r.existingName}”
+                    ({r.existingEmail ?? 'no email'}) —{' '}
+                    {r.reason === 'ambiguous-email'
+                      ? 'more than one existing entry shares this email.'
+                      : 'the name matches but the email does not.'}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+
+          {school.missingFromSis.length > 0 && (
+            <details className="mt-1">
+              <summary className="cursor-pointer text-xs font-medium text-slate-600">
+                In Speddy, not in your SIS ({school.missingFromSis.length})
+              </summary>
+              <ul className="mt-1 space-y-0.5 pl-4 text-xs text-slate-500">
+                {school.missingFromSis.map((m) => (
+                  <li key={m.teacherId}>{m.name} — left in place; removing is your call.</li>
+                ))}
+              </ul>
+            </details>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * District-admin Preview → Apply for the teacher sync (SPE-438).
+ *
+ * The owner's model: the SIS says who the teachers are, so Apply makes them
+ * OFFICIAL in one step — directory entry plus a ready sign-in account, no
+ * temp-password ceremony. Teachers are never emailed by this; they sign in
+ * with Google or use "Forgot password" whenever the school tells them to.
+ */
+export default function DistrictTeacherSyncPanel() {
+  const [running, setRunning] = useState<'dry-run' | 'apply' | null>(null);
+  const [result, setResult] = useState<TeacherSyncResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async (mode: 'dry-run' | 'apply') => {
+    let expectedChanges: number | undefined;
+    if (mode === 'apply') {
+      const plan = result?.plan;
+      if (!plan) return;
+      expectedChanges = writableCount(plan);
+      const accounts = accountCount(plan);
+      const confirmed = window.confirm(
+        `Apply the teacher sync?\n\nThis makes ${expectedChanges} change(s) to your teacher ` +
+          `lists, including ${accounts} teacher(s) who will get sign-in access. No emails are ` +
+          'sent — teachers can sign in with Google or use “Forgot password” when you tell them ' +
+          'Speddy is ready. Rows needing your review are not touched.',
+      );
+      if (!confirmed) return;
+    }
+
+    setRunning(mode);
+    setError(null);
+    if (mode === 'dry-run') setResult(null);
+
+    // Above the server's worst case (full SIS pagination + account creation).
+    const abort = new AbortController();
+    const timer = setTimeout(() => abort.abort(), 180_000);
+    try {
+      const res = await fetch('/api/district/teacher-sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        cache: 'no-store',
+        signal: abort.signal,
+        body: JSON.stringify(mode === 'apply' ? { mode, expectedChanges } : { mode }),
+      });
+      const json: unknown = await res.json().catch(() => null);
+      if (!res.ok) {
+        const message =
+          typeof (json as { error?: unknown })?.error === 'string'
+            ? (json as { error: string }).error
+            : `The sync could not run (HTTP ${res.status}).`;
+        setError(message);
+        return;
+      }
+      if (!isTeacherSyncResponse(json)) {
+        setError('The sync returned an unreadable response. Nothing was written.');
+        return;
+      }
+      setResult(json);
+    } catch (err) {
+      const timedOut = err instanceof DOMException && err.name === 'AbortError';
+      setError(
+        timedOut
+          ? 'Gave up waiting for your SIS. The run may still be finishing — try the preview again in a moment.'
+          : 'Could not reach the sync. Nothing was written.',
+      );
+    } finally {
+      clearTimeout(timer);
+      setRunning(null);
+    }
+  };
+
+  const plan = result?.plan ?? null;
+  const canApply = plan !== null && result?.mode === 'dry-run' && writableCount(plan) > 0;
+  const conflicts = (result?.written ?? []).flatMap((w) => w.accountConflicts);
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-slate-900">Teacher sync</p>
+          <p className="mt-0.5 max-w-2xl text-xs text-slate-500">
+            Fills each school&apos;s teacher list from your SIS and gives every teacher sign-in
+            access, in one step. Preview first — it shows exactly what would change and writes
+            nothing. No emails are sent to teachers.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => run('dry-run')}
+            disabled={running !== null}
+            className="rounded-md bg-white px-3 py-2 text-sm font-medium text-slate-700 border border-slate-300 hover:bg-slate-100 disabled:opacity-50 transition-colors"
+          >
+            {running === 'dry-run' ? 'Previewing…' : 'Preview (no changes)'}
+          </button>
+          {canApply && (
+            <button
+              type="button"
+              onClick={() => run('apply')}
+              disabled={running !== null}
+              className="rounded-md bg-slate-900 px-3 py-2 text-sm font-medium text-white hover:bg-slate-700 disabled:opacity-50 transition-colors"
+            >
+              {running === 'apply' ? 'Applying…' : `Apply ${writableCount(plan)} change(s)`}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700"
+        >
+          {error}
+        </div>
+      )}
+
+      <div role="status" aria-live="polite" className="contents">
+        {result && (
+          <div className="mt-3 space-y-2">
+            {result.mode === 'apply' && result.written && (
+              <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">
+                Done.{' '}
+                {result.written
+                  .map(
+                    (w) =>
+                      `${w.schoolName}: ${w.created} added (${w.accountsCreated} with sign-in), ` +
+                      `${w.adopted} linked, ${w.updated} updated`,
+                  )
+                  .join(' · ') || 'Nothing needed writing.'}
+              </div>
+            )}
+
+            {conflicts.length > 0 && (
+              <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+                <p className="font-medium">
+                  {conflicts.length} teacher(s) added without sign-in — their email already has a
+                  Speddy account:
+                </p>
+                <ul className="mt-1 list-disc pl-4">
+                  {conflicts.map((c) => (
+                    <li key={c.email}>
+                      {c.name} · {c.email}
+                    </li>
+                  ))}
+                </ul>
+                <p className="mt-1">
+                  Usually this means the person already uses Speddy in another role. Nothing was
+                  changed on the existing account.
+                </p>
+              </div>
+            )}
+
+            {plan?.schools.map((school) => (
+              <SchoolSection key={school.schoolId} school={school} />
+            ))}
+
+            <p className="text-xs text-slate-400">
+              From your SIS: {plan?.feedTeacherRows} teacher record(s) of {plan?.feedTotalRows}{' '}
+              staff record(s).
+              {plan && plan.unmappedSisSchools.length > 0 && (
+                <>
+                  {' '}
+                  SIS schools not set up in Speddy:{' '}
+                  {plan.unmappedSisSchools
+                    .map((s) => `${s.name} (${s.teacherRows} teachers)`)
+                    .join(', ')}
+                  .
+                </>
+              )}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/admin/district-teacher-sync-panel.tsx
+++ b/app/components/admin/district-teacher-sync-panel.tsx
@@ -21,12 +21,27 @@ interface TeacherSyncResponse {
 
 function isTeacherSyncResponse(value: unknown): value is TeacherSyncResponse {
   if (typeof value !== 'object' || value === null) return false;
-  const body = value as { mode?: unknown; plan?: unknown };
+  const body = value as { mode?: unknown; plan?: unknown; written?: unknown };
   if (body.mode !== 'dry-run' && body.mode !== 'apply') return false;
   if (typeof body.plan !== 'object' || body.plan === null) return false;
-  return Array.isArray((body.plan as { schools?: unknown }).schools);
+  if (!Array.isArray((body.plan as { schools?: unknown }).schools)) return false;
+  // `written` renders its new fields directly — a malformed 200 must land in
+  // the "unreadable response" branch, not throw mid-render.
+  if (body.written !== undefined) {
+    if (!Array.isArray(body.written)) return false;
+    for (const entry of body.written) {
+      const w = entry as { accountsCreated?: unknown; accountConflicts?: unknown };
+      if (typeof w?.accountsCreated !== 'number' || !Array.isArray(w?.accountConflicts)) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
+// Local copy of the server's `writableChangeCount` (that module is
+// server-only and cannot enter this bundle). Drift fails loudly: apply is
+// count-bound, so a mismatched copy 409s instead of writing the wrong set.
 const writableCount = (plan: TeacherSyncPlan): number =>
   plan.schools
     .filter((s) => !s.refusal)
@@ -218,16 +233,27 @@ export default function DistrictTeacherSyncPanel() {
         return;
       }
       if (!isTeacherSyncResponse(json)) {
-        setError('The sync returned an unreadable response. Nothing was written.');
+        // On apply, "nothing was written" would be a claim we cannot make —
+        // the server may have completed and answered in a shape we failed to
+        // read. Honest guidance: re-preview and look at the current state.
+        setError(
+          mode === 'apply'
+            ? 'The response could not be read, so the outcome is unknown. Run the preview again — it shows the current state.'
+            : 'The preview returned an unreadable response. Nothing was written.',
+        );
         return;
       }
       setResult(json);
     } catch (err) {
       const timedOut = err instanceof DOMException && err.name === 'AbortError';
+      // An apply that left the browser may have finished on the server —
+      // "nothing was written" is only claimable for a preview.
       setError(
-        timedOut
-          ? 'Gave up waiting for your SIS. The run may still be finishing — try the preview again in a moment.'
-          : 'Could not reach the sync. Nothing was written.',
+        mode === 'apply'
+          ? 'The connection dropped mid-run, so the outcome is unknown — the sync may have finished on the server. Run the preview again; it shows the current state.'
+          : timedOut
+            ? 'Gave up waiting for your SIS. Try the preview again in a moment.'
+            : 'Could not reach the sync. Nothing was written.',
       );
     } finally {
       clearTimeout(timer);
@@ -237,7 +263,11 @@ export default function DistrictTeacherSyncPanel() {
 
   const plan = result?.plan ?? null;
   const canApply = plan !== null && result?.mode === 'dry-run' && writableCount(plan) > 0;
-  const conflicts = (result?.written ?? []).flatMap((w) => w.accountConflicts);
+  // School-scoped keys: the same email can legitimately conflict at two
+  // schools (multi-school teachers plan one row per school).
+  const conflicts = (result?.written ?? []).flatMap((w) =>
+    w.accountConflicts.map((c) => ({ ...c, schoolId: w.schoolId })),
+  );
 
   return (
     <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
@@ -305,7 +335,7 @@ export default function DistrictTeacherSyncPanel() {
                 </p>
                 <ul className="mt-1 list-disc pl-4">
                   {conflicts.map((c) => (
-                    <li key={c.email}>
+                    <li key={`${c.schoolId}:${c.email}`}>
                       {c.name} · {c.email}
                     </li>
                   ))}

--- a/app/components/internal/teacher-sync-card.tsx
+++ b/app/components/internal/teacher-sync-card.tsx
@@ -216,7 +216,8 @@ export default function TeacherSyncCard({ connectionId }: { connectionId: string
       expectedChanges = writableCount(plan);
       const confirmed = window.confirm(
         `Apply the teacher sync?\n\nThis writes ${expectedChanges} change(s) to the live ` +
-          'teacher directory (creates, adoptions, and updates shown in the preview). ' +
+          'teacher directory, and created teachers with an email get a sign-in account in the ' +
+          'same step (no emails sent; Google SSO / forgot-password access). ' +
           'Review rows and refused schools are not touched.',
       );
       if (!confirmed) return;
@@ -323,8 +324,21 @@ export default function TeacherSyncCard({ connectionId }: { connectionId: string
               <div className="rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-200">
                 Applied.{' '}
                 {result.written
-                  .map((w) => `${w.schoolName}: ${w.created} created, ${w.adopted} adopted, ${w.updated} updated`)
+                  .map(
+                    (w) =>
+                      `${w.schoolName}: ${w.created} created (${w.accountsCreated} with sign-in), ` +
+                      `${w.adopted} adopted, ${w.updated} updated`,
+                  )
                   .join(' · ') || 'Nothing was writable.'}
+                {result.written.some((w) => w.accountConflicts.length > 0) && (
+                  <span className="mt-1 block text-amber-200">
+                    Sign-in skipped (email already has a Speddy account):{' '}
+                    {result.written
+                      .flatMap((w) => w.accountConflicts)
+                      .map((c) => `${c.name} · ${c.email}`)
+                      .join(' · ')}
+                  </span>
+                )}
               </div>
             )}
 

--- a/app/components/internal/teacher-sync-card.tsx
+++ b/app/components/internal/teacher-sync-card.tsx
@@ -26,10 +26,22 @@ interface TeacherSyncResponse {
  */
 function isTeacherSyncResponse(value: unknown): value is TeacherSyncResponse {
   if (typeof value !== 'object' || value === null) return false;
-  const body = value as { mode?: unknown; plan?: unknown };
+  const body = value as { mode?: unknown; plan?: unknown; written?: unknown };
   if (body.mode !== 'dry-run' && body.mode !== 'apply') return false;
   if (typeof body.plan !== 'object' || body.plan === null) return false;
-  return Array.isArray((body.plan as { schools?: unknown }).schools);
+  if (!Array.isArray((body.plan as { schools?: unknown }).schools)) return false;
+  // `written` renders its new fields directly — a malformed 200 must land in
+  // the "unreadable response" branch, not throw mid-render.
+  if (body.written !== undefined) {
+    if (!Array.isArray(body.written)) return false;
+    for (const entry of body.written) {
+      const w = entry as { accountsCreated?: unknown; accountConflicts?: unknown };
+      if (typeof w?.accountsCreated !== 'number' || !Array.isArray(w?.accountConflicts)) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 function writableCount(plan: TeacherSyncPlan): number {
@@ -252,18 +264,24 @@ export default function TeacherSyncCard({ connectionId }: { connectionId: string
         return;
       }
       if (!isTeacherSyncResponse(json)) {
-        setError('The sync returned an unreadable response. Nothing was written.');
+        setError(
+          mode === 'apply'
+            ? 'The response could not be read, so the outcome is unknown. Re-run the preview — it shows the current state.'
+            : 'The preview returned an unreadable response. Nothing was written.',
+        );
         return;
       }
       setResult(json);
     } catch (err) {
       const timedOut = err instanceof DOMException && err.name === 'AbortError';
+      // An apply that left the browser may have finished on the server —
+      // "nothing was written" is only claimable for a preview.
       setError(
-        timedOut
-          ? mode === 'apply'
-            ? 'Gave up waiting for the district’s SIS. The apply may still be running — re-run the preview before trying again.'
-            : 'Gave up waiting for the district’s SIS. Try the preview again in a moment.'
-          : 'Could not reach the sync. Nothing was written.',
+        mode === 'apply'
+          ? 'The connection dropped mid-run, so the outcome is unknown — the apply may have finished. Re-run the preview; it shows the current state.'
+          : timedOut
+            ? 'Gave up waiting for the district’s SIS. Try the preview again in a moment.'
+            : 'Could not reach the sync. Nothing was written.',
       );
     } finally {
       clearTimeout(timer);

--- a/lib/sis/teacher-directory-sync.ts
+++ b/lib/sis/teacher-directory-sync.ts
@@ -194,6 +194,27 @@ export interface TeacherSyncPlan {
 const trimOrNull = (v: unknown): string | null =>
   typeof v === 'string' && v.trim() ? v.trim() : null;
 
+/**
+ * The same deliberately-simple shape check the admin creation route uses
+ * (no regex — ReDoS posture). Applied in the feed pick so an unusable email
+ * behaves as NO email everywhere at once: the preview's "with sign-in"
+ * count, the dedupe, the adopt rung, and the apply all agree — instead of
+ * GoTrue rejecting it mid-apply and wedging the run on the same row forever
+ * (PR #833 review).
+ */
+function isPlausibleEmail(email: string): boolean {
+  const atIndex = email.indexOf('@');
+  const lastDotIndex = email.lastIndexOf('.');
+  return (
+    atIndex > 0 &&
+    atIndex < email.length - 1 &&
+    lastDotIndex > atIndex &&
+    lastDotIndex < email.length - 1 &&
+    !email.includes(' ') &&
+    email.length <= 254
+  );
+}
+
 /** Lowercased alphanumerics only — the school-name matching alphabet. */
 const normName = (v: string): string => v.toLowerCase().replace(/[^a-z0-9]/g, '');
 
@@ -616,11 +637,12 @@ export function toFeedTeacher(raw: RawOneRosterUser): FeedTeacher | null {
   // A row with no name at all cannot become a picker entry anyone recognizes.
   if (!firstName && !lastName) return null;
   const identifier = trimOrNull(raw.identifier);
+  const email = trimOrNull(raw.email);
   return {
     sourcedId,
     firstName,
     lastName,
-    email: trimOrNull(raw.email),
+    email: email !== null && isPlausibleEmail(email) ? email : null,
     identifier,
     grades: Array.isArray(raw.grades)
       ? raw.grades.filter((g): g is string => typeof g === 'string' && g.trim() !== '')
@@ -729,6 +751,19 @@ export async function loadTeacherSyncInput(
   }
 
   return { feedSchools, feedTeachers, speddySchools, existingTeachers, studentCounts };
+}
+
+/**
+ * The count Apply binds to: every write the plan would make, refused schools
+ * excluded. One definition for both routes so the 409 drift check can never
+ * disagree with itself. (The two client panels carry local copies — this
+ * module is server-only and cannot enter their bundles — with comments
+ * pointing here; a drifted copy fails the count-binding loudly, not silently.)
+ */
+export function writableChangeCount(plan: TeacherSyncPlan): number {
+  return plan.schools
+    .filter((s) => !s.refusal)
+    .reduce((sum, s) => sum + s.creates.length + s.adopts.length + s.updates.length, 0);
 }
 
 /** Counts-only view of a plan — the ONLY shape this module ever logs. */
@@ -845,10 +880,45 @@ export async function applyTeacherSyncPlan(params: {
 }
 
 /**
+ * Undo a provisioned account: profile row FIRST, then the auth user.
+ *
+ * The order is load-bearing and was verified against the live schema:
+ * `profiles.id` references `auth.users(id)` with NO cascade, so deleting the
+ * auth user while its profile exists fails on the FK — the exact path the
+ * first version swallowed with an empty catch (PR #833 review, confirmed
+ * live). Both steps inspect their returned error (the admin API RESOLVES
+ * with `{ error }`, it does not reject) and a failed rollback is logged
+ * loudly by id — our own UUID, no PII — because an orphaned sign-in-capable
+ * account that nothing will retry is exactly what an operator must hear
+ * about. Never throws: rollback failing must not mask the original error.
+ */
+async function rollbackAccount(admin: SupabaseClient, accountId: string): Promise<void> {
+  try {
+    const { error: profileError } = await admin.from('profiles').delete().eq('id', accountId);
+    if (profileError) {
+      log.error('Rollback could not remove the profile of an orphaned account', undefined, {
+        accountId,
+        reason: profileError.message,
+      });
+    }
+    const { error: authError } = await admin.auth.admin.deleteUser(accountId);
+    if (authError) {
+      log.error('Rollback could not remove an orphaned auth account', undefined, {
+        accountId,
+        reason: authError.message,
+      });
+    }
+  } catch (err) {
+    log.error('Rollback of an orphaned account threw', err, { accountId });
+  }
+}
+
+/**
  * One login account for one planned create — the account half of the
  * create-teacher-account route, minus the temp-password relay. Returns
  * 'conflict' when the email is already registered to any Speddy account.
- * Cleans up the auth user itself if the profile steps fail, then rethrows.
+ * Cleans up after itself (profile then auth user) if a later step fails,
+ * then rethrows.
  */
 async function createLoginAccount(
   admin: SupabaseClient,
@@ -867,8 +937,14 @@ async function createLoginAccount(
     user_metadata: { full_name: fullName, role: 'teacher', created_by_admin: true },
   });
   if (error || !data?.user) {
+    // The stable GoTrue code first; the prose match stays as a fallback for
+    // older gateway shapes — message wording is not a contract (PR #833).
+    const code = (error as { code?: string } | null)?.code;
     const message = (error?.message ?? '').toLowerCase();
-    if (message.includes('already') && (message.includes('registered') || message.includes('exists'))) {
+    if (
+      code === 'email_exists' ||
+      (message.includes('already') && (message.includes('registered') || message.includes('exists')))
+    ) {
       return 'conflict';
     }
     throw new Error(
@@ -902,10 +978,7 @@ async function createLoginAccount(
 
     return { accountId: data.user.id };
   } catch (err) {
-    await admin.auth.admin.deleteUser(data.user.id).catch(() => {
-      // The rollback failing must not mask the original error; the partial
-      // audit and the thrown message are the operator's pointer.
-    });
+    await rollbackAccount(admin, data.user.id);
     throw err;
   }
 }
@@ -923,6 +996,13 @@ async function applySchools(
     throw new Error('Supabase URL and service role key are required to provision accounts.');
   }
   const admin = createSupabaseAdminClient(supabaseUrl, serviceRoleKey);
+
+  // Accounts provisioned in THIS run, by email. A multi-school teacher plans
+  // one create per school with the same email; the second school must link
+  // the account the first just made — reporting our own minutes-old account
+  // as "already uses Speddy in another role" would be false, and the row
+  // would stay unlinked (PR #833 review).
+  const provisionedThisRun = new Map<string, string>();
 
   for (const school of plan.schools) {
     if (school.refusal) continue;
@@ -945,21 +1025,26 @@ async function applySchools(
     // already linked — no window where a teacher exists accountless and a
     // parallel process could half-see them. Stop-on-failure posture holds:
     // a failed teacher stops the run (rolling back their own auth user);
-    // completed teachers stay and are audited.
+    // completed teachers stay and are audited. Outcome counters move ONLY
+    // after the row lands, so a partial audit never reports a teacher the
+    // database does not have (Codex/self-review, PR #833).
     for (const c of school.creates) {
       let accountId: string | null = null;
-      if (c.email) {
+      let outcome: 'account' | 'account-reused' | 'conflict' | 'directory-only';
+      const emailKey = c.email ? c.email.toLowerCase().trim() : null;
+      if (emailKey && provisionedThisRun.has(emailKey)) {
+        accountId = provisionedThisRun.get(emailKey) as string;
+        outcome = 'account-reused';
+      } else if (c.email) {
         const provisioned = await createLoginAccount(admin, c, school);
         if (provisioned === 'conflict') {
-          result.accountConflicts.push({
-            name: `${c.firstName} ${c.lastName}`.trim(),
-            email: c.email,
-          });
+          outcome = 'conflict';
         } else {
           accountId = provisioned.accountId;
+          outcome = 'account';
         }
       } else {
-        result.directoryOnly += 1;
+        outcome = 'directory-only';
       }
 
       const { data, error } = await supabase
@@ -980,17 +1065,31 @@ async function applySchools(
         ])
         .select('id');
       if (error) {
-        // The account exists but its directory row does not: undo the account
-        // so a re-run's plan (which only sees `teachers`) stays truthful.
-        if (accountId) {
-          await admin.auth.admin.deleteUser(accountId).catch(() => {});
+        // A freshly minted account whose directory row never landed must not
+        // survive: a re-run's plan reads only `teachers` and would report its
+        // own orphan as a conflict forever. A REUSED account belongs to an
+        // earlier, committed row — it stays.
+        if (accountId && outcome === 'account') {
+          await rollbackAccount(admin, accountId);
         }
         // Stop rather than continue past a failed school: a partial apply that
         // keeps going reports success about a state it does not know.
         throw new Error(`Creating teachers for ${school.schoolName} failed: ${error.message}`);
       }
-      result.created += (data ?? []).length;
-      if (accountId && (data ?? []).length > 0) result.accountsCreated += 1;
+      if ((data ?? []).length > 0) {
+        result.created += (data ?? []).length;
+        if (outcome === 'account' && emailKey && accountId) {
+          result.accountsCreated += 1;
+          provisionedThisRun.set(emailKey, accountId);
+        } else if (outcome === 'conflict' && c.email) {
+          result.accountConflicts.push({
+            name: `${c.firstName} ${c.lastName}`.trim(),
+            email: c.email,
+          });
+        } else if (outcome === 'directory-only') {
+          result.directoryOnly += 1;
+        }
+      }
     }
 
     for (const adopt of school.adopts) {

--- a/lib/sis/teacher-directory-sync.ts
+++ b/lib/sis/teacher-directory-sync.ts
@@ -34,9 +34,11 @@
  *
  * Server-only: dials an external SIS with a decrypted credential.
  */
+import { createClient as createSupabaseAdminClient, type SupabaseClient } from '@supabase/supabase-js';
 import { logger } from '@/lib/logger';
 import { createServiceClient } from '@/lib/supabase/server';
 import { logServerAuditEvent } from '@/lib/supabase/audit-log-server';
+import { generateTemporaryPassword } from '@/lib/utils/password-generator';
 import { OneRosterClient, type RawOneRosterUser } from '@/lib/integrations/oneroster';
 import { ONEROSTER_URL_LABELS, assertSafeSisUrl } from './ssrf-guard';
 import { oneRosterTokenUrlCandidates } from './oneroster-setup';
@@ -757,6 +759,17 @@ export interface SchoolWriteResult {
   created: number;
   adopted: number;
   updated: number;
+  /** Of `created`, how many got a sign-in account in the same step. */
+  accountsCreated: number;
+  /** Created as directory-only because the feed carried no email. */
+  directoryOnly: number;
+  /**
+   * The email already belongs to SOME Speddy account (plausibly a provider —
+   * special-ed staff can appear in the teacher feed too). The directory row
+   * is still created, accountless; attaching a login to an existing identity
+   * is a human decision, never a sync's (owner decision, 2026-08-10).
+   */
+  accountConflicts: { name: string; email: string }[];
 }
 
 /**
@@ -764,9 +777,20 @@ export interface SchoolWriteResult {
  * Review candidates and missing-from-SIS rows are never written — the first
  * needs a human's "same person", the second is a delete this sync does not do.
  *
- * Writes run through the service role: this is the staff-gated concierge
- * path (SPE-427 pattern), not a district session. Adoption re-checks
- * `sis_id IS NULL` in the WHERE so a concurrent apply cannot double-stamp.
+ * CREATES ALSO PROVISION SIGN-IN (owner decision, 2026-08-10): a created
+ * teacher with an email gets a real account in the same step — auth user
+ * (random password, never shown to anyone), teacher-role profile, and the
+ * directory row linked — mirroring /api/admin/create-teacher-account minus
+ * the temp-password ceremony. Nothing is emailed; the teacher signs in via
+ * Google SSO or "Forgot password", both of which ride on owning the district
+ * inbox. An email already registered to ANY Speddy account is a conflict:
+ * the row lands accountless and a human decides — the sync never attaches a
+ * login to an existing identity.
+ *
+ * Writes run through the service role behind an authorized route (Speddy
+ * staff via /internal, or a district admin for their own district). Adoption
+ * re-checks `sis_id IS NULL` in the WHERE so a concurrent apply cannot
+ * double-stamp.
  */
 export async function applyTeacherSyncPlan(params: {
   plan: TeacherSyncPlan;
@@ -780,14 +804,20 @@ export async function applyTeacherSyncPlan(params: {
   // Written in BOTH outcomes. Stop-on-failure means a school can fail after
   // earlier schools committed, and service-role writes that happened must
   // never go unrecorded because a later school threw (CodeRabbit, PR #831).
-  // Counts only, per the module's logging rule.
+  // Counts only, per the module's logging rule — conflicts as a NUMBER here;
+  // the names live only in the response for the reviewing human.
   const recordOutcome = async (partial: boolean) => {
-    const written = results.map(({ schoolId, created, adopted, updated }) => ({
-      schoolId,
-      created,
-      adopted,
-      updated,
-    }));
+    const written = results.map(
+      ({ schoolId, created, adopted, updated, accountsCreated, directoryOnly, accountConflicts }) => ({
+        schoolId,
+        created,
+        adopted,
+        updated,
+        accountsCreated,
+        directoryOnly,
+        accountConflicts: accountConflicts.length,
+      }),
+    );
     await logServerAuditEvent({
       user_id: params.actorId,
       action: 'sis_teacher_sync_applied',
@@ -814,11 +844,86 @@ export async function applyTeacherSyncPlan(params: {
   return results;
 }
 
+/**
+ * One login account for one planned create — the account half of the
+ * create-teacher-account route, minus the temp-password relay. Returns
+ * 'conflict' when the email is already registered to any Speddy account.
+ * Cleans up the auth user itself if the profile steps fail, then rethrows.
+ */
+async function createLoginAccount(
+  admin: SupabaseClient,
+  create: PlannedCreate,
+  school: { schoolId: string; schoolName: string },
+): Promise<{ accountId: string } | 'conflict'> {
+  const email = (create.email as string).toLowerCase().trim();
+  const fullName = `${create.firstName} ${create.lastName}`.trim();
+
+  const { data, error } = await admin.auth.admin.createUser({
+    email,
+    // Random and immediately discarded: access rides on the district inbox
+    // ("Forgot password") or Google SSO, never on a relayed secret.
+    password: generateTemporaryPassword(),
+    email_confirm: true,
+    user_metadata: { full_name: fullName, role: 'teacher', created_by_admin: true },
+  });
+  if (error || !data?.user) {
+    const message = (error?.message ?? '').toLowerCase();
+    if (message.includes('already') && (message.includes('registered') || message.includes('exists'))) {
+      return 'conflict';
+    }
+    throw new Error(
+      `Creating a sign-in account at ${school.schoolName} failed: ${error?.message ?? 'no user returned'}`,
+    );
+  }
+
+  try {
+    // Same RPC + school_id fix-up as the admin route, so a sync-provisioned
+    // teacher is indistinguishable from a hand-provisioned one.
+    const { error: profileError } = await admin.rpc('create_profile_for_new_user', {
+      user_id: data.user.id,
+      user_email: email,
+      user_metadata: {
+        full_name: fullName,
+        role: 'teacher',
+        school_site: school.schoolName,
+        school_district: '',
+        state: '',
+        works_at_multiple_schools: false,
+        additional_schools: [],
+      },
+    });
+    if (profileError) throw new Error(`Profile creation failed: ${profileError.message}`);
+
+    const { error: updateError } = await admin
+      .from('profiles')
+      .update({ school_id: school.schoolId })
+      .eq('id', data.user.id);
+    if (updateError) throw new Error(`Profile school update failed: ${updateError.message}`);
+
+    return { accountId: data.user.id };
+  } catch (err) {
+    await admin.auth.admin.deleteUser(data.user.id).catch(() => {
+      // The rollback failing must not mask the original error; the partial
+      // audit and the thrown message are the operator's pointer.
+    });
+    throw err;
+  }
+}
+
 async function applySchools(
   supabase: ReturnType<typeof createServiceClient>,
   plan: TeacherSyncPlan,
   results: SchoolWriteResult[],
 ): Promise<void> {
+  // The raw admin client, exactly as /api/admin/create-teacher-account builds
+  // it: auth.admin lives here, not on the SSR service client.
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Supabase URL and service role key are required to provision accounts.');
+  }
+  const admin = createSupabaseAdminClient(supabaseUrl, serviceRoleKey);
+
   for (const school of plan.schools) {
     if (school.refusal) continue;
     const result: SchoolWriteResult = {
@@ -827,34 +932,65 @@ async function applySchools(
       created: 0,
       adopted: 0,
       updated: 0,
+      accountsCreated: 0,
+      directoryOnly: 0,
+      accountConflicts: [],
     };
     // Pushed BEFORE the writes, counts accumulating on the shared reference:
     // a school that fails halfway must still contribute what it DID write to
     // the partial-outcome audit record, not vanish from it.
     results.push(result);
 
-    if (school.creates.length > 0) {
-      const rows = school.creates.map((c) => ({
-        first_name: c.firstName,
-        last_name: c.lastName,
-        email: c.email,
-        school_id: school.schoolId,
-        school_site: school.schoolName,
-        grade_level: c.gradeLevel,
-        created_by_admin: false,
-        sis_source: TEACHER_SIS_SOURCE,
-        sis_id: c.sisId,
-      }));
+    // One teacher at a time, account first, so each directory row is born
+    // already linked — no window where a teacher exists accountless and a
+    // parallel process could half-see them. Stop-on-failure posture holds:
+    // a failed teacher stops the run (rolling back their own auth user);
+    // completed teachers stay and are audited.
+    for (const c of school.creates) {
+      let accountId: string | null = null;
+      if (c.email) {
+        const provisioned = await createLoginAccount(admin, c, school);
+        if (provisioned === 'conflict') {
+          result.accountConflicts.push({
+            name: `${c.firstName} ${c.lastName}`.trim(),
+            email: c.email,
+          });
+        } else {
+          accountId = provisioned.accountId;
+        }
+      } else {
+        result.directoryOnly += 1;
+      }
+
       const { data, error } = await supabase
         .from('teachers')
-        .insert(rows)
+        .insert([
+          {
+            first_name: c.firstName,
+            last_name: c.lastName,
+            email: c.email,
+            school_id: school.schoolId,
+            school_site: school.schoolName,
+            grade_level: c.gradeLevel,
+            created_by_admin: false,
+            sis_source: TEACHER_SIS_SOURCE,
+            sis_id: c.sisId,
+            account_id: accountId,
+          },
+        ])
         .select('id');
       if (error) {
+        // The account exists but its directory row does not: undo the account
+        // so a re-run's plan (which only sees `teachers`) stays truthful.
+        if (accountId) {
+          await admin.auth.admin.deleteUser(accountId).catch(() => {});
+        }
         // Stop rather than continue past a failed school: a partial apply that
         // keeps going reports success about a state it does not know.
         throw new Error(`Creating teachers for ${school.schoolName} failed: ${error.message}`);
       }
-      result.created = (data ?? []).length;
+      result.created += (data ?? []).length;
+      if (accountId && (data ?? []).length > 0) result.accountsCreated += 1;
     }
 
     for (const adopt of school.adopts) {


### PR DESCRIPTION
Owner decisions (2026-08-10): Apply makes a teacher **official in one step** — no two-step provisioning, no temp-password ceremony — and the call belongs to the **district admin**, not Speddy staff on `/internal`.

## Accounts on apply

A created teacher with an email gets a sign-in account in the same pass: auth user (random password, discarded — never shown to anyone), teacher-role profile via the same `create_profile_for_new_user` RPC the admin creation route uses, and the directory row born linked (`account_id`). Nothing is emailed at creation; access rides on owning the district inbox — **"Forgot password"** (accounts are email-pre-verified) or **Google SSO** (the provisioned-account gate already admits them).

Guardrails:
- **Email-less feed rows** → directory-only, counted (`directoryOnly`).
- **Email already registered to any Speddy account** (provider overlap is real — special-ed staff can appear in teacher feeds) → the row lands **accountless** in a named `accountConflicts` bucket for a human; the sync never attaches a login to an existing identity, and nothing on that identity is touched.
- **Rollbacks:** a profile failure deletes its own auth user; a failed directory insert deletes the just-created orphan account, so a re-run's plan (which reads only `teachers`) stays truthful.
- Audit rows and logs stay **counts-only** (conflicts as a number); names/emails exist only in the response for the reviewing human.

## The district admin surface

- `POST /api/district/teacher-sync` — same engine as the internal route, district authorization: own district resolved from the caller's grants (a request can never name a district or connection), **district_admin only** with the SPE-436 dual-role grant re-check; `district_tech` is refused — teacher PII and account provisioning are outside its integrations-only line (SPE-393). Count-bound apply (409 on drift) intact.
- **Preview → Apply panel on `/dashboard/admin/directories`** (light-theme, district-admin language): per-school diff with a "with sign-in access" count, review rows called out, apply behind a confirm that states the account count and the no-emails posture, conflicts surfaced after apply with plain-language explanation.
- The `/internal` staff card stays as the concierge fallback on the same engine, its copy updated to mention account provisioning.
- Site-admin delegation for larger districts is the eventual shape — deliberately not built here.

## Verification

- 116 tests across the sync suites, all green; typecheck and lint clean; full unit run green (the 3 `tests/integration/*` failures pre-date this branch and fail identically on `main`).
- Apply suite: account provisioned + linked with mirror-of-admin-route assertions; conflict → accountless row + bucket + nothing touched on the existing identity; email-less → no attempt; both rollback paths (profile failure, orphaned account after insert failure); refused schools provision nothing; counts-only audit/logs.
- New district route suite: unauth / no-grant / `district_tech` refusals dial nothing and write nothing; dual-role admit; connection/credential gates; validation and count-binding; actor + connection provably from grants, never the request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcxL3WefHrAjGStyvVJrAo

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcxL3WefHrAjGStyvVJrAo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added district teacher synchronization with preview and apply workflows.
  * Added per-school sync results, including additions, updates, exclusions, and SIS discrepancies.
  * Teachers with email addresses can receive sign-in accounts during synchronization; teachers without emails remain directory-only.
  * Added reporting for account conflicts and created accounts.

* **Bug Fixes**
  * Added safeguards for authorization, stale previews, missing credentials, validation errors, and failed account creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->