### PR TITLE
SDC auto-link: provider accounts ↔ classroom entries, both entry orders (SPE-481)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1136,7 +1136,10 @@ only the accounts THEY create), which left all four Rodeo Hills SDC teachers
 and both JSHS hybrids unlinked until the SPE-481 backfill. Multi-school
 caveat: matching uses the profile's primary school only.
 `sdc_autolink_on_teacher_write` / `sdc_autolink_on_profile_write`
-(20260813_spe481_sdc_auto_link.sql).
+(20260813_spe481_sdc_auto_link.sql; superseded in place by `_v2` — links on
+email/school edits too, one linked row per account — and `_v3` — per-account
+advisory lock serializing concurrent linkers, SPE-141 pattern; read all three
+as one unit).
 
 **RLS**: SELECT = own rows ∪ any school in `get_my_school_ids()` (the
 school-wide breadth is what makes cross-provider protection work) ∪ blocks

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1126,6 +1126,18 @@ pattern). No new role or flag — SPE-358 stays parked. The sim fixture carries
 one such persona (Derek, `rsp.juniper`, `SDC_LINKED_PROVIDERS` in the
 manifest).
 
+**The link creates itself (SPE-481).** Database triggers auto-link the two
+halves in EITHER entry order — a new classroom entry matching a Resource
+Specialist profile, or a new/updated resource profile matching a waiting
+entry — on exact email + same school, `resource` role only, never
+overwriting, only when unambiguous. This exists because nothing else made
+the link for the SDC shape (teacher-login creation and the SIS sync link
+only the accounts THEY create), which left all four Rodeo Hills SDC teachers
+and both JSHS hybrids unlinked until the SPE-481 backfill. Multi-school
+caveat: matching uses the profile's primary school only.
+`sdc_autolink_on_teacher_write` / `sdc_autolink_on_profile_write`
+(20260813_spe481_sdc_auto_link.sql).
+
 **RLS**: SELECT = own rows ∪ any school in `get_my_school_ids()` (the
 school-wide breadth is what makes cross-provider protection work) ∪ blocks
 naming the caller's linked classroom as **destination** (a gen-ed teacher sees

--- a/supabase/migrations/20260813_spe481_sdc_auto_link.sql
+++ b/supabase/migrations/20260813_spe481_sdc_auto_link.sql
@@ -1,0 +1,137 @@
+-- SPE-481: auto-link SDC dual-role accounts — teachers.account_id is the gate
+-- for the mainstreaming features (SPE-478), and nothing created it for the
+-- SDC shape: gen-ed teacher-login creation links automatically, the SIS sync
+-- links accounts it creates, but PROVIDER accounts and classroom-directory
+-- entries arrive through separate flows and stayed unlinked (found in prod:
+-- all four Rodeo Hills SDC teachers had both halves, zero links; the
+-- linkTeacherToProfile query function exists but no UI calls it).
+--
+-- The rule, applied in BOTH entry orders so it can never be missed (owner
+-- decision 2026-08-13):
+--   * classroom entry arrives (admin add / CSV / SIS / any future path) →
+--     link if it exactly matches a Resource Specialist profile;
+--   * provider profile arrives or gains its email/school/role → link any
+--     waiting classroom entry.
+--
+-- Guardrails: exact email match (case-insensitive), same school_id
+-- (primary-school match only for multi-school providers — conservative),
+-- role = 'resource' only (the documented SDC convention, SPE-355; a speech
+-- provider never silently gains the gate), never overwrites an existing
+-- link, and acts only when the match is unambiguous.
+--
+-- Database-level on purpose: a trigger catches every entry path in one
+-- place, in either order, including flows that don't exist yet. Both
+-- functions are SECURITY DEFINER — the deciding read (profiles ↔ teachers)
+-- must not depend on the inserting role's RLS view.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- Order A: classroom entry arrives after (or without) the provider account
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.sdc_autolink_on_teacher_write()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  match_count integer;
+  matched_profile uuid;
+BEGIN
+  IF NEW.account_id IS NOT NULL OR NEW.email IS NULL OR NEW.school_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT count(*), min(p.id::text)::uuid
+    INTO match_count, matched_profile
+  FROM profiles p
+  WHERE lower(p.email) = lower(NEW.email)
+    AND p.school_id = NEW.school_id
+    AND p.role = 'resource';
+
+  IF match_count = 1 THEN
+    NEW.account_id := matched_profile;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.sdc_autolink_on_teacher_write() IS
+  'SPE-481: BEFORE INSERT on teachers — if the new unlinked entry exactly matches one Resource Specialist profile (email + school), link it. The SDC dual-role gate (SPE-478) depends on this link existing.';
+
+CREATE TRIGGER trg_teachers_sdc_autolink
+  BEFORE INSERT ON public.teachers
+  FOR EACH ROW EXECUTE FUNCTION public.sdc_autolink_on_teacher_write();
+
+-- ---------------------------------------------------------------------------
+-- Order B: provider account arrives after the classroom entry — including
+-- creation flows that set school_id in a second step (create-teacher-account
+-- does; provider creation may), hence UPDATE OF the deciding columns.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.sdc_autolink_on_profile_write()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+BEGIN
+  IF NEW.role <> 'resource' OR NEW.email IS NULL OR NEW.school_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  UPDATE public.teachers t
+  SET account_id = NEW.id
+  WHERE t.account_id IS NULL
+    AND t.email IS NOT NULL
+    AND t.school_id = NEW.school_id
+    AND lower(t.email) = lower(NEW.email)
+    -- Ambiguity guard (belt and braces — auth emails are unique): stand down
+    -- if a SECOND resource profile also matches this entry.
+    AND NOT EXISTS (
+      SELECT 1 FROM profiles p2
+      WHERE p2.id <> NEW.id
+        AND p2.role = 'resource'
+        AND p2.school_id = t.school_id
+        AND lower(p2.email) = lower(t.email)
+    );
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.sdc_autolink_on_profile_write() IS
+  'SPE-481: AFTER INSERT/UPDATE on profiles — when a Resource Specialist account appears (or gains its email/school), link any waiting unlinked classroom entry that exactly matches. Mirror of sdc_autolink_on_teacher_write.';
+
+CREATE TRIGGER trg_profiles_sdc_autolink
+  AFTER INSERT OR UPDATE OF email, school_id, role ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION public.sdc_autolink_on_profile_write();
+
+-- ---------------------------------------------------------------------------
+-- One-time backfill: the identical rule over existing data, with the
+-- exactly-one guard enforced on BOTH sides. Previewed read-only before this
+-- migration was applied: six 1:1 matches, all JSUSD (four Rodeo Hills SDC
+-- teachers + the two John Swett High SDC/Resource hybrids), zero ambiguous.
+-- ---------------------------------------------------------------------------
+WITH candidates AS (
+  SELECT t.id AS teacher_row, p.id AS profile_id
+  FROM teachers t
+  JOIN profiles p
+    ON lower(p.email) = lower(t.email)
+   AND p.school_id = t.school_id
+   AND p.role = 'resource'
+  WHERE t.account_id IS NULL
+    AND t.email IS NOT NULL
+    AND t.school_id IS NOT NULL
+),
+unambiguous AS (
+  SELECT c.teacher_row, c.profile_id
+  FROM candidates c
+  WHERE (SELECT count(*) FROM candidates c2 WHERE c2.teacher_row = c.teacher_row) = 1
+    AND (SELECT count(*) FROM candidates c3 WHERE c3.profile_id = c.profile_id) = 1
+)
+UPDATE public.teachers t
+SET account_id = u.profile_id
+FROM unambiguous u
+WHERE t.id = u.teacher_row;
+
+COMMIT;

