### PR TITLE
SPE-477: scope the scheduler's session cache to templates only

### DIFF
--- a/__tests__/unit/lib/scheduling/data-manager-template-scope.test.ts
+++ b/__tests__/unit/lib/scheduling/data-manager-template-scope.test.ts
@@ -1,0 +1,224 @@
+/**
+ * SPE-477: the scheduler's session cache fetched EVERY row for a provider's
+ * students — recurring templates and the dated instances materialized from them
+ * (SPE-291 keeps a rolling 12-week horizon of those) — capped at 10,000.
+ *
+ * Instances outrun templates roughly 40:1, so the cap was a real ceiling that
+ * arrives on a calendar: the largest provider in prod carried 7,868 instances
+ * against 203 templates, 81% of the cap, growing every week the horizon rolls.
+ * Past it, PostgREST truncates in unspecified order and returns success — so the
+ * auto-scheduler would quietly start planning around a partial schedule, with no
+ * error anywhere. Nothing else fetched here wants instances either: SPE-474 was
+ * the same confusion showing up as double-booked slots.
+ *
+ * The mock below APPLIES the filters (and the row cap) rather than recording
+ * them, so these assert what the scheduler ends up holding — not that some
+ * particular line was written.
+ */
+
+type Row = Record<string, unknown>;
+
+// `mock`-prefixed so the jest.mock factory (hoisted above imports) may reference it.
+const mockState: { rows: Record<string, Row[]> } = { rows: {} };
+
+type Predicate = (row: Row) => boolean;
+
+/** `student_id.in.(a,b),assigned_to_specialist_id.eq.p1` → OR of two predicates. */
+function parseOr(clause: string): Predicate {
+  const parts = clause.split(/,(?=[a-z_]+\.(?:in|eq)\.)/);
+  const predicates: Predicate[] = parts.map((part) => {
+    const inMatch = part.match(/^([a-z_]+)\.in\.\((.*)\)$/);
+    if (inMatch) {
+      const values = new Set(inMatch[2].split(',').filter(Boolean));
+      return (row: Row) => values.has(String(row[inMatch[1]]));
+    }
+    const eqMatch = part.match(/^([a-z_]+)\.eq\.(.*)$/);
+    if (eqMatch) return (row: Row) => row[eqMatch[1]] === eqMatch[2];
+    throw new Error(`unhandled .or() clause: ${part}`);
+  });
+  return (row: Row) => predicates.some((p) => p(row));
+}
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    rpc: () => ({ single: async () => ({ data: null, error: { message: 'unavailable' } }) }),
+    from: (table: string) => {
+      const predicates: Predicate[] = [];
+      let rowLimit: number | null = null;
+
+      const query: any = {
+        select: () => query,
+        eq: (col: string, val: unknown) => {
+          predicates.push((row) => row[col] === val);
+          return query;
+        },
+        is: (col: string, val: unknown) => {
+          if (val !== null) throw new Error(`unhandled .is(${col}, ${String(val)})`);
+          predicates.push((row) => row[col] === null || row[col] === undefined);
+          return query;
+        },
+        in: (col: string, vals: unknown[]) => {
+          const set = new Set(vals);
+          predicates.push((row) => set.has(row[col] as never));
+          return query;
+        },
+        or: (clause: string) => {
+          predicates.push(parseOr(clause));
+          return query;
+        },
+        order: () => query,
+        limit: (n: number) => {
+          rowLimit = n;
+          return query;
+        },
+        single: async () => ({ data: null, error: { message: 'no row' } }),
+        then: (resolve: (r: unknown) => unknown) => {
+          let data = (mockState.rows[table] || []).filter((row) => predicates.every((p) => p(row)));
+          // PostgREST truncates at the cap and still reports success — the
+          // silent failure this ticket is about.
+          if (rowLimit !== null) data = data.slice(0, rowLimit);
+          return Promise.resolve(resolve({ data, error: null }));
+        },
+      };
+      return query;
+    },
+  }),
+}));
+
+import { SchedulingDataManager } from '@/lib/scheduling/scheduling-data-manager';
+
+const PROVIDER_ID = 'provider-1';
+const SCHOOL_ID = '061899002301';
+
+function manager(role: string | null = null) {
+  const mgr = SchedulingDataManager.getInstance() as any;
+  mgr.cacheMetadata = { lastFetched: new Date(), isStale: false, fetchErrors: [], queryCount: 0 };
+  mgr.providerId = PROVIDER_ID;
+  mgr.providerRole = role;
+  mgr.schoolId = SCHOOL_ID;
+  mgr.schoolSite = null;
+  mgr.schoolDistrict = null;
+  return mgr;
+}
+
+const student = (id: string) => ({ id, provider_id: PROVIDER_ID, school_id: SCHOOL_ID });
+
+/** A recurring template: no date, present on the weekly grid. */
+const template = (id: string, studentId: string) => ({
+  id,
+  student_id: studentId,
+  provider_id: PROVIDER_ID,
+  day_of_week: 1,
+  start_time: '09:00:00',
+  session_date: null,
+  is_template: true,
+  deleted_at: null,
+});
+
+/** A dated instance materialized from a template — same day and time. */
+const instance = (id: string, studentId: string, date: string) => ({
+  ...template(id, studentId),
+  id,
+  session_date: date,
+  is_template: false,
+});
+
+beforeEach(() => {
+  mockState.rows = {};
+});
+
+describe('SchedulingDataManager holds templates only (SPE-477)', () => {
+  it('drops dated instances for a plain provider', async () => {
+    mockState.rows.students = [student('s1')];
+    mockState.rows.schedule_sessions = [
+      template('t1', 's1'),
+      instance('i1', 's1', '2026-08-17'),
+      instance('i2', 's1', '2026-08-24'),
+      template('t2', 's1'),
+    ];
+
+    const sessions = await manager().fetchExistingSessions();
+
+    expect(sessions.map((s: Row) => s.id).sort()).toEqual(['t1', 't2']);
+  });
+
+  it('drops soft-deleted templates, which are invisible everywhere else', async () => {
+    // A deleted template still occupies its slot in this cache, so the
+    // scheduler treats a freed-up time as taken and refuses to place there.
+    mockState.rows.students = [student('s1')];
+    mockState.rows.schedule_sessions = [
+      template('live', 's1'),
+      { ...template('deleted', 's1'), deleted_at: '2026-08-01T00:00:00Z' },
+    ];
+
+    const sessions = await manager().fetchExistingSessions();
+
+    expect(sessions.map((s: Row) => s.id)).toEqual(['live']);
+  });
+
+  it('scopes the specialist path too — that branch fetches the most rows', async () => {
+    // Specialists read their own students' sessions OR anything assigned to
+    // them, so this is the widest query in the file and the one nearest the cap.
+    mockState.rows.students = [
+      student('s1'),
+      // Another provider's student at this school, delegated to me.
+      { id: 'other-student', provider_id: 'provider-2', school_id: SCHOOL_ID },
+    ];
+    mockState.rows.schedule_sessions = [
+      template('mine', 's1'),
+      instance('mine-dated', 's1', '2026-08-17'),
+      { ...template('mine-deleted', 's1'), deleted_at: '2026-08-01T00:00:00Z' },
+      { ...template('assigned', 'other-student'), assigned_to_specialist_id: PROVIDER_ID },
+      {
+        ...instance('assigned-dated', 'other-student', '2026-08-17'),
+        assigned_to_specialist_id: PROVIDER_ID,
+      },
+    ];
+
+    const sessions = await manager('resource').fetchExistingSessions();
+
+    expect(sessions.map((s: Row) => s.id).sort()).toEqual(['assigned', 'mine']);
+  });
+
+  it('scopes the specialist-with-no-students path', async () => {
+    mockState.rows.students = [{ id: 'other-student', provider_id: 'provider-2', school_id: SCHOOL_ID }];
+    mockState.rows.schedule_sessions = [
+      { ...template('assigned', 'other-student'), assigned_to_specialist_id: PROVIDER_ID },
+      {
+        ...instance('assigned-dated', 'other-student', '2026-08-17'),
+        assigned_to_specialist_id: PROVIDER_ID,
+      },
+      {
+        ...template('assigned-deleted', 'other-student'),
+        assigned_to_specialist_id: PROVIDER_ID,
+        deleted_at: '2026-08-01T00:00:00Z',
+      },
+    ];
+
+    const sessions = await manager('speech').fetchExistingSessions();
+
+    expect(sessions.map((s: Row) => s.id)).toEqual(['assigned']);
+  });
+});
+
+describe('the 10,000-row cap stops being a deadline (SPE-477)', () => {
+  it('keeps every template for a caseload whose instances would blow the cap', async () => {
+    // The prod shape, scaled past the ceiling: one provider, a couple hundred
+    // recurring sessions, and a 12-week horizon of instances behind them.
+    // PostgREST returns rows in unspecified order, so model the worst case —
+    // instances first. Unscoped, the read fills all 10,000 rows with instances
+    // and the provider's real weekly schedule never arrives, reported as
+    // success. The assertion that matters is the one on the templates.
+    mockState.rows.students = [student('s1')];
+    const instances = Array.from({ length: 10_000 }, (_, i) =>
+      instance(`i${i}`, 's1', '2026-08-17'),
+    );
+    const templates = Array.from({ length: 203 }, (_, i) => template(`t${i}`, 's1'));
+    mockState.rows.schedule_sessions = [...instances, ...templates];
+
+    const sessions = await manager().fetchExistingSessions();
+
+    expect(sessions).toHaveLength(203);
+    expect(sessions.every((s: Row) => s.session_date === null)).toBe(true);
+  });
+});

