### PR TITLE
feat: rename user-facing "CARE" to "Referrals"

### DIFF
--- a/app/(dashboard)/dashboard/admin/care/page.tsx
+++ b/app/(dashboard)/dashboard/admin/care/page.tsx
@@ -62,7 +62,7 @@ export default function DistrictCarePage() {
         setReferrals(referralsData);
       } catch (err) {
         console.error('Error loading CARE data:', err);
-        setError(err instanceof Error ? err.message : 'Failed to load CARE data');
+        setError(err instanceof Error ? err.message : 'Failed to load referral data');
       } finally {
         setLoading(false);
       }
@@ -98,7 +98,7 @@ export default function DistrictCarePage() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center py-12">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
-          <p className="mt-2 text-gray-600">Loading CARE referrals...</p>
+          <p className="mt-2 text-gray-600">Loading referrals...</p>
         </div>
       </div>
     );
@@ -139,11 +139,11 @@ export default function DistrictCarePage() {
             Admin Dashboard
           </Link>
           <span>/</span>
-          <span className="text-gray-900">CARE Referrals</span>
+          <span className="text-gray-900">Referrals</span>
         </div>
-        <h1 className="text-2xl font-bold text-gray-900">CARE Referrals</h1>
+        <h1 className="text-2xl font-bold text-gray-900">Referrals</h1>
         <p className="mt-1 text-sm text-gray-600">
-          View all CARE referrals across your district
+          View all referrals across your district
         </p>
       </div>
 

--- a/app/(dashboard)/dashboard/admin/create-account/page.tsx
+++ b/app/(dashboard)/dashboard/admin/create-account/page.tsx
@@ -742,7 +742,7 @@ export default function CreateAccountPage() {
                 <p>
                   A District Tech Admin only sees the Integrations area, where they
                   connect your student information system. They cannot see students,
-                  schedules, CARE, or any other part of Speddy.
+                  schedules, referrals, or any other part of Speddy.
                 </p>
                 <p className="mt-2">
                   They&apos;ll be asked to choose a new password the first time they sign in.

--- a/app/(dashboard)/dashboard/admin/page.tsx
+++ b/app/(dashboard)/dashboard/admin/page.tsx
@@ -527,7 +527,7 @@ export default function AdminDashboardPage() {
                 </svg>
               </div>
               <div className="ml-4">
-                <h3 className="text-sm font-semibold text-gray-900">CARE Referrals</h3>
+                <h3 className="text-sm font-semibold text-gray-900">Referrals</h3>
                 <p className="text-sm text-gray-600">View student support referrals</p>
               </div>
             </Link>

--- a/app/(dashboard)/dashboard/admin/students/page.tsx
+++ b/app/(dashboard)/dashboard/admin/students/page.tsx
@@ -203,16 +203,16 @@ export default function AdminStudentsPage() {
           });
           if (!res.ok) {
             const body = await res.json().catch(() => ({}));
-            throw new Error(body?.error || 'Failed to delete CARE referral');
+            throw new Error(body?.error || 'Failed to delete referral');
           }
         })
       );
       // Clear only after success, so a partial failure keeps the modal open to retry.
       setCareMatches([]);
-      showToast('Related CARE records deleted', 'success');
+      showToast('Related referral records deleted', 'success');
     } catch (err) {
       console.error('Error deleting CARE records:', err);
-      showToast(err instanceof Error ? err.message : 'Failed to delete CARE records', 'error');
+      showToast(err instanceof Error ? err.message : 'Failed to delete referral records', 'error');
     }
   };
 
@@ -467,15 +467,15 @@ export default function AdminStudentsPage() {
         isOpen={careMatches.length > 0}
         onClose={() => setCareMatches([])}
         onConfirm={deleteCareMatches}
-        title="Delete related CARE records?"
+        title="Delete related referral records?"
         message={
           careMatches.length > 0
-            ? `We found ${careMatches.length} CARE referral(s) matching this student's name (${careMatches
+            ? `We found ${careMatches.length} referral(s) matching this student's name (${careMatches
                 .map(m => m.student_name)
                 .join(', ')}). These hold special-education referral data and are not removed automatically. Delete them too? This cannot be undone.`
             : ''
         }
-        confirmLabel="Delete CARE records"
+        confirmLabel="Delete referral records"
         variant="danger"
       />
     </div>

--- a/app/(dashboard)/dashboard/care/[caseId]/page.tsx
+++ b/app/(dashboard)/dashboard/care/[caseId]/page.tsx
@@ -335,7 +335,7 @@ export default function CaseDetailPage() {
                 href="/dashboard/admin/care"
                 className="mt-2 inline-block text-sm font-medium text-purple-600 hover:text-purple-500"
               >
-                Back to CARE Referrals
+                Back to District Referrals
               </Link>
             </div>
           </div>

--- a/app/(dashboard)/dashboard/care/page.tsx
+++ b/app/(dashboard)/dashboard/care/page.tsx
@@ -215,7 +215,7 @@ export default function CareDashboardPage() {
     return (
       <div className="max-w-4xl mx-auto py-8 px-4">
         <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-yellow-800">
-          Please select a school to view CARE referrals.
+          Please select a school to view referrals.
         </div>
       </div>
     );
@@ -237,9 +237,9 @@ export default function CareDashboardPage() {
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">CARE Dashboard</h1>
+          <h1 className="text-2xl font-bold text-gray-900">Referrals</h1>
           <p className="text-sm text-gray-500 mt-1">
-            Child Assistance Response in Education
+            Student support referrals and cases
           </p>
         </div>
         <button

--- a/app/(internal)/internal/create-admin/page.tsx
+++ b/app/(internal)/internal/create-admin/page.tsx
@@ -305,7 +305,7 @@ export default function CreateAdminPage() {
             {adminType === 'district_admin'
               ? 'Can manage all schools in the district'
               : adminType === 'district_tech'
-                ? 'SIS integrations only — no students, schedules or CARE'
+                ? 'SIS integrations only — no students, schedules or referrals'
                 : 'Can manage a single school'}
           </p>
         </div>

--- a/app/api/admin/care-referrals/[referralId]/route.ts
+++ b/app/api/admin/care-referrals/[referralId]/route.ts
@@ -31,13 +31,13 @@ export const DELETE = withRoute<{ referralId: string }>({}, async ({ userId, par
     .single();
 
   if (error || !referral) {
-    return NextResponse.json({ error: 'CARE referral not found' }, { status: 404 });
+    return NextResponse.json({ error: 'Referral not found' }, { status: 404 });
   }
 
   const rls = await createClient();
   if (!referral.school_id || !(await isAdminForSchool(rls, userId, referral.school_id))) {
     return NextResponse.json(
-      { error: 'You do not have permission to delete this CARE referral' },
+      { error: 'You do not have permission to delete this referral' },
       { status: 403 }
     );
   }
@@ -45,7 +45,7 @@ export const DELETE = withRoute<{ referralId: string }>({}, async ({ userId, par
   const { error: delErr } = await service.from('care_referrals').delete().eq('id', referralId);
   if (delErr) {
     log.error('Failed to delete CARE referral', delErr);
-    return NextResponse.json({ error: 'Failed to delete CARE referral' }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to delete referral' }, { status: 500 });
   }
 
   log.info('CARE referral deleted by admin', { referralId, deletedBy: userId });

--- a/app/api/admin/providers/[providerId]/route.ts
+++ b/app/api/admin/providers/[providerId]/route.ts
@@ -99,9 +99,9 @@ export const DELETE = withRoute<{ providerId: string }>({}, async ({ userId, par
 
   // --- Preflight: NOT NULL references that do not cascade would hard-block the delete. ---
   const blockerSpecs: Array<{ label: string; table: string; column: string }> = [
-    { label: 'CARE referral(s) created', table: 'care_referrals', column: 'referring_user_id' },
-    { label: 'CARE meeting note(s)', table: 'care_meeting_notes', column: 'created_by' },
-    { label: 'CARE case status change(s)', table: 'care_case_status_history', column: 'changed_by' },
+    { label: 'referral(s) created', table: 'care_referrals', column: 'referring_user_id' },
+    { label: 'referral meeting note(s)', table: 'care_meeting_notes', column: 'created_by' },
+    { label: 'referral case status change(s)', table: 'care_case_status_history', column: 'changed_by' },
     { label: 'school year activation(s)', table: 'activated_school_years', column: 'activated_by' },
   ];
 

--- a/app/components/admin/district-care-table.tsx
+++ b/app/components/admin/district-care-table.tsx
@@ -54,7 +54,7 @@ export function DistrictCareTable({ referrals, isLoading }: DistrictCareTablePro
   if (referrals.length === 0) {
     return (
       <div className="bg-white border border-gray-200 rounded-lg p-8 text-center text-gray-500">
-        No CARE referrals found.
+        No referrals found.
       </div>
     );
   }

--- a/app/components/care/add-referral-modal.tsx
+++ b/app/components/care/add-referral-modal.tsx
@@ -167,7 +167,7 @@ export function AddReferralModal({ isOpen, onClose, onSubmit, lockedTeacher }: A
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} title="Add CARE Referral">
+    <Modal isOpen={isOpen} onClose={handleClose} title="Add Referral">
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && (
           <div className="p-3 bg-red-50 border border-red-200 rounded-md text-red-700 text-sm">

--- a/app/components/care/case-detail-header.tsx
+++ b/app/components/care/case-detail-header.tsx
@@ -60,7 +60,7 @@ export function CaseDetailHeader({ caseData }: CaseDetailHeaderProps) {
         <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
         </svg>
-        Back to CARE Dashboard
+        Back to Referrals
       </Link>
 
       {/* Header */}

--- a/app/components/landing/speddy-landing.tsx
+++ b/app/components/landing/speddy-landing.tsx
@@ -190,7 +190,7 @@ function resolve(sel: Sel): Resolved {
         note: '',
       },
       {
-        name: 'Referral tracking (CARE)',
+        name: 'Referral tracking',
         status: 'live',
         graphic: 'care',
         benefit: isPriv
@@ -294,7 +294,7 @@ function resolve(sel: Sel): Resolved {
         note: '',
       },
       {
-        name: 'Referral oversight (CARE)',
+        name: 'Referral oversight',
         status: 'live',
         graphic: 'care',
         benefit:
@@ -397,9 +397,9 @@ function resolve(sel: Sel): Resolved {
         benefit:
           'The whole ' +
           (isCharter ? 'network' : 'district') +
-          '’s CARE queue in one place — including the private-school referrals your district receives.',
+          '’s referral queue in one place — including the private-school referrals your district receives.',
         points: [
-          'Every school’s CARE queue in one place',
+          'Every school’s referral queue in one place',
           'Includes private-school referrals you receive',
           'Spot bottlenecks before they grow',
         ],

--- a/app/components/landing/speddy-mock.tsx
+++ b/app/components/landing/speddy-mock.tsx
@@ -916,7 +916,7 @@ function CareMock({ type }: { type: SchoolType }) {
       >
         <div>
           <div style={{ fontSize: 13, color: 'rgba(15,23,42,0.55)', fontWeight: 500 }}>
-            CARE · referral queue
+            Referral queue
           </div>
           <div style={{ fontSize: 18, color: '#0F172A', fontWeight: 700, marginTop: 2 }}>
             4 active cases

--- a/app/components/navigation/navbar.tsx
+++ b/app/components/navigation/navbar.tsx
@@ -102,7 +102,7 @@ export default function Navbar() {
         { name: 'Schools', href: '/dashboard/admin/schools' },
         { name: 'Directories', href: '/dashboard/admin/directories' },
         { name: 'Curriculums', href: '/dashboard/admin/curriculums' },
-        { name: 'CARE', href: '/dashboard/admin/care' },
+        { name: 'Referrals', href: '/dashboard/admin/care' },
       ];
     } else if (role === 'district_tech') {
       // District Tech Admins only ever see the integrations portal (SPE-393).
@@ -124,7 +124,7 @@ export default function Navbar() {
         { name: 'Staff', href: '/dashboard/admin/staff' },
         { name: 'Students', href: '/dashboard/admin/students' },
         { name: 'Chat', href: '/dashboard/chat' },
-        { name: 'CARE', href: '/dashboard/care' },
+        { name: 'Referrals', href: '/dashboard/care' },
       ];
     } else if (role === 'teacher') {
       // Teachers see their dashboard, students in resource, and special activities
@@ -159,7 +159,7 @@ export default function Navbar() {
         { name: 'Meetings', href: '/dashboard/meetings' },
         { name: 'Plan', href: '/dashboard/plan' },
         { name: 'Chat', href: '/dashboard/chat' },
-        { name: 'CARE', href: '/dashboard/care' },
+        { name: 'Referrals', href: '/dashboard/care' },
       ];
     } else if (role === 'speech' || role === 'ot' || role === 'counseling' || role === 'psychologist') {
       // Speech, OT, Counseling, Psychologist providers see standard navigation WITHOUT Tools

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1216,7 +1216,21 @@ Two properties worth knowing before relying on it:
 
 ## 8. CARE / Referrals Model
 
-CARE (the student-support / referral workflow) is a self-contained set of four
+> **Naming — read this before you grep.** The module is called **"Referrals"**
+> everywhere a user can see it (nav label, page headings, modal titles, toasts,
+> API error messages, landing-page copy). Everything *underneath* still carries
+> the original **CARE** name and was deliberately left alone: the five `care_*`
+> tables, their RLS policies, indexes and constraints, `get_care_assignable_users`,
+> the `/dashboard/care` routes, the `Care*` TypeScript types, and the
+> `lib/supabase/queries/care-*.ts` files. That mismatch is intentional, not drift
+> — renaming the schema would invalidate the district data-privacy paperwork in
+> `docs/ndpa/`, which cites `care_referrals.student_name`,
+> `care_referrals.referral_reason`, `care_referrals.requested_by`,
+> `care_meeting_notes` and `care_action_items` by exact table/column name as the
+> inventory of what Speddy collects. Code comments and server logs keep saying
+> "CARE" on purpose, so they still point at the tables they describe.
+
+CARE (the student-support / referral workflow) is a self-contained set of five
 tables. Crucially, a referral identifies the student by **free-text name** — it
 is **not** foreign-keyed to `students` (which is why student deletion can only
 surface CARE by name match; see §7).
@@ -1226,6 +1240,7 @@ erDiagram
     CARE_REFERRALS    ||--o| CARE_CASES         : "case (immediate for Lane B)"
     CARE_CASES        ||--o{ CARE_MEETING_NOTES : "notes"
     CARE_CASES        ||--o{ CARE_ACTION_ITEMS  : "action items"
+    CARE_CASES        ||--o{ CARE_CASE_STATUS_HISTORY : "status audit trail"
 
     CARE_REFERRALS {
         uuid id PK
@@ -1261,6 +1276,13 @@ erDiagram
         date due_date
         timestamptz completed_at
     }
+    CARE_CASE_STATUS_HISTORY {
+        uuid id PK
+        uuid case_id FK
+        text status
+        uuid changed_by FK
+        timestamptz created_at
+    }
 ```
 
 - **Two intake lanes**, chosen at submit time by `referral_source`
@@ -1280,7 +1302,8 @@ erDiagram
   notes/action-items reach scope via the `case → referral` join; insert policies
   require `referring_user_id` / `created_by = auth.uid()`.
 - **Cascade & soft delete:** `care_cases`, `care_meeting_notes`,
-  `care_action_items` are all `ON DELETE CASCADE` from their parents — deleting a
+  `care_action_items`, `care_case_status_history` are all `ON DELETE CASCADE`
+  from their parents — deleting a
   referral removes its entire tree. Referrals also support **soft delete**
   (`deleted_at`, `softDeleteReferral`). Admin hard-delete goes through
   `app/api/admin/care-referrals/[referralId]` (service role after a school-scope

--- a/docs/CAPABILITIES_MATRIX.md
+++ b/docs/CAPABILITIES_MATRIX.md
@@ -97,7 +97,7 @@ person using it.
 | 1 | Schedule building — provider | Provider | ✅ |
 | 2 | Schedule building — site admin (Master Schedule) | Site admin | ✅ |
 | 3 | IEP meeting calendaring (Meetings) | Site admin + Provider | 🗓️ rolling out |
-| 4 | Referral tracking (CARE) | All roles | ✅ |
+| 4 | Referral tracking | All roles | ✅ |
 | 5 | Student & caseload management | Provider | ✅ |
 | 6 | Lesson planning & materials | Provider | 🔶 (AI features flag-gated) |
 | 7 | Progress monitoring & assessment | Provider | ✅ |
@@ -178,7 +178,7 @@ chain. The organizer sees everyone's availability without asking anyone.
 watch the dashboard; teachers just receive accurate calendar invites; parents
 confirm by link or phone.
 
-### 2.4 Referral tracking (CARE)
+### 2.4 Referral tracking
 
 The front door for student concerns, before and around the IEP: a shared
 queue instead of sticky notes and hallway conversations.
@@ -193,7 +193,7 @@ queue instead of sticky notes and hallway conversations.
     referral starts the legal clock immediately: the case opens on arrival
     with the assessment-plan due date pre-calculated (15 days, CA Ed. Code).
 - Cases carry meeting notes, action items with owners and due dates, current
-  disposition, and follow-up dates — the whole SST/CARE-meeting paper trail
+  disposition, and follow-up dates — the whole SST-meeting paper trail
   in one place.
 - School-scoped: the team sees their school's queue; district admins see
   across schools.
@@ -314,7 +314,7 @@ in charter networks and private-school learning-support teams.
 | Provider schedule building | 👁 | 👁 | ✅ | 👁 (their students) | 👁 (assigned sessions) | — |
 | Master Schedule (bells, specials, yard duty) | 👁 | ✅ | ✏️ (can enter site data; consumes it) | ✏️ (own class activities) | — | — |
 | IEP meeting calendaring 🗓️ | 👁 (planned) | 🔶 rules setup shipped; dashboard planned | 🗓️ planner in review; reschedule planned | ✏️ one-time availability (shipped) | — | — |
-| Referral tracking (CARE) | 👁 across schools | ✅ oversight | ✅ works the queue | ✏️ submits + follows | 👁 | — |
+| Referral tracking | 👁 across schools | ✅ oversight | ✅ works the queue | ✏️ submits + follows | 👁 | — |
 | Student & caseload management | 👁 across schools | 👁 school-wide | ✅ | 👁 (their students) | 👁 (their students) | — |
 | Lesson planning & materials | — | — | ✅ | — | 👁 view-only | — |
 | Progress monitoring & assessment | 👁 | 👁 | ✅ | — | ✏️ (curriculum progress) | — |
@@ -348,7 +348,7 @@ never change with level.
 | Provider schedule building | ✅ | 🗓️ hidden today; period-based scheduling is the Middle/High module roadmap | 🗓️ same as middle |
 | Master Schedule (site admin) | ✅ | ✅ | ✅ |
 | IEP meeting calendaring | 🗓️ auto-assembles the team (single classroom teacher) | 🗓️ case manager picks the gen-ed teacher(s) | 🗓️ same as middle |
-| Referral tracking (CARE) | ✅ | ✅ | ✅ |
+| Referral tracking | ✅ | ✅ | ✅ |
 | Student & caseload management | ✅ full, incl. sessions/minutes and attendance | 🔶 caseload-first: goals, accommodations, assessments; session/attendance fields hidden | 🔶 same as middle |
 | Lesson planning & materials | ✅ (Plan calendar + materials) | 🔶 materials are grade-driven and work; the Plan calendar is hidden | 🔶 same as middle |
 | Progress monitoring & assessment | ✅ | 🔶 goal-driven tools work; attendance widgets hidden | 🔶 same as middle |
@@ -378,7 +378,7 @@ type-by-type read below (today every school must sit under a district).
 | Provider schedule building | ✅ | ✅ as-is | ✅ mechanics transfer directly to learning-support sessions |
 | Master Schedule (site admin) | ✅ | ✅ as-is | ✅ as-is (bell schedules and specials exist everywhere) |
 | IEP meeting calendaring | 🗓️ | 🗓️ as-is (charters run IEPs) | 🗓️ reframed: support-plan / family meetings — same engine, no IDEA clock |
-| Referral tracking (CARE) | ✅ both lanes, incl. the private-school referral intake **received by the district** | ✅ both lanes | 🔶 discussion lane fits (internal concern → learning-support review); the statutory compliance lane doesn't apply |
+| Referral tracking | ✅ both lanes, incl. the private-school referral intake **received by the district** | ✅ both lanes | 🔶 discussion lane fits (internal concern → learning-support review); the statutory compliance lane doesn't apply |
 | Student & caseload management | ✅ IEP-organized | ✅ IEP-organized | 🔶 the goal/accommodation/minutes mechanics fit **support plans**; IEP-specific fields (triennials, IDEA categories) don't apply |
 | Lesson planning & materials | 🔶 (AI flag) | 🔶 same | 🔶 same — grade-driven, not school-type-driven |
 | Progress monitoring & assessment | ✅ | ✅ | ✅ goal-indexed progress works for any plan's goals |
@@ -389,8 +389,8 @@ type-by-type read below (today every school must sit under a district).
 **Type-by-type read:**
 
 - **Public district.** The built-for environment. District hierarchy, admin
-  oversight, SEIS import, CARE's statutory clocks, and the IEP data model all
-  assume it.
+  oversight, SEIS import, the referral module's statutory clocks, and the IEP
+  data model all assume it.
 - **Charter.** Same product in practice — charters are public schools running
   IEPs — with the *buyer* being the school or network rather than a district
   office. In California, Speddy runs **alongside SEIS** (SEIS writes the IEP
@@ -408,8 +408,8 @@ type-by-type read below (today every school must sit under a district).
   (a private school currently has to be attached to a district record) and
   IEP-centric labels in the UX. Both are bounded adaptations, identified in
   the market research, not rebuilds. Until then, private schools appear in
-  Speddy mainly from the **district side** — as a referral source in CARE's
-  compliance lane.
+  Speddy mainly from the **district side** — as a referral source in the
+  referral module's compliance lane.
 
 ---
 
@@ -446,8 +446,8 @@ What this document supports deciding (kept as observations, not a design):
 
 ## Sources
 
-- `docs/ARCHITECTURE.md` — roles, portals, elementary/secondary split, CARE
-  model, scheduling model.
+- `docs/ARCHITECTURE.md` — roles, portals, elementary/secondary split, the
+  referral (`care_*`) model, scheduling model.
 - [Feature Overview for School Districts](https://linear.app/speddy/document/speddy-feature-overview-for-school-districts-81737db18ac1)
   (Linear) — provider feature inventory.
 - `docs/IEP_MEETING_SCHEDULING_SPEC.md` + PRs #684/#685 (merged), #686 (in

--- a/lib/supabase/hooks/use-care-data.ts
+++ b/lib/supabase/hooks/use-care-data.ts
@@ -95,7 +95,7 @@ export function useCareData(options?: UseCareDataOptions): UseCareDataReturn {
       setState(prev => ({
         ...prev,
         loading: false,
-        error: err instanceof Error ? err.message : 'Failed to load CARE data',
+        error: err instanceof Error ? err.message : 'Failed to load referral data',
       }));
     }
   }, [currentSchool?.school_id, teacherId, skip]);


### PR DESCRIPTION
## What changed

The module is now called **"Referrals"** everywhere a user can see it:

| Surface | Before | After |
|---|---|---|
| Nav label (district admin, site admin, resource) | `CARE` | `Referrals` |
| Dashboard heading + subtitle | `CARE Dashboard` / "Child Assistance Response in Education" | `Referrals` / "Student support referrals and cases" |
| District page (heading, breadcrumb, empty + loading states) | `CARE Referrals` | `Referrals` |
| Add-referral modal title | `Add CARE Referral` | `Add Referral` |
| Back-links | `Back to CARE Dashboard` / `Back to CARE Referrals` | `Back to Referrals` / `Back to District Referrals` |
| Student-deletion confirm dialog + toasts | `Delete related CARE records?` | `Delete related referral records?` |
| Admin API error responses | `CARE referral not found` | `Referral not found` |
| Landing page | `Referral tracking (CARE)`, "CARE queue" | `Referral tracking`, "referral queue" |

The acronym expansion in the dashboard subtitle was the one spot where "CARE" was spelled out to users; it's replaced with a plain descriptor.

## What deliberately did **not** change

Everything under the label keeps the original name, so this carries **no migration and no route change**:

- the five `care_*` tables, their RLS policies, indexes and constraints
- `get_care_assignable_users`
- the `/dashboard/care`, `/dashboard/care/[caseId]` and `/dashboard/admin/care` routes (so no bookmarks break, and the `isCareRoute` gate in `middleware.ts` is untouched)
- the `Care*` TypeScript types and `lib/supabase/queries/care-*.ts`
- code comments and server logs, which keep saying "CARE" so they still point at the tables they describe

The reason for stopping here is concrete: the district data-privacy paperwork in `docs/ndpa/` cites `care_referrals.student_name`, `care_referrals.referral_reason`, `care_referrals.requested_by`, `care_meeting_notes` and `care_action_items` **by exact table/column name** as the inventory of what Speddy collects. Renaming the schema would make those documents factually wrong and force a re-issue to districts and counsel.

## Docs

- `ARCHITECTURE.md` §8 gains a "read this before you grep" note explaining the intentional UI/schema name split, so the mismatch reads as a decision rather than drift.
- `CAPABILITIES_MATRIX.md` drops the `(CARE)` suffix from the feature name it shares with the landing page (that doc states it describes "what the user sees and does").
- Corrects pre-existing staleness the new note exposed: §8 said "four tables" and its ERD omitted `care_case_status_history`, added back in 20260106. Now charted, and added to the cascade list — its `case_id` FK is `ON DELETE CASCADE`, confirmed against the live schema.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — no errors (two pre-existing warnings in untouched files)
- `npm test` — 109 suites, 1247 passed, 0 failed
- `/code-review` at high effort. It confirmed no tests, Playwright selectors, or sim-district scripts key off the old strings, and no client code matches on the changed API error messages. It caught one real regression: the rename had collapsed two links on the case-detail page into the identical text "Back to Referrals" pointing at different destinations for district admins. Fixed — the read-only notice now reads "Back to District Referrals".

No database read or write path changed, so the real-session RLS rule doesn't apply here; the diff is string literals only.

## Note for follow-up

I couldn't check the Help Scout help-center articles from this session (the Docs API key isn't linked). If published support articles mention CARE, they'd need the same rename.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3G5Bwk9XtFzVH4uRuojWp)_