### PR TITLE
Conflict detection: compare sessions within their own layer (SPE-476)

### DIFF
--- a/__tests__/unit/lib/scheduling/session-conflict-layers.test.ts
+++ b/__tests__/unit/lib/scheduling/session-conflict-layers.test.ts
@@ -90,20 +90,27 @@ jest.mock('@/lib/supabase/client', () => ({
   },
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { updateExistingSessionsForStudent } = require('@/lib/scheduling/session-requirement-sync');
 
 /**
  * Runs the sync with unchanged requirements, which skips the duration and count
  * steps and exercises conflict detection on its own.
+ *
+ * Asserts the run actually succeeded before returning. `updateExistingSessionsForStudent`
+ * swallows every error into `{ success: false }`, so without this a broken
+ * fixture would leave `flagged` empty and every "must not flag" case below would
+ * pass for the wrong reason — the exact failure these tests exist to catch.
  */
 async function detectConflicts() {
   flagged = [];
-  await updateExistingSessionsForStudent(
+  const result = await updateExistingSessionsForStudent(
     'student-1',
     { minutes_per_session: 30, sessions_per_week: 2 },
     { minutes_per_session: 30, sessions_per_week: 2 }
   );
+  expect(result).toMatchObject({ success: true });
+  // Detection genuinely ran and agrees with what was written.
+  expect(result.conflictCount).toBe(flagged.length);
   return flagged;
 }
 

--- a/__tests__/unit/lib/scheduling/session-conflict-layers.test.ts
+++ b/__tests__/unit/lib/scheduling/session-conflict-layers.test.ts
@@ -1,0 +1,207 @@
+/**
+ * SPE-476: `detectSessionConflicts` compared every one of a student's sessions
+ * against every other by weekday alone, with no template/instance distinction.
+ *
+ * A dated instance is generated from its template and shares its weekday and
+ * time by construction, so each instance was reported as overlapping its own
+ * parent. Since `updateStudent` runs this whenever `sessions_per_week` or
+ * `minutes_per_session` changes, simply editing a student's service minutes
+ * conflict-flagged their entire materialized schedule. In prod, 144 of the 145
+ * flags were that false positive — against exactly one real double-booking.
+ *
+ * The rule is that the two layers are not comparable: templates are compared
+ * against templates on the same weekday, instances against instances on the
+ * same date. These tests pin both directions — no false positive across the
+ * layers, and genuine double-bookings within a layer still caught.
+ */
+
+type Row = {
+  id: string;
+  student_id: string;
+  provider_id: string | null;
+  service_type: string | null;
+  day_of_week: number | null;
+  start_time: string | null;
+  end_time: string | null;
+  session_date: string | null;
+  is_template: boolean;
+  deleted_at: string | null;
+  status: string;
+  is_completed: boolean;
+};
+
+/** Sessions the mocked database returns for the student. */
+let rows: Row[] = [];
+/** Every id passed to markConflictingSessions, with its reason. */
+let flagged: Array<{ id: string; reason: string }> = [];
+
+function template(id: string, day: number, start: string, end: string): Row {
+  return {
+    id,
+    student_id: 'student-1',
+    provider_id: 'provider-1',
+    service_type: 'resource',
+    day_of_week: day,
+    start_time: start,
+    end_time: end,
+    session_date: null,
+    is_template: true,
+    deleted_at: null,
+    status: 'active',
+    is_completed: false,
+  };
+}
+
+/** A dated occurrence of a template: same weekday and time, a concrete date. */
+function instance(id: string, date: string, day: number, start: string, end: string): Row {
+  return { ...template(id, day, start, end), id, session_date: date, is_template: false };
+}
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => {
+    const chain = (): any => {
+      const state: { update?: Record<string, unknown>; id?: string } = {};
+      const self: any = {
+        select: () => self,
+        eq: (column: string, value: string) => {
+          if (column === 'id') state.id = value;
+          return self;
+        },
+        is: () => self,
+        neq: () => self,
+        order: () => self,
+        update: (payload: Record<string, unknown>) => {
+          state.update = payload;
+          return self;
+        },
+        insert: () => self,
+        delete: () => self,
+        single: async () => ({ data: null, error: null }),
+        then: (resolve: (v: unknown) => unknown) => {
+          if (state.update && state.id && state.update.has_conflict === true) {
+            flagged.push({ id: state.id, reason: String(state.update.conflict_reason) });
+          }
+          return Promise.resolve(resolve({ data: rows, error: null }));
+        },
+      };
+      return self;
+    };
+    return { from: () => chain() };
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { updateExistingSessionsForStudent } = require('@/lib/scheduling/session-requirement-sync');
+
+/**
+ * Runs the sync with unchanged requirements, which skips the duration and count
+ * steps and exercises conflict detection on its own.
+ */
+async function detectConflicts() {
+  flagged = [];
+  await updateExistingSessionsForStudent(
+    'student-1',
+    { minutes_per_session: 30, sessions_per_week: 2 },
+    { minutes_per_session: 30, sessions_per_week: 2 }
+  );
+  return flagged;
+}
+
+const flaggedIds = (f: Array<{ id: string }>) => f.map(x => x.id).sort();
+
+describe('session conflict detection respects the template/instance layers (SPE-476)', () => {
+  it('does not flag an instance for overlapping its own template', async () => {
+    // The exact prod shape: one Tuesday template and the dates generated from it.
+    rows = [
+      template('t1', 2, '10:30:00', '11:00:00'),
+      instance('i1', '2026-08-04', 2, '10:30:00', '11:00:00'),
+      instance('i2', '2026-08-11', 2, '10:30:00', '11:00:00'),
+      instance('i3', '2026-08-18', 2, '10:30:00', '11:00:00'),
+    ];
+    expect(await detectConflicts()).toEqual([]);
+  });
+
+  it('does not flag instances of two different templates on the same weekday', async () => {
+    // Same weekday, non-overlapping times: legitimate, and their instances
+    // inherit the same non-overlap. A weekday-only comparison saw four sessions
+    // on Tuesday and flagged the lot.
+    rows = [
+      template('t1', 2, '09:00:00', '09:30:00'),
+      template('t2', 2, '10:00:00', '10:30:00'),
+      instance('i1', '2026-08-04', 2, '09:00:00', '09:30:00'),
+      instance('i2', '2026-08-04', 2, '10:00:00', '10:30:00'),
+    ];
+    expect(await detectConflicts()).toEqual([]);
+  });
+
+  it('does not flag instances on different dates that share a weekday and time', async () => {
+    // Every Tuesday at 09:00 across a term is one weekly session, not a pile-up.
+    rows = [
+      instance('i1', '2026-08-04', 2, '09:00:00', '09:30:00'),
+      instance('i2', '2026-08-11', 2, '09:00:00', '09:30:00'),
+      instance('i3', '2026-08-18', 2, '09:00:00', '09:30:00'),
+    ];
+    expect(await detectConflicts()).toEqual([]);
+  });
+
+  it('still flags two templates that genuinely overlap on the same weekday', async () => {
+    // The one real double-booking in prod had exactly this shape.
+    rows = [
+      template('t1', 2, '08:00:00', '08:30:00'),
+      template('t2', 2, '08:10:00', '08:40:00'),
+    ];
+    expect(flaggedIds(await detectConflicts())).toEqual(['t1', 't2']);
+  });
+
+  it('still flags two instances that genuinely overlap on the same date', async () => {
+    rows = [
+      instance('i1', '2026-08-04', 2, '08:00:00', '08:30:00'),
+      instance('i2', '2026-08-04', 2, '08:10:00', '08:40:00'),
+    ];
+    expect(flaggedIds(await detectConflicts())).toEqual(['i1', 'i2']);
+  });
+
+  it('propagates a genuine template overlap to the instances that inherit it', async () => {
+    // A real double-booking should be visible on the dates it actually lands on.
+    rows = [
+      template('t1', 2, '08:00:00', '08:30:00'),
+      template('t2', 2, '08:10:00', '08:40:00'),
+      instance('i1', '2026-08-04', 2, '08:00:00', '08:30:00'),
+      instance('i2', '2026-08-04', 2, '08:10:00', '08:40:00'),
+    ];
+    expect(flaggedIds(await detectConflicts())).toEqual(['i1', 'i2', 't1', 't2']);
+  });
+
+  it('treats back-to-back sessions as adjacent, not overlapping', async () => {
+    rows = [
+      template('t1', 2, '09:00:00', '09:30:00'),
+      template('t2', 2, '09:30:00', '10:00:00'),
+    ];
+    expect(await detectConflicts()).toEqual([]);
+  });
+
+  it('keeps templates on different weekdays independent', async () => {
+    rows = [
+      template('t1', 1, '09:00:00', '09:30:00'),
+      template('t2', 2, '09:00:00', '09:30:00'),
+    ];
+    expect(await detectConflicts()).toEqual([]);
+  });
+
+  it('ignores unscheduled placeholders, which have no day or time yet', async () => {
+    rows = [
+      template('t1', 2, '09:00:00', '09:30:00'),
+      { ...template('u1', 2, '09:00:00', '09:30:00'), day_of_week: null, start_time: null, end_time: null },
+    ];
+    expect(await detectConflicts()).toEqual([]);
+  });
+
+  it('reports the overlap reason providers see', async () => {
+    rows = [
+      template('t1', 2, '08:00:00', '08:30:00'),
+      template('t2', 2, '08:10:00', '08:40:00'),
+    ];
+    const result = await detectConflicts();
+    expect(result[0].reason).toMatch(/Overlaps with another session for this student/);
+  });
+});

--- a/lib/scheduling/session-requirement-sync.ts
+++ b/lib/scheduling/session-requirement-sync.ts
@@ -403,6 +403,40 @@ async function adjustSessionCount(
 }
 
 /**
+ * The set a session may be compared against when looking for overlaps (SPE-476).
+ *
+ * Sessions live in two layers and the layers are not comparable:
+ *   - a **template** (`session_date IS NULL`) describes a weekly pattern, so it
+ *     is compared against other templates on the same weekday;
+ *   - a **dated instance** is one concrete occurrence, so it is compared against
+ *     other instances on that same date.
+ *
+ * Comparing across the layers is what produced the bug this key exists to stop:
+ * an instance is generated from its template and therefore shares its weekday
+ * and time by construction, so a weekday-only comparison reported EVERY
+ * instance as overlapping its own parent. Editing a student's service minutes
+ * conflict-flagged their entire materialized schedule — 144 of the 145 flags in
+ * prod when this was found were that false positive, against exactly one real
+ * double-booking.
+ *
+ * Grouping instances by date rather than weekday keeps genuine instance-level
+ * double-bookings detectable: two occurrences on the same date share a date,
+ * and by definition a weekday too.
+ *
+ * `session_date IS NULL` is the template test used throughout this file
+ * (see `adjustSessionCount` and the template count in the caller); it agrees
+ * with `is_template` on every row in prod.
+ */
+function overlapComparisonKey(session: {
+  session_date?: string | null;
+  day_of_week?: number | null;
+}): string {
+  return session.session_date == null
+    ? `template:${session.day_of_week}`
+    : `date:${session.session_date}`;
+}
+
+/**
  * Detects conflicts in sessions after updates
  */
 async function detectSessionConflicts(
@@ -442,10 +476,13 @@ async function detectSessionConflicts(
       conflicts.push('Session extends beyond 5:00 PM');
     }
 
-    // Conflict 2: Overlaps with another session for the same student
+    // Conflict 2: Overlaps with another session for the same student.
+    // Only within the same layer — a template against templates on its weekday,
+    // an instance against instances on its date. See overlapComparisonKey.
+    const sessionKey = overlapComparisonKey(session);
     const overlappingSessions = sessions.filter(other =>
       other.id !== session.id &&
-      other.day_of_week === session.day_of_week &&
+      overlapComparisonKey(other) === sessionKey &&
       other.start_time && other.end_time && // Ensure other session is scheduled
       timesOverlap(session.start_time!, session.end_time!, other.start_time, other.end_time)
     );


### PR DESCRIPTION
Editing a student's service minutes conflict-flagged their entire materialized schedule. Third and last site of the template/instance confusion behind SPE-474 and SPE-473.

## The bug

`detectSessionConflicts` compared every one of a student's sessions against every other **by weekday alone**:

```ts
const overlappingSessions = sessions.filter(other =>
  other.id !== session.id &&
  other.day_of_week === session.day_of_week &&
  ...
);
```

A dated instance is generated from its template and shares its weekday and time by construction, so every instance was reported as overlapping its own parent. `updateStudent` runs this whenever `sessions_per_week` or `minutes_per_session` changes — so simply editing a student's minutes painted `has_conflict` across their whole schedule.

**Prod today: 145 flags, of which 144 are this false positive.** The single genuine one is a student with two Tuesday templates at 08:00–08:30 and 08:10–08:40, faithfully reproduced across all 39 of their materialized Tuesdays.

## The fix

Sessions now only compare within their own layer:

- a **template** (`session_date IS NULL`) against templates on the same **weekday**;
- a dated **instance** against instances on the same **date**.

Grouping instances by date rather than weekday is what keeps genuine instance-level double-bookings detectable — two occurrences on one date share a date, and by definition a weekday too. So the rule loses nothing: it still catches the real overlap above, at both layers.

`session_date IS NULL` is the template test already used elsewhere in this file (`adjustSessionCount`, and the template count in the caller), and it agrees with `is_template` on every row in prod.

## Verification

Typecheck, lint, and the full suite green (1434 passing; the 3 failing `tests/integration/*` suites need live DB credentials and fail identically on a clean tree).

Ten tests covering both directions — no cross-layer false positive, genuine overlaps still caught at each layer, plus adjacency and unscheduled-placeholder edges. Mutation-checked twice:

- Reverting to the weekday-only comparison fails exactly the three cross-layer tests while the genuine-overlap tests keep passing — the asymmetry the bug actually had.
- Injecting a DB failure fails all 10. Before the self-review it failed only 4: the helper discarded `updateExistingSessionsForStudent`'s result, which swallows errors into `{success: false}`, so the "must not flag" cases would have gone green on a broken fixture. It now asserts success and cross-checks `conflictCount` against what was written.

**Sim district, real signed-in session** (`rsp.willow`), reproducing the original trigger:

- Baseline after reset: 0 flagged instances, 0 flagged templates across all six grades.
- Edited sessions/week for 10 students (grades 2 and 3) through the Students page — the exact action that previously flagged all 38 grade-3 instances.
- Result: **0 flagged instances, 0 flagged templates, 0 `needs_attention`.**
- Positive control that detection actually ran rather than silently no-opping: all 10 students got their new unscheduled template row created with fresh `updated_at`, which is step 3 of the sync completing — so steps 4 (detect) and 5 (mark) executed.
- Fixture torn down, `sim:verify --expect-empty` all zeros, re-seeded green.

## Existing flags in prod

This PR changes detection going forward; it does not backfill the 144 stale flags. They clear on their own by two routes:

- the 27 flagged **templates** — the only ones the schedule grid renders — are re-validated and cleared by `reconcileStaleConflictsForProvider` (SPE-288) on schedule-page load;
- the 118 flagged **instances** clear via `resetSessionsToActive` the next time that student's requirements are edited. Note the reconciler scopes itself to `session_date IS NULL`, so it does not touch them.

So there's no user-visible residue, but a one-off cleanup is available if you'd rather not wait — happy to do it as a separate, explicitly-approved change.

Closes SPE-476.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQdotbcQEfBNAgp1NFRQek)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session conflict detection by comparing recurring sessions by weekday and dated sessions by calendar date.
  * Prevented false conflicts between recurring templates and dated session instances.
  * Continued identifying genuine overlapping sessions while allowing adjacent and unscheduled sessions appropriately.
  * Improved conflict reporting and synchronization accuracy.

* **Tests**
  * Added comprehensive coverage for overlap detection, conflict propagation, and synchronization results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->