--- a/lib/scheduling/optimized-scheduler.ts
+++ b/lib/scheduling/optimized-scheduler.ts
@@ -236,9 +236,11 @@ export class OptimizedScheduler {
     //     negative and removed it from the grid entirely — a calendar with a
     //     handful of sessions could present as having no room at all.
     //
-    // Scoped to the scheduler's own context on purpose: the shared data manager
-    // still serves unfiltered rows to the calendar and conflict paths, which
-    // legitimately work in dated instances.
+    // SPE-477 has since scoped the shared data manager to templates as well, so
+    // this filter no longer has anything to remove in practice. It stays as the
+    // scheduler's own statement of what its context must contain — the two
+    // failures above are silent ones, and a cache that starts serving instances
+    // again should not be able to reintroduce them from a distance.
     const existingSessions = filterScheduledSessions(this.dataManager.getExistingSessions())
       .filter(session => session.is_template === true && session.deleted_at == null);
 

--- a/lib/scheduling/scheduling-data-manager.ts
+++ b/lib/scheduling/scheduling-data-manager.ts
@@ -457,19 +457,30 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
 
     const studentIds = students?.map(s => s.id) || [];
 
-    // SPE-474: the 10,000-row cap below has no ORDER BY, so which rows survive
-    // truncation is arbitrary — and dated instances outnumber templates roughly
-    // 40:1 (the largest provider in prod carries 203 templates against 7,868
-    // instances, 8,071 rows against a 10,000 cap). Once a provider crosses it,
-    // arbitrary truncation could drop the recurring templates while keeping
-    // their instances, and the auto-scheduler would then read a student as
-    // having FEWER weekly sessions than they do and create duplicates.
+    // SPE-477: this cache holds the WEEKLY schedule — recurring templates only,
+    // never the dated instances materialized from them.
     //
-    // Ordering templates first makes truncation deterministic and drops
-    // instances rather than templates. It does not shrink what any caller
-    // receives — same cap, same rows below it. The cap itself still needs
-    // raising or paginating (SPE-477).
-    const TEMPLATES_FIRST = { column: 'is_template', options: { ascending: false } } as const;
+    // Every consumer wants templates and only templates:
+    //   - the schedule page's own session fetch already scopes to
+    //     `session_date IS NULL`, and merges this cache into that same list, so
+    //     anything else here leaks a population the page never asked for;
+    //   - the auto-scheduler builds the weekly grid, and filtered instances back
+    //     out client-side after they broke it (SPE-474);
+    //   - manual placement generates Mon–Fri slots and counts conflicts against
+    //     them, where instances inflate every count the same way;
+    //   - the undo snapshot restores the template schedule.
+    //
+    // Fetching them was also what made the 10,000-row cap a real ceiling:
+    // instances outrun templates roughly 40:1 (the largest provider in prod
+    // carried 7,868 instances against 203 templates — 8,071 rows, 81% of the
+    // cap, growing every week as the horizon rolls). Scoped to templates that
+    // provider reads 203 rows, so the cap stops being a deadline.
+    //
+    // `session_date IS NULL` is the template test the page's own query uses; it
+    // agrees with `is_template = true` on every row in prod. SPE-474's
+    // templates-first ordering is gone with it — it existed so arbitrary
+    // truncation would drop instances rather than templates, which cannot arise
+    // when instances are never fetched.
 
     // For specialist users, also fetch sessions assigned to them (even from other providers' students)
     let sessionsResult;
@@ -483,7 +494,8 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
           .from('schedule_sessions')
           .select('*')
           .or(`student_id.in.(${studentIds.join(',')}),assigned_to_specialist_id.eq.${this.providerId}`)
-          .order(TEMPLATES_FIRST.column, TEMPLATES_FIRST.options)
+          .is('session_date', null)
+          .is('deleted_at', null)
           .limit(10000);
       } else {
         // No students, only fetch assigned sessions
@@ -491,7 +503,8 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
           .from('schedule_sessions')
           .select('*')
           .eq('assigned_to_specialist_id', this.providerId!)
-          .order(TEMPLATES_FIRST.column, TEMPLATES_FIRST.options)
+          .is('session_date', null)
+          .is('deleted_at', null)
           .limit(10000);
       }
 
@@ -540,7 +553,8 @@ export class SchedulingDataManager implements SchedulingDataManagerInterface {
         .select('*')
         .eq('provider_id', this.providerId!)
         .in('student_id', studentIds)
-        .order(TEMPLATES_FIRST.column, TEMPLATES_FIRST.options)
+        .is('session_date', null)
+        .is('deleted_at', null)
         .limit(10000);
     }
 


### PR DESCRIPTION
## What

`SchedulingDataManager.fetchExistingSessions()` fetched every `schedule_sessions` row for a provider's students — recurring templates **and** the dated instances materialized from them (SPE-291 keeps a rolling 12-week horizon) — capped at 10,000 rows.

Instances outrun templates roughly 40:1, so that cap was a ceiling arriving on a calendar: the largest provider in prod carried **7,868 instances against 203 templates — 8,071 rows, 81% of the cap**, growing every week the horizon rolls. Past it, PostgREST truncates in unspecified order and still reports success, so the auto-scheduler would quietly plan around a partial schedule with no error anywhere.

This adds `.is('session_date', null).is('deleted_at', null)` to all three query branches. Same provider now reads **203 rows instead of 8,071**.

## Why templates-only is correct here

No consumer of this cache wants instances:

- the schedule page's own fetch is already `session_date IS NULL` in all three branches (`use-schedule-data.ts:186-235`) and **merges this cache into that same list** (`:398-427`) — so the cache was leaking a population the page never asked for;
- the auto-scheduler builds the weekly grid and filtered instances back out client-side after they produced double-booked slots (SPE-474);
- manual placement generates Mon–Fri slots and counts conflicts against them;
- the undo snapshot restores the template schedule.

Soft-deleted templates were being loaded too, which made the scheduler treat a freed-up slot as taken.

SPE-474's templates-first ordering goes with this change — it existed so arbitrary truncation would drop instances rather than templates, which cannot arise when instances are never fetched.

## Verification

**Unit tests** (`data-manager-template-scope.test.ts`, 5 cases) — the mock *applies* the filters and the row cap rather than recording them, so they assert what the scheduler ends up holding. Each of the three branches is pinned independently: dropping either `.is()` from any branch fails a test (mutation-checked both ways). One case models the prod shape past the ceiling — 10,000 instances behind 203 templates — and asserts every template survives.

**Sim district walk** (required: this is a browser DB read). Rachel (resource, Willow) signed in for real; every `schedule_sessions` response captured off the wire.

| | reads | rows returned | dated |
|---|---|---|---|
| before (main) | 7 | 598 | **402** |
| after | 7 | 196 | **0** |

The data manager's own read went from **250 rows → 49** for her caseload, and every read now carries both filters in the query string.

Then an end-to-end auto-schedule run through the UI: raised a student to 3x/wk on the Students page (the seed leaves no unscheduled placeholders, so the requirement sync mints them), ran Auto-Schedule, and confirmed in the DB that all 3 sessions were placed, **every other student stayed exactly at their required count**, each new slot holds 1 session (ceiling is 8), and zero sessions came back flagged `has_conflict`.

Lifecycle closed: teardown → `sim:verify --expect-empty` all zeros → reset → green verify.

**Gates:** typecheck clean, lint clean, full suite green (1464 passed). `/code-review` at high effort found no correctness bug; its one finding — a comment in `optimized-scheduler.ts` that the scoping change made untrue — is fixed in the second commit.

## Not covered

- Soft-deleted templates were not exercised in the sim walk (the seed has none, and hand-writing sim rows is off-limits). That path is covered by unit tests only.
- Only the resource-provider path was walked; the specialist-with-no-students branch is unit-tested but not walked.

## Follow-up filed

The sim seed creates no unscheduled placeholder rows for any persona, so Auto-Schedule is disabled out of the box for every sim provider — a walk has to create the work first. Logged separately as a fixture gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQdotbcQEfBNAgp1NFRQek)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduling now consistently uses active recurring templates while excluding dated sessions and deleted templates.
  * Prevented large numbers of dated sessions from limiting the recurring templates available to schedulers.
  * Improved scheduling results for providers, specialists, and specialists without students.

* **Tests**
  * Added coverage for filtering, deletion handling, and large scheduling datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->