### PR TITLE
Auto-Schedule picker: say when a grouping option can't act on the caseload (SPE-482)

### DIFF
--- a/__tests__/unit/components/schedule/auto-schedule-picker-coverage.test.tsx
+++ b/__tests__/unit/components/schedule/auto-schedule-picker-coverage.test.tsx
@@ -47,9 +47,12 @@ describe('Auto-Schedule picker reports grouping coverage (SPE-482)', () => {
     renderPicker(BANCROFT);
     const note = coverage('teacher-grouped');
     expect(note).toMatch(/None of your 4 students/i);
-    // Says what will actually happen, and where to fix it.
-    expect(note).toMatch(/same way as Balanced/i);
+    // Says what will actually happen, and where to fix it. Deliberately does
+    // NOT claim the run is identical to Balanced — it isn't (see the note in
+    // groupabilityNote), and overclaiming would be a lie the provider can't check.
+    expect(note).toMatch(/can't group anyone/i);
     expect(note).toMatch(/Students page/i);
+    expect(note).not.toMatch(/same way as Balanced/i);
   });
 
   it('does not warn about grades on the same caseload, because grades are recorded', () => {
@@ -67,6 +70,8 @@ describe('Auto-Schedule picker reports grouping coverage (SPE-482)', () => {
     ]);
     expect(coverage('teacher-grouped')).toMatch(/No two students here share a teacher/i);
     expect(coverage('grade-grouped')).toMatch(/No two students here share a grade/i);
+    // Same reason: these students are not scheduled the Balanced way.
+    expect(coverage('teacher-grouped')).not.toMatch(/Balanced/i);
   });
 
   it('confirms full coverage without alarming language', () => {
@@ -77,6 +82,7 @@ describe('Auto-Schedule picker reports grouping coverage (SPE-482)', () => {
     const note = coverage('grade-grouped');
     expect(note).toMatch(/All 2 students share a grade/i);
     expect(note).not.toMatch(/Balanced/i);
+    expect(note).not.toMatch(/no one to group/i);
   });
 
   it('says nothing at all for the non-grouping options', () => {

--- a/__tests__/unit/components/schedule/auto-schedule-picker-coverage.test.tsx
+++ b/__tests__/unit/components/schedule/auto-schedule-picker-coverage.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * SPE-482: a grouping option is a silent no-op for students it cannot key.
+ *
+ * Observed on a real caseload: the provider picked "Group by teacher", none of
+ * their ten students had a teacher recorded, and the run produced an ordinary
+ * balanced schedule with no explanation — the option looked broken rather than
+ * inapplicable. The picker now says so before the run, and points at the data.
+ *
+ * These tests use that exact caseload shape: every student has a grade, none
+ * has a teacher.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { AutoScheduleOptionsModal } from '@/app/components/schedule/auto-schedule-options-modal';
+
+/** The Bancroft shape: grades recorded, teachers blank. */
+const BANCROFT = [
+  { grade_level: '5', teacher_id: null, teacher_name: null },
+  { grade_level: '5', teacher_id: null, teacher_name: null },
+  { grade_level: '4', teacher_id: null, teacher_name: null },
+  { grade_level: '3', teacher_id: null, teacher_name: null },
+];
+
+function renderPicker(students: Array<Record<string, unknown>> = []) {
+  render(
+    <AutoScheduleOptionsModal
+      isOpen
+      onClose={() => {}}
+      sessionCount={12}
+      strategy="balanced"
+      onStrategyChange={() => {}}
+      onConfirm={() => {}}
+      students={students as never}
+    />
+  );
+}
+
+const coverage = (strategy: string) =>
+  screen.queryByTestId(`strategy-coverage-${strategy}`)?.textContent ?? '';
+
+describe('Auto-Schedule picker reports grouping coverage (SPE-482)', () => {
+  it('warns that Group by teacher will do nothing when no teachers are recorded', () => {
+    renderPicker(BANCROFT);
+    const note = coverage('teacher-grouped');
+    expect(note).toMatch(/None of your 4 students/i);
+    // Says what will actually happen, and where to fix it.
+    expect(note).toMatch(/same way as Balanced/i);
+    expect(note).toMatch(/Students page/i);
+  });
+
+  it('does not warn about grades on the same caseload, because grades are recorded', () => {
+    renderPicker(BANCROFT);
+    const note = coverage('grade-grouped');
+    expect(note).not.toMatch(/None of your/i);
+    // 4 of 4 share a grade with someone (two 5s, and 4/3 are alone) -> 2 of 4.
+    expect(note).toMatch(/2 of 4 students share a grade/i);
+  });
+
+  it('warns when the field is recorded but nobody shares one', () => {
+    renderPicker([
+      { grade_level: '1', teacher_id: 't-1', teacher_name: null },
+      { grade_level: '2', teacher_id: 't-2', teacher_name: null },
+    ]);
+    expect(coverage('teacher-grouped')).toMatch(/No two students here share a teacher/i);
+    expect(coverage('grade-grouped')).toMatch(/No two students here share a grade/i);
+  });
+
+  it('confirms full coverage without alarming language', () => {
+    renderPicker([
+      { grade_level: '3', teacher_id: 't-1', teacher_name: null },
+      { grade_level: '3', teacher_id: 't-1', teacher_name: null },
+    ]);
+    const note = coverage('grade-grouped');
+    expect(note).toMatch(/All 2 students share a grade/i);
+    expect(note).not.toMatch(/Balanced/i);
+  });
+
+  it('says nothing at all for the non-grouping options', () => {
+    renderPicker(BANCROFT);
+    expect(screen.queryByTestId('strategy-coverage-balanced')).toBeNull();
+    expect(screen.queryByTestId('strategy-coverage-morning-first')).toBeNull();
+  });
+
+  it('stays silent when no caseload is available rather than guessing', () => {
+    renderPicker([]);
+    expect(screen.queryByTestId('strategy-coverage-teacher-grouped')).toBeNull();
+    expect(screen.queryByTestId('strategy-coverage-grade-grouped')).toBeNull();
+  });
+
+  it('still renders every strategy option alongside the notes', () => {
+    renderPicker(BANCROFT);
+    for (const label of ['Balanced', 'Group by grade', 'Group by teacher', 'Prefer mornings']) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+});

--- a/__tests__/unit/components/schedule/schedule-header-passes-students.test.tsx
+++ b/__tests__/unit/components/schedule/schedule-header-passes-students.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * SPE-482: the coverage note is only useful if the caseload actually reaches
+ * the picker, and it travels through three components to get there
+ * (page -> ScheduleHeader -> ScheduleSessions -> AutoScheduleOptionsModal).
+ *
+ * That wire has already broken silently once: ScheduleHeader accepted no
+ * `students` prop at all, so the page's caseload was dropped on the floor with
+ * no type error and no test failure — the feature rendered nothing in
+ * production while its unit tests passed, because those tests handed props
+ * straight to the modal.
+ *
+ * This drives the chain from the top component down, so a dropped prop fails
+ * here rather than in front of a provider.
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: { getUser: async () => ({ data: { user: { id: 'provider-1' } } }) },
+    from: () => {
+      const chain: any = {};
+      for (const op of ['select', 'eq', 'in', 'is', 'not', 'order']) chain[op] = () => chain;
+      chain.then = (resolve: (v: unknown) => unknown) =>
+        Promise.resolve(resolve({ data: [], error: null }));
+      return chain;
+    },
+  }),
+}));
+
+jest.mock('@/lib/supabase/hooks/use-auto-schedule', () => ({
+  useAutoSchedule: () => ({
+    scheduleBatchStudents: jest.fn(),
+    placeSessionsManually: jest.fn(),
+  }),
+}));
+
+jest.mock('@/app/components/schedule/undo-schedule', () => ({
+  saveScheduleSnapshot: jest.fn(),
+  saveScheduledSessionIds: jest.fn(),
+  UndoSchedule: () => null,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ScheduleHeader } = require('@/app/(dashboard)/dashboard/schedule/components/schedule-header');
+
+/** The caseload shape that exposed this: grades recorded, teachers blank. */
+const CASELOAD = [
+  { grade_level: '5', teacher_id: null, teacher_name: null },
+  { grade_level: '5', teacher_id: null, teacher_name: null },
+  { grade_level: '3', teacher_id: null, teacher_name: null },
+];
+
+function openPicker(students?: Array<Record<string, unknown>>) {
+  render(
+    <ScheduleHeader
+      unscheduledCount={5}
+      unscheduledPanelCount={5}
+      currentSchool={{ school_site: 'Bancroft', school_district: 'MDUSD' }}
+      onScheduleComplete={() => {}}
+      students={students}
+    />
+  );
+  fireEvent.click(screen.getByRole('button', { name: /Auto-Schedule Sessions/i }));
+}
+
+describe('the caseload reaches the picker through the component chain (SPE-482)', () => {
+  it('shows the teacher warning when the header is given the caseload', () => {
+    openPicker(CASELOAD);
+    expect(screen.getByTestId('strategy-coverage-teacher-grouped').textContent).toMatch(
+      /None of your 3 students/i
+    );
+  });
+
+  it('shows grade coverage from that same caseload', () => {
+    openPicker(CASELOAD);
+    expect(screen.getByTestId('strategy-coverage-grade-grouped').textContent).toMatch(
+      /2 of 3 students share a grade/i
+    );
+  });
+
+  it('renders no coverage note when the header is given no caseload', () => {
+    // The pre-fix production behaviour. Pinned so a future prop drop is a
+    // failure here and not a silently blank picker.
+    openPicker(undefined);
+    expect(screen.queryByTestId('strategy-coverage-teacher-grouped')).toBeNull();
+  });
+});

--- a/__tests__/unit/lib/scheduling/scheduling-strategy.test.ts
+++ b/__tests__/unit/lib/scheduling/scheduling-strategy.test.ts
@@ -206,3 +206,39 @@ describe('grouping coverage summary (SPE-482)', () => {
     }
   });
 });
+
+describe('coverage is only meaningful over the roster that will be scheduled (SPE-482)', () => {
+  // The schedule page's `students` array carries a provider's own caseload AND,
+  // for specialist roles, students from other providers' caseloads delegated to
+  // them (use-schedule-data appends those by assigned_to_specialist_id).
+  // Auto-Schedule rebuilds its roster with provider_id = me and never places the
+  // delegated ones, so coverage must be summarized over the owned students only.
+  // This pins the skew that would otherwise be reported.
+  const owned = [
+    { grade_level: '3', teacher_id: null, teacher_name: null },
+    { grade_level: '4', teacher_id: null, teacher_name: null },
+  ];
+  const delegatedFromAnotherProvider = [
+    { grade_level: '5', teacher_id: 't-9', teacher_name: null },
+    { grade_level: '5', teacher_id: 't-9', teacher_name: null },
+  ];
+
+  it('reports no teacher coverage for the owned caseload', () => {
+    expect(summarizeGroupability(owned, 'teacher-grouped')).toEqual({
+      total: 2,
+      withKey: 0,
+      groupable: 0,
+    });
+  });
+
+  it('would hide that fact if delegated students were mixed in', () => {
+    // Same owned students, plus two delegated ones who share a teacher: the
+    // "nobody has a teacher" warning silently downgrades to a partial count,
+    // describing students the run will never touch.
+    const mixed = [...owned, ...delegatedFromAnotherProvider];
+    const summary = summarizeGroupability(mixed, 'teacher-grouped')!;
+    expect(summary.withKey).toBe(2);
+    expect(summary.groupable).toBe(2);
+    expect(summary.total).toBe(4);
+  });
+});

--- a/__tests__/unit/lib/scheduling/scheduling-strategy.test.ts
+++ b/__tests__/unit/lib/scheduling/scheduling-strategy.test.ts
@@ -4,6 +4,7 @@ import {
   getGroupingKey,
   isGroupingStrategy,
   isSchedulingStrategy,
+  summarizeGroupability,
 } from '@/lib/scheduling/scheduling-strategy';
 
 /**
@@ -117,5 +118,91 @@ describe('scheduling strategy options (SPE-473)', () => {
     // Guards against a stale persisted value being trusted.
     expect(isSchedulingStrategy('two-pass')).toBe(false);
     expect(isSchedulingStrategy(undefined)).toBe(false);
+  });
+});
+
+describe('grouping coverage summary (SPE-482)', () => {
+  const withTeacher = (id: string, teacher: string | null) => ({
+    grade_level: '3',
+    teacher_id: teacher,
+    teacher_name: null,
+  });
+
+  it('reports nothing for strategies that do not group', () => {
+    const students = [withTeacher('a', 't-1'), withTeacher('b', 't-1')];
+    expect(summarizeGroupability(students, 'balanced')).toBeNull();
+    expect(summarizeGroupability(students, 'morning-first')).toBeNull();
+  });
+
+  it('reports zero coverage when nobody has the field — the real-caseload case', () => {
+    // Ten students, no teacher on any of them: "Group by teacher" is a silent
+    // no-op, which is exactly what this summary exists to surface.
+    const students = Array.from({ length: 10 }, (_, i) => withTeacher(`s${i}`, null));
+    expect(summarizeGroupability(students, 'teacher-grouped')).toEqual({
+      total: 10,
+      withKey: 0,
+      groupable: 0,
+    });
+  });
+
+  it('separates "has the field" from "has a peer to group with"', () => {
+    // Everyone has a teacher, but each teacher is unique — nothing to group.
+    const students = [withTeacher('a', 't-1'), withTeacher('b', 't-2'), withTeacher('c', 't-3')];
+    expect(summarizeGroupability(students, 'teacher-grouped')).toEqual({
+      total: 3,
+      withKey: 3,
+      groupable: 0,
+    });
+  });
+
+  it('counts only students who actually share a key', () => {
+    const students = [
+      withTeacher('a', 't-1'),
+      withTeacher('b', 't-1'),
+      withTeacher('c', 't-2'), // alone in their class
+      withTeacher('d', null),  // no teacher at all
+    ];
+    expect(summarizeGroupability(students, 'teacher-grouped')).toEqual({
+      total: 4,
+      withKey: 3,
+      groupable: 2,
+    });
+  });
+
+  it('summarizes grade coverage independently of teacher coverage', () => {
+    // The Bancroft shape: every student has a grade, none has a teacher.
+    const students = [
+      { grade_level: '5', teacher_id: null, teacher_name: null },
+      { grade_level: '5', teacher_id: null, teacher_name: null },
+      { grade_level: '1', teacher_id: null, teacher_name: null },
+    ];
+    expect(summarizeGroupability(students, 'grade-grouped')).toEqual({
+      total: 3,
+      withKey: 3,
+      groupable: 2,
+    });
+    expect(summarizeGroupability(students, 'teacher-grouped')).toEqual({
+      total: 3,
+      withKey: 0,
+      groupable: 0,
+    });
+  });
+
+  it('handles an empty caseload without dividing by zero', () => {
+    expect(summarizeGroupability([], 'grade-grouped')).toEqual({
+      total: 0,
+      withKey: 0,
+      groupable: 0,
+    });
+  });
+
+  it('gives every grouping option a noun for the picker to use', () => {
+    for (const option of SCHEDULING_STRATEGY_OPTIONS) {
+      if (isGroupingStrategy(option.value)) {
+        expect(option.groupingNoun).toBeTruthy();
+      } else {
+        expect(option.groupingNoun).toBeNull();
+      }
+    }
   });
 });

--- a/app/(dashboard)/dashboard/schedule/components/schedule-header.tsx
+++ b/app/(dashboard)/dashboard/schedule/components/schedule-header.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { ScheduleSessions } from '../../../../components/schedule/schedule-sessions';
+import type { GroupableStudent } from '../../../../../lib/scheduling/scheduling-strategy';
 import { UndoSchedule } from '../../../../components/schedule/undo-schedule';
 
 interface ScheduleHeaderProps {
@@ -12,6 +13,8 @@ interface ScheduleHeaderProps {
     school_district: string;
   } | null;
   onScheduleComplete: () => void;
+  /** Caseload at the current school; the Auto-Schedule picker reports what each grouping option can act on. */
+  students?: readonly GroupableStudent[];
   /** SPE-478: shown only for providers with a linked classroom (the SDC dual-role marker). */
   showMainstreamingButton?: boolean;
   onAddMainstreamingBlock?: () => void;
@@ -22,6 +25,7 @@ export function ScheduleHeader({
   unscheduledPanelCount,
   currentSchool,
   onScheduleComplete,
+  students,
   showMainstreamingButton = false,
   onAddMainstreamingBlock
 }: ScheduleHeaderProps) {
@@ -50,6 +54,7 @@ export function ScheduleHeader({
             currentSchool={currentSchool}
             unscheduledCount={unscheduledCount}
             unscheduledPanelCount={unscheduledPanelCount}
+            students={students}
           />
           <UndoSchedule onComplete={onScheduleComplete} />
         </div>

--- a/app/(dashboard)/dashboard/schedule/page.tsx
+++ b/app/(dashboard)/dashboard/schedule/page.tsx
@@ -549,6 +549,7 @@ export default function SchedulePage() {
             unscheduledPanelCount={unscheduledSessions.length}
             currentSchool={currentSchool}
             onScheduleComplete={handleScheduleComplete}
+            students={students}
             showMainstreamingButton={hasOwnClassroom}
             onAddMainstreamingBlock={() => setMainstreamingModalOpen(true)}
           />

--- a/app/(dashboard)/dashboard/schedule/page.tsx
+++ b/app/(dashboard)/dashboard/schedule/page.tsx
@@ -63,6 +63,18 @@ export default function SchedulePage() {
     () => !!currentUserId && teachers.some(t => t.account_id === currentUserId),
     [teachers, currentUserId]
   );
+  // SPE-482: the caseload Auto-Schedule will actually place, which is the
+  // provider's OWN students. For specialist roles `students` also carries
+  // students from other providers' caseloads that are delegated to this user
+  // (use-schedule-data appends them by assigned_to_specialist_id), while
+  // handleScheduleSessions rebuilds its roster with provider_id = me and never
+  // touches them. Reporting grouping coverage over the mixed array would
+  // describe a population the run ignores — delegated students sharing a
+  // teacher could hide that none of the provider's own students are groupable.
+  const ownedStudents = useMemo(
+    () => students.filter(student => student.provider_id === currentUserId),
+    [students, currentUserId]
+  );
   const [mainstreamingModalOpen, setMainstreamingModalOpen] = useState(false);
   const handleMainstreamingBlockDelete = useCallback(
     async (blockId: string) => {
@@ -549,7 +561,7 @@ export default function SchedulePage() {
             unscheduledPanelCount={unscheduledSessions.length}
             currentSchool={currentSchool}
             onScheduleComplete={handleScheduleComplete}
-            students={students}
+            students={ownedStudents}
             showMainstreamingButton={hasOwnClassroom}
             onAddMainstreamingBlock={() => setMainstreamingModalOpen(true)}
           />

--- a/app/components/schedule/auto-schedule-options-modal.tsx
+++ b/app/components/schedule/auto-schedule-options-modal.tsx
@@ -25,22 +25,28 @@ function groupabilityNote(
 ): { text: string; tone: 'warning' | 'info' } | null {
   if (!summary || !noun || summary.total === 0) return null;
 
+  // Deliberately phrased in terms of grouping outcomes, never as "identical to
+  // Balanced". That equivalence isn't true: a student with a key the strategy
+  // recognises — even a unique one nobody shares — still takes the grouping
+  // capacity ladder, which opens at the full group ceiling rather than
+  // Balanced's conservative first pass. What the provider needs to know is
+  // whether anyone gets grouped, which is exactly what these say.
   if (summary.withKey === 0) {
     return {
       tone: 'warning',
-      text: `None of your ${summary.total} students here have a ${noun} recorded, so this will schedule the same way as Balanced. Add ${noun}s on the Students page to use this option.`,
+      text: `None of your ${summary.total} students here have a ${noun} recorded, so this option can't group anyone. Add ${noun}s on the Students page to use it.`,
     };
   }
   if (summary.groupable === 0) {
     return {
       tone: 'warning',
-      text: `No two students here share a ${noun}, so there is no one to group — this will schedule the same way as Balanced.`,
+      text: `No two students here share a ${noun}, so there is no one to group.`,
     };
   }
   if (summary.groupable < summary.total) {
     return {
       tone: 'info',
-      text: `${summary.groupable} of ${summary.total} students share a ${noun} with someone. The rest are placed the balanced way.`,
+      text: `${summary.groupable} of ${summary.total} students share a ${noun} with someone. The others have no one to group with.`,
     };
   }
   return {

--- a/app/components/schedule/auto-schedule-options-modal.tsx
+++ b/app/components/schedule/auto-schedule-options-modal.tsx
@@ -4,8 +4,50 @@ import { Modal } from '../ui/modal';
 import { Button } from '../ui/button';
 import {
   SCHEDULING_STRATEGY_OPTIONS,
+  summarizeGroupability,
+  type GroupableStudent,
+  type GroupabilitySummary,
   type SchedulingStrategy,
 } from '../../../lib/scheduling/scheduling-strategy';
+
+/**
+ * What a grouping option can actually do with this caseload, in plain words
+ * (SPE-482). Returns null when there is nothing worth saying.
+ *
+ * The case this exists for: a provider picks "Group by teacher", none of their
+ * students have a teacher recorded, and the run silently produces a balanced
+ * schedule with no explanation. Telling them BEFORE the run costs nothing and
+ * points at the fix, which is their data rather than the option.
+ */
+function groupabilityNote(
+  summary: GroupabilitySummary | null,
+  noun: string | null
+): { text: string; tone: 'warning' | 'info' } | null {
+  if (!summary || !noun || summary.total === 0) return null;
+
+  if (summary.withKey === 0) {
+    return {
+      tone: 'warning',
+      text: `None of your ${summary.total} students here have a ${noun} recorded, so this will schedule the same way as Balanced. Add ${noun}s on the Students page to use this option.`,
+    };
+  }
+  if (summary.groupable === 0) {
+    return {
+      tone: 'warning',
+      text: `No two students here share a ${noun}, so there is no one to group — this will schedule the same way as Balanced.`,
+    };
+  }
+  if (summary.groupable < summary.total) {
+    return {
+      tone: 'info',
+      text: `${summary.groupable} of ${summary.total} students share a ${noun} with someone. The rest are placed the balanced way.`,
+    };
+  }
+  return {
+    tone: 'info',
+    text: `All ${summary.total} students share a ${noun} with someone.`,
+  };
+}
 
 interface AutoScheduleOptionsModalProps {
   isOpen: boolean;
@@ -22,6 +64,12 @@ interface AutoScheduleOptionsModalProps {
   strategy: SchedulingStrategy;
   onStrategyChange: (strategy: SchedulingStrategy) => void;
   onConfirm: () => void;
+  /**
+   * The caseload at the current school, used only to tell the provider how much
+   * each grouping option can act on. Optional: with none passed, the picker
+   * simply shows no coverage note.
+   */
+  students?: readonly GroupableStudent[];
 }
 
 /**
@@ -39,6 +87,7 @@ export function AutoScheduleOptionsModal({
   strategy,
   onStrategyChange,
   onConfirm,
+  students = [],
 }: AutoScheduleOptionsModalProps) {
   return (
     <Modal
@@ -73,6 +122,12 @@ export function AutoScheduleOptionsModal({
         <div className="mt-4 space-y-2">
           {SCHEDULING_STRATEGY_OPTIONS.map((option) => {
             const isSelected = option.value === strategy;
+            // Shown on every grouping option, not just the selected one, so the
+            // coverage is visible while choosing rather than after.
+            const note = groupabilityNote(
+              summarizeGroupability(students, option.value),
+              option.groupingNoun
+            );
             return (
               <label
                 key={option.value}
@@ -99,6 +154,23 @@ export function AutoScheduleOptionsModal({
                   <span className="mt-0.5 block text-sm text-gray-600">
                     {option.description}
                   </span>
+                  {note && (
+                    <span
+                      data-testid={`strategy-coverage-${option.value}`}
+                      className={`mt-1.5 block text-sm ${
+                        note.tone === 'warning'
+                          ? 'font-medium text-amber-700'
+                          : 'text-gray-500'
+                      }`}
+                    >
+                      {note.tone === 'warning' && (
+                        <span aria-hidden="true" className="mr-1">
+                          ⚠
+                        </span>
+                      )}
+                      {note.text}
+                    </span>
+                  )}
                 </span>
               </label>
             );

--- a/app/components/schedule/schedule-sessions.tsx
+++ b/app/components/schedule/schedule-sessions.tsx
@@ -11,6 +11,7 @@ import { ManualPlacementModal } from './manual-placement-modal';
 import { AutoScheduleOptionsModal } from './auto-schedule-options-modal';
 import {
   DEFAULT_SCHEDULING_STRATEGY,
+  type GroupableStudent,
   type SchedulingStrategy,
 } from '../../../lib/scheduling/scheduling-strategy';
 
@@ -22,9 +23,11 @@ interface ScheduleSessionsProps {
   } | null;
   unscheduledCount: number;
   unscheduledPanelCount: number;
+  /** Caseload at the current school, for the picker's grouping-coverage note. */
+  students?: readonly GroupableStudent[];
 }
 
-export function ScheduleSessions({ onComplete, currentSchool, unscheduledCount, unscheduledPanelCount }: ScheduleSessionsProps) {
+export function ScheduleSessions({ onComplete, currentSchool, unscheduledCount, unscheduledPanelCount, students }: ScheduleSessionsProps) {
   const [isProcessing, setIsProcessing] = useState(false);
   const [showOptionsModal, setShowOptionsModal] = useState(false);
   // Kept across runs within the page session so a provider re-running the
@@ -293,6 +296,7 @@ export function ScheduleSessions({ onComplete, currentSchool, unscheduledCount, 
         strategy={strategy}
         onStrategyChange={setStrategy}
         onConfirm={handleScheduleSessions}
+        students={students}
       />
 
       <ManualPlacementModal

--- a/lib/scheduling/scheduling-strategy.ts
+++ b/lib/scheduling/scheduling-strategy.ts
@@ -41,30 +41,36 @@ export const SCHEDULING_STRATEGY_OPTIONS: ReadonlyArray<{
   value: SchedulingStrategy;
   label: string;
   description: string;
+  /** What this strategy groups on, in the provider's words. Null when it doesn't group. */
+  groupingNoun: string | null;
 }> = [
   {
     value: 'balanced',
     label: 'Balanced',
     description:
       'Spread sessions evenly across your days and keep group sizes small. A good default when you have no particular preference.',
+    groupingNoun: null,
   },
   {
     value: 'grade-grouped',
     label: 'Group by grade',
     description:
       'Put students in the same grade into the same time slots, so you can run them together as a group.',
+    groupingNoun: 'grade',
   },
   {
     value: 'teacher-grouped',
     label: 'Group by teacher',
     description:
       'Pull students from the same class at the same time, so each teacher is interrupted once instead of several times.',
+    groupingNoun: 'teacher',
   },
   {
     value: 'morning-first',
     label: 'Prefer mornings',
     description:
       'Fill the earliest available times first, leaving afternoons freer for meetings, testing and paperwork.',
+    groupingNoun: null,
   },
 ];
 
@@ -109,4 +115,50 @@ export function getGroupingKey(
     default:
       return null;
   }
+}
+
+/**
+ * How much of a caseload a grouping strategy can actually act on (SPE-482).
+ *
+ * A grouping strategy is a silent no-op for any student it cannot key: with no
+ * teacher recorded, "Group by teacher" places every student by the balanced
+ * rules and the provider is told nothing. That is exactly what happened on a
+ * real caseload where all ten students had no teacher — the run looked like the
+ * option had simply failed.
+ *
+ * Two different numbers matter, and neither implies the other:
+ *   - `withKey`: how many students have the field at all. Zero means the data
+ *     is missing, which the provider can fix.
+ *   - `groupable`: how many share their key with at least one other student.
+ *     A student with a unique teacher has the data and still cannot be grouped,
+ *     because grouping needs a peer.
+ *
+ * Returns null for non-grouping strategies, which have nothing to report.
+ */
+export interface GroupabilitySummary {
+  /** Students on the caseload being scheduled. */
+  total: number;
+  /** Students with the field this strategy groups on recorded. */
+  withKey: number;
+  /** Students sharing that field with at least one other — the ones with a peer to join. */
+  groupable: number;
+}
+
+export function summarizeGroupability(
+  students: readonly GroupableStudent[],
+  strategy: SchedulingStrategy
+): GroupabilitySummary | null {
+  if (!isGroupingStrategy(strategy)) return null;
+
+  const keys = students.map((student) => getGroupingKey(student, strategy));
+  const countsByKey = new Map<string, number>();
+  for (const key of keys) {
+    if (key) countsByKey.set(key, (countsByKey.get(key) ?? 0) + 1);
+  }
+
+  return {
+    total: students.length,
+    withKey: keys.filter((key): key is string => key !== null).length,
+    groupable: keys.filter((key) => key !== null && countsByKey.get(key)! > 1).length,
+  };
 }

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -273,7 +273,7 @@ export function teacherRecordId(key: string): string {
  * SPE-478: provider personas who ALSO own a classroom-teacher entry — the SDC
  * dual-role pattern (SPE-355). The link (teachers.account_id pointing at the
  * persona's auth user) is what the app treats as the SDC marker, gating the
- * SDC scheduling affordances (mainstreaming blocks now; SPE-479 class blocks
+ * SDC scheduling affordances (mainstreaming blocks now; SPE-482 class blocks
  * later), so the fixture must hold at least one such persona. Derek
  * (rsp.juniper) carries it: a single-site elementary RSP whose account
  * doubles as a classroom teacher at Juniper.

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -273,7 +273,7 @@ export function teacherRecordId(key: string): string {
  * SPE-478: provider personas who ALSO own a classroom-teacher entry — the SDC
  * dual-role pattern (SPE-355). The link (teachers.account_id pointing at the
  * persona's auth user) is what the app treats as the SDC marker, gating the
- * SDC scheduling affordances (mainstreaming blocks now; SPE-482 class blocks
+ * SDC scheduling affordances (mainstreaming blocks now; SPE-479 class blocks
  * later), so the fixture must hold at least one such persona. Derek
  * (rsp.juniper) carries it: a single-site elementary RSP whose account
  * doubles as a classroom teacher at Juniper.

--- a/scripts/sim-district/teardown.ts
+++ b/scripts/sim-district/teardown.ts
@@ -139,7 +139,14 @@ export async function teardown(admin: Admin): Promise<Record<string, number>> {
 
   // 6. Teachers, permissions, school assignments.
   deleted['teachers'] = await deleteWhereIn(admin, 'teachers', 'school_id', SIM_SCHOOL_IDS);
+  // `admin_permissions` carries TWO foreign keys to profiles — `admin_id` (who
+  // holds the permission) and `granted_by` (who gave it). Sweeping only
+  // `admin_id` leaves any row a sim admin granted, and that surviving row then
+  // blocks the granter's profile delete, which blocks the school delete, and
+  // teardown dies on a schools FK error that names neither table.
   deleted['admin_permissions'] = await deleteWhereIn(admin, 'admin_permissions', 'admin_id', simUserIds);
+  deleted['admin_permissions (granted_by)'] =
+    await deleteWhereIn(admin, 'admin_permissions', 'granted_by', simUserIds);
   deleted['provider_schools'] = await deleteWhereIn(admin, 'provider_schools', 'provider_id', simUserIds);
 
   // 7. Profiles, then auth users (the runtime-resolved exception in invariant 1).


### PR DESCRIPTION
Found by running the new grouping options against a real caseload. Blair picked **Group by teacher** at Bancroft, where all ten students have no teacher recorded — neither `teacher_id` nor `teacher_name`. Every student fell back to balanced placement, which is correct, and nothing said so. From the outside the option looks broken rather than inapplicable, with no hint that the fix is the student data.

## The change

The picker now reports, under each grouping option, what it can do with this caseload:

| Situation | Note |
|---|---|
| Nobody has the field | ⚠ "None of your 10 students here have a teacher recorded, so this option can't group anyone. Add teachers on the Students page to use it." |
| Field present, nobody shares one | ⚠ "No two students here share a teacher, so there is no one to group." |
| Partial | "6 of 10 students share a teacher with someone. The others have no one to group with." |
| Full | "All 10 students share a teacher with someone." |

Shown on every grouping option rather than only the selected one, so coverage is visible while choosing rather than after a full run. Nothing renders for Balanced or Prefer mornings.

Two numbers are tracked because neither implies the other: `withKey` (has the field — a data problem the provider can fix) and `groupable` (shares it with at least one other — a caseload-shape fact they can't). A student with a unique teacher has the data and still has nobody to group with.

`summarizeGroupability` lives beside `getGroupingKey` so the picker and the scheduler can't drift on what "groupable" means. **No new queries** — the schedule page already loads the caseload.

## What the self-review caught

Worth calling out, because both would have shipped:

- **The feature was a no-op.** The page never passed `students` to `ScheduleHeader` — I had misread an adjacent `ConflictFilterPanel` call site as the header's. The modal always received `[]`, the note never rendered, and every test passed props straight to the modal so none could see it. Now wired, plus a test that drives the real chain from `ScheduleHeader` down — dropping the prop again fails 2 of its 3 cases.
- **The copy overclaimed.** It said a run would "schedule the same way as Balanced" when nothing could be grouped. Not true: a student with a key the strategy recognises — even a unique one — still takes the grouping capacity ladder, which opens at the full group ceiling instead of Balanced's conservative first pass of 3. The notes now describe grouping outcomes, which is both accurate and what the provider needs.

## Verification

Typecheck, lint, full suite green (1460 passing; the 3 failing `tests/integration/*` suites need live DB credentials and fail identically on a clean tree). 18 new tests across the pure function, the modal, and the component chain.

**Sim district, real signed-in session** (`rsp.willow`) — the check no unit test can do, since the bug was a dropped prop between components:

- Coverage notes rendered from real page data: *"All 28 students share a grade with someone."* / *"All 28 students share a teacher with someone."* — correct for Willow's fixture.
- No false "nothing recorded" warning on a populated caseload; Balanced correctly shows no note.
- Fixture torn down, `sim:verify --expect-empty` all zeros, reseeded green.

## Also included: a sim-harness fix

Teardown died on a schools FK error while restoring the fixture. `admin_permissions` has two foreign keys to profiles — `admin_id` and `granted_by` — and teardown swept only `admin_id`; a surviving row blocks the granter's profile delete, which blocks the school delete. A direct profile delete reproduces it (`violates foreign key constraint admin_permissions_granted_by_fkey`).

**Honest caveat:** on the run that went green afterwards the new `granted_by` sweep deleted 0 rows, because every grantee happened to be a sim user the `admin_id` sweep already covered. So the gap is real and worth closing, but I have not shown it caused the failure I hit — that may have been residual state from an earlier interrupted reset in the same session. Recorded as-is rather than dressed up as a clean fix.

Closes SPE-482.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQdotbcQEfBNAgp1NFRQek)_