### PR TITLE
Scheduler: scope bell schedules and special activities to the current school year (SPE-458)

### DIFF
--- a/__tests__/unit/lib/scheduling/data-manager-school-year-scope.test.ts
+++ b/__tests__/unit/lib/scheduling/data-manager-school-year-scope.test.ts
@@ -1,0 +1,169 @@
+/**
+ * SPE-458: the scheduler loaded bell schedules and special activities filtered
+ * only by school, never by school_year — so once a school held more than one
+ * year, conflict detection unioned them all. A period retimed or removed for
+ * the new year kept blocking slots, because last year's row was still in the
+ * result set.
+ *
+ * Every other reader is year-scoped: the provider Bell Schedules and Special
+ * Activities pages both pin to getCurrentSchoolYear(). The scheduler was the
+ * one reader ignoring the column, which made it possible for a bell schedule
+ * nobody can see in the app to still block scheduling.
+ *
+ * The mock below applies the filters rather than merely recording them, so
+ * these assert what the scheduler ends up holding — not that some particular
+ * line was written.
+ */
+
+type Row = Record<string, unknown>;
+
+// `mock`-prefixed so the jest.mock factory (hoisted above imports) may reference it.
+const mockState: { rows: Record<string, Row[]> } = { rows: {} };
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      const filters: Array<[string, string, unknown]> = [];
+
+      const query: any = {
+        select: () => query,
+        eq: (col: string, val: unknown) => {
+          filters.push(['eq', col, val]);
+          return query;
+        },
+        is: (col: string, val: unknown) => {
+          filters.push(['is', col, val]);
+          return query;
+        },
+        then: (resolve: (r: unknown) => unknown) => {
+          const data = (mockState.rows[table] || []).filter((row) =>
+            filters.every(([op, col, val]) =>
+              op === 'is' ? row[col] === null || row[col] === undefined : row[col] === val,
+            ),
+          );
+          return Promise.resolve(resolve({ data, error: null }));
+        },
+      };
+      return query;
+    },
+  }),
+}));
+
+import { SchedulingDataManager } from '@/lib/scheduling/scheduling-data-manager';
+import { getCurrentSchoolYear } from '@/lib/school-year';
+
+const THIS_YEAR = getCurrentSchoolYear();
+const LAST_YEAR = (() => {
+  const start = parseInt(THIS_YEAR.split('-')[0], 10);
+  return `${start - 1}-${start}`;
+})();
+
+const SCHOOL_ID = '061899002301';
+const SCHOOL_SITE = 'Rodeo Hills Elementary';
+
+function manager() {
+  const mgr = SchedulingDataManager.getInstance() as any;
+  mgr.cacheMetadata = { lastFetched: new Date(), isStale: false, fetchErrors: [], queryCount: 0 };
+  mgr.schoolYear = THIS_YEAR;
+  return mgr;
+}
+
+beforeEach(() => {
+  mockState.rows = {};
+});
+
+describe('SchedulingDataManager year scoping (SPE-458)', () => {
+  it('loads only the current year for a school holding two years of bell schedules', async () => {
+    mockState.rows.bell_schedules = [
+      { id: 'now-recess', school_id: SCHOOL_ID, school_year: THIS_YEAR },
+      { id: 'now-lunch', school_id: SCHOOL_ID, school_year: THIS_YEAR },
+      // Retimed for the new year; this row is invisible in the app and must not
+      // block a slot the new year freed up.
+      { id: 'last-year-lunch', school_id: SCHOOL_ID, school_year: LAST_YEAR },
+    ];
+
+    const mgr = manager();
+    mgr.schoolId = SCHOOL_ID;
+    mgr.schoolSite = null;
+
+    const rows = await mgr.fetchForSchool('bell_schedules', 'Bell schedules');
+
+    expect(rows.map((r: Row) => r.id).sort()).toEqual(['now-lunch', 'now-recess']);
+  });
+
+  it('scopes the legacy school_site pass by year too, not just the school_id pass', async () => {
+    // Walnut Acres' shape: school_site set, school_id NULL. The year filter has
+    // to reach this pass as well, or half the fix is missing for exactly the
+    // school SPE-463 was about.
+    mockState.rows.bell_schedules = [
+      { id: 'legacy-now', school_site: SCHOOL_SITE, school_id: null, school_year: THIS_YEAR },
+      { id: 'legacy-old', school_site: SCHOOL_SITE, school_id: null, school_year: LAST_YEAR },
+    ];
+
+    const mgr = manager();
+    mgr.schoolId = null;
+    mgr.schoolSite = SCHOOL_SITE;
+
+    const rows = await mgr.fetchForSchool('bell_schedules', 'Bell schedules');
+
+    expect(rows.map((r: Row) => r.id)).toEqual(['legacy-now']);
+  });
+
+  it('still returns both key shapes for the current year — year scoping must not undo SPE-463', async () => {
+    mockState.rows.special_activities = [
+      { id: 'by-id', school_id: SCHOOL_ID, school_year: THIS_YEAR },
+      { id: 'legacy', school_site: SCHOOL_SITE, school_id: null, school_year: THIS_YEAR },
+      { id: 'by-id-old', school_id: SCHOOL_ID, school_year: LAST_YEAR },
+    ];
+
+    const mgr = manager();
+    mgr.schoolId = SCHOOL_ID;
+    mgr.schoolSite = SCHOOL_SITE;
+
+    const rows = await mgr.fetchForSchool('special_activities', 'Special activities');
+
+    expect(rows.map((r: Row) => r.id).sort()).toEqual(['by-id', 'legacy']);
+  });
+
+  it('never issues an unscoped query, even when a school has only one year', async () => {
+    // The bug was dormant precisely because every school had one year. A fix
+    // that only works when two years exist would look green here forever.
+    mockState.rows.bell_schedules = [{ id: 'only', school_id: SCHOOL_ID, school_year: THIS_YEAR }];
+
+    const mgr = manager();
+    mgr.schoolId = SCHOOL_ID;
+    mgr.schoolSite = SCHOOL_SITE;
+    mgr.schoolYear = LAST_YEAR; // ask for a year this school has no rows in
+
+    const rows = await mgr.fetchForSchool('bell_schedules', 'Bell schedules');
+
+    expect(rows).toEqual([]);
+  });
+});
+
+describe('SchedulingDataManager cache reuse across the Aug 1 rollover (SPE-458)', () => {
+  it('treats a cache built in a previous school year as not initialized', () => {
+    const mgr = manager();
+    mgr.initialized = true;
+    mgr.schoolSite = SCHOOL_SITE;
+    mgr.schoolDistrict = 'John Swett Unified';
+    mgr.schoolId = SCHOOL_ID;
+    mgr.schoolYear = LAST_YEAR;
+
+    // Same school, same district, same id — only the year is stale. The
+    // singleton outlives any one page, so without this the auto-scheduler
+    // would reuse last year's bell schedules straight from memory.
+    expect(mgr.isInitializedForSchool(SCHOOL_SITE, 'John Swett Unified', SCHOOL_ID)).toBe(false);
+  });
+
+  it('still reports initialized for the current year', () => {
+    const mgr = manager();
+    mgr.initialized = true;
+    mgr.schoolSite = SCHOOL_SITE;
+    mgr.schoolDistrict = 'John Swett Unified';
+    mgr.schoolId = SCHOOL_ID;
+    mgr.schoolYear = THIS_YEAR;
+
+    expect(mgr.isInitializedForSchool(SCHOOL_SITE, 'John Swett Unified', SCHOOL_ID)).toBe(true);
+  });
+});

--- a/__tests__/unit/lib/scheduling/data-manager-school-year-scope.test.ts
+++ b/__tests__/unit/lib/scheduling/data-manager-school-year-scope.test.ts
@@ -22,6 +22,9 @@ const mockState: { rows: Record<string, Row[]> } = { rows: {} };
 
 jest.mock('@/lib/supabase/client', () => ({
   createClient: () => ({
+    // The batch RPC throws for every provider at every school today (see the
+    // SPE-463 note in the data manager), so the parallel path is what runs.
+    rpc: () => ({ single: async () => ({ data: null, error: { message: 'unavailable' } }) }),
     from: (table: string) => {
       const filters: Array<[string, string, unknown]> = [];
 
@@ -35,6 +38,10 @@ jest.mock('@/lib/supabase/client', () => ({
           filters.push(['is', col, val]);
           return query;
         },
+        or: () => query,
+        in: () => query,
+        limit: () => query,
+        single: async () => ({ data: null, error: { message: 'no row' } }),
         then: (resolve: (r: unknown) => unknown) => {
           const data = (mockState.rows[table] || []).filter((row) =>
             filters.every(([op, col, val]) =>
@@ -165,5 +172,27 @@ describe('SchedulingDataManager cache reuse across the Aug 1 rollover (SPE-458)'
     mgr.schoolYear = THIS_YEAR;
 
     expect(mgr.isInitializedForSchool(SCHOOL_SITE, 'John Swett Unified', SCHOOL_ID)).toBe(true);
+  });
+
+  // The cache-key guard above only fires when a caller asks. refresh() does
+  // not ask — it reloads in place whenever the 15-minute cache goes stale.
+  // Deriving the year once at initialize() therefore left a page open across
+  // the rollover reloading against last year indefinitely, reading back as
+  // zero rows with no error. Re-deriving on every load closes both doors.
+  it('re-derives the year on every load, so a refresh after the rollover moves to the new year', async () => {
+    mockState.rows.bell_schedules = [{ id: 'a', school_id: SCHOOL_ID, school_year: THIS_YEAR }];
+
+    const mgr = manager();
+    mgr.providerId = 'provider-1';
+    mgr.schoolSite = SCHOOL_SITE;
+    mgr.schoolDistrict = 'John Swett Unified';
+    mgr.schoolId = SCHOOL_ID;
+    mgr.schoolYear = LAST_YEAR; // cache built before Aug 1
+
+    await mgr.refresh();
+
+    expect(mgr.schoolYear).toBe(THIS_YEAR);
+    // And the reload actually picked up the current year's rows.
+    expect(mgr.data.data.bellSchedules.size).toBeGreaterThan(0);
   });
 });

--- a/lib/scheduling/scheduling-data-manager.ts
+++ b/lib/scheduling/scheduling-data-manager.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/client';
+import { getCurrentSchoolYear } from '@/lib/school-year';
 import type { Database } from '@/src/types';
 import type {
   Student,
@@ -35,7 +36,16 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
   private schoolSite: string | null = null;
   private schoolDistrict: string | null = null;
   private schoolId: string | null = null;
-  
+
+  // SPE-458: the school year this cache holds. Set from getCurrentSchoolYear()
+  // at initialize() rather than passed in — no scheduling caller has a year
+  // selector (the provider Bell Schedules and Special Activities pages both pin
+  // to the current year, and scheduling only ever happens in the year you are
+  // in). Seeded here as well so it is never null if a fetch runs before
+  // initialize(): an unset year would silently mean "every year", which is the
+  // bug this field exists to close.
+  private schoolYear: string = getCurrentSchoolYear();
+
   // Core data structures
   private data: VersionedSchedulingData = {
     data: {
@@ -101,6 +111,7 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
     this.schoolSite = schoolSite;
     this.schoolDistrict = schoolDistrict;
     this.schoolId = schoolId || null;
+    this.schoolYear = getCurrentSchoolYear();
     this.data.version.modifiedBy = providerId;
 
     await this.loadAllData();
@@ -123,12 +134,21 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
    * instead — which finds nothing for schools migrated to school_id. Without
    * this, a caller that HAS the school_id would reuse that weaker cache and
    * silently keep the old behaviour.
+   *
+   * SPE-458: the cached school year is checked against the current one too.
+   * This singleton outlives any one page, so a tab left open across the Aug 1
+   * rollover would otherwise keep serving last year's bell schedules from
+   * memory — the same "invisible but active" failure the school_year filter
+   * closes at the query. No parameter for it: callers have no year to pass,
+   * the only correct value is the current one, so this asks "is this cache
+   * still for the year we are in?".
    */
   public isInitializedForSchool(schoolSite: string, schoolDistrict?: string, schoolId?: string): boolean {
     return this.initialized &&
            this.schoolSite === schoolSite &&
            this.schoolDistrict === (schoolDistrict || this.schoolDistrict) &&
-           (schoolId === undefined || this.schoolId === schoolId);
+           (schoolId === undefined || this.schoolId === schoolId) &&
+           this.schoolYear === getCurrentSchoolYear();
   }
   
   /**
@@ -155,6 +175,11 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
       // empty set, processBatchData would cache that, and the auto-scheduler
       // would go back to ignoring every bell schedule — the exact bug SPE-463
       // fixed. Key those CTEs on school_id at the same time, or drop the RPC.
+      //
+      // SPE-458: those same CTEs also select every school_year at once, which
+      // the parallel path below no longer does. Repairing the RPC without
+      // adding a school_year filter would reintroduce that bug on this path
+      // only — visible just at schools holding two years of data.
       const { data, error } = await this.supabase.rpc('get_scheduling_data_batch', {
         p_provider_id: this.providerId!,
         p_school_site: this.schoolSite!
@@ -286,6 +311,16 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
    * contain characters that are significant in PostgREST's filter grammar
    * ("Mt. Diablo Elementary"), and a mis-escaped filter fails into an empty
    * result — reintroducing exactly this bug, silently.
+   *
+   * SPE-458: both passes are also scoped to the current school year. Without
+   * it, conflict detection unioned every year a school had ever stored, so a
+   * period retimed or removed for the new year kept blocking slots from last
+   * year's row. Every other reader is year-scoped — the provider Bell
+   * Schedules and Special Activities pages both pin to getCurrentSchoolYear()
+   * — which made the scheduler the one place a schedule nobody can see in the
+   * app could still block scheduling. Safe to filter unconditionally: the
+   * column is NOT NULL on both tables, defaulted to current_school_year(),
+   * so there are no unlabelled rows for an .eq() to strand.
    */
   private async fetchForSchool<T>(
     table: 'bell_schedules' | 'special_activities',
@@ -297,6 +332,7 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
       const { data, error } = await this.supabase
         .from(table)
         .select('*')
+        .eq('school_year', this.schoolYear)
         .eq('school_id', this.schoolId);
 
       if (error) {
@@ -310,6 +346,7 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
       let query = this.supabase
         .from(table)
         .select('*')
+        .eq('school_year', this.schoolYear)
         .eq('school_site', this.schoolSite);
 
       // When we already matched by school_id, this pass is only for strays the

--- a/lib/scheduling/scheduling-data-manager.ts
+++ b/lib/scheduling/scheduling-data-manager.ts
@@ -111,7 +111,6 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
     this.schoolSite = schoolSite;
     this.schoolDistrict = schoolDistrict;
     this.schoolId = schoolId || null;
-    this.schoolYear = getCurrentSchoolYear();
     this.data.version.modifiedBy = providerId;
 
     await this.loadAllData();
@@ -157,7 +156,14 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
   private async loadAllData(): Promise<void> {
     const startTime = performance.now();
     this.cacheMetadata.fetchErrors = [];
-    
+
+    // SPE-458: re-derived on every load, not once at initialize(). refresh()
+    // comes through here too — it fires whenever the 15-minute cache goes
+    // stale — so pinning the year at initialize() would leave a page open
+    // across the Aug 1 rollover reloading against last year forever, which
+    // reads back as zero rows with no error.
+    this.schoolYear = getCurrentSchoolYear();
+
     try {
       // Try to use the batch RPC if available.
       //
@@ -315,12 +321,25 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
    * SPE-458: both passes are also scoped to the current school year. Without
    * it, conflict detection unioned every year a school had ever stored, so a
    * period retimed or removed for the new year kept blocking slots from last
-   * year's row. Every other reader is year-scoped — the provider Bell
-   * Schedules and Special Activities pages both pin to getCurrentSchoolYear()
-   * — which made the scheduler the one place a schedule nobody can see in the
-   * app could still block scheduling. Safe to filter unconditionally: the
-   * column is NOT NULL on both tables, defaulted to current_school_year(),
-   * so there are no unlabelled rows for an .eq() to strand.
+   * year's row — a schedule nobody can see in the app still blocking
+   * scheduling. Safe to filter unconditionally: the column is NOT NULL on both
+   * tables, defaulted to current_school_year(), so there are no unlabelled
+   * rows for an .eq() to strand.
+   *
+   * Two things this does NOT cover, both tracked separately — do not read this
+   * filter as meaning the whole app is year-scoped:
+   *
+   *   - The provider Bell Schedules / Special Activities settings pages pin to
+   *     getCurrentSchoolYear(), but the schedule GRID
+   *     (use-schedule-data.ts) and the drag-time conflict checks in
+   *     session-update-service.ts both still read every year at once. Until
+   *     those are scoped too, a school holding two years can see the grid
+   *     shade a slot this scheduler considers free.
+   *   - A school whose rows were never carried forward into the new year now
+   *     loads ZERO periods rather than last year's. That is the honest
+   *     reading of the data, and it matches what the settings pages already
+   *     show — but "no bell schedules" means nothing is protected, so the
+   *     empty case is logged below rather than passing silently.
    */
   private async fetchForSchool<T>(
     table: 'bell_schedules' | 'special_activities',
@@ -363,6 +382,19 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
       } else if (data) {
         rows.push(...(data as T[]));
       }
+    }
+
+    // SPE-458: an empty year-scoped read is not an error, but it is the shape
+    // of a school whose schedules were never carried into the new year — and
+    // "no periods" means the auto-scheduler protects nothing, the same end
+    // state as SPE-463. Loud in the log rather than silent, since no query
+    // failed and fetchErrors would stay clean.
+    if (rows.length === 0) {
+      console.warn(
+        `[DataManager] No ${label.toLowerCase()} found for ${this.schoolSite ?? this.schoolId} ` +
+        `in ${this.schoolYear}. Nothing will be protected for this school — check the ` +
+        `schedules were carried forward into the current school year.`,
+      );
     }
 
     return rows;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "sim:verify-teacher-link-writes": "tsx scripts/sim-district/verify-teacher-link-writes.ts",
     "sim:verify-special-activities-rls": "tsx scripts/sim-district/verify-special-activities-rls.ts",
     "sim:verify-multi-school-rls": "tsx scripts/sim-district/verify-multi-school-rls.ts",
+    "sim:verify-scheduler-year-scope": "tsx scripts/sim-district/verify-scheduler-year-scope.ts",
     "sim:verify-provider-schools-rls": "tsx scripts/sim-district/verify-provider-schools-rls.ts",
     "sim:verify-sis-rls": "tsx scripts/sim-district/verify-sis-connections-rls.ts",
     "sim:verify-sis-lifecycle": "tsx scripts/sim-district/verify-sis-lifecycle.ts",

--- a/scripts/sim-district/verify-scheduler-year-scope.ts
+++ b/scripts/sim-district/verify-scheduler-year-scope.ts
@@ -1,0 +1,165 @@
+/**
+ * SPE-458 — the scheduler's bell schedule / special activity reads are scoped
+ * to the current school year, checked with a REAL signed-in session.
+ *
+ * Same reason this is a script and not a jest test as its siblings: our unit
+ * tests mock the Supabase client, so they cannot see RLS at all. They pass
+ * identically whether the database returns the rows or refuses them. This is a
+ * change to what the scheduler READS from the browser, so it has to be
+ * exercised against the real database through a provider's own session.
+ *
+ * It drives the ACTUAL SchedulingDataManager.fetchForSchool() — not a re-typed
+ * copy of its query — with the session injected, so what runs here is the code
+ * the app runs.
+ *
+ * The contract asserted here:
+ *   - the current year's rows all come back under RLS (the SPE-463 failure
+ *     mode is the dangerous one: "nothing" means the auto-scheduler books
+ *     straight over lunch, silently);
+ *   - a different school year returns NOTHING through that same code path.
+ *
+ * That second check is what makes this discriminating rather than decorative.
+ * The sim district holds a single school year, so "prior year is empty" would
+ * be trivially true if it were asserted on its own. Asserted through the same
+ * call that just returned 120 rows for the current year, it is not: with the
+ * school_year filter removed, the prior-year call returns those same 120 rows
+ * (verified by reverting the fix), because an unfiltered read unions every
+ * year the school has ever stored. That union IS the bug.
+ *
+ * Traps deliberately avoided (CLAUDE.md):
+ *   - the fixture is proven non-empty with the service client FIRST, so the
+ *     exclusion check cannot pass for the wrong reason;
+ *   - fetchErrors is asserted empty, because a malformed filter fails into an
+ *     empty result that looks identical to correct exclusion;
+ *   - the row count is compared to ground truth, not merely to zero, so a
+ *     filter that strands half the rows cannot pass.
+ *
+ * Requires a seeded sim district (`npm run sim:reset -- --yes`). Read-only —
+ * it does not modify sim data.
+ *
+ * Usage: npm run sim:verify-scheduler-year-scope
+ */
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createAdmin, requireEnv } from './lib';
+import { derivePassword, personaEmail } from './manifest';
+import { SchedulingDataManager } from '@/lib/scheduling/scheduling-data-manager';
+import { getCurrentSchoolYear } from '@/lib/school-year';
+
+const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+const secret = requireEnv('SIM_DISTRICT_PASSWORD');
+const admin = createAdmin();
+
+let failures = 0;
+function check(ok: boolean, label: string, detail = ''): void {
+  if (!ok) failures++;
+  console.log(`  [${ok ? 'ok  ' : 'FAIL'}] ${label.padEnd(56)} ${detail}`);
+}
+
+async function signIn(personaKey: string): Promise<SupabaseClient> {
+  const email = personaEmail(personaKey);
+  const client = createClient(url, anon, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: derivePassword(secret, email),
+  });
+  if (error) {
+    throw new Error(`sim login failed for ${email} — is the district seeded? (${error.message})`);
+  }
+  return client;
+}
+
+(async () => {
+  const thisYear = getCurrentSchoolYear();
+  const startYear = parseInt(thisYear.split('-')[0], 10);
+  const priorYear = `${startYear - 1}-${startYear}`;
+
+  console.log(`\nSPE-458 scheduler year scoping — current school year ${thisYear}\n`);
+
+  // Rachel is a resource provider at Sim Willow Elementary.
+  const session = await signIn('rachel');
+
+  const { data: schools } = await session
+    .from('provider_schools')
+    .select('school_id, school_site')
+    .limit(1);
+  const school = (schools || [])[0] as { school_id: string | null; school_site: string | null };
+  check(!!school, 'provider resolves a school through their own session',
+    school ? (school.school_site ?? school.school_id ?? '') : 'none');
+  if (!school) {
+    process.exit(1);
+  }
+
+  // Ground truth via the service client: what SHOULD be visible for this school
+  // this year. Compared against, not just "> 0", so a filter that strands some
+  // rows cannot slip through.
+  let truth = admin
+    .from('bell_schedules')
+    .select('id', { count: 'exact', head: true })
+    .eq('school_year', thisYear);
+  truth = school.school_id
+    ? truth.eq('school_id', school.school_id)
+    : truth.eq('school_site', school.school_site!);
+  const { count: expected } = await truth;
+  check((expected ?? 0) > 0, 'fixture actually HAS current-year bell schedules',
+    `service-client count=${expected}`);
+
+  // Drive the real code path with the real session.
+  const mgr = SchedulingDataManager.getInstance() as unknown as {
+    supabase: SupabaseClient;
+    cacheMetadata: { lastFetched: Date; isStale: boolean; fetchErrors: string[]; queryCount: number };
+    schoolId: string | null;
+    schoolSite: string | null;
+    schoolYear: string;
+    fetchForSchool: (t: string, l: string) => Promise<Array<{ school_year: string }>>;
+  };
+  mgr.supabase = session;
+  mgr.cacheMetadata = { lastFetched: new Date(), isStale: false, fetchErrors: [], queryCount: 0 };
+  mgr.schoolId = school.school_id;
+  mgr.schoolSite = school.school_site;
+
+  mgr.schoolYear = thisYear;
+  const current = await mgr.fetchForSchool('bell_schedules', 'Bell schedules');
+  check(current.length > 0, 'current year returns rows under RLS', `rows=${current.length}`);
+  check(current.length === expected, 'and returns ALL of them, not a subset',
+    `got=${current.length} expected=${expected}`);
+  check(mgr.cacheMetadata.fetchErrors.length === 0,
+    'no query errors (a failed filter reads as empty)',
+    mgr.cacheMetadata.fetchErrors.join('; ') || 'none');
+  check(current.every((r) => r.school_year === thisYear),
+    'every row returned really is the current year');
+
+  mgr.schoolYear = priorYear;
+  mgr.cacheMetadata.fetchErrors = [];
+  const prior = await mgr.fetchForSchool('bell_schedules', 'Bell schedules');
+  check(prior.length === 0, `prior year (${priorYear}) is excluded`, `rows=${prior.length}`);
+  check(mgr.cacheMetadata.fetchErrors.length === 0,
+    'exclusion is a real filter, not a query error',
+    mgr.cacheMetadata.fetchErrors.join('; ') || 'none');
+
+  mgr.schoolYear = thisYear;
+  const activities = await mgr.fetchForSchool('special_activities', 'Special activities');
+  check(activities.length > 0, 'special activities: current year returns rows',
+    `rows=${activities.length}`);
+  check(activities.every((r) => r.school_year === thisYear),
+    'special activities: every row is the current year');
+
+  mgr.schoolYear = priorYear;
+  const priorActivities = await mgr.fetchForSchool('special_activities', 'Special activities');
+  check(priorActivities.length === 0, 'special activities: prior year is excluded',
+    `rows=${priorActivities.length}`);
+
+  await session.auth.signOut();
+
+  if (failures > 0) {
+    console.log(`\n${failures} check(s) FAILED.\n`);
+    process.exit(1);
+  }
+  console.log('\nAll checks passed.\n');
+  process.exit(0);
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/sim-district/verify-scheduler-year-scope.ts
+++ b/scripts/sim-district/verify-scheduler-year-scope.ts
@@ -139,17 +139,39 @@ async function signIn(personaKey: string): Promise<SupabaseClient> {
     'exclusion is a real filter, not a query error',
     mgr.cacheMetadata.fetchErrors.join('; ') || 'none');
 
+  // Special activities get the same treatment, ground truth included. Asserting
+  // only "prior year is empty" here would go green on a query error, which is
+  // the trap this script exists to avoid.
+  let actTruth = admin
+    .from('special_activities')
+    .select('id', { count: 'exact', head: true })
+    .eq('school_year', thisYear);
+  actTruth = school.school_id
+    ? actTruth.eq('school_id', school.school_id)
+    : actTruth.eq('school_site', school.school_site!);
+  const { count: expectedActivities } = await actTruth;
+  check((expectedActivities ?? 0) > 0, 'fixture actually HAS current-year special activities',
+    `service-client count=${expectedActivities}`);
+
   mgr.schoolYear = thisYear;
+  mgr.cacheMetadata.fetchErrors = [];
   const activities = await mgr.fetchForSchool('special_activities', 'Special activities');
-  check(activities.length > 0, 'special activities: current year returns rows',
-    `rows=${activities.length}`);
+  check(activities.length === expectedActivities,
+    'special activities: current year returns ALL rows',
+    `got=${activities.length} expected=${expectedActivities}`);
+  check(mgr.cacheMetadata.fetchErrors.length === 0,
+    'special activities: no query errors', mgr.cacheMetadata.fetchErrors.join('; ') || 'none');
   check(activities.every((r) => r.school_year === thisYear),
     'special activities: every row is the current year');
 
   mgr.schoolYear = priorYear;
+  mgr.cacheMetadata.fetchErrors = [];
   const priorActivities = await mgr.fetchForSchool('special_activities', 'Special activities');
   check(priorActivities.length === 0, 'special activities: prior year is excluded',
     `rows=${priorActivities.length}`);
+  check(mgr.cacheMetadata.fetchErrors.length === 0,
+    'special activities: exclusion is a real filter, not a query error',
+    mgr.cacheMetadata.fetchErrors.join('; ') || 'none');
 
   await session.auth.signOut();
 


### PR DESCRIPTION
Closes SPE-458.

The scheduler loaded bell schedules and special activities filtered only by school, never by `school_year`. Once a school holds more than one year, conflict detection unions every year together — so a period retimed or removed for the new year keeps blocking slots, because last year's row is still in the result set. Both scheduling paths are affected, since the batch/auto scheduler and the interactive drag path share this data manager.

**Dormant today.** No school has bell schedule or special activity rows in more than one year (verified in prod). It arms the first time any school gets a second year, which the year-activation copy flow does deliberately.

## The change

```ts
.eq('school_year', this.schoolYear)   // both passes in fetchForSchool
```

The year comes from `getCurrentSchoolYear()` in `loadAllData()` rather than being passed in — no scheduling caller has a year selector, and scheduling only happens in the year you're in. Filtering unconditionally is safe: `school_year` is `NOT NULL DEFAULT current_school_year()` on both tables, so there are no unlabelled rows for an `.eq()` to strand.

`isInitializedForSchool()` now checks the cached year too. The data manager is a singleton that outlives any one page, so a tab open across the Aug 1 rollover would otherwise keep serving last year's schedules from memory — the same failure, one layer up.

## What the self-review caught

Three real defects, each confirmed against the code before changing anything:

- **`refresh()` bypassed the rollover guard entirely.** I derived the year once at `initialize()`, but `refresh()` reloads in place whenever the 15-minute cache goes stale and never re-derived it. A page open across Aug 1 would keep querying last year *forever*, reading back as zero rows with no error. Moved the derivation to `loadAllData()`, which both paths share.
- **A comment I wrote was false.** It claimed "every other reader is year-scoped". Only the provider *settings* pages are. The schedule grid (`use-schedule-data.ts`) and the drag-time conflict checks (`session-update-service.ts`) both still read every year at once — so fixing the data manager alone makes the readers *disagree*. Corrected, both gaps named in the comment, and filed as SPE-469.
- **The new sim script had the gap its own header warns about.** The special-activities half asserted only that the prior year came back empty — no ground-truth count, no `fetchErrors` check — so it could have gone green on a query error.

## Changed failure mode — flagging deliberately

A school whose schedules were never carried into the new year now loads **zero** periods rather than last year's. That's the honest reading of the data and it matches what the settings pages already show, but "no bell schedules" means nothing is protected — the same end state as SPE-463. No query fails, so `fetchErrors` stays clean and it would pass silently; it's now logged. Related to SPE-461.

## Verification

Unit tests mock the Supabase client and can't see RLS, so this was exercised against the real database with a real signed-in session: `npm run sim:verify-scheduler-year-scope` drives the **actual** `fetchForSchool()` through a provider's own RLS-enforced session.

It discriminates rather than decorates — with the filter removed, the prior-year call returns the same 120 rows as the current-year call, which is the bug itself. It also asserts the current year returns *all* rows against a service-client ground truth, since the dangerous direction is the SPE-463 one where "nothing" means the scheduler books straight over lunch.

Every unit test was checked against the code it guards: reverting the query filter fails 4, reverting the cache-key guard fails 1, reverting the `loadAllData()` derivation fails 1.

Green: `tsc --noEmit`, `npm run lint` (0 errors), `npm test` (116 suites, 1315 passed), `npm run sim:verify`, `npm run sim:verify-scheduler-year-scope`.

## Found along the way, not fixed here

- **SPE-468 — soft-deleted special activities still block slots. Live in prod, 3 rows**, one since December. Every other reader filters `deleted_at`; the scheduler doesn't. Same function, different axis. Kept separate because it's a live user-facing change and this one is dormant — different blast radii.
- **SPE-469** — the two other unscoped readers above.
- **SPE-470** — `ARCHITECTURE.md` has no school-year section, after four school-year bugs in one week.
- `school_hours` has **no `school_year` column at all**, so it can't be year-scoped without a schema migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoBCMXfYGEriXEWtRyt1bK

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBCMXfYGEriXEWtRyt1bK)_