### PR TITLE
Regenerate database types, consolidate activity colors (SPE-351, SPE-34)

### DIFF
--- a/__tests__/unit/lib/constants/activity-colors.test.ts
+++ b/__tests__/unit/lib/constants/activity-colors.test.ts
@@ -1,0 +1,125 @@
+/**
+ * SPE-34 — the consolidation must not repaint anything.
+ *
+ * Four components defined the same seven activity types in three formats, and
+ * they did NOT agree: the rotation-groups panel's `solid` hues are unrelated to
+ * the other three (Library violet vs blue, STEAM and STEM sharing one amber, PE
+ * blue vs red). Moving them into one file makes that disagreement visible for
+ * the first time, and the obvious next instinct — "harmonize them" — is a
+ * visual change, which this ticket explicitly excludes.
+ *
+ * So these tests pin the values as they were before the move. If someone later
+ * decides `solid` should match the rest, that is a design decision and this
+ * file is where it should be argued, not a silent tidy-up.
+ *
+ * The second block guards the subtler trap: Tailwind's JIT only emits classes
+ * it finds as complete literal text. A refactor to `bg-${hue}-200` typechecks,
+ * passes every other test, and ships a page with no colours on it.
+ */
+import {
+  ACTIVITY_FILTER_CLASSES,
+  ACTIVITY_GRID_CLASSES,
+  ACTIVITY_HEX,
+  ACTIVITY_SOLID_HEX,
+  COLORED_ACTIVITY_TYPES,
+  DEFAULT_ACTIVITY_FILTER_CLASSES,
+  DEFAULT_ACTIVITY_GRID_CLASSES,
+  DEFAULT_ACTIVITY_HEX,
+  DEFAULT_ACTIVITY_SOLID_HEX,
+} from '@/lib/constants/activity-colors';
+
+describe('activity colors are unchanged by the consolidation (SPE-34)', () => {
+  it('keeps the rotation-groups panel solid hues, including their oddities', () => {
+    expect(ACTIVITY_SOLID_HEX).toEqual({
+      Library: '#8B5CF6',
+      STEAM: '#F59E0B',
+      STEM: '#F59E0B', // deliberately identical to STEAM, as it was
+      Garden: '#10B981',
+      Music: '#EC4899',
+      ART: '#EF4444',
+      PE: '#3B82F6',
+    });
+    expect(DEFAULT_ACTIVITY_SOLID_HEX).toBe('#6B7280');
+  });
+
+  it('keeps the rotation schedule item bg/border hex pairs', () => {
+    expect(ACTIVITY_HEX).toEqual({
+      Library: { bg: '#BFDBFE', border: '#60A5FA' },
+      STEAM: { bg: '#FED7AA', border: '#FB923C' },
+      STEM: { bg: '#99F6E4', border: '#2DD4BF' },
+      Garden: { bg: '#D9F99D', border: '#84CC16' },
+      Music: { bg: '#DDD6FE', border: '#A78BFA' },
+      ART: { bg: '#F5D0FE', border: '#E879F9' },
+      PE: { bg: '#FECACA', border: '#F87171' },
+    });
+    expect(DEFAULT_ACTIVITY_HEX).toEqual({ bg: '#E5E7EB', border: '#9CA3AF' });
+  });
+
+  it('keeps the admin grid Tailwind classes', () => {
+    expect(ACTIVITY_GRID_CLASSES).toEqual({
+      Library: 'bg-blue-200 border-blue-400',
+      STEAM: 'bg-orange-200 border-orange-400',
+      STEM: 'bg-teal-200 border-teal-400',
+      Garden: 'bg-lime-200 border-lime-400',
+      Music: 'bg-violet-200 border-violet-400',
+      ART: 'bg-fuchsia-200 border-fuchsia-400',
+      PE: 'bg-red-200 border-red-400',
+    });
+    expect(DEFAULT_ACTIVITY_GRID_CLASSES).toBe('bg-gray-200 border-gray-400');
+  });
+
+  it('keeps the filter chip Tailwind classes', () => {
+    expect(ACTIVITY_FILTER_CLASSES).toEqual({
+      Library: { bg: 'bg-blue-50', border: 'border-blue-300', selectedBg: 'bg-blue-200' },
+      STEAM: { bg: 'bg-orange-50', border: 'border-orange-300', selectedBg: 'bg-orange-200' },
+      STEM: { bg: 'bg-teal-50', border: 'border-teal-300', selectedBg: 'bg-teal-200' },
+      Garden: { bg: 'bg-lime-50', border: 'border-lime-300', selectedBg: 'bg-lime-200' },
+      Music: { bg: 'bg-violet-50', border: 'border-violet-300', selectedBg: 'bg-violet-200' },
+      ART: { bg: 'bg-fuchsia-50', border: 'border-fuchsia-300', selectedBg: 'bg-fuchsia-200' },
+      PE: { bg: 'bg-red-50', border: 'border-red-300', selectedBg: 'bg-red-200' },
+    });
+    expect(DEFAULT_ACTIVITY_FILTER_CLASSES).toEqual({
+      bg: 'bg-gray-50',
+      border: 'border-gray-300',
+      selectedBg: 'bg-gray-200',
+    });
+  });
+
+  it('covers every colored type in all four maps', () => {
+    for (const type of COLORED_ACTIVITY_TYPES) {
+      expect(ACTIVITY_SOLID_HEX[type]).toBeDefined();
+      expect(ACTIVITY_HEX[type]).toBeDefined();
+      expect(ACTIVITY_GRID_CLASSES[type]).toBeDefined();
+      expect(ACTIVITY_FILTER_CLASSES[type]).toBeDefined();
+    }
+  });
+});
+
+describe('the Tailwind classes stay statically analyzable', () => {
+  const allClassStrings = [
+    ...Object.values(ACTIVITY_GRID_CLASSES),
+    DEFAULT_ACTIVITY_GRID_CLASSES,
+    ...Object.values(ACTIVITY_FILTER_CLASSES).flatMap((v) => Object.values(v)),
+    ...Object.values(DEFAULT_ACTIVITY_FILTER_CLASSES),
+  ];
+
+  it('writes every class as a whole literal, never interpolated', () => {
+    // Tailwind's JIT greps source text. `bg-${hue}-200` is invisible to it, so
+    // the class is purged and the element renders unstyled — a failure no
+    // typecheck and no other test in this repo would catch.
+    for (const s of allClassStrings) {
+      expect(s).not.toMatch(/\$\{|\+/);
+      expect(s).toMatch(/^[a-z0-9- ]+$/);
+    }
+  });
+
+  it('is covered by a Tailwind content glob', () => {
+    // These literals only survive a build because tailwind.config.ts scans
+    // lib/. Without that glob every class above is purged: verified by
+    // rebuilding with the glob removed, which drops all of them from the CSS.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const config = require('../../../../tailwind.config.ts').default;
+    const globs: string[] = config.content;
+    expect(globs.some((g) => g.startsWith('./lib/'))).toBe(true);
+  });
+});

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/activity-type-filter.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/activity-type-filter.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { ActivityContextMenu } from './activity-context-menu';
 import { AvailabilityModal } from './availability-modal';
 import { deleteActivityAvailability } from '../../../../../../lib/supabase/queries/activity-availability';
+import { ACTIVITY_FILTER_CLASSES, DEFAULT_ACTIVITY_FILTER_CLASSES } from '@/lib/constants/activity-colors';
 
 interface ActivityTypeFilterProps {
   selectedTypes: Set<string>;
@@ -16,17 +17,6 @@ interface ActivityTypeFilterProps {
   inUseActivityTypes?: Set<string>;
 }
 
-const ACTIVITY_COLOR_MAP: Record<string, { bg: string; border: string; selectedBg: string }> = {
-  Library: { bg: 'bg-blue-50', border: 'border-blue-300', selectedBg: 'bg-blue-200' },
-  STEAM: { bg: 'bg-orange-50', border: 'border-orange-300', selectedBg: 'bg-orange-200' },
-  STEM: { bg: 'bg-teal-50', border: 'border-teal-300', selectedBg: 'bg-teal-200' },
-  Garden: { bg: 'bg-lime-50', border: 'border-lime-300', selectedBg: 'bg-lime-200' },
-  Music: { bg: 'bg-violet-50', border: 'border-violet-300', selectedBg: 'bg-violet-200' },
-  ART: { bg: 'bg-fuchsia-50', border: 'border-fuchsia-300', selectedBg: 'bg-fuchsia-200' },
-  PE: { bg: 'bg-red-50', border: 'border-red-300', selectedBg: 'bg-red-200' },
-};
-
-const DEFAULT_COLOR = { bg: 'bg-gray-50', border: 'border-gray-300', selectedBg: 'bg-gray-200' };
 
 export function ActivityTypeFilter({
   selectedTypes,
@@ -110,7 +100,7 @@ export function ActivityTypeFilter({
       <div className="flex items-center gap-1">
         {availableTypes.map((type) => {
           const isSelected = selectedTypes.has(type);
-          const colors = ACTIVITY_COLOR_MAP[type] || DEFAULT_COLOR;
+          const colors = ACTIVITY_FILTER_CLASSES[type] || DEFAULT_ACTIVITY_FILTER_CLASSES;
 
           return (
             <button

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/admin-schedule-grid.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/admin-schedule-grid.tsx
@@ -16,6 +16,7 @@ import type { YardDutyZone } from '../../../../../../lib/supabase/queries/yard-d
 import type { BellScheduleWithCreator } from '../types';
 import type { FullDayAvailability } from '../../../../../../lib/supabase/queries/activity-availability';
 import type { RotationPairWithGroups, RotationGroupMemberWithTeacher } from '../../../../../../lib/supabase/queries/rotation-groups';
+import { ACTIVITY_GRID_CLASSES, DEFAULT_ACTIVITY_GRID_CLASSES } from '@/lib/constants/activity-colors';
 
 // Special period names that indicate daily time markers
 const DAILY_TIME_PERIOD_NAMES = ['School Start', 'Dismissal', 'Early Dismissal'] as const;
@@ -83,17 +84,6 @@ const GRADE_COLOR_MAP: Record<string, string> = {
   '5': 'bg-slate-400 border-slate-600',
 };
 
-const ACTIVITY_COLOR_MAP: Record<string, string> = {
-  Library: 'bg-blue-200 border-blue-400',
-  STEAM: 'bg-orange-200 border-orange-400',
-  STEM: 'bg-teal-200 border-teal-400',
-  Garden: 'bg-lime-200 border-lime-400',
-  Music: 'bg-violet-200 border-violet-400',
-  ART: 'bg-fuchsia-200 border-fuchsia-400',
-  PE: 'bg-red-200 border-red-400',
-};
-
-const DEFAULT_ACTIVITY_COLOR = 'bg-gray-200 border-gray-400';
 const YARD_DUTY_COLOR = 'bg-amber-200 border-amber-400';
 const INSTRUCTION_COLOR = 'bg-red-100 border-red-300';
 
@@ -440,8 +430,8 @@ export function AdminScheduleGrid({
 
   // Get color for a special activity based on its type
   const getActivityColor = (activityName: string | null): string => {
-    if (!activityName) return DEFAULT_ACTIVITY_COLOR;
-    return ACTIVITY_COLOR_MAP[activityName] || DEFAULT_ACTIVITY_COLOR;
+    if (!activityName) return DEFAULT_ACTIVITY_GRID_CLASSES;
+    return ACTIVITY_GRID_CLASSES[activityName] || DEFAULT_ACTIVITY_GRID_CLASSES;
   };
 
   return (

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/rotation-groups-panel.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/rotation-groups-panel.tsx
@@ -5,6 +5,7 @@ import { Button } from '../../../../../components/ui/button';
 import { TrashIcon } from '@heroicons/react/24/outline';
 import { SidebarSection } from './sidebar-section';
 import { deleteRotationPair, type RotationPairWithGroups } from '../../../../../../lib/supabase/queries/rotation-groups';
+import { ACTIVITY_SOLID_HEX, DEFAULT_ACTIVITY_SOLID_HEX } from '@/lib/constants/activity-colors';
 
 interface RotationGroupsPanelProps {
   rotationPairs: RotationPairWithGroups[];
@@ -137,18 +138,8 @@ export function RotationGroupsPanel({
   );
 }
 
-// Activity type color map (matching existing pattern)
 function getActivityColor(activityType: string): string {
-  const colorMap: Record<string, string> = {
-    'Library': '#8B5CF6',
-    'STEAM': '#F59E0B',
-    'STEM': '#F59E0B',
-    'Garden': '#10B981',
-    'Music': '#EC4899',
-    'ART': '#EF4444',
-    'PE': '#3B82F6',
-  };
-  return colorMap[activityType] || '#6B7280';
+  return ACTIVITY_SOLID_HEX[activityType] || DEFAULT_ACTIVITY_SOLID_HEX;
 }
 
 function getTotalMemberCount(pair: RotationPairWithGroups): number {

--- a/app/(dashboard)/dashboard/admin/master-schedule/components/rotation-schedule-item.tsx
+++ b/app/(dashboard)/dashboard/admin/master-schedule/components/rotation-schedule-item.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { ACTIVITY_HEX, DEFAULT_ACTIVITY_HEX } from '@/lib/constants/activity-colors';
 
 interface RotationScheduleItemProps {
   activityA: string;
@@ -13,21 +14,8 @@ interface RotationScheduleItemProps {
   overlapTotal?: number;
 }
 
-// Activity type to color map (matching existing pattern)
-const ACTIVITY_COLORS: Record<string, { bg: string; border: string }> = {
-  Library: { bg: '#BFDBFE', border: '#60A5FA' },
-  STEAM: { bg: '#FED7AA', border: '#FB923C' },
-  STEM: { bg: '#99F6E4', border: '#2DD4BF' },
-  Garden: { bg: '#D9F99D', border: '#84CC16' },
-  Music: { bg: '#DDD6FE', border: '#A78BFA' },
-  ART: { bg: '#F5D0FE', border: '#E879F9' },
-  PE: { bg: '#FECACA', border: '#F87171' },
-};
-
-const DEFAULT_COLOR = { bg: '#E5E7EB', border: '#9CA3AF' };
-
 function getActivityColor(activityType: string): { bg: string; border: string } {
-  return ACTIVITY_COLORS[activityType] || DEFAULT_COLOR;
+  return ACTIVITY_HEX[activityType] || DEFAULT_ACTIVITY_HEX;
 }
 
 export function RotationScheduleItem({

--- a/lib/constants/activity-colors.ts
+++ b/lib/constants/activity-colors.ts
@@ -1,0 +1,105 @@
+/**
+ * Activity-type colors, in one place (SPE-34).
+ *
+ * The same seven activity types were coloured in four components, in three
+ * different formats, with no link between them — so "make Garden green" meant
+ * finding all four and getting all four right.
+ *
+ * ## This is a consolidation, not a reconciliation
+ *
+ * The four maps did NOT agree, and this file deliberately preserves that
+ * disagreement value-for-value. `solid` (the rotation-groups panel) assigns
+ * hues that have nothing to do with the other three: Library is violet there
+ * and blue everywhere else, STEAM and STEM share one amber, PE is blue rather
+ * than red. Unifying them would change what the app renders, and SPE-34's
+ * acceptance criteria are explicit that there is no visual change.
+ *
+ * So: one source of truth for WHERE the colors live, with the existing values
+ * intact. Whether `solid` should be brought in line with the rest is a design
+ * decision, and a separate one.
+ *
+ * ## Why the Tailwind classes are written out in full
+ *
+ * Tailwind's JIT scans source text for complete class names — it cannot see
+ * `bg-${hue}-200`. Every class below is a whole literal for that reason, and
+ * `tailwind.config.ts` had to learn to scan `lib/` for them to survive a build.
+ */
+
+/** The activity types that carry a colour. Anything else falls back to grey. */
+export const COLORED_ACTIVITY_TYPES = [
+  'Library',
+  'STEAM',
+  'STEM',
+  'Garden',
+  'Music',
+  'ART',
+  'PE',
+] as const;
+
+export type ColoredActivityType = (typeof COLORED_ACTIVITY_TYPES)[number];
+
+/**
+ * Solid hex, used by the rotation-groups panel for its activity dots.
+ * Its hues are its own — see the note above before "fixing" them.
+ */
+export const ACTIVITY_SOLID_HEX: Record<string, string> = {
+  Library: '#8B5CF6',
+  STEAM: '#F59E0B',
+  STEM: '#F59E0B',
+  Garden: '#10B981',
+  Music: '#EC4899',
+  ART: '#EF4444',
+  PE: '#3B82F6',
+};
+
+export const DEFAULT_ACTIVITY_SOLID_HEX = '#6B7280';
+
+/** Background/border hex pair, used by the rotation schedule item. */
+export const ACTIVITY_HEX: Record<string, { bg: string; border: string }> = {
+  Library: { bg: '#BFDBFE', border: '#60A5FA' },
+  STEAM: { bg: '#FED7AA', border: '#FB923C' },
+  STEM: { bg: '#99F6E4', border: '#2DD4BF' },
+  Garden: { bg: '#D9F99D', border: '#84CC16' },
+  Music: { bg: '#DDD6FE', border: '#A78BFA' },
+  ART: { bg: '#F5D0FE', border: '#E879F9' },
+  PE: { bg: '#FECACA', border: '#F87171' },
+};
+
+export const DEFAULT_ACTIVITY_HEX = { bg: '#E5E7EB', border: '#9CA3AF' };
+
+/** Tailwind bg+border pair, used by the admin schedule grid. */
+export const ACTIVITY_GRID_CLASSES: Record<string, string> = {
+  Library: 'bg-blue-200 border-blue-400',
+  STEAM: 'bg-orange-200 border-orange-400',
+  STEM: 'bg-teal-200 border-teal-400',
+  Garden: 'bg-lime-200 border-lime-400',
+  Music: 'bg-violet-200 border-violet-400',
+  ART: 'bg-fuchsia-200 border-fuchsia-400',
+  PE: 'bg-red-200 border-red-400',
+};
+
+export const DEFAULT_ACTIVITY_GRID_CLASSES = 'bg-gray-200 border-gray-400';
+
+/**
+ * Tailwind classes for the filter chips, which need a third state (selected).
+ * Lighter shades than the grid so an unselected chip reads as a control rather
+ * than as a block on the schedule.
+ */
+export const ACTIVITY_FILTER_CLASSES: Record<
+  string,
+  { bg: string; border: string; selectedBg: string }
+> = {
+  Library: { bg: 'bg-blue-50', border: 'border-blue-300', selectedBg: 'bg-blue-200' },
+  STEAM: { bg: 'bg-orange-50', border: 'border-orange-300', selectedBg: 'bg-orange-200' },
+  STEM: { bg: 'bg-teal-50', border: 'border-teal-300', selectedBg: 'bg-teal-200' },
+  Garden: { bg: 'bg-lime-50', border: 'border-lime-300', selectedBg: 'bg-lime-200' },
+  Music: { bg: 'bg-violet-50', border: 'border-violet-300', selectedBg: 'bg-violet-200' },
+  ART: { bg: 'bg-fuchsia-50', border: 'border-fuchsia-300', selectedBg: 'bg-fuchsia-200' },
+  PE: { bg: 'bg-red-50', border: 'border-red-300', selectedBg: 'bg-red-200' },
+};
+
+export const DEFAULT_ACTIVITY_FILTER_CLASSES = {
+  bg: 'bg-gray-50',
+  border: 'border-gray-300',
+  selectedBg: 'bg-gray-200',
+};

--- a/lib/constants/activity-colors.ts
+++ b/lib/constants/activity-colors.ts
@@ -22,7 +22,14 @@
  *
  * Tailwind's JIT scans source text for complete class names — it cannot see
  * `bg-${hue}-200`. Every class below is a whole literal for that reason, and
- * `tailwind.config.ts` had to learn to scan `lib/` for them to survive a build.
+ * `tailwind.config.ts` lists THIS FILE by name in its content globs so they
+ * survive a build.
+ *
+ * It lists the file rather than `./lib/**` on purpose: scanning all of lib/
+ * would also un-purge class names in other lib/ files and repaint unrelated UI.
+ * Those classes are genuinely dead today — the CARE category badges and the
+ * AI-lesson student badges among them — which is a real bug, tracked in
+ * SPE-504. Fixing it is a visual change and belongs to that ticket, not here.
  */
 
 /** The activity types that carry a colour. Anything else falls back to grey. */

--- a/lib/supabase/queries/chat.ts
+++ b/lib/supabase/queries/chat.ts
@@ -106,6 +106,13 @@ export async function listMyConversations(
     p_school_id: schoolId ?? undefined,
   });
   if (error) throw error;
+  // This cast is load-bearing, not decoration (SPE-351). The generated type for
+  // get_my_conversations marks every column non-nullable and types `kind` as a
+  // plain string, because that is all Supabase's generator can infer from a
+  // RETURNS TABLE signature. The function is LEFT JOIN-based, so student_id,
+  // other_id, other_name, other_role and last_message_at really are null
+  // depending on the conversation kind. Dropping this cast to "just use the
+  // generated type" would compile and then null-deref at runtime.
   const rows = (data ?? []) as Array<{
     id: string;
     kind: 'student' | 'direct';

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -253,6 +253,27 @@ export type Database = {
         }
         Relationships: []
       }
+      api_rate_limits: {
+        Row: {
+          created_at: string
+          endpoint: string
+          id: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          endpoint: string
+          id?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          endpoint?: string
+          id?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       assessment_types: {
         Row: {
           category: string
@@ -398,6 +419,27 @@ export type Database = {
           resource_type?: string | null
           timestamp?: string
           user_id?: string | null
+        }
+        Relationships: []
+      }
+      backup_spe459_school_year_retag: {
+        Row: {
+          previous_school_year: string
+          retagged_at: string
+          row_id: string
+          table_name: string
+        }
+        Insert: {
+          previous_school_year: string
+          retagged_at?: string
+          row_id: string
+          table_name: string
+        }
+        Update: {
+          previous_school_year?: string
+          retagged_at?: string
+          row_id?: string
+          table_name?: string
         }
         Relationships: []
       }
@@ -720,13 +762,20 @@ export type Database = {
         Row: {
           academic_testing_completed: boolean | null
           academic_testing_date: string | null
+          ap_due_date: string | null
+          ap_due_date_note: string | null
           ap_received_date: string | null
+          ap_sent_date: string | null
           assigned_to: string | null
           created_at: string | null
           current_disposition: string | null
+          eligibility_category: string | null
+          eligibility_meeting_date: string | null
+          eligibility_outcome: string | null
           follow_up_date: string | null
           id: string
           iep_due_date: string | null
+          iep_due_date_note: string | null
           ot_testing_completed: boolean | null
           ot_testing_date: string | null
           ot_testing_needed: boolean | null
@@ -743,13 +792,20 @@ export type Database = {
         Insert: {
           academic_testing_completed?: boolean | null
           academic_testing_date?: string | null
+          ap_due_date?: string | null
+          ap_due_date_note?: string | null
           ap_received_date?: string | null
+          ap_sent_date?: string | null
           assigned_to?: string | null
           created_at?: string | null
           current_disposition?: string | null
+          eligibility_category?: string | null
+          eligibility_meeting_date?: string | null
+          eligibility_outcome?: string | null
           follow_up_date?: string | null
           id?: string
           iep_due_date?: string | null
+          iep_due_date_note?: string | null
           ot_testing_completed?: boolean | null
           ot_testing_date?: string | null
           ot_testing_needed?: boolean | null
@@ -766,13 +822,20 @@ export type Database = {
         Update: {
           academic_testing_completed?: boolean | null
           academic_testing_date?: string | null
+          ap_due_date?: string | null
+          ap_due_date_note?: string | null
           ap_received_date?: string | null
+          ap_sent_date?: string | null
           assigned_to?: string | null
           created_at?: string | null
           current_disposition?: string | null
+          eligibility_category?: string | null
+          eligibility_meeting_date?: string | null
+          eligibility_outcome?: string | null
           follow_up_date?: string | null
           id?: string
           iep_due_date?: string | null
+          iep_due_date_note?: string | null
           ot_testing_completed?: boolean | null
           ot_testing_date?: string | null
           ot_testing_needed?: boolean | null
@@ -850,8 +913,12 @@ export type Database = {
           district_id: string | null
           grade: string
           id: string
+          private_school_name: string | null
           referral_reason: string
+          referral_source: string
           referring_user_id: string
+          request_received_date: string | null
+          requested_by: string | null
           school_id: string | null
           state_id: string | null
           status: string
@@ -868,8 +935,12 @@ export type Database = {
           district_id?: string | null
           grade: string
           id?: string
+          private_school_name?: string | null
           referral_reason: string
+          referral_source: string
           referring_user_id: string
+          request_received_date?: string | null
+          requested_by?: string | null
           school_id?: string | null
           state_id?: string | null
           status?: string
@@ -886,8 +957,12 @@ export type Database = {
           district_id?: string | null
           grade?: string
           id?: string
+          private_school_name?: string | null
           referral_reason?: string
+          referral_source?: string
           referring_user_id?: string
+          request_received_date?: string | null
+          requested_by?: string | null
           school_id?: string | null
           state_id?: string | null
           status?: string
@@ -1220,6 +1295,117 @@ export type Database = {
           user_id?: string | null
         }
         Relationships: []
+      }
+      district_curriculums: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          curriculum_id: string
+          district_id: string
+          id: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          curriculum_id: string
+          district_id: string
+          id?: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          curriculum_id?: string
+          district_id?: string
+          id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "district_curriculums_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "district_curriculums_district_id_fkey"
+            columns: ["district_id"]
+            isOneToOne: false
+            referencedRelation: "districts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      district_sis_connections: {
+        Row: {
+          aeries_certificate_encrypted: string | null
+          base_url: string | null
+          created_at: string
+          created_by: string | null
+          credential_hint: string | null
+          district_id: string
+          dpa_cleared_at: string | null
+          id: string
+          last_test_result: Json | null
+          last_tested_at: string | null
+          oneroster_client_id_encrypted: string | null
+          oneroster_client_secret_encrypted: string | null
+          sis_type: string
+          status: string
+          token_url: string | null
+          updated_at: string
+        }
+        Insert: {
+          aeries_certificate_encrypted?: string | null
+          base_url?: string | null
+          created_at?: string
+          created_by?: string | null
+          credential_hint?: string | null
+          district_id: string
+          dpa_cleared_at?: string | null
+          id?: string
+          last_test_result?: Json | null
+          last_tested_at?: string | null
+          oneroster_client_id_encrypted?: string | null
+          oneroster_client_secret_encrypted?: string | null
+          sis_type: string
+          status?: string
+          token_url?: string | null
+          updated_at?: string
+        }
+        Update: {
+          aeries_certificate_encrypted?: string | null
+          base_url?: string | null
+          created_at?: string
+          created_by?: string | null
+          credential_hint?: string | null
+          district_id?: string
+          dpa_cleared_at?: string | null
+          id?: string
+          last_test_result?: Json | null
+          last_tested_at?: string | null
+          oneroster_client_id_encrypted?: string | null
+          oneroster_client_secret_encrypted?: string | null
+          sis_type?: string
+          status?: string
+          token_url?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "district_sis_connections_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "district_sis_connections_district_id_fkey"
+            columns: ["district_id"]
+            isOneToOne: false
+            referencedRelation: "districts"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       districts: {
         Row: {
@@ -1728,6 +1914,13 @@ export type Database = {
             referencedRelation: "students"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "iep_meetings_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "unmatched_student_teachers"
+            referencedColumns: ["student_id"]
+          },
         ]
       }
       instruction_schedules: {
@@ -1789,6 +1982,27 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      landing_signups: {
+        Row: {
+          audience: string | null
+          created_at: string
+          email: string
+          id: string
+        }
+        Insert: {
+          audience?: string | null
+          created_at?: string
+          email: string
+          id?: string
+        }
+        Update: {
+          audience?: string | null
+          created_at?: string
+          email?: string
+          id?: string
+        }
+        Relationships: []
       }
       lesson_adjustment_queue: {
         Row: {
@@ -3901,6 +4115,13 @@ export type Database = {
             referencedRelation: "students"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "student_parent_contacts_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "unmatched_student_teachers"
+            referencedColumns: ["student_id"]
+          },
         ]
       }
       student_performance_metrics: {
@@ -4173,6 +4394,8 @@ export type Database = {
           phone_number: string | null
           school_id: string | null
           school_site: string | null
+          sis_id: string | null
+          sis_source: string | null
           updated_at: string | null
         }
         Insert: {
@@ -4188,6 +4411,8 @@ export type Database = {
           phone_number?: string | null
           school_id?: string | null
           school_site?: string | null
+          sis_id?: string | null
+          sis_source?: string | null
           updated_at?: string | null
         }
         Update: {
@@ -4203,6 +4428,8 @@ export type Database = {
           phone_number?: string | null
           school_id?: string | null
           school_site?: string | null
+          sis_id?: string | null
+          sis_source?: string | null
           updated_at?: string | null
         }
         Relationships: [
@@ -4740,6 +4967,19 @@ export type Database = {
       }
     }
     Functions: {
+      _groups_v2_retire_if_empty: {
+        Args: { p_group_ref: string }
+        Returns: undefined
+      }
+      _groups_v2_stamp: {
+        Args: {
+          p_color: number
+          p_group_ref: string
+          p_name: string
+          p_template_id: string
+        }
+        Returns: undefined
+      }
       can_access_conversation: {
         Args: { p_conversation_id: string; p_uid: string }
         Returns: boolean
@@ -4771,6 +5011,7 @@ export type Database = {
         Args: { p_student_id: string; p_uid: string }
         Returns: boolean
       }
+      chat_shares_site: { Args: { p_a: string; p_b: string }; Returns: boolean }
       copy_schedule_to_year: {
         Args: { p_from_year: string; p_school_id: string; p_to_year: string }
         Returns: Json
@@ -4779,6 +5020,7 @@ export type Database = {
         Args: { user_email: string; user_id: string; user_metadata: Json }
         Returns: undefined
       }
+      current_school_year: { Args: never; Returns: string }
       delete_chat_message: {
         Args: { p_message_id: string }
         Returns: undefined
@@ -4839,10 +5081,6 @@ export type Database = {
           start_time: string
         }[]
       }
-      find_shared_child_candidates: {
-        Args: { p_school_id: string; p_rows: Json }
-        Returns: Json
-      }
       find_school_ids_by_names: {
         Args: {
           p_school_district_name: string
@@ -4855,6 +5093,10 @@ export type Database = {
           matched_school_id: string
           matched_state_id: string
         }[]
+      }
+      find_shared_child_candidates: {
+        Args: { p_rows: Json; p_school_id: string }
+        Returns: Json
       }
       find_team_members: {
         Args: {
@@ -4939,18 +5181,18 @@ export type Database = {
       get_my_conversations: {
         Args: { p_school_id?: string }
         Returns: {
-          id: string
-          kind: 'student' | 'direct'
-          student_id: string | null
-          school_id: string | null
-          student_initials: string | null
-          student_grade: string | null
-          other_id: string | null
-          other_name: string | null
-          other_role: string | null
-          last_message_at: string | null
-          last_message_preview: string | null
           created_at: string
+          id: string
+          kind: string
+          last_message_at: string
+          last_message_preview: string
+          other_id: string
+          other_name: string
+          other_role: string
+          school_id: string
+          student_grade: string
+          student_id: string
+          student_initials: string
           unread: boolean
         }[]
       }
@@ -5085,6 +5327,36 @@ export type Database = {
           state_id: string
         }[]
       }
+      groups_v2_assign: {
+        Args: { p_assignee: string; p_delivered_by: string; p_group_id: string }
+        Returns: undefined
+      }
+      groups_v2_form: { Args: { p_session_ids: string[] }; Returns: string }
+      groups_v2_join: {
+        Args: { p_group_id: string; p_session_id: string }
+        Returns: undefined
+      }
+      groups_v2_leave: { Args: { p_session_id: string }; Returns: undefined }
+      groups_v2_merge: {
+        Args: { p_from_group_id: string; p_into_group_id: string }
+        Returns: undefined
+      }
+      groups_v2_rename: {
+        Args: { p_color: number; p_group_id: string; p_name: string }
+        Returns: undefined
+      }
+      groups_v2_split: {
+        Args: { p_group_id: string; p_session_ids: string[] }
+        Returns: string
+      }
+      import_child_candidates: {
+        Args: { p_rows: Json; p_school_id: string }
+        Returns: {
+          child_id: string
+          idx: number
+          reason: string
+        }[]
+      }
       increment_referral_uses: {
         Args: { referrer_user_id: string }
         Returns: undefined
@@ -5110,16 +5382,29 @@ export type Database = {
         Args: { target_user_id: string }
         Returns: boolean
       }
+      matching_provider_student_ids: {
+        Args: { p_student_id: string }
+        Returns: string[]
+      }
+      merge_iep_goals: {
+        Args: { p_entries: Json; p_provider_id: string }
+        Returns: {
+          error_message: string
+          matched_student_id: string
+          ord: number
+          success: boolean
+        }[]
+      }
+      merge_iep_goals_array: {
+        Args: { p_existing: string[]; p_incoming: string[] }
+        Returns: string[]
+      }
+      norm_student_name: {
+        Args: { p_first: string; p_last: string }
+        Returns: string
+      }
       normalize_district_name: {
         Args: { district_name: string }
-        Returns: string
-      }
-      open_direct_conversation: {
-        Args: { p_other_id: string }
-        Returns: string
-      }
-      open_student_conversation: {
-        Args: { p_student_id: string }
         Returns: string
       }
       normalize_existing_school_data: {
@@ -5128,6 +5413,14 @@ export type Database = {
           records_updated: number
           table_name: string
         }[]
+      }
+      open_direct_conversation: {
+        Args: { p_other_id: string }
+        Returns: string
+      }
+      open_student_conversation: {
+        Args: { p_student_id: string }
+        Returns: string
       }
       recalculate_session_end_time: {
         Args: { p_minutes_per_session: number; p_start_time: string }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,10 +5,15 @@ const config: Config = {
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',
-    // Shared constants files hold whole Tailwind class names (SPE-34's
-    // activity colors). The JIT only emits classes it finds as literal text,
-    // so without this the class-based maps would be purged from the build.
-    './lib/**/*.{js,ts,jsx,tsx,mdx}',
+    // One file, not './lib/**' (SPE-34). The JIT only emits classes it finds as
+    // literal text, so the activity-color maps must be scanned or they are
+    // purged — but scanning all of lib/ ALSO un-purges class names sitting in
+    // other lib/ files, which repaints unrelated UI (measured: 36 new
+    // selectors, only ~22 of them these colors). Whether that other UI should
+    // have been styled all along is a real question, and a separate one — see
+    // the ticket linked from lib/constants/activity-colors.ts. Scoping to the
+    // one file keeps this refactor's promise of no visual change.
+    './lib/constants/activity-colors.ts',
   ],
   theme: {
     extend: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,10 @@ const config: Config = {
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',
+    // Shared constants files hold whole Tailwind class names (SPE-34's
+    // activity colors). The JIT only emits classes it finds as literal text,
+    // so without this the class-based maps would be purged from the build.
+    './lib/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
Third batch of the `auto-deployable` backlog.

## SPE-351 — regenerate `src/types/database.ts`

Wholesale regeneration, so the file matches the database again rather than the subset SPE-347 hand-spliced in. Closes the drift the ticket named, verified missing-before / present-after:

- `api_rate_limits` — the whole table
- `care_cases` — `ap_due_date`, `ap_due_date_note`, `ap_sent_date`, `eligibility_category`, `eligibility_meeting_date`, `eligibility_outcome`, `iep_due_date_note`

SPE-347's `children` table and `students.child_id` survive — they come from the live schema anyway, so the splice is now simply what the generator emits.

Most of the remaining diff is the generator re-sorting RPC definitions alphabetically; every function present before is still present (checked individually). One real change: `get_my_conversations`'s `Returns` had been hand-narrowed and now reflects generator output. The self-review flagged that this matters — the function is `LEFT JOIN`-based, so those nulls are genuine, and nothing breaks only because `listMyConversations` re-casts to a nullable shape. That cast now looks redundant sitting next to the generated type, so it's commented as load-bearing: removing it would compile and then null-deref.

## SPE-34 — one source of truth for activity colors

Seven activity types were coloured in four components in three formats, with nothing connecting them.

**This is a consolidation, not a reconciliation.** The four maps did *not* agree, and the shared file preserves that value-for-value — the rotation-groups panel's `solid` hues are unrelated to the other three (Library violet vs blue, STEAM and STEM sharing one amber, PE blue vs red). Unifying them would repaint the UI, which the ticket's acceptance criteria exclude. A test pins every value, so "harmonize these" has to be argued rather than slipped in as a tidy-up.

### The trap this hit, and why the self-review mattered

Tailwind's JIT only emits classes it finds as literal text in scanned files, and `tailwind.config.ts` didn't scan `lib/`. Moving the class-based maps there silently purged them — the admin schedule grid and filter chips would have shipped with **no colours at all**.

My first fix was `./lib/**/*`, and the deep review caught that this over-corrects: it also un-purges class names in *other* `lib/` files, repainting unrelated UI. Measured by diffing emitted CSS selectors — 36 new classes, only ~22 of them these colours.

Final state: the glob names the single file. Re-measured across two real builds:

| glob | selectors added | selectors removed |
|---|---|---|
| none (main today) | — | — |
| `./lib/constants/activity-colors.ts` | **17, all activity colours** | **0** |

### Also filed
**SPE-504** — the classes that broad glob would have un-purged are genuinely dead today: `CARE_CATEGORY_COLORS` (used as a `className` in the district CARE table), the AI-lesson student badges, and an accommodations heading all render colourless because their only definition lives under `lib/`. Real bug, but fixing it is a visual change, so it's yours to call rather than something to ride along here.

## Not in this batch
**SPE-48** (legacy manual-lesson cleanup) turned out not to be dead code. `calendar-week-view.tsx` fetches manual lessons every week change, groups them by date, computes `dayManualLessons` per day — and never renders it. Users can create a manual lesson today and it silently never appears. Deleting the "unused" view modal would cement that rather than clean anything up, so I've stripped `auto-deployable` from the ticket and written up both directions there for you.

## Verification
- `npm run typecheck` — clean
- `npm run lint` — clean (two pre-existing warnings in unrelated master-schedule files)
- `npm test` — 136 suites, 1542 passed, 12 skipped
- two full `next build` runs, diffing emitted CSS selectors, to prove the glob change repaints nothing
- `/code-review` at high effort; both findings fixed in `f4f96f4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011g7ZDiAanE2CREwjfAozZG

---
_Generated by [Claude Code](https://claude.ai/code/session_011g7ZDiAanE2CREwjfAozZG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Standardized activity colors across schedule items, rotation groups, admin grids, and activity filters.
  - Improved consistency of color backgrounds, borders, labels, and filter states.
  - Added neutral fallback styling for unsupported or unrecognized activity types.
  - Expanded platform support for school-year data, curriculum, SIS connections, care records, referrals, student matching, and group management.
- **Quality Improvements**
  - Added safeguards to ensure activity colors and styling remain consistent across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->