### PR TITLE
Docs: how to approach CodeStack about SEIS, and the IEP vendor landscape outside CA

### DIFF
--- a/docs/integrations/iep-vendor-landscape.md
+++ b/docs/integrations/iep-vendor-landscape.md
@@ -190,9 +190,11 @@ page cites 1,100+ districts — the discrepancy is recorded in
 `docs/integrations/seis-outreach.md` and doesn't change the argument), and we
 have a pilot there. **This is not an argument to leave California.** It's an argument that
 the integration story gets dramatically better the moment we sell outside it —
-useful mainly for deciding where we expand *second*, and for knowing that the
-manual-upload burden is a California-specific tax rather than a permanent
-feature of the category.
+useful mainly for deciding where we expand *second*, and as a reason to suspect
+the manual-upload burden may be specific to the California SEIS workflow rather
+than a permanent feature of the category. That's a hypothesis this scan
+motivates, not one it proves — a single automated feed at one vendor doesn't
+establish that districts elsewhere avoid manual uploads.
 
 ## Verification limits
 
@@ -209,8 +211,10 @@ NDPA status, what our importer accepts — are internal and cited to repo docs i
   guidance should be confirmed against the Ed-Fi docs directly before we design
   against them.
 - **The Frontline→LiftEd goals claim is the load-bearing one in this document**
-  and rests on two independent CentralReach-authored sources (their blog and
-  their release notes) rather than a direct read of the LiftEd help article.
+  and rests on two **separate but both CentralReach-authored** sources (their
+  blog and their release notes) rather than a direct read of the LiftEd help
+  article. Two documents from the same company are not independent
+  corroboration.
   Confirm it before we build a strategy on it. And note: what that feed carries
   for *them* is not a commitment of what it would carry for us.
 - **The Stepwell↔PowerSchool integration is unverified** — it surfaced in a

--- a/docs/integrations/iep-vendor-landscape.md
+++ b/docs/integrations/iep-vendor-landscape.md
@@ -1,0 +1,214 @@
+# IEP systems outside California — who is actually open to integrating?
+
+> **Market research, 2026-08-14.** Answers the question: *if we sell outside
+> California, where SEIS isn't used, are the other IEP data/compliance systems
+> more amenable to integrations?*
+>
+> **Short answer: yes, substantially — and for a structural reason, not a
+> technical one.** Three of the four major vendors already run third-party
+> integrations in production, one of which is almost exactly what we want. And a
+> new open standard (Ed-Fi's Special Education Data Model, May 2026) is the first
+> credible path to the one thing no SIS integration can ever carry: **goal text**.
+>
+> Companion to `docs/integrations/seis.md` (the same question asked about
+> California) and `docs/integrations/seis-outreach.md` (how we approach
+> CodeStack). Related: the *SIS Integration* project (SPE-392 → SPE-420).
+>
+> **This is a market scan, not a build plan.** Nothing here has been verified
+> against a vendor directly — see *Verification limits* at the bottom before
+> relying on any single claim.
+
+## Why the answer is structural
+
+In California the IEP system is run by a **public agency**. CodeStack is a
+department of the San Joaquin County Office of Education, it has a near-monopoly
+across California SELPAs, and it has no commercial reason to build a partner
+program. Public agencies don't chase integration partnerships; they manage
+support burden and risk.
+
+Everywhere else the IEP system is a **private vendor competing for district
+contracts**, and "we integrate with the other tools you use" is something they
+put in sales collateral. That flips the incentive completely: we stop asking a
+public agency for a favor and start offering a vendor a selling point.
+
+## The four that matter
+
+| Vendor | Footprint | Openness | The precedent |
+|---|---|---|---|
+| **Frontline IEP** | Strong in NJ, NY, PA, TX | Documented third-party integrations; SOC 2; sFTP flat files + API over SSL | **CentralReach LiftEd receives an automated nightly send of new-student demographics *and* in-force IEP data**, plus updates and newly issued IEPs through the year — provided at no cost to NJ districts. Also integrates with Genesis Educational Services, Education Solutions Development, Computer Resource Inc., Computer Solutions Inc., and Mindex SchoolTool. |
+| **Everway** (Embrace + SpedTrack) | SpedTrack alone across 26 states, strong Midwest/South | Publishes a public integration guide; advertises two-way SIS sync | Consolidating fast, see below |
+| **PowerSchool Special Programs** | Very large | Formal **ISV Partner Program** with a three-badge certification process (integration testing, survey, session with a PowerSchool solutions engineer); Special Programs integrates via the PowerSchool SIS REST API | **Stepwell**, a third-party special-education compliance and monitoring platform, integrated with Special Programs |
+| **PCG** (EDPlan / EasyIEP) | EDPlan 3,000+ districts; EasyIEP across 30+ states; runs statewide systems | Least approachable directly — statewide contracts, government-consulting sales motion | But they **co-authored the Ed-Fi special education standard** (below), which may matter more |
+
+### The Frontline precedent deserves emphasis
+
+A third-party special-education application **already receives a nightly
+automated feed of live IEP data from a major IEP vendor.** That is precisely the
+thing we're trying to get out of SEIS, it exists in production for somebody
+else, and it was framed as a benefit to districts rather than a favor to a
+vendor. When we approach Frontline we are asking for a second instance of an
+established pattern, not for a first.
+
+### Everway is consolidating the mid-market
+
+Worth tracking as a single entity now rather than as separate products:
+
+- **March 2024** — Everway formed from the merger of n2y and Texthelp; majority
+  backed by Five Arrows (Rothschild & Co).
+- **30 January 2025** — Embrace Education joins Everway.
+- **8 January 2026** — SpedTrack joins Everway, from Euna Solutions. (Ownership
+  chain: Ion Wave Technologies → GTY Technology, renamed Euna Solutions →
+  Everway.) SpedTrack was founded 20+ years ago in Springfield, MO. Everway
+  stated no immediate changes for SpedTrack customers and that the brand
+  continues for the foreseeable future.
+
+Private-equity-backed roll-ups want ecosystem stories and move faster than
+either a public agency or a large incumbent. This is likely the easiest group to
+actually get on a call.
+
+### Statewide systems are a different game
+
+Some states run one IEP system for everyone — North Carolina's **ECATS** (PCG)
+covers all PK-13 public schools; Tennessee's **TN PULSE** is the state system of
+record for IEPs and 504 plans, having replaced EasyIEP. These are the *least*
+amenable to a small vendor asking directly, because the relationship is a state
+procurement, not a district one. The flip side is obvious: win the state and you
+win every district in it. That's a much later-stage motion than where we are.
+
+## The bigger finding: Ed-Fi's Special Education Data Model
+
+**Ed-Fi Data Standard v6.1 (released 7 May 2026)** introduced an **early-access
+Special Education Data Model (SEDM)** — five new entities covering the IEP
+itself (`studentIEP`), **goals**, services/prescriptions, and IDEA compliance
+events, with supporting descriptors. It was developed collaboratively by **PCG,
+Education Analytics, and the South Carolina Department of Education**. Feedback
+runs through Data Standard RFC 28b. The model also appears in CEDS via the
+Access 4 Learning community.
+
+Two things make this the most strategically interesting item in this document.
+
+**First, the adoption guidance points directly at companies like us.** To limit
+implementation overhead while the model matures, Ed-Fi recommends **initial
+adoption by special education vendors rather than SIS vendors.** That is an open
+door aimed at exactly our category.
+
+**Second, it is the only path that has ever addressed goals.** The reason the
+SEIS problem is hard — and the reason `docs/integrations/aeries-sped-mapping.md`
+lists goal text as gap #3 — is that goals are free-text IEP content with no
+field in any student information system to land in. Every SIS-mediated path we
+have (Aeries today, any other SIS tomorrow) structurally cannot carry them.
+SEDM is the first serious attempt to model IEP goals as structured, exchangeable
+data. If it takes hold, the hardest part of this problem stops being N private
+negotiations and becomes a standard we implement once.
+
+**Caveats, stated plainly:**
+
+- It is **early access**, roughly three months old, and explicitly expected to
+  evolve on community feedback. No production implementation turned up.
+- **Adopting a standard does not deliver data.** A district still has to
+  authorize a feed. SEDM changes the shape of the pipe, not the permission.
+- **Ed-Fi adoption is state-by-state.** Ed-Fi's own published case studies name
+  Indiana, Michigan, Texas, Arizona, Nebraska and South Carolina; 29 states were
+  represented at their 2025 Technical Congress. **California is not among the
+  named states** — it runs CALPADS, its own system in its own format. Treat that
+  as an absence in Ed-Fi's marketing rather than a confirmed negative, but no
+  evidence of statewide California Ed-Fi adoption turned up. Either way, this is
+  an advantage we only get by selling outside California.
+
+**A cheap credibility hook:** the CA-NDPA we're already executing is a Student
+Data Privacy Consortium instrument, and SDPC sits inside Access 4 Learning — the
+same standards community where SEDM lives in CEDS. We're already a participant
+in that world, which is worth saying out loud when we engage.
+
+## What does not get easier anywhere
+
+- **Rostering aggregators will not solve this.** Clever, ClassLink and Edlink
+  carry demographics, rosters, sections and SSO. They do **not** carry IEP
+  content. They solve a different problem and are not a shortcut here.
+- **Every path still requires district authorization.** That is FERPA, not
+  vendor obstruction, and it is correct. No standard or partner program removes
+  it.
+- **The per-district sales motion is unchanged.** An integration makes the
+  product better; it does not make distribution free.
+- **Infinite Campus is gated.** Per third-party integration documentation
+  (Edlink), full Campus API access requires a partnership-level commitment, and
+  developers without one are limited to OneRoster — which is rostering, so it
+  doesn't reach IEP content anyway. No specifics on their special education
+  module's API surface turned up; unverified.
+
+## Recommended order of approach
+
+At our stage the right ranking is not "biggest install base." It's **who will
+answer an email and has done this before.**
+
+1. **Frontline.** Has the exact precedent, meaningful footprint in NJ/NY/PA/TX,
+   and has already decided this is a thing they do. Best first conversation.
+2. **Everway (SpedTrack / Embrace).** Smallest and hungriest of the group,
+   publishes integration documentation, 26 states. Most likely to actually
+   engage a startup.
+3. **PowerSchool Special Programs.** Real program, real precedent, but
+   large-company slow — and understandably conservative since the December 2024
+   breach of its PowerSource support portal (disclosed to customers 7 January
+   2025; roughly 60M student and 10M teacher records across ~18,000 districts;
+   the largest K-12 education data breach on record). They also own the SIS, so
+   they are partly a competitor.
+4. **Ed-Fi SEDM.** Not a partner — a standard. Engage now: read the model,
+   comment on RFC 28b, join the community conversation. Nearly free, costs
+   nothing if it stalls, and positions us early on the only generic path to
+   goals. It will not deliver data next quarter.
+
+## Keeping this in proportion
+
+SEIS covers on the order of 1,000–1,500 California LEAs and we have a pilot
+there. **This is not an argument to leave California.** It's an argument that
+the integration story gets dramatically better the moment we sell outside it —
+useful mainly for deciding where we expand *second*, and for knowing that the
+manual-upload burden is a California-specific tax rather than a permanent
+feature of the category.
+
+## Verification limits
+
+Everything here comes from public sources and **none of it has been confirmed
+with a vendor.** Specifically:
+
+- `docs.ed-fi.org` and `spedtrack.com` are **blocked by this environment's
+  network egress proxy**, so the Ed-Fi SEDM details and SpedTrack's integration
+  posture are grounded in search-result excerpts of those pages rather than a
+  direct read. The SEDM entity list and the "special education vendors rather
+  than SIS vendors" guidance should be confirmed against the Ed-Fi docs directly
+  before we design against them.
+- Vendor footprint numbers come from vendor marketing and vary by source.
+- The Frontline↔CentralReach integration is described in CentralReach's and
+  LiftEd's own documentation. What it carries for *them* is not a commitment of
+  what it would carry for us.
+- General market-size figures were deliberately excluded; the available sources
+  were low-quality SEO market-research aggregators and none of them would change
+  a decision.
+
+## Sources
+
+- **Ed-Fi:** [v6.1 release notes](https://docs.ed-fi.org/reference/data-exchange/data-standard/whats-new/whats-new-v61/) ·
+  [A4L — SEDM in CEDS](https://files.a4l.org/home/Events/2025_03_17_A4L-Annual-Meeting/Presentations/2025_03_19-3b-SEDM.pdf) ·
+  [Ed-Fi state case studies](https://www.ed-fi.org/resources/case-studies/indiana/) ·
+  [Data Standard overview](https://docs.ed-fi.org/reference/data-exchange/data-standards/)
+- **Frontline:** [CR LiftEd ↔ Frontline IEP automated integration](https://help.theliftedapp.com/en/articles/8181959-the-frontline-iep-automated-integration-with-cr-lifted) ·
+  [CentralReach announcement](https://centralreach.com/blog/centralreach-announces-new-integration-with-frontline-iep-software-leader/) ·
+  [Frontline Special Ed technical buying guide FAQs](https://www.frontlineeducation.com/wp-content/uploads/2018/11/Frontline_Special_Ed_Interventions_Technical_Buying_Guide_FAQs_.pdf)
+- **PowerSchool:** [ISV partner badging](https://www.powerschool.com/news/powerschools-new-partner-badging-system-provides-verification-independent-software-vendor-integration/) ·
+  [Special Programs plugin/integration docs](https://sp-programs.powerschool-docs.com/special-programs-sys-admin/latest/special-programs-plugin) ·
+  [PowerSchool SIS incident page](https://www.powerschool.com/security/sis-incident/) ·
+  [TechCrunch on the breach](https://techcrunch.com/2025/03/10/what-powerschool-isnt-saying-about-its-massive-student-data-breach/)
+- **Everway:** [SpedTrack joins Everway](https://www.everway.com/news/spedtrack-joins-everway/) ·
+  [Euna's announcement of the same](https://eunasolutions.com/resources/spedtrack-joins-everway-to-expand-support-for-special-education-teams/) ·
+  [Embrace joins Everway](https://www.everway.com/press/embrace-education-joins-everway/)
+- **PCG / statewide:** [EasyIEP](https://publicconsultinggroup.com/education/education-products/easyiep-web-based-special-education-case-management/) ·
+  [EDPlan](https://www.edplan.com/) · [NC ECATS](https://www.dpi.nc.gov/districts-schools/classroom-resources/exceptional-children/every-child-accountability-tracking-system-ecats) ·
+  [TN PULSE](https://www.tn.gov/education/families/student-support/special-education/tn-pulse.html)
+- **Aggregators:** [Edlink supported providers](https://ed.link/docs/providers) ·
+  [Edlink on Infinite Campus API access](https://ed.link/community/what-data-can-the-infinite-campus-api-access/)
+
+**Source of truth:** this file is market research, not a description of our
+system — it has no code to track. The Speddy-side facts it leans on live in
+`docs/integrations/seis.md` (the manual uploads and why goals are the hard
+part), `docs/integrations/aeries-sped-mapping.md` (gap #3, goal text is not in
+the SIS), and `docs/ndpa/ca-ndpa-execution-packet.md` (the SDPC/NDPA tie-in).

--- a/docs/integrations/iep-vendor-landscape.md
+++ b/docs/integrations/iep-vendor-landscape.md
@@ -10,9 +10,10 @@
 > new open standard (Ed-Fi's Special Education Data Model, May 2026) is the first
 > credible path to the one thing no SIS integration can ever carry: **goal text**.
 >
-> Companion to `docs/integrations/seis.md` (the same question asked about
-> California) and `docs/integrations/seis-outreach.md` (how we approach
-> CodeStack). Related: the *SIS Integration* project (SPE-392 → SPE-420).
+> Companion to [**SEIS — can we pull data automatically?**](./seis.md) (the same
+> question asked about California) and
+> [**SEIS — how to approach CodeStack**](./seis-outreach.md) (how we make that
+> ask). Related: the *SIS Integration* project (SPE-392 → SPE-420).
 >
 > **This is a market scan, not a build plan.** Nothing here has been verified
 > against a vendor directly — see *Verification limits* at the bottom before
@@ -35,7 +36,7 @@ public agency for a favor and start offering a vendor a selling point.
 
 | Vendor | Footprint | Openness | The precedent |
 |---|---|---|---|
-| **Frontline IEP** | Strong in NJ, NY, PA, TX | Documented third-party integrations; SOC 2; sFTP flat files + API over SSL | **CentralReach LiftEd receives an automated nightly send of new-student demographics *and* in-force IEP data**, plus updates and newly issued IEPs through the year — provided at no cost to NJ districts. Also integrates with Genesis Educational Services, Education Solutions Development, Computer Resource Inc., Computer Solutions Inc., and Mindex SchoolTool. |
+| **Frontline IEP** (formerly IEP Direct) | Strong in NJ, NY, PA, TX | Documented third-party integrations; SOC 2; sFTP flat files + API over SSL | **CentralReach LiftEd receives an automated nightly feed carrying student demographics *and IEP goals and objectives*** — delivered as two files (a Student File and an IEP File), updated nightly as new IEPs are issued, at no cost to NJ districts. Also integrates with Genesis Educational Services, Education Solutions Development, Computer Resource Inc., Computer Solutions Inc., and Mindex SchoolTool. |
 | **Everway** (Embrace + SpedTrack) | SpedTrack alone across 26 states, strong Midwest/South | Publishes a public integration guide; advertises two-way SIS sync | Consolidating fast, see below |
 | **PowerSchool Special Programs** | Very large | Formal **ISV Partner Program** with a three-badge certification process (integration testing, survey, session with a PowerSchool solutions engineer); Special Programs integrates via the PowerSchool SIS REST API | **Stepwell**, a third-party special-education compliance and monitoring platform, integrated with Special Programs |
 | **PCG** (EDPlan / EasyIEP) | EDPlan 3,000+ districts; EasyIEP across 30+ states; runs statewide systems | Least approachable directly — statewide contracts, government-consulting sales motion | But they **co-authored the Ed-Fi special education standard** (below), which may matter more |
@@ -43,11 +44,17 @@ public agency for a favor and start offering a vendor a selling point.
 ### The Frontline precedent deserves emphasis
 
 A third-party special-education application **already receives a nightly
-automated feed of live IEP data from a major IEP vendor.** That is precisely the
-thing we're trying to get out of SEIS, it exists in production for somebody
-else, and it was framed as a benefit to districts rather than a favor to a
-vendor. When we approach Frontline we are asking for a second instance of an
-established pattern, not for a first.
+automated feed of live IEP data — including goals and objectives — from a major
+IEP vendor.** Per CentralReach's own documentation the sync produces a *Student
+File* with demographics and an *IEP File* containing goals and objectives,
+delivered nightly to a secure site.
+
+That matters more than a generic "they do integrations." **Goal text is the hard
+part** — it's the one thing no SIS-mediated path we've examined can carry (see
+`docs/integrations/aeries-sped-mapping.md`, gap #3), and it's the reason the
+SEIS problem stays manual. Frontline is proof that a commercial IEP vendor will
+move goal data to a third party when a district wants it. When we approach them
+we're asking for a second instance of an established pattern, not a first.
 
 ### Everway is consolidating the mid-market
 
@@ -92,14 +99,25 @@ implementation overhead while the model matures, Ed-Fi recommends **initial
 adoption by special education vendors rather than SIS vendors.** That is an open
 door aimed at exactly our category.
 
-**Second, it is the only path that has ever addressed goals.** The reason the
-SEIS problem is hard — and the reason `docs/integrations/aeries-sped-mapping.md`
-lists goal text as gap #3 — is that goals are free-text IEP content with no
-field in any student information system to land in. Every SIS-mediated path we
-have (Aeries today, any other SIS tomorrow) structurally cannot carry them.
-SEDM is the first serious attempt to model IEP goals as structured, exchangeable
-data. If it takes hold, the hardest part of this problem stops being N private
-negotiations and becomes a standard we implement once.
+**Second, it is the first *vendor-neutral* standard for goals we've found.**
+Goal text is the part that stays stuck: it's free-text IEP content, and none of
+the SIS-mediated paths we've actually examined expose it —
+`docs/integrations/aeries-sped-mapping.md` lists it as gap #3 for **Aeries**,
+which is the only SIS API we've inspected in depth.
+
+Scope that honestly: it's a finding about the paths we've reviewed, not a law
+about every SIS. Another vendor's special-education module, a custom field
+mapping, or a different API may well expose goals, and we haven't checked —
+Infinite Campus's special-education surface (below) is explicitly unverified.
+Don't discard a non-Aeries district's SIS path on this basis without inspecting
+that SIS first.
+
+What's distinctive about SEDM is that it isn't vendor-specific. Frontline
+already moves goals to a third party (above), but on Frontline's terms, for
+Frontline customers. SEDM is the first serious attempt to model IEP goals as
+structured, exchangeable data in a standard anyone can implement. If it takes
+hold, the hardest part of this problem stops being N private negotiations and
+becomes one implementation.
 
 **Caveats, stated plainly:**
 
@@ -115,19 +133,25 @@ negotiations and becomes a standard we implement once.
   evidence of statewide California Ed-Fi adoption turned up. Either way, this is
   an advantage we only get by selling outside California.
 
-**A cheap credibility hook:** the CA-NDPA we're already executing is a Student
-Data Privacy Consortium instrument, and SDPC sits inside Access 4 Learning — the
-same standards community where SEDM lives in CEDS. We're already a participant
-in that world, which is worth saying out loud when we engage.
+**A possible credibility hook — but not yet.** The CA-NDPA we're working through
+is a Student Data Privacy Consortium instrument, and SDPC sits inside Access 4
+Learning, the same standards community where SEDM lives in CEDS. That's a real
+connection *once it's real*: as of this writing the DPA is unsigned and
+**CITE/CSPA registration is still outstanding**
+(`docs/ndpa/ca-ndpa-execution-packet.md` §8, item 17). **Do not describe Speddy
+as a participant in that community during outreach until registration is
+complete** — describe the draft-agreement work instead. Overstating affiliation
+to a standards body is precisely the kind of claim that costs credibility the
+moment someone checks it (the SPE-134 claim-accuracy principle).
 
 ## What does not get easier anywhere
 
 - **Rostering aggregators will not solve this.** Clever, ClassLink and Edlink
   carry demographics, rosters, sections and SSO. They do **not** carry IEP
   content. They solve a different problem and are not a shortcut here.
-- **Every path still requires district authorization.** That is FERPA, not
-  vendor obstruction, and it is correct. No standard or partner program removes
-  it.
+- **Every path still needs district approval and a FERPA-compliant data-sharing
+  basis.** That's a feature, not vendor obstruction. No standard or partner
+  program removes it.
 - **The per-district sales motion is unchanged.** An integration makes the
   product better; it does not make distribution free.
 - **Infinite Campus is gated.** Per third-party integration documentation
@@ -148,10 +172,12 @@ answer an email and has done this before.**
    engage a startup.
 3. **PowerSchool Special Programs.** Real program, real precedent, but
    large-company slow — and understandably conservative since the December 2024
-   breach of its PowerSource support portal (disclosed to customers 7 January
-   2025; roughly 60M student and 10M teacher records across ~18,000 districts;
-   the largest K-12 education data breach on record). They also own the SIS, so
-   they are partly a competitor.
+   breach of its PowerSource support portal, disclosed to customers on 7 January
+   2025 and affecting a very large number of students across many thousands of
+   schools. (Reported record counts and "largest ever" framings vary by outlet;
+   we haven't verified any specific figure against a primary source, and none of
+   them change the conclusion — the posture is what matters.) They also own the
+   SIS, so they are partly a competitor.
 4. **Ed-Fi SEDM.** Not a partner — a standard. Engage now: read the model,
    comment on RFC 28b, join the community conversation. Nearly free, costs
    nothing if it stalls, and positions us early on the only generic path to
@@ -159,8 +185,10 @@ answer an email and has done this before.**
 
 ## Keeping this in proportion
 
-SEIS covers on the order of 1,000–1,500 California LEAs and we have a pilot
-there. **This is not an argument to leave California.** It's an argument that
+SEIS covers 1,500+ California LEAs (`docs/integrations/seis.md`; CodeStack's own
+page cites 1,100+ districts — the discrepancy is recorded in
+`docs/integrations/seis-outreach.md` and doesn't change the argument), and we
+have a pilot there. **This is not an argument to leave California.** It's an argument that
 the integration story gets dramatically better the moment we sell outside it —
 useful mainly for deciding where we expand *second*, and for knowing that the
 manual-upload burden is a California-specific tax rather than a permanent
@@ -168,19 +196,31 @@ feature of the category.
 
 ## Verification limits
 
-Everything here comes from public sources and **none of it has been confirmed
-with a vendor.** Specifically:
+Every **vendor-side** claim here comes from public sources, and **none of it has
+been confirmed with a vendor.** (The Speddy-side facts — our pilot district, our
+NDPA status, what our importer accepts — are internal and cited to repo docs in
+*Source of truth* below.) Specifically:
 
-- `docs.ed-fi.org` and `spedtrack.com` are **blocked by this environment's
-  network egress proxy**, so the Ed-Fi SEDM details and SpedTrack's integration
-  posture are grounded in search-result excerpts of those pages rather than a
-  direct read. The SEDM entity list and the "special education vendors rather
-  than SIS vendors" guidance should be confirmed against the Ed-Fi docs directly
-  before we design against them.
+- `docs.ed-fi.org`, `spedtrack.com` and `help.theliftedapp.com` are **blocked by
+  this environment's network egress proxy**, so the Ed-Fi SEDM details,
+  SpedTrack's integration posture, and the LiftEd field list are grounded in
+  search-result excerpts and secondary pages rather than a direct read. The SEDM
+  entity list and the "special education vendors rather than SIS vendors"
+  guidance should be confirmed against the Ed-Fi docs directly before we design
+  against them.
+- **The Frontline→LiftEd goals claim is the load-bearing one in this document**
+  and rests on two independent CentralReach-authored sources (their blog and
+  their release notes) rather than a direct read of the LiftEd help article.
+  Confirm it before we build a strategy on it. And note: what that feed carries
+  for *them* is not a commitment of what it would carry for us.
+- **The Stepwell↔PowerSchool integration is unverified** — it surfaced in a
+  search summary of PowerSchool's partner material, and we have no primary
+  source for its scope. Treat it as "a third-party SpEd tool appears to have
+  integrated," not as a known-good precedent.
+- **Everway's integration posture is inferred**, not documented to us. The
+  acquisition facts are sourced (below); the claim that they'd be easiest to
+  engage is a judgement call about company size and incentives.
 - Vendor footprint numbers come from vendor marketing and vary by source.
-- The Frontline↔CentralReach integration is described in CentralReach's and
-  LiftEd's own documentation. What it carries for *them* is not a commitment of
-  what it would carry for us.
 - General market-size figures were deliberately excluded; the available sources
   were low-quality SEO market-research aggregators and none of them would change
   a decision.
@@ -191,7 +231,12 @@ with a vendor.** Specifically:
   [A4L — SEDM in CEDS](https://files.a4l.org/home/Events/2025_03_17_A4L-Annual-Meeting/Presentations/2025_03_19-3b-SEDM.pdf) ·
   [Ed-Fi state case studies](https://www.ed-fi.org/resources/case-studies/indiana/) ·
   [Data Standard overview](https://docs.ed-fi.org/reference/data-exchange/data-standards/)
-- **Frontline:** [CR LiftEd ↔ Frontline IEP automated integration](https://help.theliftedapp.com/en/articles/8181959-the-frontline-iep-automated-integration-with-cr-lifted) ·
+- **Frontline:** [Frontline + CR LiftEd — integrating data collection with IEP management](https://centralreach.com/blog/frontline-and-cr-lifted-integrating-data-collection-with-iep-management/)
+  and [LiftEd 4.7.0 release notes](https://centralreach.my.site.com/s/article/lifted-4-7-0-frontline-iep-integration-platform-stability-and-bug-fixes)
+  (the two sources for the *Student File + IEP File containing goals and
+  objectives* claim) ·
+  [CR LiftEd ↔ Frontline IEP automated integration](https://help.theliftedapp.com/en/articles/8181959-the-frontline-iep-automated-integration-with-cr-lifted)
+  (egress-blocked here) ·
   [CentralReach announcement](https://centralreach.com/blog/centralreach-announces-new-integration-with-frontline-iep-software-leader/) ·
   [Frontline Special Ed technical buying guide FAQs](https://www.frontlineeducation.com/wp-content/uploads/2018/11/Frontline_Special_Ed_Interventions_Technical_Buying_Guide_FAQs_.pdf)
 - **PowerSchool:** [ISV partner badging](https://www.powerschool.com/news/powerschools-new-partner-badging-system-provides-verification-independent-software-vendor-integration/) ·

--- a/docs/integrations/seis-outreach.md
+++ b/docs/integrations/seis-outreach.md
@@ -157,8 +157,13 @@ we've asked.**
   (`docs/ndpa/jsusd-dpa-fix-sheet.md`). The draft email hedges this — replace
   the bracket with whatever is true on the day it's sent. Do not claim a signed
   agreement that isn't signed.
+- **Pilot still active.** The draft says we're "currently in a pilot with John
+  Swett Unified." Confirm that's still true on the day it's sent — a stale pilot
+  claim is worse than no pilot claim, and it's the sentence the whole
+  member-agency framing rests on.
 - **District consent to be named.** Confirm John Swett is comfortable being
-  referenced by name before sending, and before offering them for a call.
+  referenced by name and approves the exact wording, before sending and before
+  offering them for a call.
 - **Re-read `docs/integrations/seis.md`** for the current state of the three
   manual uploads — the specific reports named in the email should still match
   what `lib/import/detect-import-file.ts` recognises.

--- a/docs/integrations/seis-outreach.md
+++ b/docs/integrations/seis-outreach.md
@@ -1,0 +1,182 @@
+# SEIS — how to approach CodeStack
+
+> **Outreach plan, 2026-08-14.** Answers the question: *if we ask SEIS (or the
+> team that runs it) about building an integration, what do we actually say?*
+>
+> This is the follow-through on the open recommendation in
+> `docs/integrations/seis.md`: *"Asking CodeStack directly is the only way to
+> close this… a single email could make the rest of this document moot."*
+> That doc establishes **what** we want and why no public API turned up. This
+> one covers **who to ask, how to frame it, and what to send.**
+>
+> **Status:** not yet sent. Companion to `docs/integrations/seis.md` and
+> `docs/integrations/iep-vendor-landscape.md` (the same question asked about
+> every other state). Related: SPE-276 (Chrome extension, parked), the *SIS
+> Integration* project (SPE-392 → SPE-420).
+
+## The core reframe
+
+Don't approach them as a software vendor asking for an API. Approach as **the
+tool a district they already serve has chosen**, asking a small, answerable
+question.
+
+That matters because of who "the team that runs SEIS" is. **CodeStack is a
+department of the San Joaquin County Office of Education** — a public agency,
+not a private software company. It serves all 58 California county offices of
+education, 106 of the 120 SELPAs, and 1,100+ districts, and also builds EDJOIN,
+the California School Dashboard, SARC and others.
+
+The implications are the whole strategy:
+
+- They are **not defending market share** the way a private vendor would. The
+  competitive-threat framing that would worry a commercial IEP vendor is less
+  of a factor here.
+- They **have no budget or appetite for one-off vendor projects.** A request
+  that reads as "please build something for us" costs them money they don't
+  have and support burden they don't want.
+- They **answer to their member agencies.** A SELPA or district asking for
+  something carries far more weight than a startup asking.
+
+So the strongest version of this ask has **John Swett Unified on the call with
+you.** It converts the request from *"a vendor wants access to your data"* into
+*"our customer wants their own data to reach a tool they bought."*
+
+> **Figures vary by source.** `docs/integrations/seis.md` cites 115 SELPAs and
+> 1,500+ LEAs; CodeStack's own page cites 106 of 120 SELPAs and 1,100+
+> districts. The discrepancy is unresolved and doesn't change the argument —
+> either way SEIS is the dominant California system. Don't quote a precise
+> number at them; they know their own footprint.
+
+## Three things that make or break it
+
+**1. Say what you're not, immediately.** The default assumption on their side
+will be *"this company wants to be an IEP system."* We don't. IEPs get written
+in SEIS and compliance lives in SEIS; Speddy is the scheduling and caseload
+layer downstream of that. Stating this in the first paragraph turns us from a
+threat into something that arguably makes SEIS **stickier**, not less needed.
+
+**2. Ask small.** Not *"please build us an API."* Ask whether a **sanctioned
+path exists** for a district to authorize a third party to read a slice of its
+own SEIS data — read-only, district-scoped, revocable. That is a question a
+busy person can answer in one reply. "Build us an API" is a project proposal
+and gets no reply at all.
+
+**3. Point at their own product as the precedent.** They already run **SEIS
+Integration** — a nightly sync between a district's SIS and SEIS, in either
+direction, covering student-record fields. The machinery for moving data under
+district control exists and they operate it. We're asking whether it (or
+something like it) can have a district-authorized third-party endpoint — not
+whether such a thing can be invented.
+
+## The draft
+
+Adjust the bracketed items before sending (see *Check before sending* below).
+
+> **Subject:** Question about district-authorized data access from SEIS
+>
+> Hi —
+>
+> I'm the founder of Speddy (Orchestrate LLC, Sacramento). We're a scheduling
+> and caseload-management tool for special education providers, currently in a
+> pilot with John Swett Unified and [working through / operating under] a
+> California NDPA with them.
+>
+> First, so it's clear where we sit: **we are not an IEP system and have no
+> plans to become one.** IEPs get written in SEIS, and compliance lives in
+> SEIS. What we handle is the week after that — building provider schedules,
+> tracking sessions and service delivery, keeping caseloads organized.
+>
+> The problem I'm trying to solve is narrow. Today our providers export three
+> reports out of SEIS — the student & goals report, deliveries, and IEP dates —
+> and re-upload them to us by hand every time something changes. It's duplicate
+> entry, and duplicate entry means the schedule gets built on stale data.
+>
+> My question: **is there a sanctioned path for a district to authorize a third
+> party to read a limited slice of its own SEIS data on its behalf?** Read-only,
+> scoped to that district, revocable by them at any time. I'm not asking you to
+> build a public API — just whether a path exists, and if so what the process,
+> requirements, and cost look like.
+>
+> I ask because you already run SEIS Integration for district SIS syncs, so the
+> mechanics of moving data under district control clearly exist. And it's the
+> standard pattern on the SIS side — Aeries districts issue read-only vendor
+> certificates scoped per API, which is the shape I have in mind.
+>
+> If the answer is no, that's genuinely useful and I'll stop asking. If it's
+> worth a conversation, I'd be glad to set one up with our pilot district on the
+> line, so you're hearing the need from a member agency rather than just from me.
+>
+> Thanks for your time,
+> Blair Stewart
+> Owner, Orchestrate LLC (Speddy) · help@speddy.xyz
+
+## Where to send it
+
+| Channel | Notes |
+|---|---|
+| **Via the pilot district's SELPA** ← *preferred* | Ask John Swett who their SELPA's SEIS contact is. SELPAs have standing working relationships with CodeStack; a warm intro lands somewhere a support ticket never will. |
+| [SEIS help center](https://seis.org/helpcenter) | Routes to end-user support. Likely to die there — support staff have no mandate to answer partnership questions. |
+| 866-468-2891 / (209) 468-5914 | Same problem, but a phone call can at least ask *who* the right person is. Useful as a router, not as the ask. |
+| [CodeStack via SJCOE](https://www.sjcoe.org/services-and-support/codestack) | The department itself, one level up from SEIS user support. |
+
+## The Chrome extension question
+
+`speddy-chrome-extension/` reads SEIS pages inside the provider's own
+authenticated session. It is parked (SPE-276), compare-only, and cannot write
+student data today. Whether reading SEIS pages this way is acceptable under a
+district's SEIS terms is a real question, and `docs/integrations/seis.md`
+already flags that it should be **asked, not assumed**.
+
+**Recommended: hold it for the first live conversation, not the first email.**
+The opening contact is about establishing what we are. Leading with "we built
+something that reads your pages" frames us as a scraper before they know we're
+not a competitor. But raise it in the first real conversation — well before we
+build anything further on that path.
+
+The alternative (disclose in the first email) buys maximum candor and means it
+can never be characterized as something we hid. It costs the framing of the
+first impression. Either way the rule holds: **nothing ships on that path until
+we've asked.**
+
+## What to realistically expect
+
+1. **Most likely — "no third-party API; talk to your district about SEIS↔SIS
+   sync."** Not a failure. That confirms Path 2 in `docs/integrations/seis.md`,
+   which is already the recommended plan, and it comes with their authority
+   behind it.
+2. **Upside — "here's our process and what it costs."** Then it becomes a
+   scoping question, and the pilot district matters more than ever.
+3. **Silence.** The most likely outcome of a cold support ticket, and the whole
+   reason the SELPA route is worth the extra step.
+
+## Check before sending
+
+- **NDPA status.** As of the 2026-07-28 review (re-verified 2026-08-04) the
+  JSUSD CA-NDPA v1.5 was a **draft under review, not executed**
+  (`docs/ndpa/jsusd-dpa-fix-sheet.md`). The draft email hedges this — replace
+  the bracket with whatever is true on the day it's sent. Do not claim a signed
+  agreement that isn't signed.
+- **District consent to be named.** Confirm John Swett is comfortable being
+  referenced by name before sending, and before offering them for a call.
+- **Re-read `docs/integrations/seis.md`** for the current state of the three
+  manual uploads — the specific reports named in the email should still match
+  what `lib/import/detect-import-file.ts` recognises.
+
+## Sources
+
+- [CodeStack (SJCOE)](https://www.sjcoe.org/services-and-support/codestack) ·
+  [SEIS](https://seis.org/) · [SEIS help center](https://seis.org/helpcenter) ·
+  [SEIS Integration portal](https://integration.seis.org/)
+- [Aeries API Security](https://support.aeries.com/support/solutions/articles/14000068197-api-security)
+  (the read-only district-issued certificate model cited in the email)
+
+> **Verification limit.** `seis.org` and `integration.seis.org` are blocked by
+> this environment's network egress proxy, so SEIS-side claims here come from
+> search-result excerpts of SEIS's own pages rather than a direct read — the
+> same limit recorded in `docs/integrations/seis.md`.
+
+**Source of truth:** `docs/integrations/seis.md` (what we want and why);
+`lib/import/detect-import-file.ts` (the three manual uploads named in the
+email); `docs/ndpa/jsusd-dpa-fix-sheet.md` (pilot + NDPA status);
+`docs/ndpa/ca-ndpa-execution-packet.md` (legal entity, address, contact);
+`speddy-chrome-extension/` + SPE-276 (extension status).

--- a/docs/integrations/seis-outreach.md
+++ b/docs/integrations/seis-outreach.md
@@ -4,15 +4,16 @@
 > team that runs it) about building an integration, what do we actually say?*
 >
 > This is the follow-through on the open recommendation in
-> `docs/integrations/seis.md`: *"Asking CodeStack directly is the only way to
-> close this… a single email could make the rest of this document moot."*
-> That doc establishes **what** we want and why no public API turned up. This
-> one covers **who to ask, how to frame it, and what to send.**
+> [`seis.md`](./seis.md): *"Asking CodeStack directly is the only way to close
+> this… a single email could make the rest of this document moot."* That doc
+> establishes **what** we want and why no public API turned up. This one covers
+> **who to ask, how to frame it, and what to send.**
 >
-> **Status:** not yet sent. Companion to `docs/integrations/seis.md` and
-> `docs/integrations/iep-vendor-landscape.md` (the same question asked about
-> every other state). Related: SPE-276 (Chrome extension, parked), the *SIS
-> Integration* project (SPE-392 → SPE-420).
+> **Status:** not yet sent. Companion to
+> [**SEIS — can we pull data automatically?**](./seis.md) and
+> [**IEP systems outside California**](./iep-vendor-landscape.md) (the same
+> question asked about every other state). Related: SPE-276 (Chrome extension,
+> parked), the *SIS Integration* project (SPE-392 → SPE-420).
 
 ## The core reframe
 

--- a/docs/integrations/seis.md
+++ b/docs/integrations/seis.md
@@ -14,11 +14,12 @@
 > extension, parked), the *SIS Integration* project (SPE-392 → SPE-420).
 >
 > **Follow-ups to this document:**
-> `docs/integrations/seis-outreach.md` — how we actually approach CodeStack
-> (framing, draft email, channels), the follow-through on the "ask them
-> directly" recommendation in Path 1 below.
-> `docs/integrations/iep-vendor-landscape.md` — the same question asked of every
-> IEP system *outside* California, where the answer is markedly more positive.
+> [**SEIS — how to approach CodeStack**](./seis-outreach.md) — how we actually
+> make the ask (framing, draft email, channels), the follow-through on the "ask
+> them directly" recommendation in Path 1 below.
+> [**IEP systems outside California**](./iep-vendor-landscape.md) — the same
+> question asked of every IEP system *outside* California, where the answer is
+> markedly more positive.
 
 ## What we upload manually today
 
@@ -51,8 +52,9 @@ and manages integrations internally, so a private or negotiated interface can't
 be ruled out from the outside. **Asking CodeStack directly is the only way to
 close this**, and it's worth doing before concluding Path 1 is dead — a single
 email could make the rest of this document moot.
-**See `docs/integrations/seis-outreach.md`** for how to make that ask: who to
-contact, the framing that makes a public agency say yes, and a draft to send.
+**See [how to approach CodeStack](./seis-outreach.md)** for how to make that ask:
+who to contact, the framing that makes a public agency say yes, and a draft to
+send.
 
 The one thing SEIS calls "integration" is **SEIS Integration**: an automated
 **nightly sync between a district's SIS and SEIS**, arranged directly between the

--- a/docs/integrations/seis.md
+++ b/docs/integrations/seis.md
@@ -12,6 +12,13 @@
 >
 > Companion to `docs/integrations/aeries.md`. Related: SPE-276 (Chrome
 > extension, parked), the *SIS Integration* project (SPE-392 → SPE-420).
+>
+> **Follow-ups to this document:**
+> `docs/integrations/seis-outreach.md` — how we actually approach CodeStack
+> (framing, draft email, channels), the follow-through on the "ask them
+> directly" recommendation in Path 1 below.
+> `docs/integrations/iep-vendor-landscape.md` — the same question asked of every
+> IEP system *outside* California, where the answer is markedly more positive.
 
 ## What we upload manually today
 
@@ -44,6 +51,8 @@ and manages integrations internally, so a private or negotiated interface can't
 be ruled out from the outside. **Asking CodeStack directly is the only way to
 close this**, and it's worth doing before concluding Path 1 is dead — a single
 email could make the rest of this document moot.
+**See `docs/integrations/seis-outreach.md`** for how to make that ask: who to
+contact, the framing that makes a public agency say yes, and a draft to send.
 
 The one thing SEIS calls "integration" is **SEIS Integration**: an automated
 **nightly sync between a district's SIS and SEIS**, arranged directly between the


### PR DESCRIPTION
Docs only — no code, no schema, no behavior change.

`docs/integrations/seis.md` ended by recommending we ask CodeStack directly ("a single email could make the rest of this document moot") without saying what that email should say. These two docs are the follow-through, plus the same question asked of the rest of the country.

## `docs/integrations/seis-outreach.md` — the approach to CodeStack

SEIS is run by a **department of the San Joaquin County Office of Education**, so this is a public-agency pitch, not a vendor pitch. The doc covers:

- **The reframe** — ask as the tool a district they serve has chosen, not as a vendor wanting data. The strongest version has the pilot district on the call.
- **Three framing rules** — say what we're *not* (not an IEP system) in the first paragraph; ask a small answerable question (*does a district-authorized read-only path exist?*) rather than "build us an API"; cite **SEIS Integration** as their own precedent for moving data under district control.
- **A draft email**, ready to adjust and send.
- **Channels ranked** — via the pilot district's SELPA first; the cold support line is likely to die in end-user support.
- **When to raise the parked Chrome extension** (SPE-276) — recommendation is the first live conversation, not the first email, with the tradeoff stated either way.
- **Check before sending** — notably that the JSUSD CA-NDPA was a *draft under review, not executed*, as of the last review, so the draft hedges that claim rather than overstating it.

## `docs/integrations/iep-vendor-landscape.md` — outside California

The answer is materially more positive, for a structural reason: outside CA the IEP system is a commercial vendor competing for district contracts rather than a public agency, so integration is a selling point rather than a support burden.

- **Frontline** already sends an automated nightly feed of in-force IEP data to a third-party SpEd app (CentralReach LiftEd) — essentially the thing we want, in production, for someone else.
- **PowerSchool Special Programs** has a formal ISV partner program with certification badging, plus the Stepwell precedent.
- **Everway** is consolidating the mid-market (Embrace Jan 2025, SpedTrack Jan 2026) and is likely the easiest to actually get on a call.
- **PCG** runs statewide systems (NC ECATS, formerly TN EasyIEP) — least approachable directly, but see below.
- **Ed-Fi v6.1 (May 2026)** shipped an early-access **Special Education Data Model** covering `studentIEP`, goals, services and IDEA events, co-authored by PCG, Education Analytics and the South Carolina DOE — and its adoption guidance recommends *special education vendors* over SIS vendors. It's the first standard that models **goal text**, the one thing no SIS-mediated path can structurally carry (`aeries-sped-mapping.md` gap #3).

Recommends approaching Frontline first and engaging the Ed-Fi RFC now, while keeping it in proportion: this argues for where we expand *second*, not for leaving California.

## Verification limits (recorded in both docs)

This environment's egress proxy blocks `seis.org`, `docs.ed-fi.org` and `spedtrack.com`, so those claims rest on search-result excerpts rather than direct reads, and **no vendor has been contacted**. Both docs flag which specific claims need confirming before we design against them. General market-size figures were deliberately excluded — the available sources were low-quality aggregators that wouldn't change a decision.

Also adds cross-links from `docs/integrations/seis.md` so both are discoverable from the doc that prompted them. All referenced paths verified to exist; no CI gate touches markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012TpSDrQF7kyrKQRBRAGz5n

---
_Generated by [Claude Code](https://claude.ai/code/session_012TpSDrQF7kyrKQRBRAGz5n)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added market research covering IEP vendors, integration options, procurement considerations, and data standards.
  * Added an outreach plan for requesting district-authorized, read-only SEIS data access.
  * Documented contact strategies, verification steps, consent requirements, and expected responses.
  * Added cross-references connecting SEIS integration guidance with vendor research and outreach materials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->