### PR TITLE
Hide the IEP-PDF import while the AI kill switch is off (SPE-494)

### DIFF
--- a/__tests__/unit/app/api/features.test.ts
+++ b/__tests__/unit/app/api/features.test.ts
@@ -1,0 +1,53 @@
+/**
+ * GET /api/features (SPE-494) — reports which flag-gated features are on so
+ * client surfaces can hide dead entry points. Pins that the flag is read per
+ * request (a flip takes effect without a restart) and that the route answers
+ * while the AI switch is OFF — that is the whole point of it.
+ */
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: async () => ({
+        data: { user: { id: '11111111-1111-4111-8111-111111111111' } },
+        error: null,
+      }),
+    },
+  }),
+}));
+
+jest.mock('@/lib/monitoring/logger', () => ({
+  log: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { GET } from '@/app/api/features/route';
+
+const makeRequest = () => new NextRequest('http://localhost/api/features');
+
+describe('GET /api/features', () => {
+  beforeEach(() => {
+    delete process.env.AI_FEATURES_ENABLED;
+  });
+
+  it('reports aiFeatures false while the switch is off', async () => {
+    const res = await GET(makeRequest(), { params: Promise.resolve({}) });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ aiFeatures: false });
+  });
+
+  it('reports aiFeatures true when the switch is on, per request', async () => {
+    let res = await GET(makeRequest(), { params: Promise.resolve({}) });
+    expect((await res.json()).aiFeatures).toBe(false);
+
+    process.env.AI_FEATURES_ENABLED = 'true';
+    res = await GET(makeRequest(), { params: Promise.resolve({}) });
+    expect((await res.json()).aiFeatures).toBe(true);
+  });
+
+  it('treats anything but the literal "true" as off', async () => {
+    process.env.AI_FEATURES_ENABLED = '1';
+    const res = await GET(makeRequest(), { params: Promise.resolve({}) });
+    expect((await res.json()).aiFeatures).toBe(false);
+  });
+});

--- a/__tests__/unit/app/api/features.test.ts
+++ b/__tests__/unit/app/api/features.test.ts
@@ -26,8 +26,15 @@ import { GET } from '@/app/api/features/route';
 const makeRequest = () => new NextRequest('http://localhost/api/features');
 
 describe('GET /api/features', () => {
+  const ORIGINAL_FLAG = process.env.AI_FEATURES_ENABLED;
+
   beforeEach(() => {
     delete process.env.AI_FEATURES_ENABLED;
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_FLAG === undefined) delete process.env.AI_FEATURES_ENABLED;
+    else process.env.AI_FEATURES_ENABLED = ORIGINAL_FLAG;
   });
 
   it('reports aiFeatures false while the switch is off', async () => {

--- a/__tests__/unit/components/students/accommodations-pdf-import.test.tsx
+++ b/__tests__/unit/components/students/accommodations-pdf-import.test.tsx
@@ -6,11 +6,17 @@
  * Availability gate on the accommodations PDF import (SPE-494): the entry
  * point renders ONLY after /api/features confirms AI features are on. While
  * the kill switch is off (or the check fails) the component renders nothing —
- * matching how every other AI surface stays out of reach. All data fictional.
+ * matching how every other AI surface stays out of reach. Only a confirmed
+ * "on" is cached across mounts. All data fictional.
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
-import { AccommodationsPdfImport } from '@/app/components/students/accommodations-pdf-import';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import {
+  AccommodationsPdfImport,
+  __resetAiFeaturesProbeForTests,
+} from '@/app/components/students/accommodations-pdf-import';
+
+const ORIGINAL_FETCH = global.fetch;
 
 const renderImport = () =>
   render(
@@ -25,8 +31,16 @@ const mockFeatures = (impl: () => Promise<unknown>) => {
   global.fetch = jest.fn(impl) as unknown as typeof fetch;
 };
 
+/** Drain the availability promise chain so assertions run after it settled. */
+const settle = () => act(async () => new Promise((resolve) => setTimeout(resolve, 0)));
+
+beforeEach(() => {
+  __resetAiFeaturesProbeForTests();
+});
+
 afterEach(() => {
-  jest.restoreAllMocks();
+  global.fetch = ORIGINAL_FETCH;
+  jest.clearAllMocks();
 });
 
 describe('AccommodationsPdfImport availability gate', () => {
@@ -34,6 +48,7 @@ describe('AccommodationsPdfImport availability gate', () => {
     mockFeatures(async () => ({ ok: true, json: async () => ({ aiFeatures: false }) }));
     const { container } = renderImport();
     await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/features'));
+    await settle();
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -43,19 +58,39 @@ describe('AccommodationsPdfImport availability gate', () => {
     expect(await screen.findByRole('button', { name: /import from iep pdf/i })).toBeInTheDocument();
   });
 
+  it('asks once per page load once confirmed on, but re-asks after an off answer', async () => {
+    mockFeatures(async () => ({ ok: true, json: async () => ({ aiFeatures: false }) }));
+    renderImport();
+    await settle();
+    renderImport();
+    await settle();
+    // "off" is never cached — each mount re-asks so a flipped switch shows up.
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+
+    mockFeatures(async () => ({ ok: true, json: async () => ({ aiFeatures: true }) }));
+    renderImport();
+    await settle();
+    renderImport();
+    await settle();
+    // Confirmed "on" is cached for the page: the second mount asks nothing.
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it('stays hidden when the availability check fails (fail-closed)', async () => {
     mockFeatures(async () => {
       throw new Error('network down');
     });
     const { container } = renderImport();
-    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    await settle();
+    expect(global.fetch).toHaveBeenCalled();
     expect(container).toBeEmptyDOMElement();
   });
 
   it('stays hidden on a non-OK response (fail-closed)', async () => {
     mockFeatures(async () => ({ ok: false, json: async () => ({ error: 'nope' }) }));
     const { container } = renderImport();
-    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    await settle();
+    expect(global.fetch).toHaveBeenCalled();
     expect(container).toBeEmptyDOMElement();
   });
 });

--- a/__tests__/unit/components/students/accommodations-pdf-import.test.tsx
+++ b/__tests__/unit/components/students/accommodations-pdf-import.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Availability gate on the accommodations PDF import (SPE-494): the entry
+ * point renders ONLY after /api/features confirms AI features are on. While
+ * the kill switch is off (or the check fails) the component renders nothing —
+ * matching how every other AI surface stays out of reach. All data fictional.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { AccommodationsPdfImport } from '@/app/components/students/accommodations-pdf-import';
+
+const renderImport = () =>
+  render(
+    <AccommodationsPdfImport
+      studentId="22222222-2222-4222-8222-222222222222"
+      existingAccommodations={[]}
+      onAdd={jest.fn()}
+    />
+  );
+
+const mockFeatures = (impl: () => Promise<unknown>) => {
+  global.fetch = jest.fn(impl) as unknown as typeof fetch;
+};
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('AccommodationsPdfImport availability gate', () => {
+  it('renders nothing while AI features are off', async () => {
+    mockFeatures(async () => ({ ok: true, json: async () => ({ aiFeatures: false }) }));
+    const { container } = renderImport();
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/features'));
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the import entry point once AI features are on', async () => {
+    mockFeatures(async () => ({ ok: true, json: async () => ({ aiFeatures: true }) }));
+    renderImport();
+    expect(await screen.findByRole('button', { name: /import from iep pdf/i })).toBeInTheDocument();
+  });
+
+  it('stays hidden when the availability check fails (fail-closed)', async () => {
+    mockFeatures(async () => {
+      throw new Error('network down');
+    });
+    const { container } = renderImport();
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('stays hidden on a non-OK response (fail-closed)', async () => {
+    mockFeatures(async () => ({ ok: false, json: async () => ({ error: 'nope' }) }));
+    const { container } = renderImport();
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/app/api/features/route.ts
+++ b/app/api/features/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { withRoute } from '@/lib/api/with-route';
+import { isAiEnabled, withRoute } from '@/lib/api/with-route';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -12,12 +12,12 @@ export const dynamic = 'force-dynamic';
  * (the Tools page is not linked in any role's nav).
  *
  * Deliberately NOT aiGated: this route must answer while the switch is off.
- * The flag is read per request, matching the with-route gate, so flipping
- * AI_FEATURES_ENABLED shows/hides the UI on the next load with no redeploy.
- * Exposes only booleans — never configuration detail.
+ * The flag is read per request via the same helper the route gate uses, so
+ * flipping AI_FEATURES_ENABLED shows/hides the UI on the next load with no
+ * redeploy. Exposes only booleans — never configuration detail.
  */
 export const GET = withRoute({}, async () => {
   return NextResponse.json({
-    aiFeatures: process.env.AI_FEATURES_ENABLED === 'true',
+    aiFeatures: isAiEnabled(),
   });
 });

--- a/app/api/features/route.ts
+++ b/app/api/features/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { withRoute } from '@/lib/api/with-route';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * Which flag-gated features are available right now (SPE-494). Client surfaces
+ * embedded in always-reachable UI (e.g. the accommodations PDF import inside
+ * the student-details modal) ask this instead of rendering a dead entry point —
+ * every other AI surface is simply unreachable while the kill switch is off
+ * (the Tools page is not linked in any role's nav).
+ *
+ * Deliberately NOT aiGated: this route must answer while the switch is off.
+ * The flag is read per request, matching the with-route gate, so flipping
+ * AI_FEATURES_ENABLED shows/hides the UI on the next load with no redeploy.
+ * Exposes only booleans — never configuration detail.
+ */
+export const GET = withRoute({}, async () => {
+  return NextResponse.json({
+    aiFeatures: process.env.AI_FEATURES_ENABLED === 'true',
+  });
+});

--- a/app/components/students/accommodations-pdf-import.tsx
+++ b/app/components/students/accommodations-pdf-import.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '../ui/button';
 
 // Mirrors the server limit (which in turn respects the platform's ~4.5MB
@@ -39,6 +39,25 @@ export function AccommodationsPdfImport({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [proposals, setProposals] = useState<Proposal[] | null>(null);
+
+  // Hidden until the server confirms AI features are on (SPE-494). AI surfaces
+  // stay out of reach while the kill switch is off, and this one lives inside
+  // an always-reachable modal — so it has to ask. Fail-closed: any fetch error
+  // keeps it hidden.
+  const [available, setAvailable] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/features')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!cancelled && data?.aiFeatures === true) setAvailable(true);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const reset = () => {
     setError(null);
@@ -119,6 +138,8 @@ export function AccommodationsPdfImport({
     onAdd(proposals.filter((p) => p.checked).map((p) => p.text));
     reset();
   };
+
+  if (!available) return null;
 
   return (
     <div className="space-y-2">

--- a/app/components/students/accommodations-pdf-import.tsx
+++ b/app/components/students/accommodations-pdf-import.tsx
@@ -15,6 +15,32 @@ interface Proposal {
   checked: boolean;
 }
 
+// Availability probe for the AI kill switch (SPE-494), shared across mounts so
+// tab-flipping inside the modal doesn't re-ask. Only a confirmed "on" is
+// cached: while the switch is off (or the check fails) the next mount asks
+// again, so flipping the switch shows the button on the next modal open
+// without a full page reload. Fail-closed on any error or non-OK response.
+let aiConfirmedOn: Promise<boolean> | null = null;
+
+function checkAiFeatures(): Promise<boolean> {
+  if (aiConfirmedOn) return aiConfirmedOn;
+  const probe = fetch('/api/features')
+    .then((res) => (res.ok ? res.json() : null))
+    .then((data) => (data as { aiFeatures?: unknown } | null)?.aiFeatures === true)
+    .catch(() => false)
+    .then((on) => {
+      if (!on) aiConfirmedOn = null;
+      return on;
+    });
+  aiConfirmedOn = probe;
+  return probe;
+}
+
+/** Test-only: clear the module-level probe cache between cases. */
+export function __resetAiFeaturesProbeForTests() {
+  aiConfirmedOn = null;
+}
+
 interface AccommodationsPdfImportProps {
   studentId: string;
   /** Current accommodations in the form, used to flag already-listed proposals. */
@@ -42,18 +68,14 @@ export function AccommodationsPdfImport({
 
   // Hidden until the server confirms AI features are on (SPE-494). AI surfaces
   // stay out of reach while the kill switch is off, and this one lives inside
-  // an always-reachable modal — so it has to ask. Fail-closed: any fetch error
-  // keeps it hidden.
+  // an always-reachable modal — so it has to ask.
   const [available, setAvailable] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/features')
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (!cancelled && data?.aiFeatures === true) setAvailable(true);
-      })
-      .catch(() => {});
+    checkAiFeatures().then((on) => {
+      if (!cancelled && on) setAvailable(true);
+    });
     return () => {
       cancelled = true;
     };

--- a/app/components/students/student-details-modal.tsx
+++ b/app/components/students/student-details-modal.tsx
@@ -866,7 +866,7 @@ export function StudentDetailsModal({
                 <div className="space-y-1">
                   <h3 className="font-medium text-gray-900">Accommodations</h3>
                   <p className="text-sm text-gray-600">
-                    Add IEP accommodations for this student, or import them from the IEP PDF
+                    Add IEP accommodations for this student
                   </p>
                 </div>
 

--- a/lib/api/with-route.ts
+++ b/lib/api/with-route.ts
@@ -12,6 +12,15 @@ import { checkUserRateLimit, type RateLimitRule } from './rate-limit-user';
 // read per request (not cached at module load) so a change takes effect on
 // the next request rather than requiring a fresh process.
 
+/**
+ * The master AI kill switch, read per request. Shared by the `aiGated` route
+ * gate below and `/api/features` (SPE-494) so the UI's idea of "on" can never
+ * drift from what the gate actually enforces.
+ */
+export function isAiEnabled(): boolean {
+  return process.env.AI_FEATURES_ENABLED === 'true';
+}
+
 interface WithRouteConfig<TBody, TQuery> {
   /** Require an authenticated user (default true). When false, `userId` is ''. */
   auth?: boolean;
@@ -92,7 +101,7 @@ export function withRoute<
       // master switch.
       if (config.aiGated) {
         const enabled =
-          process.env.AI_FEATURES_ENABLED === 'true' ||
+          isAiEnabled() ||
           (config.aiEnableFlag != null && process.env[config.aiEnableFlag] === 'true');
         if (!enabled) {
           return NextResponse.json({ error: 'Not found' }, { status: 404 });

--- a/scripts/sim-district/manifest.ts
+++ b/scripts/sim-district/manifest.ts
@@ -882,6 +882,10 @@ export const DECLARED_UNSEEDED_TABLES: string[] = [
   // Children of swept IEP tables — cleaned by ON DELETE CASCADE from
   // iep_meetings / student_parent_contacts, so no direct sweep key needed:
   'iep_meeting_attendees', 'parent_confirmation_tokens',
+  // SDC per-student blocked times (PR #860): every FK (children, students,
+  // profiles, schools) is ON DELETE CASCADE, so teardown's parent deletes
+  // clean it — created live via the app when a run exercises SDC scheduling:
+  'student_blocked_times',
   // AI-generated content (AI gated off; generation costs real tokens):
   'exit_tickets', 'exit_ticket_results', 'progress_checks', 'progress_check_results',
   'saved_worksheets', 'worksheet_submissions', 'lesson_adjustment_queue',


### PR DESCRIPTION
Founder-reported follow-up to #862: the "Import from IEP PDF" affordance rendered on the Accommodations tab even though `AI_FEATURES_ENABLED` is off in production. The route correctly 404s, but a provider could pick a file and hit a dead-end error. Every other AI surface is unreachable while the switch is off — the Tools page (lessons / exit tickets / progress checks) is not linked in any role's navigation — so the import was the one AI entry point that showed. This brings it in line.

## Changes

- **`GET /api/features`** (new, authenticated, deliberately **not** `aiGated` — it must answer while the switch is off): reports `{ aiFeatures }` from the same per-request env read the route gate uses. Flipping `AI_FEATURES_ENABLED` therefore shows/hides the UI on the next page load with **no redeploy**, in both directions. Exposes only a boolean.
- **`AccommodationsPdfImport`** renders nothing until the check confirms the feature is on. Fail-closed: a fetch error or non-OK response keeps it hidden.
- **Student-details modal** subtitle no longer advertises the import ("…or import them from the IEP PDF" dropped); the callout inside the gated component already explains the option when it's visible.

## Verification

- 7 new tests: the features route reads the flag per request and treats anything but the literal `"true"` as off; the component renders nothing while off, appears when on, and stays hidden on error/non-OK (fail-closed) — plus the full CI gate (typecheck, lint, `jest __tests__ lib`: 1,500 passed) green locally.
- Sim-district walk against this branch's preview deployment: pending below (will confirm the button is absent for a signed-in provider while the switch is off, and the manual Add Accommodation path is untouched).
- **Pre-existing, not this PR:** `next build` without Supabase env vars fails on `/api/cron/daily-schedule-emails` on clean `main` (arrived with the #860 stack; Vercel builds are unaffected since they have the vars). Logged separately in Linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY9BS2dSWqJC9KHkGGF4iZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY9BS2dSWqJC9KHkGGF4iZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a feature availability check for AI-powered functionality.
  * The accommodations PDF import option now appears only when AI features are enabled and available.
  * Updated accommodations guidance to focus on adding IEP accommodations.

* **Bug Fixes**
  * PDF import remains hidden when availability checks fail or return unavailable.
  * Availability results are reused only after a confirmed enabled response.

* **Tests**
  * Added coverage for feature responses, visibility conditions, failed checks, and caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->