--- a/supabase/migrations/20260813_spe481_sdc_auto_link_v2.sql
+++ b/supabase/migrations/20260813_spe481_sdc_auto_link_v2.sql
@@ -1,0 +1,109 @@
+-- SPE-481 v2: review fixes on the auto-link triggers (PR #858 — self-review
+-- + Codex, converging on the same two gaps).
+--
+-- 1. EDITS NOW LINK (Codex P1 / self-review #1). The teacher-side trigger
+--    fired on INSERT only, so correcting an entry's email (admin edit flow,
+--    SIS refresh) after the fact never created the link — recreating the
+--    exact invisible-unlinked state SPE-481 exists to kill. Fire on UPDATE
+--    of the deciding columns too.
+--
+-- 2. ONE LINKED ROW PER ACCOUNT (Codex P2 / self-review #2). Directory
+--    duplicates are possible (no unique email per school), and the triggers
+--    enforced the exactly-one guard on only one side: the profile-side
+--    UPDATE could link EVERY matching duplicate in one statement, and the
+--    teacher-side could link a duplicate beside an existing linked row —
+--    double-exposing every `teachers.account_id = auth.uid()` RLS branch
+--    and breaking `.single()` consumers. Both sides now stand down unless
+--    the account has no linked row and the match is one-to-one.
+--
+-- Accepted, documented edge (self-review #3): two truly concurrent inserts
+-- (entry + profile committing in the same instant) can each miss the other
+-- under READ COMMITTED and both land unlinked. The window is milliseconds,
+-- the failure is the pre-SPE-481 status quo (not corruption), and with (1)
+-- widening the repair surface, ANY later edit of either half's deciding
+-- columns re-fires the link. Closing it fully needs serialized locking that
+-- this concierge-scale convenience doesn't warrant.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.sdc_autolink_on_teacher_write()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  match_count integer;
+  matched_profile uuid;
+BEGIN
+  IF NEW.account_id IS NOT NULL OR NEW.email IS NULL OR NEW.school_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT count(*), min(p.id::text)::uuid
+    INTO match_count, matched_profile
+  FROM profiles p
+  WHERE lower(p.email) = lower(NEW.email)
+    AND p.school_id = NEW.school_id
+    AND p.role = 'resource';
+
+  -- One-to-one only: exactly one profile matches AND that profile has no
+  -- linked classroom row already (a duplicate entry must not become a
+  -- second row answering for the same account).
+  IF match_count = 1
+     AND NOT EXISTS (
+       SELECT 1 FROM teachers t2 WHERE t2.account_id = matched_profile
+     ) THEN
+    NEW.account_id := matched_profile;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_teachers_sdc_autolink ON public.teachers;
+CREATE TRIGGER trg_teachers_sdc_autolink
+  BEFORE INSERT OR UPDATE OF email, school_id ON public.teachers
+  FOR EACH ROW EXECUTE FUNCTION public.sdc_autolink_on_teacher_write();
+
+CREATE OR REPLACE FUNCTION public.sdc_autolink_on_profile_write()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+BEGIN
+  IF NEW.role <> 'resource' OR NEW.email IS NULL OR NEW.school_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  -- Stand down unless the account has no linked row and exactly ONE
+  -- unlinked entry matches — the mirror of the teacher-side guard.
+  IF EXISTS (SELECT 1 FROM teachers t0 WHERE t0.account_id = NEW.id) THEN
+    RETURN NULL;
+  END IF;
+  IF (SELECT count(*) FROM teachers tc
+      WHERE tc.account_id IS NULL
+        AND tc.email IS NOT NULL
+        AND tc.school_id = NEW.school_id
+        AND lower(tc.email) = lower(NEW.email)) <> 1 THEN
+    RETURN NULL;
+  END IF;
+
+  UPDATE public.teachers t
+  SET account_id = NEW.id
+  WHERE t.account_id IS NULL
+    AND t.email IS NOT NULL
+    AND t.school_id = NEW.school_id
+    AND lower(t.email) = lower(NEW.email)
+    AND NOT EXISTS (
+      SELECT 1 FROM profiles p2
+      WHERE p2.id <> NEW.id
+        AND p2.role = 'resource'
+        AND p2.school_id = t.school_id
+        AND lower(p2.email) = lower(t.email)
+    );
+  RETURN NULL;
+END;
+$$;
+
+COMMIT;

--- a/supabase/migrations/20260813_spe481_sdc_auto_link_v3.sql
+++ b/supabase/migrations/20260813_spe481_sdc_auto_link_v3.sql
@@ -1,0 +1,98 @@
+-- SPE-481 v3: serialize linking per account (CodeRabbit's one-to-one point
+-- on PR #858, sharpened).
+--
+-- v2's stand-down guards handle every SERIAL case, but two simultaneous
+-- writers (e.g. duplicate directory rows inserted in the same instant)
+-- could each pass the "no linked row yet" check before seeing the other's
+-- uncommitted link — creating the duplicate state the guards exist to
+-- prevent. Unlike the documented concurrent-miss edge (benign: degrades to
+-- pre-SPE-481 and self-repairs on any later edit), a concurrent DUPLICATE
+-- link is a bad state that persists.
+--
+-- Fix with the house pattern (SPE-141's per-provider capacity lock): both
+-- functions take the same per-account advisory lock before deciding, so
+-- link attempts for one account serialize and the second writer sees the
+-- first's committed link. The lock is transaction-scoped and per-account —
+-- no contention across different accounts.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.sdc_autolink_on_teacher_write()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  match_count integer;
+  matched_profile uuid;
+BEGIN
+  IF NEW.account_id IS NOT NULL OR NEW.email IS NULL OR NEW.school_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT count(*), min(p.id::text)::uuid
+    INTO match_count, matched_profile
+  FROM profiles p
+  WHERE lower(p.email) = lower(NEW.email)
+    AND p.school_id = NEW.school_id
+    AND p.role = 'resource';
+
+  IF match_count <> 1 THEN
+    RETURN NEW;
+  END IF;
+
+  -- Serialize link attempts for this account, then decide on committed state.
+  PERFORM pg_advisory_xact_lock(hashtextextended('sdc_autolink:' || matched_profile::text, 0));
+
+  IF NOT EXISTS (SELECT 1 FROM teachers t2 WHERE t2.account_id = matched_profile) THEN
+    NEW.account_id := matched_profile;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.sdc_autolink_on_profile_write()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+BEGIN
+  IF NEW.role <> 'resource' OR NEW.email IS NULL OR NEW.school_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  -- Same per-account lock as the teacher-side function, so the two
+  -- directions serialize against each other as well.
+  PERFORM pg_advisory_xact_lock(hashtextextended('sdc_autolink:' || NEW.id::text, 0));
+
+  IF EXISTS (SELECT 1 FROM teachers t0 WHERE t0.account_id = NEW.id) THEN
+    RETURN NULL;
+  END IF;
+  IF (SELECT count(*) FROM teachers tc
+      WHERE tc.account_id IS NULL
+        AND tc.email IS NOT NULL
+        AND tc.school_id = NEW.school_id
+        AND lower(tc.email) = lower(NEW.email)) <> 1 THEN
+    RETURN NULL;
+  END IF;
+
+  UPDATE public.teachers t
+  SET account_id = NEW.id
+  WHERE t.account_id IS NULL
+    AND t.email IS NOT NULL
+    AND t.school_id = NEW.school_id
+    AND lower(t.email) = lower(NEW.email)
+    AND NOT EXISTS (
+      SELECT 1 FROM profiles p2
+      WHERE p2.id <> NEW.id
+        AND p2.role = 'resource'
+        AND p2.school_id = t.school_id
+        AND lower(p2.email) = lower(t.email)
+    );
+  RETURN NULL;
+END;
+$$;
+
+COMMIT;


### PR DESCRIPTION
## What

The `teachers.account_id` link is the gate for the mainstreaming features (SPE-478, merged in #856) — and nothing created it for the SDC shape. Teacher-login creation and the SIS sync auto-link only the accounts **they** create; SDC teachers are provider accounts whose classroom entries arrive through separate flows. Found in prod: all four Rodeo Hills SDC teachers (Domich, Eaton, Byrnes, Larkin) and both JSHS SDC/Resource hybrids (Abdu, O'Malley) had both halves and zero links. `linkTeacherToProfile` exists in the query layer with no UI caller.

## How

Two `SECURITY DEFINER` triggers make the link self-creating in **either entry order** (Blair's requirement — "does it also work if provider is entered first and then teachers are entered after the fact?"):

- **`sdc_autolink_on_teacher_write`** — BEFORE INSERT on `teachers`: an unlinked entry matching exactly one Resource Specialist profile (case-insensitive email + same `school_id`) gets `account_id` filled before the row lands. Catches every entry path — admin add, CSV, SIS sync, future flows.
- **`sdc_autolink_on_profile_write`** — AFTER INSERT OR UPDATE OF `email, school_id, role` ON `profiles`: a resource account appearing (or gaining its email/school — creation flows set school in a second step) links any waiting entry, with an explicit ambiguity guard.

Guardrails, all owner-decided: `resource` role only (the documented SDC convention — a speech provider never silently gains the gate), primary-school match only for multi-school providers, never overwrites an existing link, acts only when the match is unambiguous.

**One-time backfill** applies the identical rule with the exactly-one guard on *both* sides.

## Verification

- **Blast-radius preview first**: the backfill's full match list was queried read-only across prod *before* applying — six 1:1 matches, all JSUSD, zero ambiguous. All six verified linked after apply.
- **Order-under-question proven live**: a real signed-in site-admin session (sim district) inserted a classroom entry matching an existing unlinked resource persona — the trigger auto-filled `account_id` through the app's actual RLS'd insert path. The provider-first order is the backfill's own evidence plus the symmetric trigger.
- **No fixture contamination**: sim re-seeded with the triggers live — verify green, and the `teachers (SDC dual-role linked)` assertion still reads exactly 1 (Derek's explicit link), proving the seed's record teachers match nothing and the trigger stands down when `account_id` arrives pre-set.

Migration is applied to prod (this PR is the repo record + `ARCHITECTURE.md` update). No app-code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPvswmLrhUoZ1QeNPQK5EZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPvswmLrhUoZ1QeNPQK5EZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically links eligible SDC classroom-teacher records with matching Resource Specialist profiles.
  * Matching works regardless of which record is created first and supports relevant email or school updates.
  * Existing records are reviewed through a one-time backfill.

* **Bug Fixes**
  * Prevents incorrect links by requiring an exact, case-insensitive email and primary-school match.
  * Avoids linking ambiguous matches or overwriting existing teacher associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->