### PR TITLE
Anchor the assistant panel under the Ask AI button and make it draggable (SPE-454)

### DIFF
--- a/app/components/assistant/assistant-panel.tsx
+++ b/app/components/assistant/assistant-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Loader2, Send, Sparkles, X } from 'lucide-react';
 import { formatDateLocal } from '@/lib/utils/date-helpers';
 
@@ -42,6 +42,21 @@ export default function AssistantPanel({ open, onClose }: AssistantPanelProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  // The panel is fixed-positioned (so it stays put while the page scrolls)
+  // but PLACED under the Ask AI button on open: left edge aligned to the
+  // button's, clamped so the whole panel is always inside the viewport.
+  // Dragging the header updates the same position; reopening re-anchors.
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const dragState = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    baseLeft: number;
+    baseTop: number;
+    width: number;
+    height: number;
+  } | null>(null);
 
   useEffect(() => {
     if (scrollRef.current) {
@@ -64,6 +79,79 @@ export default function AssistantPanel({ open, onClose }: AssistantPanelProps) {
 
   // Abandon any in-flight request when the panel unmounts.
   useEffect(() => () => abortRef.current?.abort(), []);
+
+  // Clamp a candidate position so the whole panel stays inside the viewport
+  // (8px margin), using the panel's real rendered size.
+  const clampToViewport = useCallback((top: number, left: number, width: number, height: number) => ({
+    left: Math.min(Math.max(left, 8), Math.max(window.innerWidth - width - 8, 8)),
+    top: Math.min(Math.max(top, 8), Math.max(window.innerHeight - height - 8, 8)),
+  }), []);
+
+  // On open (before paint, so there is no misplaced first frame): place the
+  // panel just below the Ask AI button, left edges aligned, clamped on-screen.
+  // On close: drop the position and any in-flight drag state, so reopening
+  // always re-anchors — and a drag interrupted by Escape can't go stale.
+  useLayoutEffect(() => {
+    if (!open) {
+      setPos(null);
+      dragState.current = null;
+      return;
+    }
+    const panel = panelRef.current;
+    const anchor = panel?.parentElement?.getBoundingClientRect();
+    if (!panel || !anchor) return;
+    const rect = panel.getBoundingClientRect();
+    setPos(clampToViewport(anchor.bottom + 8, anchor.left, rect.width, rect.height));
+  }, [open, clampToViewport]);
+
+  // Keep the panel reachable if the window is resized while open.
+  useEffect(() => {
+    if (!open) return;
+    const onResize = () => {
+      const rect = panelRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      setPos((p) => (p ? clampToViewport(p.top, p.left, rect.width, rect.height) : p));
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, [open, clampToViewport]);
+
+  const onHeaderPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    // The close button lives in the header; clicking it should not start a drag.
+    if ((e.target as HTMLElement).closest('button')) return;
+    const rect = panelRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    dragState.current = {
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      baseLeft: rect.left,
+      baseTop: rect.top,
+      width: rect.width,
+      height: rect.height,
+    };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  }, []);
+
+  const onHeaderPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const s = dragState.current;
+      if (!s || e.pointerId !== s.pointerId) return;
+      setPos(
+        clampToViewport(
+          s.baseTop + (e.clientY - s.startY),
+          s.baseLeft + (e.clientX - s.startX),
+          s.width,
+          s.height
+        )
+      );
+    },
+    [clampToViewport]
+  );
+
+  const onHeaderPointerEnd = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (dragState.current?.pointerId === e.pointerId) dragState.current = null;
+  }, []);
 
   const send = useCallback(
     async (text: string) => {
@@ -136,16 +224,30 @@ export default function AssistantPanel({ open, onClose }: AssistantPanelProps) {
   if (!open) return null;
 
   return (
-    // bottom-24 keeps the Help Scout beacon launcher (bottom-right corner)
-    // reachable while the panel is open.
+    // Opens just below the Ask AI button (left edges aligned, clamped fully
+    // on-screen), pinned to the viewport so it stays put while the page
+    // scrolls; draggable anywhere by the header.
     <div
+      ref={panelRef}
       id="speddy-assistant-panel"
-      className="fixed bottom-24 right-5 z-40 flex w-[380px] max-w-[calc(100vw-2.5rem)] flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl"
-      style={{ height: 'min(560px, calc(100vh - 10rem))' }}
+      className="fixed z-40 flex w-[380px] max-w-[calc(100vw-2.5rem)] flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl"
+      style={{
+        height: 'min(560px, calc(100vh - 7rem))',
+        top: pos?.top ?? 0,
+        left: pos?.left ?? 0,
+        visibility: pos ? 'visible' : 'hidden',
+      }}
       role="dialog"
       aria-label="Speddy Assistant"
     >
-      <div className="flex items-center justify-between border-b border-gray-200 bg-blue-600 px-4 py-3 text-white">
+      <div
+        className="flex cursor-move touch-none select-none items-center justify-between border-b border-gray-200 bg-blue-600 px-4 py-3 text-white"
+        onPointerDown={onHeaderPointerDown}
+        onPointerMove={onHeaderPointerMove}
+        onPointerUp={onHeaderPointerEnd}
+        onPointerCancel={onHeaderPointerEnd}
+        title="Drag to move"
+      >
         <div className="flex items-center gap-2">
           <Sparkles className="h-4 w-4" aria-hidden="true" />
           <span className="text-sm font-semibold">Speddy Assistant</span>

--- a/app/components/navigation/navbar.tsx
+++ b/app/components/navigation/navbar.tsx
@@ -293,18 +293,23 @@ export default function Navbar() {
             {/* Hold the slot only while the role is loading (no Help→Ask AI
                 flash); after that, a missing/failed role falls back to Help. */}
             {!roleLoaded ? null : canUseAssistant(userRole) ? (
-              <LongHoverTooltip content="Ask the Speddy Assistant about your schedule, caseload, or students, or have it draft notes and parent updates. It only sees your own data and never changes anything.">
-                <button
-                  type="button"
-                  onClick={() => setAssistantOpen((v) => !v)}
-                  aria-expanded={assistantOpen}
-                  aria-controls="speddy-assistant-panel"
-                  className="flex items-center gap-1.5 rounded-full bg-blue-600 px-4 py-1.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700"
-                >
-                  <Sparkles className="h-4 w-4" aria-hidden="true" />
-                  Ask AI
-                </button>
-              </LongHoverTooltip>
+              // relative wrapper: the assistant panel anchors to this button
+              // (opens below it, left edges aligned).
+              <div className="relative">
+                <LongHoverTooltip content="Ask the Speddy Assistant about your schedule, caseload, or students, or have it draft notes and parent updates. It only sees your own data and never changes anything.">
+                  <button
+                    type="button"
+                    onClick={() => setAssistantOpen((v) => !v)}
+                    aria-expanded={assistantOpen}
+                    aria-controls="speddy-assistant-panel"
+                    className="flex items-center gap-1.5 rounded-full bg-blue-600 px-4 py-1.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700"
+                  >
+                    <Sparkles className="h-4 w-4" aria-hidden="true" />
+                    Ask AI
+                  </button>
+                </LongHoverTooltip>
+                <AssistantPanel open={assistantOpen} onClose={() => setAssistantOpen(false)} />
+              </div>
             ) : (
               <LongHoverTooltip content="Open the help chat to get assistance with using Speddy. Our support team typically responds within a few hours.">
                 <button
@@ -353,7 +358,6 @@ export default function Navbar() {
           )}
         </div>
       </div>
-      <AssistantPanel open={assistantOpen} onClose={() => setAssistantOpen(false)} />
     </nav>
   );
 }


### PR DESCRIPTION
## What this is

Blair's UI feedback on the live assistant ([SPE-454](https://linear.app/speddy/issue/SPE-454/assistant-panel-anchor-under-ask-ai-button-drag-to-move)): the chat window now opens directly under the navbar's **Ask AI** button instead of floating in the bottom-right corner, and it's draggable by its blue header.

## Behavior

- Opens just below the button with **left edges aligned**, clamped so the whole panel always lands inside the viewport (literal left alignment overflows on typical windows, since the button sits ~300px from the right edge — the clamp shifts it left only as far as needed).
- **Pinned to the screen**: stays visible while the page scrolls behind it (preserves the old fixed-placement property — a provider can scroll their schedule while reading a reply).
- **Drag to move** by the header: native pointer capture, whole-panel viewport clamp, the close button can't start a drag, `touch-action: none` so dragging doesn't fight scrolling.
- Reopening re-anchors under the button; interrupted drags (e.g. Escape mid-drag) are discarded on close; position re-clamps on window resize.
- Placement is computed in a layout effect, so there's no misplaced first paint.

## Verification

- Typecheck, lint, full suite green (1,277 tests).
- Sim-district walk (Rachel, 1440×900): panel opens below the button fully on-screen, drags by the exact pointer delta, snaps back to the anchor on reopen — screenshots delivered to Blair.
- Deep self-review at high effort: 6 findings (narrow-viewport off-screen open, stale drag state after Escape mid-drag, first-frame flash, scroll-away regression, resize staleness, redundant drag fields) — all resolved by the fixed-position clamp rewrite in this commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhG37bBk5otJ3skFRwEzRG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The Ask AI panel now opens directly beneath the Ask AI button.
  * Panel positioning automatically adjusts to remain visible within the browser window.
  * The panel can be repositioned by dragging its header.
  * Positioning adapts when the browser window is resized.
  * The panel remains hidden until its initial position is ready, preventing visual jumps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->