### PR TITLE
School year rollover: recover the stranded data, and stop new rows being born into last year (SPE-459, SPE-460)

### DIFF
--- a/__tests__/unit/lib/school-year.test.ts
+++ b/__tests__/unit/lib/school-year.test.ts
@@ -1,0 +1,69 @@
+/**
+ * SPE-460: pin the school-year rollover rule.
+ *
+ * This rule now has TWO implementations that must agree:
+ *   - getCurrentSchoolYear() in lib/school-year.ts
+ *   - public.current_school_year() in the database, which is the DEFAULT for
+ *     school_year on bell_schedules, special_activities,
+ *     activity_type_availability and the four rotation_* tables
+ *     (supabase/migrations/20260812_spe460_current_school_year_default.sql).
+ *
+ * If they drift, rows written via the DB default land in a different year than
+ * the one every read path filters on, and become invisible the moment they are
+ * saved — which is exactly the bug SPE-459 had to recover 819 rows from.
+ *
+ * So: if you change the rule here, change the SQL function to match.
+ * The boundary is what matters — August 1, evaluated in UTC.
+ */
+import { getCurrentSchoolYear, getNextSchoolYear } from '@/lib/school-year';
+
+describe('getCurrentSchoolYear', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const at = (iso: string) => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(iso));
+  };
+
+  it('returns the prior-year label on July 31 (before the flip)', () => {
+    at('2026-07-31T23:59:59Z');
+    expect(getCurrentSchoolYear()).toBe('2025-2026');
+  });
+
+  it('flips on August 1', () => {
+    at('2026-08-01T00:00:00Z');
+    expect(getCurrentSchoolYear()).toBe('2026-2027');
+  });
+
+  it('holds through the autumn term', () => {
+    at('2026-12-15T12:00:00Z');
+    expect(getCurrentSchoolYear()).toBe('2026-2027');
+  });
+
+  it('still names the same year after the calendar year turns over', () => {
+    at('2027-01-05T12:00:00Z');
+    expect(getCurrentSchoolYear()).toBe('2026-2027');
+  });
+
+  it('evaluates the boundary in UTC, not local time', () => {
+    // 2026-08-01T00:30Z is still July 31 in US Pacific. The rule is UTC, so
+    // this must read as the new school year regardless of where it runs.
+    at('2026-08-01T00:30:00Z');
+    expect(getCurrentSchoolYear()).toBe('2026-2027');
+  });
+});
+
+describe('getNextSchoolYear', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('is always the year after the current one', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-12T00:00:00Z'));
+    expect(getCurrentSchoolYear()).toBe('2026-2027');
+    expect(getNextSchoolYear()).toBe('2027-2028');
+  });
+});

--- a/__tests__/unit/lib/supabase/queries/teacher-portal-create-activity.test.ts
+++ b/__tests__/unit/lib/supabase/queries/teacher-portal-create-activity.test.ts
@@ -1,12 +1,17 @@
 /**
  * SPE-335: the teacher create path must stamp the CURRENT school year.
  *
- * `special_activities.school_year` is NOT NULL with a hardcoded default of
- * '2025-2026'. The provider Special Activities page filters on
- * getCurrentSchoolYear(), so a row that falls back to that default disappears
- * from the provider's view the moment the year rolls over on August 1 — the
- * teacher sees their activity, the resource specialist scheduling around it
- * does not.
+ * `special_activities.school_year` is NOT NULL. The provider Special Activities
+ * page filters on getCurrentSchoolYear(), so a row written for the wrong year
+ * disappears from the provider's view — the teacher sees their activity, the
+ * resource specialist scheduling around it does not.
+ *
+ * The column used to default to a hardcoded '2025-2026', which made "fell back
+ * to the default" and "invisible" the same thing once the year rolled over on
+ * August 1 (SPE-459 had to recover 819 such rows). SPE-460 replaced that
+ * default with public.current_school_year(), so the fallback is now correct —
+ * but stamping the year explicitly is still the contract this test pins, since
+ * the app should not depend on the database to know what year it is.
  *
  * This is a mock-level test on purpose: it pins the shape of the insert
  * payload, which is the part RLS cannot tell us anything about. Whether the

--- a/app/components/bell-schedules/add-bell-schedule-form.tsx
+++ b/app/components/bell-schedules/add-bell-schedule-form.tsx
@@ -7,6 +7,7 @@ import { ConflictResolver } from '../../../lib/scheduling/conflict-resolver';
 import { useSchool } from '../../components/providers/school-context';
 import { generateActivityTimeOptions } from '../../../lib/utils/time-options';
 import { BELL_SCHEDULE_ACTIVITIES } from '../../../lib/constants/activity-types';
+import { getCurrentSchoolYear } from '../../../lib/school-year';
 
 type CreatorRole = 'provider' | 'site_admin';
 
@@ -142,6 +143,10 @@ export default function AddBellScheduleForm({
               school_id: effectiveSchoolId,
               created_by_id: user.id,
               created_by_role: creatorRole,
+              // SPE-460: set explicitly. Every read path filters on the current
+              // school year, so a row that falls back to the column default is
+              // invisible the moment it is saved.
+              school_year: getCurrentSchoolYear(),
             };
 
             const { error: insertError } = await supabase

--- a/app/components/bell-schedules/csv-import.tsx
+++ b/app/components/bell-schedules/csv-import.tsx
@@ -7,6 +7,7 @@ import type { Database } from "../../../src/types/database";
 import { useSchool } from "../../components/providers/school-context";
 import { dedupeBellSchedules, normalizeBellSchedule, createImportSummary } from '../../../lib/utils/dedupe-helpers';
 import { BELL_SCHEDULE_ACTIVITIES } from '../../../lib/constants/activity-types';
+import { getCurrentSchoolYear } from '../../../lib/school-year';
 
 interface Props {
   onSuccess: () => void;
@@ -174,12 +175,16 @@ K,Lunch,12:00,12:45
             summary.total = rawSchedules.length;
             summary.skipped = rawSchedules.length - dedupedSchedules.length;
 
-            // Get existing schedules
+            // Get existing schedules. Scoped to the current school year (SPE-460)
+            // so the dedup map cannot match — and then overwrite — a row belonging
+            // to a different year.
+            const schoolYear = getCurrentSchoolYear();
             const { data: existingSchedules } = await supabase
               .from('bell_schedules')
               .select('*')
               .eq('provider_id', user.user!.id)
-              .eq('school_id', currentSchool?.school_id || '');
+              .eq('school_id', currentSchool?.school_id || '')
+              .eq('school_year', schoolYear);
 
             // Create a map of existing schedules by normalized key
             const existingMap = new Map();
@@ -200,7 +205,8 @@ K,Lunch,12:00,12:45
                 start_time: schedule.start_time,
                 end_time: schedule.end_time,
                 school_id: currentSchool?.school_id,
-                content_hash: schedule.content_hash
+                content_hash: schedule.content_hash,
+                school_year: schoolYear
               };
 
               if (existingMap.has(schedule.normalized_key)) {

--- a/app/components/special-activities/add-special-activity-form.tsx
+++ b/app/components/special-activities/add-special-activity-form.tsx
@@ -9,6 +9,7 @@ import { generateActivityTimeOptions } from '../../../lib/utils/time-options';
 import { TeacherAutocomplete } from '../teachers/teacher-autocomplete';
 import { SPECIAL_ACTIVITY_TYPES } from '../../../lib/constants/activity-types';
 import { updateSpecialActivity } from '../../../lib/supabase/queries/special-activities';
+import { getCurrentSchoolYear } from '../../../lib/school-year';
 
 interface EditActivity {
   id: string;
@@ -123,7 +124,11 @@ export default function AddSpecialActivityForm({ teacherId: initialTeacherId, te
             day_of_week: parseInt(dayOfWeek),
             start_time: startTime,
             end_time: endTime,
-            school_id: currentSchool!.school_id
+            school_id: currentSchool!.school_id,
+            // SPE-460: set explicitly. Every read path filters on the current
+            // school year, so a row that falls back to the column default is
+            // invisible the moment it is saved.
+            school_year: getCurrentSchoolYear()
           });
 
         if (insertError) throw insertError;

--- a/app/components/special-activities/csv-import.tsx
+++ b/app/components/special-activities/csv-import.tsx
@@ -7,6 +7,7 @@ import type { Database } from "../../../src/types/database";
 import { useSchool } from "../../components/providers/school-context";
 import { dedupeSpecialActivities, normalizeSpecialActivity, createImportSummary } from '../../../lib/utils/dedupe-helpers';
 import { SPECIAL_ACTIVITY_TYPES } from '../../../lib/constants/activity-types';
+import { getCurrentSchoolYear } from '../../../lib/school-year';
 
 interface Teacher {
   id: string;
@@ -260,12 +261,16 @@ Lee,Garden,Tuesday,10:00,10:45`;
             summary.total = rawActivities.length;
             summary.skipped = rawActivities.length - dedupedActivities.length;
 
-            // Get existing activities
+            // Get existing activities. Scoped to the current school year (SPE-460)
+            // so the dedup map cannot match — and then overwrite — a row belonging
+            // to a different year.
+            const schoolYear = getCurrentSchoolYear();
             const { data: existingActivities } = await supabase
               .from('special_activities')
               .select('*')
               .eq('provider_id', user.user!.id)
-              .eq('school_id', currentSchool?.school_id || '');
+              .eq('school_id', currentSchool?.school_id || '')
+              .eq('school_year', schoolYear);
 
             // Create a map of existing activities by normalized key
             const existingMap = new Map();
@@ -287,7 +292,8 @@ Lee,Garden,Tuesday,10:00,10:45`;
                 start_time: activity.start_time,
                 end_time: activity.end_time,
                 school_id: currentSchool?.school_id,
-                content_hash: activity.content_hash
+                content_hash: activity.content_hash,
+                school_year: schoolYear
               };
 
               if (existingMap.has(activity.normalized_key)) {

--- a/app/components/special-activities/csv-import.tsx
+++ b/app/components/special-activities/csv-import.tsx
@@ -264,13 +264,21 @@ Lee,Garden,Tuesday,10:00,10:45`;
             // Get existing activities. Scoped to the current school year (SPE-460)
             // so the dedup map cannot match — and then overwrite — a row belonging
             // to a different year.
+            //
+            // Soft-deleted rows are excluded too: the update branch below writes
+            // activityData, which carries no deleted_at, so matching a tombstone
+            // would rewrite it in place and leave it deleted. The import would
+            // report "updated" and the activity would still be invisible.
+            // Excluding them means re-importing a deleted activity inserts a
+            // fresh live row instead, and the deletion stays deleted.
             const schoolYear = getCurrentSchoolYear();
             const { data: existingActivities } = await supabase
               .from('special_activities')
               .select('*')
               .eq('provider_id', user.user!.id)
               .eq('school_id', currentSchool?.school_id || '')
-              .eq('school_year', schoolYear);
+              .eq('school_year', schoolYear)
+              .is('deleted_at', null);
 
             // Create a map of existing activities by normalized key
             const existingMap = new Map();

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -888,6 +888,11 @@ export const DECLARED_UNSEEDED_TABLES: string[] = [
   // swept bespoke in teardown by district_id (same reasoning as
   // district_sis_connections above).
   'district_curriculums',
+  // SPE-459 recovery record. Not seeded and never sim-owned: it lists the exact
+  // prod rows whose school_year was re-tagged 2025-2026 -> 2026-2027 on
+  // 2026-08-12, so a reversal can be precise. RLS-enabled with no policies
+  // (service-role only). Drop it, and this entry, once the fix has held.
+  'backup_spe459_school_year_retag',
   // Personal / auxiliary:
   'documents', 'curriculum_tracking', 'calendar_connections', 'calendar_events',
   'api_keys', 'teams', 'team_members', 'material_constraints',

--- a/supabase/migrations/20260812_spe459_retag_stranded_school_year_data.sql
+++ b/supabase/migrations/20260812_spe459_retag_stranded_school_year_data.sql
@@ -1,0 +1,98 @@
+-- SPE-459: re-tag stranded 2025-2026 schedule data to 2026-2027.
+--
+-- getCurrentSchoolYear() (lib/school-year.ts) flips on August 1 with no user
+-- action. On 2026-08-01 it rolled to '2026-2027'. Every UI read path pins to
+-- that value — the provider Bell Schedules and Special Activities pages, and
+-- the admin Master Schedule year toggle, which only offers current/next year.
+-- All real-school data was still tagged '2025-2026', so on Aug 1 it silently
+-- became unreachable in the app, with no in-app path back to it (the activation
+-- dialog's copy is forward-only from the current year).
+--
+-- Scope verified against prod on 2026-08-12: every '2025-2026' row across these
+-- tables belongs to Bancroft Elementary, Mt. Diablo Elementary or Walnut Acres
+-- Elementary. The '2026-2027' year held only Sim District fixture rows, under
+-- different school_ids, so a blanket re-tag cannot touch sim data. Neither of
+-- the two unique indexes that include school_year
+-- (activity_type_availability_school_year_unique,
+-- rotation_activity_pairs_school_year_unique) can collide: each has exactly one
+-- 2025-2026 row and no 2026-2027 counterpart.
+--
+-- Re-tag in place rather than copy-forward, per product decision (Blair,
+-- 2026-08-12): copying would leave these schools with two years of data, which
+-- arms SPE-458 — the scheduler reads bell schedules and special activities with
+-- no school_year filter, so both years' rows would block slots at once.
+--
+-- rotation_week_assignments is included here even though copy_schedule_to_year
+-- deliberately omits it (its rows are keyed to concrete week dates, which do not
+-- carry forward). Included on purpose: getWeekAssignments() filters on pair_id
+-- alone and never reads school_year, so the tag has no effect on what the
+-- rotation editor shows, and moving the 69 rows with their parent pair keeps
+-- parent and children in one year rather than splitting them. What actually
+-- drives that editor's week list is school_year_config, which has no
+-- school_year column and still holds Bancroft's 2025-08-11 -> 2026-05-29 range
+-- — a separate pre-existing gap, noted on SPE-460, untouched here.
+
+BEGIN;
+
+-- Recovery record: the exact rows re-tagged here, so this is precisely
+-- reversible even after later data lands in 2026-2027.
+CREATE TABLE IF NOT EXISTS public.backup_spe459_school_year_retag (
+  table_name           text        NOT NULL,
+  row_id               uuid        NOT NULL,
+  previous_school_year text        NOT NULL,
+  retagged_at          timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (table_name, row_id)
+);
+
+COMMENT ON TABLE public.backup_spe459_school_year_retag IS
+  'SPE-459 recovery record: rows whose school_year was re-tagged 2025-2026 -> 2026-2027 on 2026-08-12. Reverse by setting school_year = previous_school_year for these ids. Safe to drop once the fix has held through a full school year.';
+
+-- No RLS policies: service-role / migration access only. Not exposed to clients.
+ALTER TABLE public.backup_spe459_school_year_retag ENABLE ROW LEVEL SECURITY;
+
+INSERT INTO public.backup_spe459_school_year_retag (table_name, row_id, previous_school_year)
+            SELECT 'bell_schedules',             id, school_year FROM bell_schedules             WHERE school_year = '2025-2026'
+  UNION ALL SELECT 'special_activities',         id, school_year FROM special_activities         WHERE school_year = '2025-2026'
+  UNION ALL SELECT 'yard_duty_assignments',      id, school_year FROM yard_duty_assignments      WHERE school_year = '2025-2026'
+  UNION ALL SELECT 'instruction_schedules',      id, school_year FROM instruction_schedules      WHERE school_year = '2025-2026'
+  UNION ALL SELECT 'activity_type_availability', id, school_year FROM activity_type_availability WHERE school_year = '2025-2026'
+  UNION ALL SELECT 'rotation_activity_pairs',    id, school_year FROM rotation_activity_pairs    WHERE school_year = '2025-2026'
+  UNION ALL SELECT 'rotation_groups',            id, school_year FROM rotation_groups            WHERE school_year = '2025-2026'
+  UNION ALL SELECT 'rotation_group_members',     id, school_year FROM rotation_group_members     WHERE school_year = '2025-2026'
+  UNION ALL SELECT 'rotation_week_assignments',  id, school_year FROM rotation_week_assignments  WHERE school_year = '2025-2026'
+ON CONFLICT (table_name, row_id) DO NOTHING;
+
+-- Parents before children, so a partially-applied run never leaves a rotation
+-- child pointing at a parent in a different year.
+UPDATE rotation_activity_pairs    SET school_year = '2026-2027' WHERE school_year = '2025-2026';
+UPDATE rotation_groups            SET school_year = '2026-2027' WHERE school_year = '2025-2026';
+UPDATE rotation_group_members     SET school_year = '2026-2027' WHERE school_year = '2025-2026';
+UPDATE rotation_week_assignments  SET school_year = '2026-2027' WHERE school_year = '2025-2026';
+UPDATE bell_schedules             SET school_year = '2026-2027' WHERE school_year = '2025-2026';
+UPDATE special_activities         SET school_year = '2026-2027' WHERE school_year = '2025-2026';
+UPDATE yard_duty_assignments      SET school_year = '2026-2027' WHERE school_year = '2025-2026';
+UPDATE instruction_schedules      SET school_year = '2026-2027' WHERE school_year = '2025-2026';
+UPDATE activity_type_availability SET school_year = '2026-2027' WHERE school_year = '2025-2026';
+
+-- Guard: fail the whole transaction if anything was left behind.
+DO $$
+DECLARE
+  remaining bigint;
+BEGIN
+  SELECT (SELECT count(*) FROM bell_schedules             WHERE school_year = '2025-2026')
+       + (SELECT count(*) FROM special_activities         WHERE school_year = '2025-2026')
+       + (SELECT count(*) FROM yard_duty_assignments      WHERE school_year = '2025-2026')
+       + (SELECT count(*) FROM instruction_schedules      WHERE school_year = '2025-2026')
+       + (SELECT count(*) FROM activity_type_availability WHERE school_year = '2025-2026')
+       + (SELECT count(*) FROM rotation_activity_pairs    WHERE school_year = '2025-2026')
+       + (SELECT count(*) FROM rotation_groups            WHERE school_year = '2025-2026')
+       + (SELECT count(*) FROM rotation_group_members     WHERE school_year = '2025-2026')
+       + (SELECT count(*) FROM rotation_week_assignments  WHERE school_year = '2025-2026')
+    INTO remaining;
+
+  IF remaining <> 0 THEN
+    RAISE EXCEPTION 'SPE-459: % rows still tagged 2025-2026 after re-tag; rolling back', remaining;
+  END IF;
+END $$;
+
+COMMIT;

--- a/supabase/migrations/20260812_spe460_current_school_year_default.sql
+++ b/supabase/migrations/20260812_spe460_current_school_year_default.sql
@@ -1,0 +1,65 @@
+-- SPE-460: replace the hardcoded '2025-2026' school_year column defaults with a
+-- function that computes the current school year.
+--
+-- Seven tables defaulted school_year to the literal '2025-2026'. Any insert that
+-- omitted the column took that default, and since every read path filters on
+-- getCurrentSchoolYear(), such a row was invisible the moment it was written —
+-- silently, with no error. Once the calendar rolled past 2025-2026 on
+-- 2026-08-01, that turned into "anything a user adds disappears on save".
+--
+-- The app-side write paths are being fixed to set school_year explicitly, but a
+-- hardcoded past year should not be the fallback in any case: several paths
+-- legitimately rely on the default (createRotationGroup, createGroupMember and
+-- upsertWeekAssignment all insert without it), and a literal year is a landmine
+-- that re-arms every August. A computed default is correct for all of them and
+-- needs no annual maintenance.
+--
+-- current_school_year() mirrors getCurrentSchoolYear() in lib/school-year.ts
+-- exactly: UTC, label 'YYYY-YYYY', flipping on August 1.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.current_school_year()
+RETURNS text
+LANGUAGE sql
+STABLE
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT CASE
+           WHEN EXTRACT(month FROM ts) >= 8
+             THEN (EXTRACT(year FROM ts)::int)::text || '-' || (EXTRACT(year FROM ts)::int + 1)::text
+           ELSE (EXTRACT(year FROM ts)::int - 1)::text || '-' || (EXTRACT(year FROM ts)::int)::text
+         END
+  FROM (SELECT now() AT TIME ZONE 'utc' AS ts) s;
+$$;
+
+COMMENT ON FUNCTION public.current_school_year() IS
+  'Current school year as ''YYYY-YYYY'', flipping on August 1 (UTC). Mirrors getCurrentSchoolYear() in lib/school-year.ts — keep the two in step.';
+
+ALTER TABLE bell_schedules             ALTER COLUMN school_year SET DEFAULT public.current_school_year();
+ALTER TABLE special_activities         ALTER COLUMN school_year SET DEFAULT public.current_school_year();
+ALTER TABLE activity_type_availability ALTER COLUMN school_year SET DEFAULT public.current_school_year();
+ALTER TABLE rotation_activity_pairs    ALTER COLUMN school_year SET DEFAULT public.current_school_year();
+ALTER TABLE rotation_groups            ALTER COLUMN school_year SET DEFAULT public.current_school_year();
+ALTER TABLE rotation_group_members     ALTER COLUMN school_year SET DEFAULT public.current_school_year();
+ALTER TABLE rotation_week_assignments  ALTER COLUMN school_year SET DEFAULT public.current_school_year();
+
+-- Guard: no school_year column may still carry a literal default.
+DO $$
+DECLARE
+  stale text;
+BEGIN
+  SELECT string_agg(table_name || '.' || column_name || ' = ' || column_default, ', ')
+    INTO stale
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND column_name = 'school_year'
+    AND column_default IS NOT NULL
+    AND column_default NOT LIKE '%current_school_year%';
+
+  IF stale IS NOT NULL THEN
+    RAISE EXCEPTION 'SPE-460: literal school_year default(s) remain: %', stale;
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
Closes SPE-459. Closes SPE-460.

Two halves of one failure, shipped together because either alone is incomplete: SPE-459 recovers the data that went missing, SPE-460 stops it happening again. Without SPE-460 the recovery undoes itself with the next thing anyone adds.

## What was broken

`getCurrentSchoolYear()` flips on **August 1** with no user action. On 2026-08-01 it rolled to `2026-2027` while every real school's schedule data was still tagged `2025-2026`, and while the `school_year` column still *defaulted* to the literal `'2025-2026'`.

So two things happened at once:

- **Everything existing went invisible.** Every UI read path pins to the current year — the provider Bell Schedules page, Special Activities, and the admin Master Schedule toggle, which only offers current/next year. A provider at Bancroft opening Bell Schedules saw an empty page where 96 entries should be. There was no way back from inside the app: the activation dialog's copy is forward-only from the current year, so with `2026-2027` empty it copies nothing into `2027-2028` and never reaches `2025-2026`.
- **Everything new was born invisible.** Both add forms and both CSV importers hand-rolled their insert and went straight to `supabase.insert()`, bypassing the query-layer helpers that stamp the year. They took the `'2025-2026'` default and vanished on save — no error, the save "succeeded". Per SPE-458 the scheduler reads these tables with no year filter, so those invisible rows still blocked slots: a provider could be blocked by a period they could not see or delete.

## SPE-459 — recover the stranded data

Re-tags **819 rows across 9 tables** in place: 246 bell schedules, 250 yard duty, 197 special activities, 69 rotation week assignments, 27 instruction schedules, 26 rotation members, 2 rotation groups, 1 rotation pair, 1 activity-type availability.

Re-tag rather than copy-forward, per product decision: copying would leave these schools with two years of data, which arms SPE-458 — both years' rows would block slots at once.

Scope was verified against prod before applying. Every `2025-2026` row belonged to Bancroft, Mt. Diablo or Walnut Acres; `2026-2027` held only Sim District fixture rows under different `school_id`s, confirmed unchanged afterward. Only two unique indexes include `school_year` and neither had a collidable counterpart. Wrapped in a transaction with a guard that rolls back if any row is left behind. Every re-tagged row id is recorded in `backup_spe459_school_year_retag` (RLS-enabled, no policies — service-role only) so the change is precisely reversible; that table is classified in the sim manifest.

## SPE-460 — stop it recurring

**Schema.** `school_year` defaulted to a hardcoded `'2025-2026'` on seven tables. Replaced with `public.current_school_year()`, mirroring `getCurrentSchoolYear()` — UTC, flipping August 1. A literal year is a landmine that re-arms every August, and several paths legitimately rely on the default (`createRotationGroup`, `createGroupMember` and `upsertWeekAssignment` all insert without it). The migration guards that no `school_year` column is left carrying a literal default.

**App.** The two add forms and both CSV importers now set the year explicitly — the app shouldn't depend on the database to know what year it is. The importers also scope their dedup lookup to the current year, so a re-import can no longer match and overwrite another year's rows.

**Also fixed, found by self-review:** the special-activities importer's dedup lookup selected soft-deleted rows, and its update branch writes no `deleted_at`. Re-importing a previously deleted activity rewrote the tombstone in place and left it deleted — the import reported "updated" and the activity stayed invisible. Tombstones are now excluded, so the re-import inserts a fresh live row.

## Verification

Unit tests mock the Supabase client and can't see RLS, so both halves were checked with **real RLS-enforced sessions** (`current_user = authenticated`):

- **SPE-459:** the exact query the Bell Schedules page issues now returns 96 bell schedules and 42 special activities for a Bancroft provider, where it returned 0. Control confirming RLS was genuinely enforced rather than silently running as service-role: 186 of 606 total rows visible, and the two schools seen are both legitimately assigned to that provider in `provider_schools`.
- **SPE-460:** an insert omitting `school_year` — exactly what the form sent before — now lands in `2026-2027` and matches `current_school_year()`, where it would have landed in the invisible `2025-2026`. Run in a transaction and rolled back, so nothing persisted.

Adds a test pinning the August 1 boundary, since the rollover rule now has two implementations that must agree.

Green: `tsc --noEmit`, `npm run lint` (only pre-existing warnings in unrelated files), `npm test` (112 suites, 1283 passed), `npm run sim:verify` including manifest schema coverage at 0 unclassified.

## Deliberately not in scope

- **SPE-458** — the scheduler and drag path read these tables with no year filter. Dormant today (every school now has exactly one year of data), but it's what makes two-year duplicates dangerous, so it gates the activation-copy flow being safe to use. Commented there with the specifics.
- **SPE-461** — `school_year_config` has no `school_year` column and still holds Bancroft's 2025-08-11 → 2026-05-29 range, so the rotation editor renders last year's week columns. Needs the school's real 2026-2027 calendar dates, which I'm not going to guess.

Review findings from Codex and CodeRabbit were each checked against the database; all four were withdrawn or answered with evidence in the threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoBCMXfYGEriXEWtRyt1bK