### PR TITLE
Auto-Schedule: count weekly templates, not dated instances (SPE-474)

### DIFF
--- a/__tests__/unit/components/schedule/auto-schedule-session-count.test.tsx
+++ b/__tests__/unit/components/schedule/auto-schedule-session-count.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * SPE-474: Auto-Schedule decided who still needs scheduling by counting a
+ * student's scheduled sessions against `sessions_per_week` — but the query had
+ * no `is_template` filter. `schedule_sessions` holds the recurring templates
+ * AND the dated instances materialized to a rolling 12-week horizon (SPE-291),
+ * and instances carry day_of_week/start_time/end_time too. So up to twelve
+ * weeks of instances were counted against a PER-WEEK number.
+ *
+ * The effect was that any student with an existing schedule read as
+ * over-scheduled and was silently skipped: observed in the sim district as
+ * "All students are fully scheduled!" while ten students each sat one session
+ * short with an unscheduled row waiting. Prod had 12,268 dated instances
+ * against 559 scheduled templates — a 23x overcount.
+ *
+ * These tests pin the filters on that query, because the bug WAS the missing
+ * filter, and pin the behaviour they produce: a student whose instances
+ * outnumber their weekly requirement must still be scheduled.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+/** Records every filter applied to a `schedule_sessions` read. */
+type Recorded = { table: string; filters: Array<[string, unknown, unknown?]> };
+const reads: Recorded[] = [];
+
+/** Rows a permissive (unfiltered) query would return, keyed by what it asks for. */
+let sessionRows: Array<Record<string, unknown>> = [];
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => {
+    const makeChain = (table: string) => {
+      const record: Recorded = { table, filters: [] };
+      const chain: any = {};
+      // Every filter link records itself and returns the chain; awaiting the
+      // chain resolves to the rows the test staged, filtered as the real
+      // PostgREST call would filter them.
+      for (const op of ['select', 'in', 'eq', 'is', 'not', 'order']) {
+        chain[op] = (...args: unknown[]) => {
+          if (op !== 'select' && op !== 'order') {
+            record.filters.push(args as [string, unknown, unknown?]);
+          }
+          return chain;
+        };
+      }
+      chain.then = (resolve: (v: unknown) => unknown) => {
+        reads.push(record);
+        let rows = table === 'schedule_sessions' ? sessionRows : [];
+        // Apply the equality/null filters the component asked for, so the test
+        // measures the query's real selectivity rather than trusting it.
+        for (const [column, value] of record.filters) {
+          if (column === 'is_template' && value === true) {
+            rows = rows.filter(r => r.is_template === true);
+          }
+          if (column === 'deleted_at' && value === null) {
+            rows = rows.filter(r => r.deleted_at == null);
+          }
+        }
+        return Promise.resolve(resolve({ data: rows, error: null }));
+      };
+      return chain;
+    };
+
+    return {
+      auth: { getUser: async () => ({ data: { user: { id: 'provider-1' } } }) },
+      from: (table: string) => {
+        if (table === 'students') {
+          const chain: any = {};
+          for (const op of ['select', 'eq', 'in', 'is', 'not']) chain[op] = () => chain;
+          chain.then = (resolve: (v: unknown) => unknown) =>
+            Promise.resolve(resolve({ data: STUDENTS, error: null }));
+          return chain;
+        }
+        return makeChain(table);
+      },
+    };
+  },
+}));
+
+const scheduleBatchStudents = jest.fn(async () => ({
+  totalScheduled: 0,
+  totalFailed: 0,
+  errors: [],
+  unplacedStudents: [],
+  canManuallyPlace: false,
+}));
+
+jest.mock('@/lib/supabase/hooks/use-auto-schedule', () => ({
+  useAutoSchedule: () => ({ scheduleBatchStudents, placeSessionsManually: jest.fn() }),
+}));
+
+jest.mock('@/app/components/schedule/undo-schedule', () => ({
+  saveScheduleSnapshot: jest.fn(),
+  saveScheduledSessionIds: jest.fn(),
+  UndoSchedule: () => null,
+}));
+
+const STUDENTS = [
+  {
+    id: 'student-1',
+    initials: 'AB',
+    grade_level: '3',
+    school_site: 'Willow',
+    school_district: 'JSUSD',
+    sessions_per_week: 2,
+    minutes_per_session: 30,
+  },
+];
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ScheduleSessions } = require('@/app/components/schedule/schedule-sessions');
+
+/** One scheduled template plus a pile of dated instances from that template. */
+function stageRows({ templates, instances }: { templates: number; instances: number }) {
+  sessionRows = [
+    ...Array.from({ length: templates }, (_, i) => ({
+      id: `t${i}`,
+      student_id: 'student-1',
+      is_template: true,
+      deleted_at: null,
+    })),
+    ...Array.from({ length: instances }, (_, i) => ({
+      id: `i${i}`,
+      student_id: 'student-1',
+      is_template: false,
+      deleted_at: null,
+    })),
+  ];
+}
+
+async function runAutoSchedule() {
+  render(
+    <ScheduleSessions
+      currentSchool={{ school_site: 'Willow', school_district: 'JSUSD' }}
+      unscheduledCount={1}
+      unscheduledPanelCount={1}
+    />
+  );
+  fireEvent.click(screen.getByRole('button', { name: /Auto-Schedule Sessions/i }));
+  fireEvent.click(await screen.findByRole('button', { name: /^Schedule Sessions$/i }));
+  await waitFor(() => expect(reads.length).toBeGreaterThan(0));
+}
+
+beforeEach(() => {
+  reads.length = 0;
+  scheduleBatchStudents.mockClear();
+  jest.spyOn(window, 'alert').mockImplementation(() => {});
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('Auto-Schedule session counting (SPE-474)', () => {
+  it('counts only live recurring templates, never dated instances', async () => {
+    stageRows({ templates: 1, instances: 24 });
+    await runAutoSchedule();
+
+    const read = reads.find(r => r.table === 'schedule_sessions');
+    expect(read).toBeDefined();
+    const columns = read!.filters.map(([column]) => column);
+    // The two filters whose absence caused the bug.
+    expect(columns).toContain('is_template');
+    expect(columns).toContain('deleted_at');
+  });
+
+  it('still schedules a student whose dated instances outnumber their weekly requirement', async () => {
+    // 1 scheduled template + 24 instances against sessions_per_week = 2.
+    // Counting instances made this read as 25 >= 2, so the student was skipped.
+    stageRows({ templates: 1, instances: 24 });
+    await runAutoSchedule();
+
+    await waitFor(() => expect(scheduleBatchStudents).toHaveBeenCalled());
+    const [batch] = scheduleBatchStudents.mock.calls[0] as unknown as [Array<{ id: string }>];
+    expect(batch.map(s => s.id)).toEqual(['student-1']);
+  });
+
+  it('leaves a genuinely fully-scheduled student alone', async () => {
+    // Two scheduled templates against sessions_per_week = 2: nothing to do.
+    // Guards the opposite failure — a filter so loose everyone looks unscheduled.
+    stageRows({ templates: 2, instances: 24 });
+    await runAutoSchedule();
+
+    await waitFor(() => expect(window.alert).toHaveBeenCalled());
+    expect(scheduleBatchStudents).not.toHaveBeenCalled();
+    expect((window.alert as jest.Mock).mock.calls[0][0]).toMatch(/fully scheduled/i);
+  });
+
+  it('does not count a soft-deleted template as scheduled time', async () => {
+    sessionRows = [
+      { id: 't0', student_id: 'student-1', is_template: true, deleted_at: null },
+      { id: 't1', student_id: 'student-1', is_template: true, deleted_at: '2026-01-01' },
+    ];
+    await runAutoSchedule();
+
+    await waitFor(() => expect(scheduleBatchStudents).toHaveBeenCalled());
+    const [batch] = scheduleBatchStudents.mock.calls[0] as unknown as [Array<{ id: string }>];
+    expect(batch.map(s => s.id)).toEqual(['student-1']);
+  });
+});

--- a/__tests__/unit/components/schedule/auto-schedule-session-count.test.tsx
+++ b/__tests__/unit/components/schedule/auto-schedule-session-count.test.tsx
@@ -49,14 +49,21 @@ jest.mock('@/lib/supabase/client', () => ({
       chain.then = (resolve: (v: unknown) => unknown) => {
         reads.push(record);
         let rows = table === 'schedule_sessions' ? sessionRows : [];
-        // Apply the equality/null filters the component asked for, so the test
-        // measures the query's real selectivity rather than trusting it.
-        for (const [column, value] of record.filters) {
+        // Apply every filter the component asked for, so the test measures the
+        // query's real selectivity rather than trusting it. Honouring the
+        // `.not(col,'is',null)` links matters as much as the equality ones:
+        // without them, dropping the day_of_week filter would let unscheduled
+        // placeholder rows count as scheduled and no test would notice.
+        for (const filter of record.filters) {
+          const [column, value, extra] = filter as [string, unknown, unknown];
           if (column === 'is_template' && value === true) {
             rows = rows.filter(r => r.is_template === true);
-          }
-          if (column === 'deleted_at' && value === null) {
-            rows = rows.filter(r => r.deleted_at == null);
+          } else if (value === null && extra === undefined) {
+            // .is(column, null)
+            rows = rows.filter(r => r[column] == null);
+          } else if (value === 'is' && extra === null) {
+            // .not(column, 'is', null)
+            rows = rows.filter(r => r[column] != null);
           }
         }
         return Promise.resolve(resolve({ data: rows, error: null }));
@@ -113,21 +120,40 @@ const STUDENTS = [
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { ScheduleSessions } = require('@/app/components/schedule/schedule-sessions');
 
-/** One scheduled template plus a pile of dated instances from that template. */
-function stageRows({ templates, instances }: { templates: number; instances: number }) {
+/** A row shaped like a real one: scheduled rows carry day/time, unscheduled don't. */
+function row(over: Record<string, unknown>) {
+  return {
+    student_id: 'student-1',
+    is_template: true,
+    deleted_at: null,
+    day_of_week: 1,
+    start_time: '09:00:00',
+    end_time: '09:30:00',
+    ...over,
+  };
+}
+
+/** Scheduled templates plus a pile of dated instances from those templates. */
+function stageRows({
+  templates,
+  instances,
+  unscheduled = 0,
+}: {
+  templates: number;
+  instances: number;
+  unscheduled?: number;
+}) {
   sessionRows = [
-    ...Array.from({ length: templates }, (_, i) => ({
-      id: `t${i}`,
-      student_id: 'student-1',
-      is_template: true,
-      deleted_at: null,
-    })),
-    ...Array.from({ length: instances }, (_, i) => ({
-      id: `i${i}`,
-      student_id: 'student-1',
-      is_template: false,
-      deleted_at: null,
-    })),
+    ...Array.from({ length: templates }, (_, i) => row({ id: `t${i}` })),
+    // Instances differ from their template only by is_template + session_date.
+    ...Array.from({ length: instances }, (_, i) =>
+      row({ id: `i${i}`, is_template: false, session_date: '2026-08-12' })
+    ),
+    // Unscheduled placeholders: templates with no day or time yet. These are
+    // exactly what the run exists to place, so they must never count.
+    ...Array.from({ length: unscheduled }, (_, i) =>
+      row({ id: `u${i}`, day_of_week: null, start_time: null, end_time: null })
+    ),
   ];
 }
 
@@ -187,11 +213,21 @@ describe('Auto-Schedule session counting (SPE-474)', () => {
     expect((window.alert as jest.Mock).mock.calls[0][0]).toMatch(/fully scheduled/i);
   });
 
+  it('does not count an unscheduled placeholder as already scheduled', async () => {
+    // 1 scheduled template + 1 unscheduled placeholder against
+    // sessions_per_week = 2. Counting the placeholder would read as 2 >= 2 and
+    // skip the student — the same "All students are fully scheduled!" symptom,
+    // from the opposite direction.
+    stageRows({ templates: 1, instances: 0, unscheduled: 1 });
+    await runAutoSchedule();
+
+    await waitFor(() => expect(scheduleBatchStudents).toHaveBeenCalled());
+    const [batch] = scheduleBatchStudents.mock.calls[0] as unknown as [Array<{ id: string }>];
+    expect(batch.map(s => s.id)).toEqual(['student-1']);
+  });
+
   it('does not count a soft-deleted template as scheduled time', async () => {
-    sessionRows = [
-      { id: 't0', student_id: 'student-1', is_template: true, deleted_at: null },
-      { id: 't1', student_id: 'student-1', is_template: true, deleted_at: '2026-01-01' },
-    ];
+    sessionRows = [row({ id: 't0' }), row({ id: 't1', deleted_at: '2026-01-01' })];
     await runAutoSchedule();
 
     await waitFor(() => expect(scheduleBatchStudents).toHaveBeenCalled());

--- a/__tests__/unit/lib/scheduling/scheduler-template-only-context.test.ts
+++ b/__tests__/unit/lib/scheduling/scheduler-template-only-context.test.ts
@@ -1,0 +1,137 @@
+// Aliased with a `mock` prefix so the jest.mock factory (hoisted above imports by
+// babel-plugin-jest-hoist) may reference it.
+import { createMockSupabaseClient as mockCreateSupabaseClient } from '@/test-utils/supabase-test-helpers';
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockCreateSupabaseClient(),
+}));
+
+import { OptimizedScheduler } from '@/lib/scheduling/optimized-scheduler';
+
+/**
+ * SPE-474: the scheduler's weekly grid was being built from dated instances as
+ * well as templates.
+ *
+ * `SchedulingDataManager.fetchExistingSessions` does `select('*')` with no
+ * `is_template` filter, and an instance carries day_of_week/start_time/end_time
+ * exactly like the template it came from. With instances materialized to a
+ * rolling 12-week horizon (SPE-291), every weekly session appeared in the grid
+ * a dozen times over. Two consequences, both pinned here:
+ *
+ *   - `scheduleStudent` derives `sessionsNeeded` from
+ *     `sessions_per_week - existingSessionsForStudent`, which hit 0 for anyone
+ *     with instances. It then placed nothing and reported SUCCESS, because
+ *     `scheduledSessions.length === sessionsNeeded` holds at 0 === 0. Fixing
+ *     only the component's gate (SPE-474's first half) would have promoted the
+ *     silent skip into a silent false success.
+ *   - `buildValidSlotsMap` subtracts overlapping sessions from a capacity of 8,
+ *     so one weekly session backed by twelve instances drove the slot negative
+ *     and dropped it from the grid — a nearly-empty calendar presenting as full
+ *     (the shape reported in SPE-273).
+ */
+
+const WEEKLY = {
+  student_id: 'student-1',
+  provider_id: 'provider-1',
+  assigned_to_sea_id: null,
+  assigned_to_specialist_id: null,
+  day_of_week: 1,
+  start_time: '09:00:00',
+  end_time: '09:30:00',
+  is_template: true,
+  deleted_at: null,
+  session_date: null,
+};
+
+/** The dated copies the top-up cron materializes from that weekly template. */
+const instancesOf = (template: typeof WEEKLY, count: number) =>
+  Array.from({ length: count }, (_, i) => ({
+    ...template,
+    id: `i${i}`,
+    is_template: false,
+    session_date: `2026-08-${String(10 + i).padStart(2, '0')}`,
+  }));
+
+async function contextFrom(sessions: Array<Record<string, unknown>>) {
+  const scheduler = new OptimizedScheduler('provider-1', 'resource', false, false) as any;
+  scheduler.dataManager = {
+    isInitializedForSchool: () => true,
+    initialize: async () => undefined,
+    getProviderWorkDays: () => [1, 2, 3, 4, 5],
+    getExistingSessions: () => sessions,
+    getCrossProviderSessions: () => new Map(),
+    getBellScheduleConflicts: () => [],
+    getMetrics: () => ({ cacheHits: 0, cacheMisses: 0 }),
+  };
+  await scheduler.initializeContext('Willow', 'JSUSD');
+  return scheduler;
+}
+
+const student = {
+  id: 'student-1',
+  initials: 'AB',
+  grade_level: '3',
+  sessions_per_week: 2,
+  minutes_per_session: 30,
+};
+
+describe('scheduler context excludes dated instances (SPE-474)', () => {
+  it('keeps the weekly template and drops its dated instances', async () => {
+    const scheduler = await contextFrom([
+      { ...WEEKLY, id: 't0' },
+      ...instancesOf(WEEKLY, 12),
+    ]);
+    expect(scheduler.context.existingSessions).toHaveLength(1);
+    expect(scheduler.context.existingSessions[0].id).toBe('t0');
+  });
+
+  it('drops soft-deleted templates too', async () => {
+    const scheduler = await contextFrom([
+      { ...WEEKLY, id: 't0' },
+      { ...WEEKLY, id: 't1', deleted_at: '2026-01-01' },
+    ]);
+    expect(scheduler.context.existingSessions.map((s: any) => s.id)).toEqual(['t0']);
+  });
+
+  it('still needs the remaining sessions rather than reporting a hollow success', async () => {
+    // 1 weekly template + 12 instances against sessions_per_week = 2. Counting
+    // the instances gave sessionsNeeded = max(0, 2 - 13) = 0: nothing placed,
+    // success reported, provider told it worked.
+    const scheduler = await contextFrom([
+      { ...WEEKLY, id: 't0' },
+      ...instancesOf(WEEKLY, 12),
+    ]);
+    const result = scheduler.scheduleStudent(student);
+
+    expect(result.scheduledSessions.length).toBeGreaterThan(0);
+    expect(result.success).toBe(true);
+  });
+
+  it('does not report success for a student it placed nothing for', async () => {
+    // The failure mode in its own right: success must mean sessions were written.
+    const scheduler = await contextFrom([
+      { ...WEEKLY, id: 't0' },
+      ...instancesOf(WEEKLY, 12),
+    ]);
+    const result = scheduler.scheduleStudent(student);
+    if (result.scheduledSessions.length === 0) {
+      expect(result.success).toBe(false);
+    }
+  });
+
+  it('leaves the weekly grid intact instead of exhausting slot capacity', async () => {
+    // 12 instances at Monday 09:00 used to subtract 12 from a capacity of 8,
+    // taking the slot negative so it was excluded from validSlots entirely.
+    const withInstances = await contextFrom([
+      { ...WEEKLY, id: 't0' },
+      ...instancesOf(WEEKLY, 12),
+    ]);
+    const templateOnly = await contextFrom([{ ...WEEKLY, id: 't0' }]);
+
+    expect(withInstances.context.validSlots.size).toBe(templateOnly.context.validSlots.size);
+    // And the Monday 09:00 slot itself survives, with one session against it.
+    const slot = withInstances.context.validSlots.get('1-09:00');
+    expect(slot).toBeDefined();
+    expect(slot.capacity).toBe(7);
+  });
+});

--- a/app/components/schedule/schedule-sessions.tsx
+++ b/app/components/schedule/schedule-sessions.tsx
@@ -122,13 +122,26 @@ export function ScheduleSessions({ onComplete, currentSchool, unscheduledCount, 
       // Get student IDs for this school to filter sessions
       const studentIds = studentsForCurrentSchool.map(s => s.id);
 
-      // Get existing SCHEDULED sessions to determine which students need scheduling
-      // IMPORTANT: Only count sessions that are already scheduled (day_of_week IS NOT NULL)
-      // Unscheduled sessions (day_of_week IS NULL) don't count as "scheduled"
+      // Get existing SCHEDULED sessions to determine which students need scheduling.
+      //
+      // Two filters carry the weight here (SPE-474):
+      //   - is_template: `schedule_sessions` holds the recurring templates AND
+      //     the dated instances materialized to a rolling 12-week horizon
+      //     (SPE-291), and instances carry day_of_week/start_time/end_time too.
+      //     Without this, up to twelve weeks of instances were counted against a
+      //     PER-WEEK number, so any student with an existing schedule read as
+      //     over-scheduled and was silently skipped — 12,268 instances vs 559
+      //     scheduled templates in prod when this was found.
+      //   - deleted_at: a soft-deleted session is not scheduled time.
+      //
+      // Only day_of_week IS NOT NULL counts as scheduled; unscheduled templates
+      // (day_of_week IS NULL) are precisely the ones this run is here to place.
       const { data: existingSessions } = await supabase
         .from('schedule_sessions')
-        .select('*')
+        .select('student_id')
         .in('student_id', studentIds)
+        .eq('is_template', true)
+        .is('deleted_at', null)
         .not('day_of_week', 'is', null)
         .not('start_time', 'is', null)
         .not('end_time', 'is', null);

--- a/lib/scheduling/optimized-scheduler.ts
+++ b/lib/scheduling/optimized-scheduler.ts
@@ -216,7 +216,27 @@ export class OptimizedScheduler {
     const workDays = this.dataManager.getProviderWorkDays(schoolSite);
 
     // Get all existing sessions (filter to only scheduled sessions with non-null day/time fields)
-    const existingSessions = filterScheduledSessions(this.dataManager.getExistingSessions());
+    //
+    // SPE-474: also drop dated instances and soft-deleted rows. The data manager
+    // fetches `select('*')` with no such filter, and an instance carries
+    // day_of_week/start_time/end_time exactly like its template, so the weekly
+    // grid was seeing up to twelve weeks of copies of every session. Two things
+    // broke on that:
+    //
+    //   - `scheduleStudent` derives `sessionsNeeded` as
+    //     `sessions_per_week - existingSessionsForStudent`, which went to 0 for
+    //     anyone with instances. It then placed nothing and reported success,
+    //     because `scheduledSessions.length === sessionsNeeded` held at 0 === 0.
+    //   - `buildValidSlotsMap` subtracts overlapping sessions from a capacity of
+    //     8, so one weekly session backed by twelve instances drove the slot
+    //     negative and removed it from the grid entirely — a calendar with a
+    //     handful of sessions could present as having no room at all.
+    //
+    // Scoped to the scheduler's own context on purpose: the shared data manager
+    // still serves unfiltered rows to the calendar and conflict paths, which
+    // legitimately work in dated instances.
+    const existingSessions = filterScheduledSessions(this.dataManager.getExistingSessions())
+      .filter(session => session.is_template === true && session.deleted_at == null);
 
     // SPE-287: cross-provider sessions for shared students (loaded once by the DataManager).
     // Snapshot per run (mirrors the existingSessions copy) so a concurrent DataManager

--- a/lib/scheduling/scheduling-data-manager.ts
+++ b/lib/scheduling/scheduling-data-manager.ts
@@ -444,6 +444,20 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
 
     const studentIds = students?.map(s => s.id) || [];
 
+    // SPE-474: the 10,000-row cap below has no ORDER BY, so which rows survive
+    // truncation is arbitrary — and dated instances outnumber templates roughly
+    // 40:1 (the largest provider in prod carries 203 templates against 7,868
+    // instances, 8,071 rows against a 10,000 cap). Once a provider crosses it,
+    // arbitrary truncation could drop the recurring templates while keeping
+    // their instances, and the auto-scheduler would then read a student as
+    // having FEWER weekly sessions than they do and create duplicates.
+    //
+    // Ordering templates first makes truncation deterministic and drops
+    // instances rather than templates. It does not shrink what any caller
+    // receives — same cap, same rows below it. The cap itself still needs
+    // raising or paginating (SPE-477).
+    const TEMPLATES_FIRST = { column: 'is_template', options: { ascending: false } } as const;
+
     // For specialist users, also fetch sessions assigned to them (even from other providers' students)
     let sessionsResult;
     if (this.providerRole && ['resource', 'speech', 'ot', 'counseling', 'specialist', 'intervention'].includes(this.providerRole)) {
@@ -456,6 +470,7 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
           .from('schedule_sessions')
           .select('*')
           .or(`student_id.in.(${studentIds.join(',')}),assigned_to_specialist_id.eq.${this.providerId}`)
+          .order(TEMPLATES_FIRST.column, TEMPLATES_FIRST.options)
           .limit(10000);
       } else {
         // No students, only fetch assigned sessions
@@ -463,6 +478,7 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
           .from('schedule_sessions')
           .select('*')
           .eq('assigned_to_specialist_id', this.providerId!)
+          .order(TEMPLATES_FIRST.column, TEMPLATES_FIRST.options)
           .limit(10000);
       }
 
@@ -511,6 +527,7 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
         .select('*')
         .eq('provider_id', this.providerId!)
         .in('student_id', studentIds)
+        .order(TEMPLATES_FIRST.column, TEMPLATES_FIRST.options)
         .limit(10000);
     }
 


### PR DESCRIPTION
Auto-Schedule was silently skipping almost every student who already had a schedule. This is very likely the largest single reason it "isn't very effective" — found during the SPE-473 sim run, fixed here.

## The bug

`schedule_sessions` holds both the recurring **templates** and the **dated instances** materialized to a rolling 12-week horizon (SPE-291). An instance carries `day_of_week` / `start_time` / `end_time` exactly like its template, and two places counted them as if they were weekly sessions.

**1. The gate** (`schedule-sessions.tsx`) decided who needs scheduling by counting scheduled sessions against `sessions_per_week`, with no `is_template` filter. A count of up to twelve weeks of instances against a *per-week* number is essentially never below it, so those students were filtered out. In prod the query counted **12,827** rows where it should have counted **559** — a 23× overcount.

**2. The scheduler itself** recomputes the same thing from `context.existingSessions`, which comes from the data manager's `select('*')` — also unfiltered, and `filterScheduledSessions` only checks day/time, which an instance has. This is the half that makes fixing the gate alone actively worse: the student now passes the gate, gets `sessionsNeeded = max(0, 2 - 13) = 0`, places nothing, and reports **success**, because `scheduledSessions.length === sessionsNeeded` holds at `0 === 0`. "All students are fully scheduled!" would have become "Successfully scheduled N students!" with nothing written.

The same polluted list feeds `buildValidSlotsMap`, which subtracts overlapping sessions from a capacity of 8 — so one weekly session backed by twelve instances drives the slot negative and removes it from the grid entirely. **That is the shape reported in [SPE-273](https://linear.app/speddy/issue/SPE-273): a nearly-empty calendar presenting as having no room.**

## The fix

Both sites now count live recurring templates only (`is_template = true`, `deleted_at IS NULL`). Scoped to the scheduler's own `getDataFromManager` rather than the shared data manager, since the calendar and conflict paths legitimately work in dated instances.

Verified in prod data that `is_template` and `session_date IS NULL` agree on every row (12,268 false/dated, 898 true/undated, no ambiguous rows and no NULLs), so `.eq('is_template', true)` cannot silently drop a real template.

The same shape exists in `_reschedule-all.tsx` and `_schedule-new-sessions.tsx`, but both are dead code imported nowhere, so they're left alone rather than half-maintained.

## Verification

Typecheck, lint, and the full suite green (1407 passing; the 3 failing `tests/integration/*` suites need live DB credentials and fail identically on a clean tree).

Ten new tests across both halves, each **mutation-checked** so they can't pass vacuously:

| Removed | Tests that fail |
|---|---|
| `.eq('is_template', true)` from the gate | 2 |
| `.is('deleted_at', null)` from the gate | 2 |
| all three `.not(col,'is',null)` from the gate | 1 |
| the scheduler's template filter | 5 |

(The three null-filters are individually redundant — an unscheduled placeholder has all three null — so only removing them together changes behavior.)

**Sim district, real signed-in session** (`rsp.willow`), reproducing the original failure:

- Five students each one session short, all with instances — the exact set skipped before. All five now scheduled: `scheduled_templates == sessions_per_week`, **zero** unscheduled rows left.
- Students `ZL` (13 instances) and `LY` (4 instances) — previously invisible to Auto-Schedule — were picked up and scheduled, with no conflict flags.
- Run reported 6 students where the pre-fix run reported 1.
- Fixture torn down, `sim:verify --expect-empty` all zeros, re-seeded green.

## Found along the way — filed, not fixed here

[SPE-476](https://linear.app/speddy/issue/SPE-476): editing a student's sessions/week flags every one of their dated instances as "Overlaps with another session for this student" — `detectSessionConflicts` compares instances against their own parent template. Same family of bug, different path (requirement sync, not the scheduler). Isolated during this run: auto-scheduled students with instances came out clean; only the edited cohort was flagged.

Closes SPE-474.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQdotbcQEfBNAgp1NFRQek)_