### PR TITLE
Upload-size guard, env-less build, CI concurrency (SPE-443, SPE-495, SPE-405)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,15 @@ on:
   schedule:
     - cron: '28 4 * * 1'
 
+# Auto-cancel superseded PR runs (SPE-405). Only pull_request runs share a
+# group; push-to-main and the weekly scheduled scan key on the unique run id,
+# so each sits in a group of one. That matters here specifically: schedule and
+# push both resolve `github.ref` to refs/heads/main, so a ref-based group would
+# make them contend — and main keeps a complete per-commit record either way.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,6 +12,13 @@ on:
   pull_request:
     branches: [ "main" ]
 
+# Auto-cancel superseded PR runs (SPE-405). This workflow is pull_request-only,
+# so the fallback arm never fires; the form is kept identical to the other
+# workflows so all four read the same way.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 # If using a dependency submission action in this workflow this permission will need to be set to:
 #
 # permissions:

--- a/.github/workflows/simple-tests.yml
+++ b/.github/workflows/simple-tests.yml
@@ -7,6 +7,14 @@ on:
     branches: [ main, master ]
   workflow_dispatch:
 
+# Auto-cancel superseded PR runs (SPE-405). Only pull_request runs share a
+# group; push-to-main and manual dispatches key on the unique run id, so each
+# sits in a group of one and is never cancelled or queued behind another —
+# main keeps a complete per-commit record.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -9,6 +9,14 @@ on:
   push:
     branches: [main]
 
+# Auto-cancel superseded PR runs (SPE-405). Only pull_request runs share a
+# group; push-to-main keys on the unique run id, so each main commit sits in a
+# group of one and is never cancelled or queued behind another — main keeps a
+# complete per-commit record.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   typecheck:
     runs-on: ubuntu-latest

--- a/__tests__/unit/lib/import/upload-size-guard.test.ts
+++ b/__tests__/unit/lib/import/upload-size-guard.test.ts
@@ -1,0 +1,188 @@
+/**
+ * SPE-443: the import upload-size guard must hold regardless of what the
+ * request's headers claim.
+ *
+ * The original guard (SPE-260) read Content-Length and rejected an over-ceiling
+ * body before formData() buffered it. That only works against a client that
+ * declares an honest, oversized length. Omitting the header, using chunked
+ * transfer-encoding, or simply understating the length skipped the check
+ * entirely and handed an unbounded body straight to formData() — precisely the
+ * memory-exhaustion case the guard exists to close.
+ *
+ * These tests drive real Request objects with real ReadableStream bodies, so
+ * they exercise the byte counting rather than a mocked header lookup.
+ */
+import {
+  readImportForm,
+  exceedsTotalUploadSize,
+  UploadTooLargeError,
+  MAX_TOTAL_UPLOAD_BYTES,
+} from '@/lib/import/parse-files';
+
+const URL_UNDER_TEST = 'http://localhost/api/import-students';
+const ONE_MB = 1024 * 1024;
+
+/**
+ * A body that never ends, delivered in 1 MB chunks.
+ *
+ * The guard must abandon the read shortly after MAX_TOTAL_UPLOAD_BYTES. The
+ * safety limit exists so a regression fails the test quickly instead of
+ * exhausting the CI runner's memory: without a cap, an endless stream would be
+ * buffered until the process dies.
+ */
+function unboundedBody(safetyLimitChunks: number) {
+  let pulls = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      pulls += 1;
+      if (pulls > safetyLimitChunks) {
+        controller.error(new Error(`read was never capped (${pulls} chunks pulled)`));
+        return;
+      }
+      controller.enqueue(new Uint8Array(ONE_MB));
+    },
+  });
+  return { stream, pulled: () => pulls };
+}
+
+function streamingRequest(body: ReadableStream<Uint8Array>, headers: Record<string, string>) {
+  // undici requires `duplex: 'half'` for a streaming request body.
+  return new Request(URL_UNDER_TEST, {
+    method: 'POST',
+    headers,
+    body,
+    duplex: 'half',
+  } as RequestInit & { duplex: 'half' });
+}
+
+const CSV_BODY = 'Last,First\nDoe,Jane\n';
+const BOUNDARY = '----speddyUploadGuardTest';
+
+/**
+ * Hand-rolled multipart bytes.
+ *
+ * Deliberately not built with `new FormData()`: under the jsdom test
+ * environment the FormData/File globals are jsdom's, while Request is Node's
+ * undici, and handing one to the other misbehaves (the same mismatch noted in
+ * import-students-preview.characterization.test.ts). Encoding by hand keeps
+ * this test on the one path that matters — undici parsing a real wire body.
+ */
+function encodeMultipart(): { bytes: Uint8Array; contentType: string } {
+  const parts = [
+    `--${BOUNDARY}\r\n`,
+    'Content-Disposition: form-data; name="studentsFile"; filename="students.csv"\r\n',
+    'Content-Type: text/csv\r\n\r\n',
+    `${CSV_BODY}\r\n`,
+    `--${BOUNDARY}\r\n`,
+    'Content-Disposition: form-data; name="currentSchoolId"\r\n\r\n',
+    'school-1\r\n',
+    `--${BOUNDARY}\r\n`,
+    'Content-Disposition: form-data; name="currentSchoolSite"\r\n\r\n',
+    'Bancroft Elementary\r\n',
+    `--${BOUNDARY}--\r\n`,
+  ].join('');
+
+  return {
+    bytes: new TextEncoder().encode(parts),
+    contentType: `multipart/form-data; boundary=${BOUNDARY}`,
+  };
+}
+
+function bodyFrom(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+describe('exceedsTotalUploadSize (Content-Length fast path)', () => {
+  const withContentLength = (value: string | null) =>
+    ({
+      headers: { get: (k: string) => (k.toLowerCase() === 'content-length' ? value : null) },
+    }) as unknown as Request;
+
+  it('rejects an honestly-declared oversized body', () => {
+    expect(exceedsTotalUploadSize(withContentLength(String(MAX_TOTAL_UPLOAD_BYTES + 1)))).toBe(true);
+  });
+
+  it('passes a normal upload through', () => {
+    expect(exceedsTotalUploadSize(withContentLength(String(ONE_MB)))).toBe(false);
+  });
+
+  // These two document why the fast path cannot be the enforcement point: it
+  // has nothing to act on, so it must say "not too large" and let the real cap
+  // in readImportForm() make the call.
+  it('cannot judge a request with no Content-Length', () => {
+    expect(exceedsTotalUploadSize(withContentLength(null))).toBe(false);
+  });
+
+  it('cannot judge a request with an unparseable Content-Length', () => {
+    expect(exceedsTotalUploadSize(withContentLength('not-a-number'))).toBe(false);
+  });
+});
+
+describe('readImportForm body ceiling (SPE-443)', () => {
+  // 60 chunks = 60 MB, comfortably past the 41 MB ceiling but small enough that
+  // a regression fails fast rather than thrashing the runner.
+  const SAFETY_LIMIT_CHUNKS = 60;
+
+  // The read must stop on the chunk that crosses the ceiling: one to exceed it,
+  // plus one the stream's internal queue has already pulled ahead.
+  const MAX_EXPECTED_CHUNKS = Math.ceil(MAX_TOTAL_UPLOAD_BYTES / ONE_MB) + 2;
+
+  it('caps an unbounded body that omits Content-Length', async () => {
+    const { stream, pulled } = unboundedBody(SAFETY_LIMIT_CHUNKS);
+    const request = streamingRequest(stream, {
+      'content-type': 'multipart/form-data; boundary=----test',
+    });
+
+    await expect(readImportForm(request)).rejects.toBeInstanceOf(UploadTooLargeError);
+
+    // Stopped at the ceiling rather than draining the stream.
+    expect(pulled()).toBeLessThanOrEqual(MAX_EXPECTED_CHUNKS);
+  });
+
+  it('caps an unbounded body that understates Content-Length', async () => {
+    const { stream, pulled } = unboundedBody(SAFETY_LIMIT_CHUNKS);
+    const request = streamingRequest(stream, {
+      'content-type': 'multipart/form-data; boundary=----test',
+      // A deliberate lie: the fast path sees a 1 KB upload and waves it through.
+      'content-length': '1024',
+    });
+
+    await expect(readImportForm(request)).rejects.toBeInstanceOf(UploadTooLargeError);
+    expect(pulled()).toBeLessThanOrEqual(MAX_EXPECTED_CHUNKS);
+  });
+
+  it('still parses a legitimate upload sent without Content-Length', async () => {
+    // The guard must cap unbounded bodies without rejecting every chunked
+    // client outright — a within-ceiling upload has to keep working.
+    const { bytes, contentType } = encodeMultipart();
+    const request = streamingRequest(bodyFrom(bytes), { 'content-type': contentType });
+
+    const form = await readImportForm(request);
+
+    expect(form.studentsFile?.name).toBe('students.csv');
+    expect(await form.studentsFile?.text()).toBe(CSV_BODY);
+    expect(form.currentSchoolId).toBe('school-1');
+    expect(form.currentSchoolSite).toBe('Bancroft Elementary');
+    expect(form.deliveriesFile).toBeNull();
+  });
+
+  it('reads the form directly when the request exposes no body stream', async () => {
+    // Nothing to buffer means nothing to cap. Callers that hand over an
+    // already-parsed form (as the route tests do) must keep working.
+    const stub = {
+      url: URL_UNDER_TEST,
+      method: 'POST',
+      formData: async () => ({ get: (k: string) => (k === 'currentSchoolId' ? 'school-9' : null) }),
+    } as unknown as Request;
+
+    const form = await readImportForm(stub);
+
+    expect(form.currentSchoolId).toBe('school-9');
+    expect(form.studentsFile).toBeNull();
+  });
+});

--- a/app/api/import-students/route.ts
+++ b/app/api/import-students/route.ts
@@ -15,7 +15,12 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { withRoute } from '@/lib/api/with-route';
-import { readImportForm, exceedsTotalUploadSize, findOversizedFile } from '@/lib/import/parse-files';
+import {
+  readImportForm,
+  exceedsTotalUploadSize,
+  findOversizedFile,
+  UploadTooLargeError,
+} from '@/lib/import/parse-files';
 import { MAX_FILE_SIZE_MB } from '@/lib/import/detect-import-file';
 import { runStudentsPreview, runUpdateOnlyPreview } from '@/lib/import/pipeline';
 import { log } from '@/lib/monitoring/logger';
@@ -76,6 +81,18 @@ export const POST = withRoute({}, async ({ req: request, userId }) => {
       ? await runStudentsPreview(ctx, form.studentsFile)
       : await runUpdateOnlyPreview(ctx);
   } catch (error: unknown) {
+    // The body outran the ceiling mid-read (SPE-443) — the Content-Length check
+    // above can't see this when the header is absent, chunked, or understated.
+    // Same status and message as the declared-size rejection.
+    if (error instanceof UploadTooLargeError) {
+      log.warn('Import upload rejected: body exceeded size ceiling while reading', { userId });
+      perf.end({ success: false });
+      return NextResponse.json(
+        { error: `Upload too large. Each file must be under ${MAX_FILE_SIZE_MB} MB.` },
+        { status: 413 }
+      );
+    }
+
     const message = error instanceof Error ? error.message : 'Unknown error';
     log.error('Student import preview error', error instanceof Error ? error : null, { userId });
 

--- a/app/components/providers/auth-provider.tsx
+++ b/app/components/providers/auth-provider.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useEffect, useState, useCallback } from "react";
 import { User } from "@supabase/supabase-js";
-import { supabase } from "../../../lib/supabase/client";
+import { getSupabaseClient } from "../../../lib/supabase/client";
 import { useRouter, usePathname } from "next/navigation";
 import { useActivityTracker } from "../../../lib/hooks/use-activity-tracker";
 import { TimeoutWarningModal } from "../auth/timeout-warning-modal";
@@ -40,7 +40,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const checkSession = useCallback(async () => {
     setLoading(true);
     try {
-      const { data: { user } } = await supabase.auth.getUser();
+      const { data: { user } } = await getSupabaseClient().auth.getUser();
       setUser(user ?? null);
       setInitialized(true);
     } catch (error) {
@@ -64,7 +64,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // Listen for auth state changes
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    } = getSupabaseClient().auth.onAuthStateChange((_event, session) => {
       setUser(session?.user ?? null);
       if (session) {
         setInitialized(true);
@@ -77,7 +77,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signIn = async (email: string, password: string) => {
     try {
       setLoading(true);
-      const { error } = await supabase.auth.signInWithPassword({
+      const { error } = await getSupabaseClient().auth.signInWithPassword({
         email,
         password,
       });
@@ -98,7 +98,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     try {
       if (typeof window !== 'undefined') {
         localStorage.removeItem('lastActivity');
-        await supabase.auth.signOut();
+        await getSupabaseClient().auth.signOut();
         if ('caches' in window) {
           const cacheNames = await caches.keys();
           await Promise.all(cacheNames.map(name => caches.delete(name)));

--- a/lib/import/parse-files.ts
+++ b/lib/import/parse-files.ts
@@ -75,64 +75,68 @@ export class UploadTooLargeError extends Error {
 }
 
 /**
- * Buffer the request body, aborting the moment it passes the total ceiling
- * (SPE-443).
+ * Wrap a body stream so it fails once it passes the total ceiling (SPE-443).
  *
- * The Content-Length check above can only act on what the client claims. This
- * counts what the client actually sends, so an unbounded body cannot be
- * buffered into memory by formData() no matter what the headers say. At most
- * one chunk beyond the ceiling is ever held before the read is abandoned.
+ * Counting in a pass-through rather than pre-buffering matters: the point of
+ * the guard is to bound memory, so it must not itself hold a second full copy
+ * of the body. Chunks flow straight on to the parser and the read is torn down
+ * on the chunk that crosses the line.
  *
- * Returns null when the request exposes no readable body — there is then
- * nothing to buffer and so nothing to cap, and the caller reads the form
- * directly.
+ * `tripped` is reported back because the failure surfaces from formData(),
+ * which may wrap the underlying stream error in its own type — the caller uses
+ * the flag to answer "was this the ceiling?" rather than matching on that.
  */
-async function readBodyWithinLimit(request: Request): Promise<Uint8Array | null> {
-  const body = request.body;
-  if (!body || typeof body.getReader !== 'function') return null;
-
-  const reader = body.getReader();
-  const chunks: Uint8Array[] = [];
+function capBodyStream(body: ReadableStream<Uint8Array>): {
+  stream: ReadableStream<Uint8Array>;
+  tripped: () => boolean;
+} {
   let total = 0;
-  try {
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (!value) continue;
-      total += value.byteLength;
-      if (total > MAX_TOTAL_UPLOAD_BYTES) throw new UploadTooLargeError();
-      chunks.push(value);
-    }
-  } finally {
-    // Release the stream so an abandoned read doesn't hold the connection.
-    await reader.cancel().catch(() => {});
-  }
-
-  const buffer = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    buffer.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return buffer;
+  let exceeded = false;
+  const stream = body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        total += chunk.byteLength;
+        if (total > MAX_TOTAL_UPLOAD_BYTES) {
+          exceeded = true;
+          throw new UploadTooLargeError();
+        }
+        controller.enqueue(chunk);
+      },
+    })
+  );
+  return { stream, tripped: () => exceeded };
 }
 
-/** Parse the multipart form from a body read under the size ceiling. */
+/**
+ * Parse the multipart form from a body read under the size ceiling.
+ *
+ * When the request exposes no readable body there is nothing to buffer and so
+ * nothing to cap, and the form is read directly.
+ */
 async function readBoundedFormData(request: Request): Promise<FormData> {
-  const body = await readBodyWithinLimit(request);
-  if (body === null) return request.formData();
+  const body = request.body;
+  if (!body || typeof body.pipeThrough !== 'function') return request.formData();
 
-  // Re-wrap the bytes actually read, so formData() parses those rather than the
-  // now-consumed original stream. Only content-type carries over: it holds the
-  // multipart boundary, whereas the original content-length may disagree with
-  // what was really sent — which is the whole point of SPE-443.
+  const { stream, tripped } = capBodyStream(body);
+
+  // Only content-type carries over: it holds the multipart boundary, whereas
+  // the original content-length may disagree with what is really being sent —
+  // which is the whole point of SPE-443.
   const contentType = request.headers?.get?.('content-type') ?? null;
   const bounded = new Request(request.url, {
     method: 'POST',
     ...(contentType ? { headers: { 'content-type': contentType } } : {}),
-    body,
-  });
-  return bounded.formData();
+    body: stream,
+    // undici requires this for a streaming request body.
+    duplex: 'half',
+  } as RequestInit & { duplex: 'half' });
+
+  try {
+    return await bounded.formData();
+  } catch (error) {
+    if (tripped()) throw new UploadTooLargeError();
+    throw error;
+  }
 }
 
 /** The first present file over the per-file cap, or null if all are within it. */

--- a/lib/import/parse-files.ts
+++ b/lib/import/parse-files.ts
@@ -26,7 +26,7 @@ export interface ImportForm {
 
 /** Read the multipart form into typed files + school context. */
 export async function readImportForm(request: Request): Promise<ImportForm> {
-  const formData = await request.formData();
+  const formData = await readBoundedFormData(request);
   return {
     studentsFile: formData.get('studentsFile') as File | null,
     deliveriesFile: formData.get('deliveriesFile') as File | null,
@@ -51,11 +51,88 @@ export const MAX_UPLOAD_FILE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
  *  cap, plus ~1 MB for multipart framing. */
 export const MAX_TOTAL_UPLOAD_BYTES = MAX_UPLOAD_FILE_BYTES * 4 + 1024 * 1024;
 
-/** True when the request's Content-Length exceeds the total-body ceiling. */
+/**
+ * True when the request's Content-Length *declares* a body over the ceiling.
+ *
+ * This is only a cheap fast path — it rejects an honest oversized upload
+ * without reading a byte. It is deliberately NOT the enforcement point: a
+ * client that omits Content-Length, uses chunked transfer-encoding, or simply
+ * understates the length sails straight through it. The real cap is applied by
+ * readImportForm(), which counts the bytes it actually reads (SPE-443).
+ */
 export function exceedsTotalUploadSize(request: Request): boolean {
   const raw = request.headers?.get?.('content-length');
   const len = raw == null ? NaN : Number(raw);
   return Number.isFinite(len) && len > MAX_TOTAL_UPLOAD_BYTES;
+}
+
+/** Thrown by readImportForm when the body read passes MAX_TOTAL_UPLOAD_BYTES. */
+export class UploadTooLargeError extends Error {
+  constructor(message = 'Upload exceeds the total size ceiling') {
+    super(message);
+    this.name = 'UploadTooLargeError';
+  }
+}
+
+/**
+ * Buffer the request body, aborting the moment it passes the total ceiling
+ * (SPE-443).
+ *
+ * The Content-Length check above can only act on what the client claims. This
+ * counts what the client actually sends, so an unbounded body cannot be
+ * buffered into memory by formData() no matter what the headers say. At most
+ * one chunk beyond the ceiling is ever held before the read is abandoned.
+ *
+ * Returns null when the request exposes no readable body — there is then
+ * nothing to buffer and so nothing to cap, and the caller reads the form
+ * directly.
+ */
+async function readBodyWithinLimit(request: Request): Promise<Uint8Array | null> {
+  const body = request.body;
+  if (!body || typeof body.getReader !== 'function') return null;
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > MAX_TOTAL_UPLOAD_BYTES) throw new UploadTooLargeError();
+      chunks.push(value);
+    }
+  } finally {
+    // Release the stream so an abandoned read doesn't hold the connection.
+    await reader.cancel().catch(() => {});
+  }
+
+  const buffer = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return buffer;
+}
+
+/** Parse the multipart form from a body read under the size ceiling. */
+async function readBoundedFormData(request: Request): Promise<FormData> {
+  const body = await readBodyWithinLimit(request);
+  if (body === null) return request.formData();
+
+  // Re-wrap the bytes actually read, so formData() parses those rather than the
+  // now-consumed original stream. Only content-type carries over: it holds the
+  // multipart boundary, whereas the original content-length may disagree with
+  // what was really sent — which is the whole point of SPE-443.
+  const contentType = request.headers?.get?.('content-type') ?? null;
+  const bounded = new Request(request.url, {
+    method: 'POST',
+    ...(contentType ? { headers: { 'content-type': contentType } } : {}),
+    body,
+  });
+  return bounded.formData();
 }
 
 /** The first present file over the per-file cap, or null if all are within it. */

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -27,5 +27,9 @@ export const createClient = <T = any>() => {
   return getSupabaseClient() as unknown as ReturnType<typeof createBrowserClient<T>>
 }
 
-// Export singleton for backward compatibility
-export const supabase = getSupabaseClient()
+// NOTE (SPE-495): do NOT re-add an eagerly-constructed `export const supabase`
+// here. createBrowserClient() throws when NEXT_PUBLIC_SUPABASE_URL/ANON_KEY are
+// absent, and a module-scope call runs on mere *import* of this file — so any
+// server module that transitively imports it (e.g. the daily-schedule-emails
+// cron, via SessionGenerator) breaks `next build` in an env-less environment.
+// Call getSupabaseClient() from inside a function instead.


### PR DESCRIPTION
Three backlog tickets, all internal — no user-facing or UX change.

## SPE-443 — import upload-size guard was bypassable

`exceedsTotalUploadSize()` only read `Content-Length`. A client that omits the header, uses chunked transfer-encoding, or simply understates the length skipped the guard entirely and handed an unbounded body to `formData()` — the exact memory-exhaustion case the guard (SPE-260) was written to close.

`readImportForm()` now counts the bytes it actually reads and tears the read down the moment it passes `MAX_TOTAL_UPLOAD_BYTES`, so the cap holds regardless of what the headers claim. The `Content-Length` check stays as a cheap fast path that rejects an honest oversized upload without reading anything; its doc comment now says plainly that it is *not* the enforcement point.

The cap rides a pass-through `TransformStream` rather than pre-buffering. That was a self-review finding worth calling out: the first cut buffered every chunk, concatenated them into a second full-size array, then handed that to a new `Request` — roughly doubling peak heap at an at-ceiling 40 MB import, a memory regression inside the guard whose whole job is bounding memory. Streaming returns peak memory to what plain `formData()` used, with the ceiling still enforced.

Two behaviours worth confirming are pinned by tests: a within-ceiling upload sent *without* `Content-Length` still parses (chunked clients are not rejected wholesale), and the new `UploadTooLargeError` maps to the same 413 and message as the declared-size rejection, so the UI is unchanged.

## SPE-495 — env-less `next build` broke on the daily-schedule-emails cron

`lib/supabase/client.ts` ended with `export const supabase = getSupabaseClient()`, constructing a browser client at **module load**. `createBrowserClient()` throws without `NEXT_PUBLIC_SUPABASE_URL`/`ANON_KEY`, so any server module that transitively imported that file broke the build on mere import — reproduced here on `/api/cron/daily-schedule-emails`, which reaches it via `SessionGenerator`.

Dropped the eager export. Its one consumer (`auth-provider`) now calls `getSupabaseClient()` inside the functions that use it — same singleton, same instance, no behaviour change. Typecheck confirms nothing else depended on it.

**This does not yet make an env-less build pass, and the ticket should stay open.** With the module-load failure gone the build now gets from "Collecting page data" all the way to static generation, where it hits a *different* instance of the same class: eight `'use client'` pages call `createClient()` in the component body, which runs during prerender. Details and the awkward case are in the follow-up ticket — the schedule page passes the client into `useTeachers()` during render, so it needs more than moving a line. That sweep touches eight user-facing pages including the most complex one in the app, so it is deliberately not bundled into this PR.

## SPE-405 — CI runs piled up instead of cancelling

None of the four PR-triggered workflows declared a `concurrency` group, so every push queued a fresh full set of runs and none of the superseded ones were cancelled.

Added one to each. The group key deviates from the ticket's suggested form on purpose: **only `pull_request` runs share a group**, while push-to-main, CodeQL's weekly schedule, and manual dispatches key on the unique run id so each sits in a group of one.

The ticket flagged that `main` must not cancel itself, and guarding `cancel-in-progress` alone does not fully achieve that. A concurrency group also caps a group at one running plus one *pending* run — a third arrival cancels the pending one. So a ref-based group would let two merges landing back-to-back silently drop a queued commit's run: the same gap-in-the-record problem, arriving through a different door. Keying non-PR runs on `github.run_id` sidesteps it entirely.

This also settles the CodeQL question in the ticket: `schedule` and `push` both resolve `github.ref` to `refs/heads/main`, so they would have contended under a ref-based key. They no longer share a group at all.

On branch protection: cancellation only ever affects runs for superseded commits. The PR head SHA always gets a full run, which is what protection evaluates.

## Verification

- Full suite green: 136 suites, 1543 tests.
- `npm run typecheck` clean.
- The two body-ceiling tests were confirmed to **fail against the pre-fix code and pass after it**, so they pin the guard rather than passing incidentally.
- SPE-495's build failure was reproduced before the change and confirmed gone after it (the build now proceeds past that route into static generation).
- All four workflow YAMLs parse, with the expected `concurrency` block.
- `/code-review` at high effort run on the branch; its one in-diff finding (the double-buffering above) is fixed, and its two out-of-scope findings are ticketed.

## Follow-ups filed

- Render-time browser-client construction blocking env-less prerender (remaining half of SPE-495).
- Unbounded request bodies on other upload routes — `/api/submit-worksheet` is the notable one, it is `auth: false`.
- `SessionGenerator` and `lib/scheduling/*` import the *browser* client into server-side cron paths. Pre-existing and unchanged here; this PR only moves the failure from import time to call time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116Lum8jZvkXt9rjvzaGct7

---
_Generated by [Claude Code](https://claude.ai/code/session_0116Lum8jZvkXt9rjvzaGct7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import upload-size enforcement, including streamed requests without reliable size headers.
  * Oversized uploads now consistently return a 413 response instead of a generic server error.
  * Improved authentication client initialization without changing sign-in or sign-out behavior.

* **Chores**
  * Added workflow concurrency controls to cancel superseded pull-request checks while preserving independent push and scheduled runs.

* **Tests**
  * Added comprehensive coverage for upload-size limits across multipart, streaming, and form-data requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->