### PR TITLE
Auto-scheduler: actually load the bell schedules it schedules around (SPE-463)

### DIFF
--- a/__tests__/unit/lib/scheduling/data-manager-school-key-fallback.test.ts
+++ b/__tests__/unit/lib/scheduling/data-manager-school-key-fallback.test.ts
@@ -1,0 +1,121 @@
+// `mock`-prefixed so the jest.mock factory (hoisted above imports) may reference it.
+const mockState: {
+  queries: Array<{ table: string; filters: Array<[string, string, unknown]> }>;
+  idRows: unknown[];
+  legacyRows: unknown[];
+} = { queries: [], idRows: [], legacyRows: [] };
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      const filters: Array<[string, string, unknown]> = [];
+      mockState.queries.push({ table, filters });
+
+      const query: any = {
+        select: () => query,
+        eq: (col: string, val: unknown) => {
+          filters.push(['eq', col, val]);
+          return query;
+        },
+        is: (col: string, val: unknown) => {
+          filters.push(['is', col, val]);
+          return query;
+        },
+        // Thenable: the code under test awaits the builder directly.
+        then: (resolve: (r: unknown) => unknown) => {
+          const matchedSchoolId = filters.some(([op, col]) => op === 'eq' && col === 'school_id');
+          return Promise.resolve(
+            resolve({ data: matchedSchoolId ? mockState.idRows : mockState.legacyRows, error: null }),
+          );
+        },
+      };
+      return query;
+    },
+  }),
+}));
+
+import { SchedulingDataManager } from '@/lib/scheduling/scheduling-data-manager';
+
+/**
+ * SPE-463: the school lookup used to be either/or — filter by school_id when we
+ * had one, otherwise by school_site. Production holds BOTH shapes at once:
+ *
+ *   Bancroft / Mt. Diablo / Rodeo Hills → school_id set, school_site NULL
+ *   Walnut Acres                        → school_site set, school_id NULL
+ *
+ * so either/or silently loads nothing for whichever set it skips, and "nothing"
+ * means the auto-scheduler books straight over lunch. The first fix for this
+ * (forwarding school_id) would have regressed Walnut Acres — 60 bell schedule
+ * rows — in exactly the way it fixed the other three. Both keys must match.
+ */
+function manager() {
+  const mgr = SchedulingDataManager.getInstance() as any;
+  mgr.cacheMetadata = { lastFetched: new Date(), isStale: false, fetchErrors: [], queryCount: 0 };
+  return mgr;
+}
+
+beforeEach(() => {
+  mockState.queries = [];
+  mockState.idRows = [];
+  mockState.legacyRows = [];
+});
+
+describe('SchedulingDataManager school-key fallback (SPE-463)', () => {
+  it('matches rows keyed by school_id AND legacy rows keyed only by school_site', async () => {
+    mockState.idRows = [{ id: 'by-id-1' }, { id: 'by-id-2' }];
+    mockState.legacyRows = [{ id: 'legacy-1' }];
+
+    const mgr = manager();
+    mgr.schoolId = '061899002301';
+    mgr.schoolSite = 'Rodeo Hills Elementary';
+
+    const rows = await mgr.fetchForSchool('bell_schedules', 'Bell schedules');
+
+    expect(rows).toHaveLength(3);
+    expect(mockState.queries).toHaveLength(2);
+  });
+
+  it('restricts the legacy pass to rows with no school_id, so nothing is double-counted', async () => {
+    const mgr = manager();
+    mgr.schoolId = '061899002301';
+    mgr.schoolSite = 'Rodeo Hills Elementary';
+
+    await mgr.fetchForSchool('bell_schedules', 'Bell schedules');
+
+    const legacyPass = mockState.queries.find(q =>
+      q.filters.some(([op, col]) => op === 'eq' && col === 'school_site'),
+    );
+    expect(legacyPass).toBeDefined();
+    expect(legacyPass!.filters).toContainEqual(['is', 'school_id', null]);
+  });
+
+  it('falls back to school_site alone when no school_id is known', async () => {
+    mockState.legacyRows = [{ id: 'legacy-1' }, { id: 'legacy-2' }];
+
+    const mgr = manager();
+    mgr.schoolId = null;
+    mgr.schoolSite = 'Walnut Acres Elementary';
+
+    const rows = await mgr.fetchForSchool('bell_schedules', 'Bell schedules');
+
+    expect(rows).toHaveLength(2);
+    expect(mockState.queries).toHaveLength(1);
+    // No school_id known, so the pass must NOT narrow to school_id IS NULL —
+    // that would drop rows the migration already keyed by id.
+    expect(mockState.queries[0].filters).not.toContainEqual(['is', 'school_id', null]);
+  });
+
+  it('applies the same handling to special activities', async () => {
+    mockState.idRows = [{ id: 'a' }];
+    mockState.legacyRows = [{ id: 'b' }];
+
+    const mgr = manager();
+    mgr.schoolId = '062271002462';
+    mgr.schoolSite = 'Walnut Acres Elementary';
+
+    const rows = await mgr.fetchForSchool('special_activities', 'Special activities');
+
+    expect(rows).toHaveLength(2);
+    expect(mockState.queries.every(q => q.table === 'special_activities')).toBe(true);
+  });
+});

--- a/__tests__/unit/lib/scheduling/scheduler-passes-school-id.test.ts
+++ b/__tests__/unit/lib/scheduling/scheduler-passes-school-id.test.ts
@@ -1,0 +1,83 @@
+// Aliased with a `mock` prefix so the jest.mock factory (hoisted above imports by
+// babel-plugin-jest-hoist) may reference it.
+import { createMockSupabaseClient as mockCreateSupabaseClient } from '@/test-utils/supabase-test-helpers';
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockCreateSupabaseClient(),
+}));
+
+import { OptimizedScheduler } from '@/lib/scheduling/optimized-scheduler';
+
+/**
+ * SPE-463: the auto-scheduler used to hardcode `undefined` for school_id when
+ * initializing the data manager. The manager then filtered bell schedules and
+ * special activities by `school_site`, which is NULL on every row written since
+ * the school_id migration — so the auto-scheduler loaded ZERO blocks at
+ * Bancroft, Mt. Diablo and Rodeo Hills (363 rows between them, all rendering
+ * fine in the UI) and would place a session straight through a grade's lunch.
+ *
+ * This is a mock-level test on purpose: it pins the argument handoff, which is
+ * where the bug lived. Whether the database then returns the right rows is not
+ * something a mocked client can tell us — that was verified separately against
+ * prod under a real RLS-enforced session.
+ */
+function makeScheduler() {
+  const initializeCalls: Array<{ schoolSite: string; schoolDistrict: string; schoolId?: string }> = [];
+  const isInitializedForSchoolCalls: Array<{ schoolSite: string; schoolDistrict?: string; schoolId?: string }> = [];
+
+  const scheduler = new OptimizedScheduler('provider-1', 'resource', false, false) as any;
+
+  scheduler.dataManager = {
+    isInitializedForSchool: (schoolSite: string, schoolDistrict?: string, schoolId?: string) => {
+      isInitializedForSchoolCalls.push({ schoolSite, schoolDistrict, schoolId });
+      return false; // force initialize() to run
+    },
+    initialize: async (
+      _providerId: string,
+      schoolSite: string,
+      schoolDistrict: string,
+      schoolId?: string,
+    ) => {
+      initializeCalls.push({ schoolSite, schoolDistrict, schoolId });
+    },
+  };
+  scheduler.getDataFromManager = async () => ({
+    workSchedule: [{ day_of_week: 1 }],
+    bellSchedules: [],
+    specialActivities: [],
+    existingSessions: [],
+    schoolHours: [],
+    crossProviderSessionsByStudent: new Map(),
+  });
+
+  return { scheduler, initializeCalls, isInitializedForSchoolCalls };
+}
+
+describe('OptimizedScheduler.initializeContext school_id handoff (SPE-463)', () => {
+  it('passes school_id through to the data manager', async () => {
+    const { scheduler, initializeCalls } = makeScheduler();
+
+    await scheduler.initializeContext('Rodeo Hills Elementary', 'JSUSD', '061899002301');
+
+    expect(initializeCalls).toHaveLength(1);
+    expect(initializeCalls[0].schoolId).toBe('061899002301');
+  });
+
+  it('includes school_id in the already-initialized check, so a school_id-less cache is not reused', async () => {
+    const { scheduler, isInitializedForSchoolCalls } = makeScheduler();
+
+    await scheduler.initializeContext('Rodeo Hills Elementary', 'JSUSD', '061899002301');
+
+    expect(isInitializedForSchoolCalls).toHaveLength(1);
+    expect(isInitializedForSchoolCalls[0].schoolId).toBe('061899002301');
+  });
+
+  it('still works when no school_id is available, rather than throwing', async () => {
+    const { scheduler, initializeCalls } = makeScheduler();
+
+    await scheduler.initializeContext('Rodeo Hills Elementary', 'JSUSD');
+
+    expect(initializeCalls).toHaveLength(1);
+    expect(initializeCalls[0].schoolId).toBeUndefined();
+  });
+});

--- a/__tests__/unit/lib/scheduling/scheduler-passes-school-id.test.ts
+++ b/__tests__/unit/lib/scheduling/scheduler-passes-school-id.test.ts
@@ -22,7 +22,12 @@ import { OptimizedScheduler } from '@/lib/scheduling/optimized-scheduler';
  * prod under a real RLS-enforced session.
  */
 function makeScheduler() {
-  const initializeCalls: Array<{ schoolSite: string; schoolDistrict: string; schoolId?: string }> = [];
+  const initializeCalls: Array<{
+    schoolSite: string;
+    schoolDistrict: string;
+    schoolId?: string;
+    providerRole?: string;
+  }> = [];
   const isInitializedForSchoolCalls: Array<{ schoolSite: string; schoolDistrict?: string; schoolId?: string }> = [];
 
   const scheduler = new OptimizedScheduler('provider-1', 'resource', false, false) as any;
@@ -37,8 +42,9 @@ function makeScheduler() {
       schoolSite: string,
       schoolDistrict: string,
       schoolId?: string,
+      providerRole?: string,
     ) => {
-      initializeCalls.push({ schoolSite, schoolDistrict, schoolId });
+      initializeCalls.push({ schoolSite, schoolDistrict, schoolId, providerRole });
     },
   };
   scheduler.getDataFromManager = async () => ({
@@ -79,5 +85,20 @@ describe('OptimizedScheduler.initializeContext school_id handoff (SPE-463)', () 
 
     expect(initializeCalls).toHaveLength(1);
     expect(initializeCalls[0].schoolId).toBeUndefined();
+  });
+
+  /**
+   * The data manager gates the specialist branch of fetchExistingSessions on
+   * providerRole, so initializing without one hides sessions assigned to this
+   * user on other providers' students — which can double-book a specialist.
+   * The manager is a singleton shared with the schedule page, so dropping the
+   * role here also clears what that page set.
+   */
+  it('passes the provider role through, so specialist-assigned sessions load', async () => {
+    const { scheduler, initializeCalls } = makeScheduler();
+
+    await scheduler.initializeContext('Rodeo Hills Elementary', 'JSUSD', '061899002301');
+
+    expect(initializeCalls[0].providerRole).toBe('resource');
   });
 });

--- a/lib/scheduling/optimized-scheduler.ts
+++ b/lib/scheduling/optimized-scheduler.ts
@@ -270,15 +270,27 @@ export class OptimizedScheduler {
    * Pre-compute all valid time slots for the school
    * This runs ONCE per scheduling session, not per student
    */
-  async initializeContext(schoolSite: string, schoolDistrict?: string): Promise<SchedulingContext> {
+  async initializeContext(
+    schoolSite: string,
+    schoolDistrict?: string,
+    schoolId?: string
+  ): Promise<SchedulingContext> {
     this.log(`Initializing scheduling context for ${schoolSite}...`);
     this.log('[PERFORMANCE] Query count before initialization:', this.performanceMetrics.totalQueries);
 
     // Initialize the data manager if not already initialized for this school
     // This ensures we reload data when switching between schools
-    if (!this.dataManager.isInitializedForSchool(schoolSite, schoolDistrict)) {
+    //
+    // SPE-463: schoolId used to be hardcoded `undefined` here, which left the
+    // data manager filtering bell schedules and special activities by
+    // `school_site`. Those columns are NULL on every row written since the
+    // school_id migration, so the auto-scheduler loaded ZERO blocks at Bancroft,
+    // Mt. Diablo and Rodeo Hills and would happily place a session through a
+    // grade's lunch. The interactive drag path already passed school_id
+    // (use-scheduling-data.ts) and was unaffected.
+    if (!this.dataManager.isInitializedForSchool(schoolSite, schoolDistrict, schoolId)) {
       // Use empty string as fallback for backward compatibility
-      await this.dataManager.initialize(this.providerId, schoolSite, schoolDistrict || '', undefined);
+      await this.dataManager.initialize(this.providerId, schoolSite, schoolDistrict || '', schoolId);
     }
 
     // Use data manager instead of direct queries

--- a/lib/scheduling/optimized-scheduler.ts
+++ b/lib/scheduling/optimized-scheduler.ts
@@ -289,8 +289,20 @@ export class OptimizedScheduler {
     // grade's lunch. The interactive drag path already passed school_id
     // (use-scheduling-data.ts) and was unaffected.
     if (!this.dataManager.isInitializedForSchool(schoolSite, schoolDistrict, schoolId)) {
-      // Use empty string as fallback for backward compatibility
-      await this.dataManager.initialize(this.providerId, schoolSite, schoolDistrict || '', schoolId);
+      // Use empty string as fallback for backward compatibility.
+      //
+      // providerRole matters: the data manager gates the specialist branch of
+      // fetchExistingSessions on it, so initializing without a role hides
+      // sessions assigned to this user on other providers' students — and the
+      // manager is a singleton shared with the schedule page, so omitting it
+      // here also wiped the role that page had set.
+      await this.dataManager.initialize(
+        this.providerId,
+        schoolSite,
+        schoolDistrict || '',
+        schoolId,
+        this.providerRole,
+      );
     }
 
     // Use data manager instead of direct queries

--- a/lib/scheduling/scheduling-data-manager.ts
+++ b/lib/scheduling/scheduling-data-manager.ts
@@ -266,53 +266,83 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
   }
   
   /**
+   * Fetch rows for the current school from a table keyed by school_id, with a
+   * fallback for rows the school_id migration never reached.
+   *
+   * SPE-463: this used to be either/or — school_id when we had one, otherwise
+   * school_site. That is a trap in both directions, because production holds
+   * both shapes at once:
+   *
+   *   - Bancroft / Mt. Diablo / Rodeo Hills: school_id set, school_site NULL
+   *   - Walnut Acres: school_site set, school_id NULL (60 bell schedule rows,
+   *     17 special activities) while its students all carry a school_id
+   *
+   * So filtering by only one key silently loads nothing for whichever set it
+   * skips — and "nothing" here means the auto-scheduler happily books over
+   * lunch. Match both: rows carrying this school_id, plus legacy rows that
+   * carry no school_id but name this school.
+   *
+   * Two queries rather than a single `.or(...)`, deliberately: school names
+   * contain characters that are significant in PostgREST's filter grammar
+   * ("Mt. Diablo Elementary"), and a mis-escaped filter fails into an empty
+   * result — reintroducing exactly this bug, silently.
+   */
+  private async fetchForSchool<T>(
+    table: 'bell_schedules' | 'special_activities',
+    label: string,
+  ): Promise<T[]> {
+    const rows: T[] = [];
+
+    if (this.schoolId) {
+      const { data, error } = await this.supabase
+        .from(table)
+        .select('*')
+        .eq('school_id', this.schoolId);
+
+      if (error) {
+        this.cacheMetadata.fetchErrors.push(`${label}: ${error.message}`);
+      } else if (data) {
+        rows.push(...(data as T[]));
+      }
+    }
+
+    if (this.schoolSite) {
+      let query = this.supabase
+        .from(table)
+        .select('*')
+        .eq('school_site', this.schoolSite);
+
+      // When we already matched by school_id, this pass is only for strays the
+      // migration missed — without this the two passes would double-count any
+      // row carrying both.
+      if (this.schoolId) {
+        query = query.is('school_id', null);
+      }
+
+      const { data, error } = await query;
+
+      if (error) {
+        this.cacheMetadata.fetchErrors.push(`${label} (legacy school_site): ${error.message}`);
+      } else if (data) {
+        rows.push(...(data as T[]));
+      }
+    }
+
+    return rows;
+  }
+
+  /**
    * Fetch bell schedules
    */
   private async fetchBellSchedules(): Promise<BellSchedule[]> {
-    let query = this.supabase
-      .from('bell_schedules')
-      .select('*');
-    
-    // Use school_id if available, otherwise fall back to school_site
-    if (this.schoolId) {
-      query = query.eq('school_id', this.schoolId);
-    } else {
-      query = query.eq('school_site', this.schoolSite!);
-    }
-    
-    const { data, error } = await query;
-    
-    if (error) {
-      this.cacheMetadata.fetchErrors.push(`Bell schedules: ${error.message}`);
-      return [];
-    }
-    
-    return data || [];
+    return this.fetchForSchool<BellSchedule>('bell_schedules', 'Bell schedules');
   }
   
   /**
    * Fetch special activities
    */
   private async fetchSpecialActivities(): Promise<SpecialActivity[]> {
-    let query = this.supabase
-      .from('special_activities')
-      .select('*');
-    
-    // Use school_id if available, otherwise fall back to school_site
-    if (this.schoolId) {
-      query = query.eq('school_id', this.schoolId);
-    } else {
-      query = query.eq('school_site', this.schoolSite!);
-    }
-    
-    const { data, error } = await query;
-    
-    if (error) {
-      this.cacheMetadata.fetchErrors.push(`Special activities: ${error.message}`);
-      return [];
-    }
-    
-    return data || [];
+    return this.fetchForSchool<SpecialActivity>('special_activities', 'Special activities');
   }
   
   /**

--- a/lib/scheduling/scheduling-data-manager.ts
+++ b/lib/scheduling/scheduling-data-manager.ts
@@ -115,12 +115,20 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
   }
 
   /**
-   * Check if the data manager is initialized for a specific school
+   * Check if the data manager is initialized for a specific school.
+   *
+   * SPE-463: schoolId participates in the check. This singleton is shared
+   * between the interactive schedule page and the auto-scheduler, and a cache
+   * populated without a school_id filters bell schedules by school_site
+   * instead — which finds nothing for schools migrated to school_id. Without
+   * this, a caller that HAS the school_id would reuse that weaker cache and
+   * silently keep the old behaviour.
    */
-  public isInitializedForSchool(schoolSite: string, schoolDistrict?: string): boolean {
+  public isInitializedForSchool(schoolSite: string, schoolDistrict?: string, schoolId?: string): boolean {
     return this.initialized &&
            this.schoolSite === schoolSite &&
-           this.schoolDistrict === (schoolDistrict || this.schoolDistrict);
+           this.schoolDistrict === (schoolDistrict || this.schoolDistrict) &&
+           (schoolId === undefined || this.schoolId === schoolId);
   }
   
   /**
@@ -131,12 +139,27 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
     this.cacheMetadata.fetchErrors = [];
     
     try {
-      // Try to use the batch RPC if available
+      // Try to use the batch RPC if available.
+      //
+      // SPE-463 — READ BEFORE "FIXING" THIS RPC. `get_scheduling_data_batch`
+      // currently throws on EVERY call, for every provider at every school:
+      // its work_schedule CTE compares `uss.site_id = p_school_site`, and
+      // site_id is uuid while p_school_site is text, so Postgres rejects the
+      // statement at plan time (42883). The batch path has therefore never
+      // returned data — the parallel path below is what actually runs.
+      //
+      // Repairing only that type error would make the RPC start succeeding,
+      // and its bell_schedules / special_activities CTEs filter on
+      // `provider_id = p_provider_id AND school_site = p_school_site`. Both
+      // columns are NULL on site-admin-created rows, so it would return an
+      // empty set, processBatchData would cache that, and the auto-scheduler
+      // would go back to ignoring every bell schedule — the exact bug SPE-463
+      // fixed. Key those CTEs on school_id at the same time, or drop the RPC.
       const { data, error } = await this.supabase.rpc('get_scheduling_data_batch', {
         p_provider_id: this.providerId!,
         p_school_site: this.schoolSite!
       }).single();
-      
+
       if (error) {
         console.log('[DataManager] Batch RPC not available, using parallel queries');
         await this.loadDataParallel();

--- a/lib/supabase/hooks/use-auto-schedule.ts
+++ b/lib/supabase/hooks/use-auto-schedule.ts
@@ -35,7 +35,14 @@ export function useAutoSchedule(debug: boolean = false) {
       if (!student.school_site) {
         throw new Error('Student school site is required but not set');
       }
-      await scheduler.initializeContext(student.school_site, student.school_district || '');
+      // SPE-463: pass school_id so bell schedules and special activities are
+      // found by school_id rather than the school_site text, which is NULL on
+      // every row written since the school_id migration.
+      await scheduler.initializeContext(
+        student.school_site,
+        student.school_district || '',
+        student.school_id || undefined
+      );
 
       // Schedule just this one student
       const results = await scheduler.scheduleBatch([student]);
@@ -120,8 +127,11 @@ export function useAutoSchedule(debug: boolean = false) {
         // Ensure data manager is initialized for this school
         // Get school_district from the first student in this school group
         const schoolDistrict = schoolStudents[0]?.school_district || '';
+        // SPE-463: students at one site all share a school_id; take it from the
+        // group so the manager filters by school_id rather than school_site.
+        const schoolId = schoolStudents[0]?.school_id || undefined;
         if (!dataManager.isInitialized() || schoolSite !== lastSchool) {
-          await dataManager.initialize(user.id, schoolSite, schoolDistrict);
+          await dataManager.initialize(user.id, schoolSite, schoolDistrict, schoolId);
           lastSchool = schoolSite;
         } else if (dataManager.isCacheStale()) {
           await dataManager.refresh();
@@ -131,8 +141,8 @@ export function useAutoSchedule(debug: boolean = false) {
         const scheduler = new OptimizedScheduler(user.id, profile.role, debug, !!profile.works_at_multiple_schools);
 
         try {
-          // Initialize context once for the school
-          await scheduler.initializeContext(schoolSite, schoolDistrict);
+          // Initialize context once for the school (SPE-463: school_id included)
+          await scheduler.initializeContext(schoolSite, schoolDistrict, schoolId);
 
           // Schedule all students at this school
           const schoolResults = await scheduler.scheduleBatch(schoolStudents);
@@ -217,12 +227,14 @@ export function useAutoSchedule(debug: boolean = false) {
       // Place sessions for each school
       for (const [schoolSite, schoolStudents] of studentsBySchool) {
         const schoolDistrict = schoolStudents[0]?.school_district || '';
-        
+        // SPE-463: see the note on the auto-schedule path above.
+        const schoolId = schoolStudents[0]?.school_id || undefined;
+
         // Create scheduler and initialize context
         const scheduler = new OptimizedScheduler(user.id, profile.role, debug, !!profile.works_at_multiple_schools);
 
         try {
-          await scheduler.initializeContext(schoolSite, schoolDistrict);
+          await scheduler.initializeContext(schoolSite, schoolDistrict, schoolId);
 
           // Try manual placement with conflict tolerance
           const result = await scheduler.tryManualPlacement(schoolStudents, true);

--- a/lib/supabase/hooks/use-auto-schedule.ts
+++ b/lib/supabase/hooks/use-auto-schedule.ts
@@ -127,11 +127,13 @@ export function useAutoSchedule(debug: boolean = false) {
         // Ensure data manager is initialized for this school
         // Get school_district from the first student in this school group
         const schoolDistrict = schoolStudents[0]?.school_district || '';
-        // SPE-463: students at one site all share a school_id; take it from the
-        // group so the manager filters by school_id rather than school_site.
-        const schoolId = schoolStudents[0]?.school_id || undefined;
+        // SPE-463: take the school_id from the first student that has one
+        // rather than from [0] — school_id is nullable, and a single
+        // unmigrated student at the head of the group would otherwise drop the
+        // whole school back to school_site-only matching.
+        const schoolId = schoolStudents.find(s => s.school_id)?.school_id || undefined;
         if (!dataManager.isInitialized() || schoolSite !== lastSchool) {
-          await dataManager.initialize(user.id, schoolSite, schoolDistrict, schoolId);
+          await dataManager.initialize(user.id, schoolSite, schoolDistrict, schoolId, profile.role);
           lastSchool = schoolSite;
         } else if (dataManager.isCacheStale()) {
           await dataManager.refresh();
@@ -228,7 +230,7 @@ export function useAutoSchedule(debug: boolean = false) {
       for (const [schoolSite, schoolStudents] of studentsBySchool) {
         const schoolDistrict = schoolStudents[0]?.school_district || '';
         // SPE-463: see the note on the auto-schedule path above.
-        const schoolId = schoolStudents[0]?.school_id || undefined;
+        const schoolId = schoolStudents.find(s => s.school_id)?.school_id || undefined;
 
         // Create scheduler and initialize context
         const scheduler = new OptimizedScheduler(user.id, profile.role, debug, !!profile.works_at_multiple_schools);


### PR DESCRIPTION
Closes SPE-463.

The auto-scheduler loaded **zero bell schedules** at Bancroft, Mt. Diablo and Rodeo Hills — 363 blocks between them, all rendering correctly in the UI, none of them constraining anything. Auto-Schedule could place a session straight through a grade's lunch or recess.

> **Scope correction.** An earlier version of this description said "bell schedules **and special activities**" throughout. Only the bell schedule half actually reaches the scheduler. Special activities are now loaded correctly into the data manager, but `getDataFromManager()` still discards them — see [Known gap](#known-gap) below. Both review bots caught the overclaim; they were right.

## Why

Three things stacked up, each hiding the next.

**1. The batch RPC has never worked.** `get_scheduling_data_batch` throws on every call, for every provider, at every school: its `work_schedule` CTE compares `uss.site_id` (uuid) with `p_school_site` (text), which Postgres rejects at plan time (`42883`). Verified by invoking it directly as a real authenticated provider. `loadAllData()` treats any error as "batch RPC not available" and silently falls back, so the "optimized" path has never once returned data.

**2. The fallback had no school id to work with.** `initializeContext` hardcoded `undefined` for `schoolId`.

**3. So it matched on `school_site`, which those rows don't have.** That column is NULL on every row written since the school_id migration. Walnut Acres and the sim fixtures still carry it, which is why they worked and hid the problem.

The interactive drag path (`use-scheduling-data.ts`) already passed `school_id` and was never affected — only auto-scheduling.

## What changed

Threads `school_id` from the student through `initializeContext` into the data manager. `students.school_id` is populated on all 563 students.

`isInitializedForSchool` now considers `school_id` too — the manager is a singleton shared with the schedule page, and without this a cache built without a school id would be reused by a caller that has one, silently keeping the old behaviour.

## What the self-review caught

Two things, both fixed in the second commit — worth reading, because the first would have shipped a fresh bug.

**The naive fix regresses Walnut Acres.** The lookup was either/or: `school_id` when present, else `school_site`. Production holds both shapes at once —

| School | school_id | school_site |
|---|---|---|
| Bancroft / Mt. Diablo / Rodeo Hills | set | NULL |
| Walnut Acres (60 bell rows, 17 activities) | **NULL** | set |

Walnut Acres students all carry a `school_id`, so forwarding it would have flipped that school onto the `school_id` branch and matched none of its rows — the same failure, transplanted. It now matches **both**: rows carrying this school id, plus legacy rows carrying no school id that name this school, narrowed to `school_id IS NULL` so nothing double-counts.

Two queries rather than one `.or(...)`, deliberately: school names contain characters significant in PostgREST's filter grammar ("Mt. Diablo Elementary"), and a mis-escaped filter fails into an empty result — which is this bug again, silently. Worth a round trip to not risk.

**`providerRole` was being wiped.** The data manager gates the specialist branch of `fetchExistingSessions` on it, so initializing without a role hides sessions assigned to this user on other providers' students and can double-book a specialist. It's a shared singleton, so omitting the role here also cleared what the schedule page had set — and the stricter `isInitializedForSchool` makes that re-init fire more often, so this PR would have turned a latent problem live. Now forwarded, and guarded by a test (added after CodeRabbit noted the mock was dropping that argument).

Also: school id is taken from the first student that has one rather than `[0]`, since it's nullable and one unmigrated student at the head of a group would drop the whole school back to name matching.

## Verification

Unit tests mock the Supabase client and can't see any of this, so it was checked against prod with **real RLS-enforced sessions**, per school and per provider (`current_user = authenticated`):

| School | filter by `school_site` (before) | filter by `school_id` (after) |
|---|---|---|
| Rodeo Hills | 0 | **177** |
| Bancroft | 0 | **96** |
| Mt. Diablo | 0 | **90** |

Every new test was confirmed to **fail against the pre-fix code** and pass after — the handoff test fails 1 of 3 without the school id and another without the role, the school-key test 3 of 4 — so they guard the behaviour rather than restate it.

Green: `tsc --noEmit`, `npm run lint` (0 errors), `npm test` (114 suites, 1293 passed), `npm run sim:verify`.

**Limit worth stating:** I verified the data layer under real sessions and pinned the wiring with tests, but could not drive the browser auto-scheduler end-to-end from here. "Auto-Schedule now avoids these windows" follows from those two; it is not directly observed.

## <a name="known-gap"></a>Known gap — special activities still don't reach the scheduler

`getDataFromManager()` builds `specialActivities` as a literal `[]` (`optimized-scheduler.ts:219-221` — *"For now, we'll leave this empty as we'd need to know all teacher names"*), so `specialActivitiesByTeacher` is empty and auto-scheduling still ignores PE, assemblies and the like.

Bell schedules get around that by enumerating a known grade set; there is no equivalent for activities because the manager exposes only `getSpecialActivityConflicts(teacherName, ...)` and nothing knows the teacher list. It needs a bulk accessor, not a one-line swap.

That stub is **SPE-318**, filed 2026-07-24 and deliberately parked pending an anticipated auto-scheduler rework. Not folded in here: it is a separate behaviour change on a ticket its owner chose to hold. What this PR does change is that the activity rows now load *correctly* into the manager, so when SPE-318 wires the accessor through, the data will be right rather than empty for a second reason.

## Also deliberately not done

The broken RPC is left in place — it fails safely, and the parallel path is what runs. But it's documented at the call site, because **repairing only its type error would re-break this**: its CTEs filter on `provider_id`/`school_site`, so it would start succeeding and return an empty set, which `processBatchData` would then cache. Its CTEs need keying on `school_id`, or the RPC needs deleting.

Related and still open: SPE-458 (no `school_year` filter on the same reads) and SPE-318 above, which also covers `schoolHours` being dropped — so day bounds still fall back to 08:00–15:00 everywhere.

## Behaviour change

This is not a silent internal fix. The auto-scheduler will now avoid bell schedule blocks it previously ignored at those three schools, so the schedules it produces will differ. Sessions already booked over a lunch stay booked — nothing here cleans up retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoBCMXfYGEriXEWtRyt1bK