### PR TITLE
Special activities protect the way they display (SPE-484 + SPE-318 + SPE-468)

### DIFF
--- a/__tests__/unit/lib/scheduling/scheduler-template-only-context.test.ts
+++ b/__tests__/unit/lib/scheduling/scheduler-template-only-context.test.ts
@@ -61,6 +61,7 @@ async function contextFrom(sessions: Array<Record<string, unknown>>) {
     getExistingSessions: () => sessions,
     getCrossProviderSessions: () => new Map(),
     getMainstreamingBlocks: () => [],
+    getSpecialActivitiesFlat: () => [],
     getBellScheduleConflicts: () => [],
     getMetrics: () => ({ cacheHits: 0, cacheMisses: 0 }),
   };

--- a/__tests__/unit/lib/scheduling/special-activity-protection.test.ts
+++ b/__tests__/unit/lib/scheduling/special-activity-protection.test.ts
@@ -132,4 +132,15 @@ describe('OptimizedScheduler slot search respects special activities (SPE-318)',
     expect(slots).toHaveLength(1);
     expect(slots[0].startTime).toBe('10:00');
   });
+
+  it('does not block on a name coincidence when the student\'s teacher has a different id', () => {
+    // The index files activities under teacher_name too, so a student whose
+    // teacher SHARES the display name but carries a different directory id
+    // finds the activity via the name key — the slot search must apply the
+    // shared rule's id-disagreement veto rather than over-block.
+    const student = { id: 's1', grade_level: '3', teacher_id: 'teacher-else', teacher_name: 'Mrs. Nova', initials: 'AB' };
+    const slots = schedulerWith(dualKeyedIndex()).findSlotsWithCapacityLimit(student, 30, 1, [1], 8, []);
+    expect(slots).toHaveLength(1);
+    expect(slots[0].startTime).toBe('10:00');
+  });
 });

--- a/__tests__/unit/lib/scheduling/special-activity-protection.test.ts
+++ b/__tests__/unit/lib/scheduling/special-activity-protection.test.ts
@@ -1,0 +1,135 @@
+// Aliased with a `mock` prefix so the jest.mock factory (hoisted above imports by
+// babel-plugin-jest-hoist) may reference it.
+import { createMockSupabaseClient as mockCreateSupabaseClient } from '@/test-utils/supabase-test-helpers';
+import {
+  findOverlappingSpecialActivity,
+  type SpecialActivityLite,
+} from '@/lib/services/session-update-service';
+
+// The scheduler constructs a Supabase client and the singleton data manager on
+// construction; mock the client module so both resolve to a harmless stub.
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockCreateSupabaseClient(),
+}));
+
+import { OptimizedScheduler } from '@/lib/scheduling/optimized-scheduler';
+
+// PE with Mrs. Nova, Monday 10:00–10:30.
+const activity = (over: Partial<SpecialActivityLite> = {}): SpecialActivityLite => ({
+  teacher_id: 'teacher-nova',
+  teacher_name: 'Mrs. Nova',
+  day_of_week: 1,
+  start_time: '10:00:00',
+  end_time: '10:30:00',
+  ...over,
+});
+
+describe('findOverlappingSpecialActivity (SPE-484)', () => {
+  it('matches by teacher directory id', () => {
+    const found = findOverlappingSpecialActivity(
+      [activity()],
+      { teacherId: 'teacher-nova', teacherName: 'MRS NOVA (drifted)' },
+      1, '10:15', '10:45'
+    );
+    expect(found).not.toBeNull();
+  });
+
+  it('falls back to exact name when the activity carries no id', () => {
+    const legacy = activity({ teacher_id: null });
+    expect(
+      findOverlappingSpecialActivity([legacy], { teacherId: null, teacherName: 'Mrs. Nova' }, 1, '10:15', '10:45')
+    ).not.toBeNull();
+  });
+
+  it('does NOT warn on a name coincidence when both sides carry disagreeing ids', () => {
+    // Two different teachers who happen to share a display name (SPE-468's
+    // string-fragility warning) — the id disagreement must win.
+    expect(
+      findOverlappingSpecialActivity(
+        [activity({ teacher_id: 'teacher-other' })],
+        { teacherId: 'teacher-nova', teacherName: 'Mrs. Nova' },
+        1, '10:15', '10:45'
+      )
+    ).toBeNull();
+  });
+
+  it('honors day and half-open interval boundaries', () => {
+    expect(
+      findOverlappingSpecialActivity([activity()], { teacherId: 'teacher-nova', teacherName: null }, 2, '10:15', '10:45')
+    ).toBeNull();
+    expect(
+      findOverlappingSpecialActivity([activity()], { teacherId: 'teacher-nova', teacherName: null }, 1, '10:30', '11:00')
+    ).toBeNull();
+    expect(
+      findOverlappingSpecialActivity([activity()], { teacherId: 'teacher-nova', teacherName: null }, 1, '09:30', '10:00')
+    ).toBeNull();
+  });
+
+  it('returns null for an empty list', () => {
+    expect(
+      findOverlappingSpecialActivity([], { teacherId: 'teacher-nova', teacherName: 'Mrs. Nova' }, 1, '10:15', '10:45')
+    ).toBeNull();
+  });
+});
+
+/**
+ * SPE-318: the auto-scheduler must skip slots overlapping the student's
+ * TEACHER's special activities — for years this data arrived as a hardcoded
+ * empty array, so the check was dead code. Inject a context whose activity
+ * index carries the dual keys initializeContext now builds (teacher_name AND
+ * teacher_id) and drive the real slot search.
+ */
+function schedulerWith(
+  activitiesByKey: Map<string, Map<number, unknown[]>>,
+): any {
+  const scheduler = new OptimizedScheduler('provider-1', 'resource') as any;
+  scheduler.context = {
+    schoolSite: 'Willow',
+    workDays: [1],
+    bellSchedules: [],
+    specialActivities: [],
+    existingSessions: [],
+    validSlots: new Map([
+      ['1-10:00', { dayOfWeek: 1, startTime: '10:00', endTime: '', available: true, capacity: 8, conflicts: [] }],
+    ]),
+    schoolHours: [],
+    studentGradeMap: new Map(),
+    crossProviderSessionsByStudent: new Map(),
+    providerAvailability: new Map(),
+    bellSchedulesByGrade: new Map(),
+    specialActivitiesByTeacher: activitiesByKey,
+    mainstreamingByStudent: new Map(),
+    cacheMetadata: { lastFetched: new Date(), isStale: false, fetchErrors: [], queryCount: 0 },
+  };
+  return scheduler;
+}
+
+const dualKeyedIndex = () => {
+  const byKey = new Map<string, Map<number, unknown[]>>();
+  const a = activity();
+  for (const key of [a.teacher_name, a.teacher_id!]) {
+    byKey.set(key, new Map([[1, [a]]]));
+  }
+  return byKey;
+};
+
+describe('OptimizedScheduler slot search respects special activities (SPE-318)', () => {
+  it('drops a slot overlapping the activity, found via teacher_id despite name drift', () => {
+    const student = { id: 's1', grade_level: '3', teacher_id: 'teacher-nova', teacher_name: 'MRS  NOVA', initials: 'AB' };
+    const slots = schedulerWith(dualKeyedIndex()).findSlotsWithCapacityLimit(student, 30, 1, [1], 8, []);
+    expect(slots).toHaveLength(0);
+  });
+
+  it('drops the slot via teacher_name for legacy students with no teacher_id', () => {
+    const student = { id: 's1', grade_level: '3', teacher_id: null, teacher_name: 'Mrs. Nova', initials: 'AB' };
+    const slots = schedulerWith(dualKeyedIndex()).findSlotsWithCapacityLimit(student, 30, 1, [1], 8, []);
+    expect(slots).toHaveLength(0);
+  });
+
+  it('places the slot when the student\'s teacher has no overlapping activity', () => {
+    const student = { id: 's1', grade_level: '3', teacher_id: 'teacher-else', teacher_name: 'Mr. Else', initials: 'AB' };
+    const slots = schedulerWith(dualKeyedIndex()).findSlotsWithCapacityLimit(student, 30, 1, [1], 8, []);
+    expect(slots).toHaveLength(1);
+    expect(slots[0].startTime).toBe('10:00');
+  });
+});

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1111,8 +1111,8 @@ the student (owner decision, 2026-08-13):
   skip like the SPE-287 cross-provider check — no human in the loop, so
   protected means protected. Blocks load through the SchedulingDataManager
   (`loadMainstreamingBlocks`, school-wide, year-scoped) and are indexed
-  per student — wired in for real from day one, unlike special activities
-  (SPE-318). The shared pure overlap rule
+  per student — wired in for real from day one. (Special activities caught up
+  in SPE-484/318/468: see the paragraph below.) The shared pure overlap rule
   (`findOverlappingMainstreamingBlock`) lives in session-update-service so the
   two paths can't drift.
 - **Grid**: the owner's blocks render as teal blocks on their Main Schedule;
@@ -1181,11 +1181,17 @@ Two things are worth knowing about the boundary here:
   validated downstream and are identical for every strategy. A strategy only
   reorders the candidate slots that get *tried*, plus the order students are
   placed in (grouping strategies place peers consecutively so each one can join
-  the slot the previous peer landed in). Note this list does **not** include
-  special activities: `getDataFromManager` still hands the scheduler an empty
-  `specialActivities` array, so that check runs against an empty index and blocks
-  nothing (SPE-318). Strategies neither improve nor worsen that — it is the same
-  blind spot for all four, including the pre-existing `balanced` behavior.
+  the slot the previous peer landed in). Special activities joined that
+  validated list in SPE-484/318/468 ("activities protect the way they
+  display"): the DataManager feeds the scheduler the school's live,
+  year-scoped activities (`getSpecialActivitiesFlat`; deleted rows filtered at
+  fetch — SPE-468), indexed under BOTH `teacher_name` and `teacher_id` so an
+  id match survives name drift; and the interactive drag warning
+  (`checkSpecialActivityConflicts`) is school-wide, no longer scoped to
+  activities the dragging provider created themselves (SPE-484's legacy
+  quirk). The shared teacher-matching rule is the pure
+  `findOverlappingSpecialActivity` in session-update-service (id preferred;
+  exact-name fallback; disagreeing ids veto a name coincidence).
 - **Grouping is decided at the day level as well as the slot level.** Days
   holding same-group peers sort ahead of the emptiest day. Without that, grouping
   is self-defeating: each peer placed makes its day one session busier, so the

--- a/lib/scheduling/optimized-scheduler.ts
+++ b/lib/scheduling/optimized-scheduler.ts
@@ -258,12 +258,13 @@ export class OptimizedScheduler {
       }
     }
     
-    // Get special activities (we'll need to query all teachers)
-    const specialActivities: SpecialActivity[] = [];
-    // For now, we'll leave this empty as we'd need to know all teacher names
+    // SPE-318: special activities, loaded school-wide by the DataManager
+    // (year-scoped and live-only per SPE-458/468). This was hardcoded [] for
+    // years — the auto-scheduler placed sessions straight through PE and
+    // assemblies while the drag path warned about them.
+    const specialActivities = this.dataManager.getSpecialActivitiesFlat();
 
-    // SPE-478: mainstreaming blocks are loaded by the DataManager for the
-    // whole school — unlike special activities above, they ARE wired in.
+    // SPE-478: mainstreaming blocks, same school-wide load.
     const mainstreamingBlocks = this.dataManager.getMainstreamingBlocks();
 
     // Get school hours from existing context or use defaults
@@ -399,16 +400,25 @@ export class OptimizedScheduler {
       }
     }
     
-    // Index special activities by teacher for O(1) lookup
-    for (const activity of preloadedData.specialActivities) {
-      if (!specialActivitiesByTeacher.has(activity.teacher_name)) {
-        specialActivitiesByTeacher.set(activity.teacher_name, new Map());
+    // Index special activities by teacher for O(1) lookup — under the display
+    // name AND, when present, the teacher directory id (SPE-484: exact-string
+    // teacher_name matching is the fragile link; ids match even when a name
+    // drifts by whitespace). The slot check consults both keys.
+    const indexActivityUnder = (key: string, activity: SpecialActivity) => {
+      if (!specialActivitiesByTeacher.has(key)) {
+        specialActivitiesByTeacher.set(key, new Map());
       }
-      const teacherMap = specialActivitiesByTeacher.get(activity.teacher_name)!;
+      const teacherMap = specialActivitiesByTeacher.get(key)!;
       if (!teacherMap.has(activity.day_of_week)) {
         teacherMap.set(activity.day_of_week, []);
       }
       teacherMap.get(activity.day_of_week)!.push(activity);
+    };
+    for (const activity of preloadedData.specialActivities) {
+      indexActivityUnder(activity.teacher_name, activity);
+      if (activity.teacher_id) {
+        indexActivityUnder(activity.teacher_id, activity);
+      }
     }
 
     // SPE-478: index mainstreaming blocks for O(1) lookup — under the
@@ -1205,11 +1215,15 @@ export class OptimizedScheduler {
         
         if (hasBellConflict) continue;
 
-        // Check special activities using cached index (O(1) lookup)
-        const teacherActivities = student.teacher_name 
-          ? this.context!.specialActivitiesByTeacher.get(student.teacher_name)?.get(day) || []
-          : [];
-        
+        // Check special activities using cached index (O(1) lookup) — by the
+        // teacher directory id when the student has one, else by name (the
+        // index carries both keys; an id match survives name drift).
+        const activityIndex = this.context!.specialActivitiesByTeacher;
+        const teacherActivities = [
+          ...(student.teacher_id ? activityIndex.get(student.teacher_id)?.get(day) || [] : []),
+          ...(student.teacher_name ? activityIndex.get(student.teacher_name)?.get(day) || [] : []),
+        ];
+
         const hasActivityConflict = teacherActivities.some(activity => {
           const hasTimeOverlap = this.hasTimeOverlap(slot.startTime, endTime, activity.start_time, activity.end_time);
           

--- a/lib/scheduling/optimized-scheduler.ts
+++ b/lib/scheduling/optimized-scheduler.ts
@@ -4,7 +4,7 @@ import { Database } from "../../src/types/database";
 import { SchedulingDataManager } from './scheduling-data-manager';
 import { ManualPlacementService } from '../services/manual-placement-service';
 import { filterScheduledSessions, type ScheduledSession } from '../utils/session-helpers';
-import { findOverlappingOtherProviderSession, findOverlappingMainstreamingBlock, type OtherProviderSessionLite } from '../services/session-update-service';
+import { findOverlappingOtherProviderSession, findOverlappingMainstreamingBlock, findOverlappingSpecialActivity, type OtherProviderSessionLite } from '../services/session-update-service';
 import { DEFAULT_SCHEDULING_CONFIG } from './scheduling-config';
 import {
   DEFAULT_SCHEDULING_STRATEGY,
@@ -1217,25 +1217,29 @@ export class OptimizedScheduler {
 
         // Check special activities using cached index (O(1) lookup) — by the
         // teacher directory id when the student has one, else by name (the
-        // index carries both keys; an id match survives name drift).
+        // index carries both keys; an id match survives name drift). The
+        // candidates then go through the same pure rule the drag warning
+        // runs, which vetoes a name-key hit whose activity carries a
+        // DIFFERENT teacher_id — two teachers sharing a display name must
+        // not block each other's students.
         const activityIndex = this.context!.specialActivitiesByTeacher;
         const teacherActivities = [
           ...(student.teacher_id ? activityIndex.get(student.teacher_id)?.get(day) || [] : []),
           ...(student.teacher_name ? activityIndex.get(student.teacher_name)?.get(day) || [] : []),
         ];
 
-        const hasActivityConflict = teacherActivities.some(activity => {
-          const hasTimeOverlap = this.hasTimeOverlap(slot.startTime, endTime, activity.start_time, activity.end_time);
-          
-          if (hasTimeOverlap) {
-            this.log(`    ❌ Special activity conflict: ${activity.activity_name} for teacher ${student.teacher_name}`);
-            this.performanceMetrics.cacheHits++;
-          }
-          
-          return hasTimeOverlap;
-        });
-        
-        if (hasActivityConflict) continue;
+        const conflictingActivity = findOverlappingSpecialActivity(
+          teacherActivities,
+          { teacherId: student.teacher_id, teacherName: student.teacher_name },
+          day,
+          slot.startTime,
+          endTime,
+        );
+        if (conflictingActivity) {
+          this.log(`    ❌ Special activity conflict: ${conflictingActivity.activity_name} for teacher ${student.teacher_name}`);
+          this.performanceMetrics.cacheHits++;
+          continue;
+        }
 
         // SPE-478: never place a session over the student's mainstreaming time.
         // A hard skip like the SPE-287 cross-provider check below — the

--- a/lib/scheduling/scheduling-data-manager.ts
+++ b/lib/scheduling/scheduling-data-manager.ts
@@ -94,6 +94,10 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
   // a session over a student's time in a gen-ed class.
   private mainstreamingBlocks: MainstreamingBlock[] = [];
 
+  // SPE-318: the same activities cacheSpecialActivities indexes, kept flat for
+  // the auto-scheduler (year-scoped and live-only at fetch — SPE-458/468).
+  private specialActivitiesFlat: SpecialActivity[] = [];
+
   private constructor(config?: DataManagerConfig) {
     this.config = { ...DEFAULT_CONFIG, ...config };
   }
@@ -359,13 +363,21 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
     label: string,
   ): Promise<T[]> {
     const rows: T[] = [];
+    // SPE-468: special_activities soft-deletes; every other reader filters
+    // deleted rows out and the scheduler must too — a deleted activity must
+    // never keep protecting a slot. bell_schedules has no deleted_at column.
+    const liveOnly = table === 'special_activities';
 
     if (this.schoolId) {
-      const { data, error } = await this.supabase
+      let query = this.supabase
         .from(table)
         .select('*')
         .eq('school_year', this.schoolYear)
         .eq('school_id', this.schoolId);
+      if (liveOnly) {
+        query = query.is('deleted_at', null);
+      }
+      const { data, error } = await query;
 
       if (error) {
         this.cacheMetadata.fetchErrors.push(`${label}: ${error.message}`);
@@ -380,6 +392,9 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
         .select('*')
         .eq('school_year', this.schoolYear)
         .eq('school_site', this.schoolSite);
+      if (liveOnly) {
+        query = query.is('deleted_at', null);
+      }
 
       // When we already matched by school_id, this pass is only for strays the
       // migration missed — without this the two passes would double-count any
@@ -737,7 +752,10 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
    */
   private cacheSpecialActivities(activities: SpecialActivity[]): void {
     this.data.data.specialActivities.clear();
-    
+    // SPE-318: keep the flat list too — the auto-scheduler builds its own
+    // per-teacher index from it (same shape it uses for mainstreaming blocks).
+    this.specialActivitiesFlat = activities;
+
     activities.forEach(activity => {
       const teacherKey = activity.teacher_name;
       if (!this.data.data.specialActivities.has(teacherKey)) {
@@ -945,6 +963,11 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
     return this.mainstreamingBlocks;
   }
 
+  /** SPE-318: every live special activity at this school (current year), flat. */
+  public getSpecialActivitiesFlat(): SpecialActivity[] {
+    return this.specialActivitiesFlat;
+  }
+
   /**
    * Check if a time slot is available (respecting 8 concurrent session limit)
    */
@@ -1040,6 +1063,7 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
     this.data.data.schoolHours = [];
     this.crossProviderSessions.clear();
     this.mainstreamingBlocks = [];
+    this.specialActivitiesFlat = [];
 
     this.cacheMetadata.isStale = true;
     this.conflicts = [];

--- a/lib/scheduling/scheduling-data-manager.ts
+++ b/lib/scheduling/scheduling-data-manager.ts
@@ -198,6 +198,12 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
       // the parallel path below no longer does. Repairing the RPC without
       // adding a school_year filter would reintroduce that bug on this path
       // only — visible just at schools holding two years of data.
+      //
+      // SPE-468/SPE-484: the special_activities CTE also has no deleted_at
+      // filter. The parallel path strips soft-deleted rows in fetchForSchool,
+      // and the scheduler now actually consumes this list (SPE-318), so a
+      // repaired RPC without that filter would resurrect deleted activities
+      // as scheduling blocks on this path only.
       const { data, error } = await this.supabase.rpc('get_scheduling_data_batch', {
         p_provider_id: this.providerId!,
         p_school_site: this.schoolSite!

--- a/lib/services/session-update-service.ts
+++ b/lib/services/session-update-service.ts
@@ -50,6 +50,51 @@ export function findOverlappingOtherProviderSession(
   return null;
 }
 
+/** SPE-484: minimal shape of a special activity for teacher-keyed overlap checks. */
+export interface SpecialActivityLite {
+  teacher_id: string | null;
+  teacher_name: string;
+  day_of_week: number;
+  start_time: string;
+  end_time: string;
+}
+
+/**
+ * SPE-484: the first special activity belonging to the student's TEACHER that
+ * overlaps [startTime, endTime) on `day`, else null. Teacher matching prefers
+ * teacher_id and falls back to exact teacher_name — the same dual matching the
+ * grid's availability layer uses, so what warns is what displays. When the
+ * student has a teacher_id and the activity carries one too, the ids must
+ * agree (a stale name coincidence must not warn). Pure (no I/O) so the rule is
+ * unit-testable without a Supabase mock. Half-open overlap, matching
+ * SessionUpdateService.hasTimeOverlap.
+ */
+export function findOverlappingSpecialActivity<T extends SpecialActivityLite>(
+  activities: T[],
+  studentTeacher: { teacherId: string | null; teacherName: string | null },
+  day: number,
+  startTime: string,
+  endTime: string,
+): T | null {
+  const start = timeToMinutes(startTime);
+  const end = timeToMinutes(endTime);
+  for (const a of activities) {
+    if (a.day_of_week !== day) continue;
+    const idMatch = !!studentTeacher.teacherId && a.teacher_id === studentTeacher.teacherId;
+    const nameMatch =
+      !!studentTeacher.teacherName &&
+      a.teacher_name === studentTeacher.teacherName &&
+      // If both sides carry ids and they disagree, the name match is a
+      // coincidence (or drift) — do not warn on it.
+      !(a.teacher_id && studentTeacher.teacherId && a.teacher_id !== studentTeacher.teacherId);
+    if (!idMatch && !nameMatch) continue;
+    if (start < timeToMinutes(a.end_time) && end > timeToMinutes(a.start_time)) {
+      return a;
+    }
+  }
+  return null;
+}
+
 /** SPE-478: minimal shape of a mainstreaming block for overlap checks. */
 export interface MainstreamingBlockLite {
   day_of_week: number;
@@ -445,7 +490,7 @@ export class SessionUpdateService {
     // conflict priority (the conflicts[0] surfaced as `error`) is unchanged.
     const checks: Array<Promise<NonNullable<ValidationResult['conflicts']>[0] | null>> = [
       this.checkBellScheduleConflicts(providerId, studentId, targetDay, targetStartTime, targetEndTime),
-      this.checkSpecialActivityConflicts(providerId, studentId, targetDay, targetStartTime, targetEndTime),
+      this.checkSpecialActivityConflicts(studentId, targetDay, targetStartTime, targetEndTime),
       // SPE-478: mainstreaming time is protected — warn any provider placing a
       // session over the student's time in a gen-ed class (overridable, like
       // every other conflict here).
@@ -547,7 +592,6 @@ export class SessionUpdateService {
    * Check for special activity conflicts
    */
   private async checkSpecialActivityConflicts(
-    providerId: string,
     studentId: string,
     day: number,
     startTime: string,
@@ -556,36 +600,46 @@ export class SessionUpdateService {
     // Get student's teacher and school information
     const { data: student } = await this.supabase
       .from('students')
-      .select('teacher_name, school_id')
+      .select('teacher_id, teacher_name, school_id')
       .eq('id', studentId)
       .single();
 
-    if (!student || !student.teacher_name || !student.school_id) {
+    if (!student || !student.school_id || (!student.teacher_id && !student.teacher_name)) {
       return null;
     }
 
-    // Only check special activities for this student's teacher and school
+    // SPE-484: school-wide, NOT scoped to the caller's provider_id — that
+    // legacy filter meant an activity entered by a site admin or another
+    // provider displayed as a band but never warned anyone else. Every
+    // activity the grid shows is one the warning must honor. Year-scoped and
+    // live-only (SPE-468's lesson: soft-deleted rows must never protect).
+    // Teacher matching happens in the pure helper (id preferred, exact-name
+    // fallback), same as the availability layer, so PostgREST or-quoting
+    // never mangles names with spaces.
     const { data: activities } = await this.supabase
       .from('special_activities')
       .select('*')
-      .eq('provider_id', providerId)
-      .eq('teacher_name', student.teacher_name)
       .eq('day_of_week', day)
-      .eq('school_id', student.school_id);
+      .eq('school_id', student.school_id)
+      .eq('school_year', getCurrentSchoolYear())
+      .is('deleted_at', null);
 
-    if (activities) {
-      for (const activity of activities) {
-        if (this.hasTimeOverlap(startTime, endTime, activity.start_time, activity.end_time)) {
-          return {
-            type: 'special_activity',
-            description: `Conflicts with special activity "${activity.activity_name}" with ${activity.teacher_name} (${activity.start_time} - ${activity.end_time})`,
-            conflictingItem: activity
-          };
-        }
-      }
+    const overlapping = findOverlappingSpecialActivity(
+      activities || [],
+      { teacherId: student.teacher_id, teacherName: student.teacher_name },
+      day,
+      startTime,
+      endTime
+    );
+    if (!overlapping) {
+      return null;
     }
 
-    return null;
+    return {
+      type: 'special_activity',
+      description: `Conflicts with special activity "${overlapping.activity_name}" with ${overlapping.teacher_name} (${overlapping.start_time} - ${overlapping.end_time})`,
+      conflictingItem: overlapping
+    };
   }
 
   /**

--- a/lib/services/session-update-service.ts
+++ b/lib/services/session-update-service.ts
@@ -352,10 +352,12 @@ export class SessionUpdateService {
       });
 
       // Clear stale conflicts for this student that this move may have resolved.
-      // clearStaleConflictsForStudent re-checks BOTH same-provider overlaps and the
-      // cross-provider double-book (SPE-255), so it won't erase a live cross-provider
-      // flag on a sibling session — and the just-moved session keeps whatever flag the
-      // validation above set, because that same authoritative check still sees it.
+      // clearStaleConflictsForStudent re-checks EVERY flag source that can set a
+      // flag here — same-provider overlaps, the cross-provider double-book
+      // (SPE-255), mainstreaming time (SPE-478), and the teacher's special
+      // activities (SPE-484) — so it won't erase a live flag on a sibling
+      // session, and the just-moved session keeps whatever flag the validation
+      // above set, because those same authoritative checks still see it.
       if (session.student_id && session.provider_id) {
         // Always check the new day for stale conflicts
         await this.clearStaleConflictsForStudent(session.student_id, session.provider_id, newDay);
@@ -597,36 +599,17 @@ export class SessionUpdateService {
     startTime: string,
     endTime: string
   ): Promise<NonNullable<ValidationResult['conflicts']>[0] | null> {
-    // Get student's teacher and school information
-    const { data: student } = await this.supabase
-      .from('students')
-      .select('teacher_id, teacher_name, school_id')
-      .eq('id', studentId)
-      .single();
-
-    if (!student || !student.school_id || (!student.teacher_id && !student.teacher_name)) {
+    // Fail-open here matches the sibling bell/mainstreaming checks (a read
+    // error means no warning); the stale-CLEAR path is where failure must
+    // fail safe, via this fetch's `failed` flag.
+    const { activities, teacher } = await this.fetchSpecialActivitiesForStudent(studentId, day);
+    if (!teacher) {
       return null;
     }
 
-    // SPE-484: school-wide, NOT scoped to the caller's provider_id — that
-    // legacy filter meant an activity entered by a site admin or another
-    // provider displayed as a band but never warned anyone else. Every
-    // activity the grid shows is one the warning must honor. Year-scoped and
-    // live-only (SPE-468's lesson: soft-deleted rows must never protect).
-    // Teacher matching happens in the pure helper (id preferred, exact-name
-    // fallback), same as the availability layer, so PostgREST or-quoting
-    // never mangles names with spaces.
-    const { data: activities } = await this.supabase
-      .from('special_activities')
-      .select('*')
-      .eq('day_of_week', day)
-      .eq('school_id', student.school_id)
-      .eq('school_year', getCurrentSchoolYear())
-      .is('deleted_at', null);
-
     const overlapping = findOverlappingSpecialActivity(
-      activities || [],
-      { teacherId: student.teacher_id, teacherName: student.teacher_name },
+      activities,
+      teacher,
       day,
       startTime,
       endTime
@@ -639,6 +622,85 @@ export class SessionUpdateService {
       type: 'special_activity',
       description: `Conflicts with special activity "${overlapping.activity_name}" with ${overlapping.teacher_name} (${overlapping.start_time} - ${overlapping.end_time})`,
       conflictingItem: overlapping
+    };
+  }
+
+  /**
+   * SPE-484: the student's teacher identity plus every live special activity
+   * at their school on `day` for the current year. School-wide, NOT scoped to
+   * the caller's provider_id — that legacy filter meant an activity entered
+   * by a site admin or another provider displayed as a band but never warned
+   * anyone else; every activity the grid shows is one the warning must
+   * honor. Live-only (SPE-468's lesson: soft-deleted rows must never
+   * protect). Both school linkages are honored — normalized rows under the
+   * student's school_id plus legacy rows carrying only a school_site name
+   * (school_id IS NULL), the same two-pass shape
+   * SchedulingDataManager.fetchForSchool uses — run as separate queries so
+   * PostgREST or-quoting never mangles school or teacher names with spaces
+   * or commas. Teacher matching happens in the pure helper (id preferred,
+   * exact-name fallback), same as the availability layer, so what warns is
+   * what displays.
+   */
+  private async fetchSpecialActivitiesForStudent(
+    studentId: string,
+    day: number
+  ): Promise<{
+    activities: Array<Database['public']['Tables']['special_activities']['Row']>;
+    /** Null when the student has no teacher or no school linkage — no
+     * activity can match them, so there is nothing to warn about or retain. */
+    teacher: { teacherId: string | null; teacherName: string | null } | null;
+    /** True when a lookup ERRORED (vs. legitimately returning nothing) — the
+     * stale-clear caller must keep flags rather than treat this as "clear". */
+    failed: boolean;
+  }> {
+    const { data: student, error: studentError } = await this.supabase
+      .from('students')
+      .select('teacher_id, teacher_name, school_id, school_site')
+      .eq('id', studentId)
+      .single();
+
+    if (studentError) {
+      return { activities: [], teacher: null, failed: true };
+    }
+    if (
+      !student ||
+      (!student.teacher_id && !student.teacher_name) ||
+      (!student.school_id && !student.school_site)
+    ) {
+      return { activities: [], teacher: null, failed: false };
+    }
+
+    const activitiesQuery = () =>
+      this.supabase
+        .from('special_activities')
+        .select('*')
+        .eq('day_of_week', day)
+        .eq('school_year', getCurrentSchoolYear())
+        .is('deleted_at', null);
+
+    const activities: Array<Database['public']['Tables']['special_activities']['Row']> = [];
+    let failed = false;
+
+    if (student.school_id) {
+      const { data, error } = await activitiesQuery().eq('school_id', student.school_id);
+      if (error) failed = true;
+      activities.push(...(data || []));
+    }
+    if (student.school_site) {
+      // Legacy rows predate school normalization — school_id was never set,
+      // so the branch above cannot see them. Mutually exclusive with it
+      // (school_id IS NULL here), so no dedupe is needed.
+      const { data, error } = await activitiesQuery()
+        .is('school_id', null)
+        .eq('school_site', student.school_site);
+      if (error) failed = true;
+      activities.push(...(data || []));
+    }
+
+    return {
+      activities,
+      teacher: { teacherId: student.teacher_id, teacherName: student.teacher_name },
+      failed,
     };
   }
 
@@ -1094,25 +1156,52 @@ export class SessionUpdateService {
         mainstreamingCheckFailed = true;
       }
 
+      // SPE-484: a flag may also exist because the session sits on the
+      // student's teacher's special activity (an overridden drag warning).
+      // Same retention contract as mainstreaming above — count the overlap
+      // as still live, and treat an errored lookup as "unknown: keep flags".
+      let specialActivities: SpecialActivityLite[] = [];
+      let activityTeacher: { teacherId: string | null; teacherName: string | null } | null = null;
+      let activityCheckFailed = false;
+      try {
+        const result = await this.fetchSpecialActivitiesForStudent(studentId, day);
+        specialActivities = result.activities;
+        activityTeacher = result.teacher;
+        activityCheckFailed = result.failed;
+      } catch (e) {
+        console.error('Special-activity stale-check threw:', e);
+        activityCheckFailed = true;
+      }
+
       // Clear a flag only when the session no longer overlaps ANY same-provider
-      // session, no longer double-books across providers, AND no longer sits on
-      // mainstreaming time.
+      // session, no longer double-books across providers, no longer sits on
+      // mainstreaming time, AND no longer sits on its teacher's special
+      // activity.
       for (const flaggedSession of flaggedSessions) {
         if (!flaggedSession.start_time || !flaggedSession.end_time) {
           continue;
         }
 
-        // Fail safe: an unverifiable cross-provider status keeps the flag.
+        // Fail safe: an unverifiable conflict source keeps the flag.
         const stillHasOverlap =
           crossCheckFailed ||
           mainstreamingCheckFailed ||
+          activityCheckFailed ||
           flaggedSessionStillConflicts(flaggedSession, allSessions, otherProviderSessions) ||
           findOverlappingMainstreamingBlock(
             mainstreamingBlocks,
             day,
             flaggedSession.start_time,
             flaggedSession.end_time
-          ) !== null;
+          ) !== null ||
+          (activityTeacher !== null &&
+            findOverlappingSpecialActivity(
+              specialActivities,
+              activityTeacher,
+              day,
+              flaggedSession.start_time,
+              flaggedSession.end_time
+            ) !== null);
 
         // If no longer overlapping, clear the conflict flag
         if (!stillHasOverlap) {

--- a/lib/supabase/hooks/use-schedule-data.ts
+++ b/lib/supabase/hooks/use-schedule-data.ts
@@ -141,6 +141,13 @@ export function useScheduleData() {
         
         // Special activities query - School-wide (all providers see all activities)
         // Exclude soft-deleted activities
+        //
+        // SPE-487: NOT year-scoped, unlike the drag-warning and auto-scheduler
+        // fetches, which honor only getCurrentSchoolYear() rows — so after a
+        // school-year rollover a prior-year band could display here while
+        // warning about and blocking nothing. Harmless today (prod holds only
+        // current-year rows) and changing what displays is a user-facing call,
+        // so the divergence is tracked there rather than fixed as a rider.
         (() => {
           let query = supabase
             .from('special_activities')

--- a/scripts/sim-district/verify-scheduler-year-scope.ts
+++ b/scripts/sim-district/verify-scheduler-year-scope.ts
@@ -141,11 +141,14 @@ async function signIn(personaKey: string): Promise<SupabaseClient> {
 
   // Special activities get the same treatment, ground truth included. Asserting
   // only "prior year is empty" here would go green on a query error, which is
-  // the trap this script exists to avoid.
+  // the trap this script exists to avoid. The truth query is live-only to
+  // match fetchForSchool's SPE-468 deleted_at filter — without it, any
+  // soft-deleted activity in the namespace makes this check false-fail.
   let actTruth = admin
     .from('special_activities')
     .select('id', { count: 'exact', head: true })
-    .eq('school_year', thisYear);
+    .eq('school_year', thisYear)
+    .is('deleted_at', null);
   actTruth = school.school_id
     ? actTruth.eq('school_id', school.school_id)
     : actTruth.eq('school_site', school.school_site!);


### PR DESCRIPTION
## What

Special activities (PE, library, assemblies) rendered as availability bands but under-protected in three known ways. This PR closes all three so what displays is what's enforced — the prerequisite Blair chose before building SDC class blocks on the activities system (SPE-479 sequencing decision):

- **SPE-484 — drag warnings were creator-only.** `checkSpecialActivityConflicts` filtered `.eq('provider_id', caller)`, a relic of the era when each provider logged their own students' teacher activities. An activity entered by a site admin or another provider displayed but never warned. Now school-wide, year-scoped, live-only.
- **SPE-318 (activities portion) — the auto-scheduler received a hardcoded `[]`.** The famous `// For now, we'll leave this empty` is gone: the DataManager keeps a flat, live, year-scoped list (`getSpecialActivitiesFlat`) and the scheduler consumes it. Batch placement now declines slots inside a teacher's activity windows, matching what the drag path warns about.
- **SPE-468 — soft-deleted rows fed the scheduler.** `fetchForSchool` now filters `deleted_at` for `special_activities` (bell_schedules has no such column), on both the school_id and legacy school_site passes. A deleted activity can no longer keep protecting a slot.

## Design details

- **Teacher matching is now a shared pure rule** — `findOverlappingSpecialActivity` (exported beside the SPE-478 mainstreaming helper): `teacher_id` preferred, exact `teacher_name` fallback for legacy rows, and **disagreeing ids veto a name coincidence** — the "Dalia··Malibran" string-fragility lesson from SPE-468 becomes a guard instead of a hazard.
- **The scheduler's per-teacher index is dual-keyed** (name + id) and the slot check consults both, so an id match survives name drift.
- **SPE-318's other blind spots stay parked** (hardcoded 08:00–15:00 window, K–5 grade range) per Blair's 2026-07-24 note pending the auto-scheduler rework — the ticket stays open with a partial-completion comment.
- **Found while here, filed separately (SPE-485):** bell-schedule drag warnings carry the *same* creator-only scoping bug — directly pilot-relevant since Rodeo Hills' bell schedules are admin-loaded. Out of this PR's approved scope.

## Behavior change (deliberate — this is the bug being fixed)

Providers will see overridable warnings where they previously got silence, and Auto-Schedule will find fewer candidate slots (it stops placing sessions during PE). Risk direction is toward correctness; nothing is hard-blocked.

## Verification

- `tsc` clean, lint clean, **127/127 suites (1479 tests)** including 8 new: the pure matching rule (id/name/veto/half-open) and the live slot search dropping/keeping slots through both index keys.
- Sim-district walk with real signed-in sessions runs next (cross-provider warning data path; auto-schedule declining an activity window through the UI; soft-deleted activity no longer blocking); results will be posted here before this is ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPvswmLrhUoZ1QeNPQK5EZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPvswmLrhUoZ1QeNPQK5EZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatic scheduling now accounts for special activities when assigning time slots.
  - Conflict checks match teachers by directory ID, with name-based fallback when needed.
  - Special activities are considered across the school for the current school year.

- **Bug Fixes**
  - Deleted activities are excluded from scheduling and conflict validation.
  - Improved handling of teacher changes and conflicting teacher information.

- **Documentation**
  - Updated scheduling architecture documentation to reflect special-activity integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->