### PR TITLE
CLAUDE.md: record standing merge approval for prompt-only assistant tunings

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -99,6 +99,15 @@ standing rule for the work at hand (then merge on green without checking back).
 The purely-internal, non-UX, all-gates-green case above is the standing
 exception where that go-ahead is already granted.
 
+**Standing merge approval — prompt-only assistant tunings (granted 2026-08-12).**
+Changes that only adjust the AI assistant's system-prompt wording in
+`lib/assistant/chat.ts` (plus their test pins in the matching test file) may
+merge on green without asking, like auto-deployable work — report each one
+after it ships. This covers wording, style rules, and the in-prompt product
+guide/reference content. It does NOT cover: the assistant's data scope (tool
+selects in `lib/assistant/tools.ts`), its UI, the API route, disclosures, or
+any other code — those still wait for my merge call.
+
 **Tracked in Linear via the `auto-deployable` label.** A ticket carries this
 label only if it meets the bar above: purely internal/technical, no user-facing
 or UX change, no schema/data migration, no dependency/security/auth/infra


### PR DESCRIPTION
Records the founder's standing approval (granted in chat, 2026-08-12) in the project instruction file so it persists across sessions: system-prompt wording changes in `lib/assistant/chat.ts` (plus their test pins) merge on green without a per-PR ask, reported after shipping. Explicitly excluded: the assistant's data scope (`lib/assistant/tools.ts`), UI, API route, and disclosure docs — those still pause for a merge call.

Docs-only, internal instruction file; merging under the existing purely-internal standing exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhG37bBk5otJ3skFRwEzRG

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhG37bBk5otJ3skFRwEzRG)_